### PR TITLE
feat: add Agent OS control plane export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ mcp/node_modules/
 mcp/build/
 mcp/.mcpregistry_*
 mcp/package-lock.json
+__pycache__/
+*.pyc

--- a/agent-os/README.md
+++ b/agent-os/README.md
@@ -1,0 +1,80 @@
+# Agent OS Control Plane
+
+Use Agoragentic as an agent-native operating layer for paid tool execution:
+quote first, check procurement policy, request or resolve supervisor approval, execute with the approved quote, and reconcile spend after the run.
+
+This is the public integration boundary. It uses only public API endpoints and does not expose Agoragentic internals, private ranking logic, database state, or settlement implementation details.
+
+## Public API Surface
+
+| Step | Endpoint | Cost | Purpose |
+|------|----------|------|---------|
+| Quote | `POST /api/commerce/quotes` | Free | Lock a listing, price, and execution rail before spend. |
+| Procurement check | `POST /api/commerce/procurement/check` | Free | Check wallet, budget, policy, and approval state. |
+| Buyer approval queue | `GET /api/approvals?role=buyer` | Free | Let a supervised buyer see requested approvals. |
+| Supervisor queue | `GET /api/approvals?role=supervisor` | Free | Let a supervisor review pending spend requests. |
+| Approval resolution | `POST /api/approvals/:id/resolve` | Free | Approve or deny one specific purchase request. |
+| Execute | `POST /api/execute` | Listing price | Execute the quote-locked provider and settle normally. |
+| Job reconciliation | `GET /api/jobs/:id/reconciliation` | Free | Inspect per-job spend and receipt state. |
+
+Control-plane calls are free. Agoragentic monetizes on paid execution and settlement, not on approvals or dashboards. The platform take rate applies when a paid listing is executed and settled.
+
+## Install
+
+No framework dependency is required for these examples.
+
+```bash
+# Node.js 18+ has fetch built in.
+node agent_os_node.mjs buyer
+
+# Python example requires requests.
+pip install requests
+python agent_os_python.py buyer
+```
+
+## Environment
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `AGORAGENTIC_API_KEY` | Yes for buyer mode | Buyer agent API key. |
+| `AGORAGENTIC_SUPERVISOR_API_KEY` | Yes for supervisor mode | Supervisor agent API key. |
+| `AGORAGENTIC_CAPABILITY_ID` | Yes for buyer mode | Capability/listing ID to quote and execute. |
+| `AGORAGENTIC_INPUT_JSON` | No | JSON input for the capability. Defaults to a small text payload. |
+| `AGORAGENTIC_BASE_URL` | No | Defaults to `https://agoragentic.com`. |
+| `AGORAGENTIC_AUTO_APPROVE` | No | Set to `true` only in a controlled test account. |
+
+## Buyer Flow
+
+1. Create a durable quote with `POST /api/commerce/quotes`.
+2. Preflight the exact capability, quoted cost, and input with `POST /api/commerce/procurement/check`.
+3. Execute through `POST /api/execute` using `quote_id` and the same input.
+4. If the buyer has supervisor policy, the first execution returns `pending_approval`.
+5. Retry the same quote/input after the supervisor approves it.
+
+The approval is one-time authorization. A successful matching execution consumes it and links the approval to the invocation.
+
+```bash
+AGORAGENTIC_API_KEY=amk_buyer \
+AGORAGENTIC_CAPABILITY_ID=cap_xxxxx \
+node agent-os/agent_os_node.mjs buyer
+```
+
+## Supervisor Flow
+
+Supervisors review pending approvals and can approve or deny them. The example does not auto-approve unless `AGORAGENTIC_AUTO_APPROVE=true` is explicitly set.
+
+```bash
+AGORAGENTIC_SUPERVISOR_API_KEY=amk_supervisor \
+node agent-os/agent_os_node.mjs supervisor
+```
+
+## Job Reconciliation
+
+For scheduled jobs, call:
+
+```bash
+curl -H "Authorization: Bearer $AGORAGENTIC_API_KEY" \
+  "https://agoragentic.com/api/jobs/job_xxxxx/reconciliation"
+```
+
+Use this to track recurring spend, success rate, receipt linkage, and budget pressure without scraping admin pages.

--- a/agent-os/agent_os_node.mjs
+++ b/agent-os/agent_os_node.mjs
@@ -1,0 +1,148 @@
+/**
+ * Agoragentic Agent OS control-plane example.
+ *
+ * Public boundary:
+ * - Uses only public API endpoints.
+ * - Approval and reconciliation calls are free control-plane calls.
+ * - Paid settlement happens only when /api/execute succeeds against a paid listing.
+ */
+
+const BASE_URL = process.env.AGORAGENTIC_BASE_URL || "https://agoragentic.com";
+const BUYER_KEY = process.env.AGORAGENTIC_API_KEY || "";
+const SUPERVISOR_KEY = process.env.AGORAGENTIC_SUPERVISOR_API_KEY || "";
+const CAPABILITY_ID = process.env.AGORAGENTIC_CAPABILITY_ID || "";
+const AUTO_APPROVE = process.env.AGORAGENTIC_AUTO_APPROVE === "true";
+const DEFAULT_INPUT = { text: "Summarize this Agent OS control-plane request." };
+
+function requireValue(value, name) {
+  if (!value) throw new Error(`Missing ${name}`);
+  return value;
+}
+
+function parseInput() {
+  const raw = process.env.AGORAGENTIC_INPUT_JSON;
+  if (!raw) return DEFAULT_INPUT;
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`AGORAGENTIC_INPUT_JSON must be valid JSON: ${err.message}`);
+  }
+}
+
+async function api(method, path, apiKey, body) {
+  const headers = { "Content-Type": "application/json" };
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+  const response = await fetch(`${BASE_URL}${path}`, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await response.text();
+  const data = text ? JSON.parse(text) : {};
+  return { status: response.status, ok: response.ok, data };
+}
+
+async function createQuote(capabilityId, input, apiKey) {
+  const result = await api("POST", "/api/commerce/quotes", apiKey, {
+    capability_id: capabilityId,
+    units: 1,
+    input,
+  });
+  if (!result.ok) throw new Error(`Quote failed: ${JSON.stringify(result.data)}`);
+  return result.data.quote;
+}
+
+async function procurementCheck(quote, input, apiKey) {
+  return api("POST", "/api/commerce/procurement/check", apiKey, {
+    capability_id: quote.capability.id,
+    quoted_cost_usdc: quote.quoted_price_usdc,
+    input,
+  });
+}
+
+async function executeWithQuote(quote, input, apiKey) {
+  return api("POST", "/api/execute", apiKey, {
+    quote_id: quote.quote_id,
+    task: quote.capability.category || quote.capability.name || quote.capability.id,
+    input,
+  });
+}
+
+async function buyerFlow() {
+  const apiKey = requireValue(BUYER_KEY, "AGORAGENTIC_API_KEY");
+  const capabilityId = requireValue(CAPABILITY_ID, "AGORAGENTIC_CAPABILITY_ID");
+  const input = parseInput();
+
+  const quote = await createQuote(capabilityId, input, apiKey);
+  console.log("quote", {
+    quote_id: quote.quote_id,
+    execution_ready: quote.execution_ready,
+    price: quote.quoted_price_usdc,
+  });
+
+  const procurement = await procurementCheck(quote, input, apiKey);
+  console.log("procurement", procurement.data.procurement_check?.decision || procurement.data);
+
+  const execution = await executeWithQuote(quote, input, apiKey);
+  if (execution.status === 202 || execution.data.error === "pending_approval") {
+    console.log("approval_required", {
+      approval_id: execution.data.approval?.approval_id || execution.data.approval?.id || null,
+      approvals_url: execution.data.approvals_url || "GET /api/approvals?role=buyer",
+      retry: "Retry this same quote_id and input after supervisor approval.",
+    });
+    return;
+  }
+  if (!execution.ok) throw new Error(`Execution failed: ${JSON.stringify(execution.data)}`);
+
+  console.log("execution", {
+    invocation_id: execution.data.invocation_id,
+    status: execution.data.status,
+    cost: execution.data.cost,
+    receipt: execution.data.receipt_id || execution.data.receipt || null,
+    approval: execution.data.approval || null,
+  });
+}
+
+async function supervisorFlow() {
+  const apiKey = requireValue(SUPERVISOR_KEY, "AGORAGENTIC_SUPERVISOR_API_KEY");
+  const queue = await api("GET", "/api/approvals?role=supervisor&status=pending&limit=10", apiKey);
+  if (!queue.ok) throw new Error(`Approval queue failed: ${JSON.stringify(queue.data)}`);
+
+  const approvals = queue.data.supervisor_queue?.approvals || queue.data.approvals || [];
+  console.log("pending_approvals", approvals.map((approval) => ({
+    id: approval.id,
+    buyer_id: approval.buyer_id,
+    capability_id: approval.capability_id,
+    cost_usdc: approval.cost_usdc,
+    status: approval.status,
+  })));
+
+  if (!AUTO_APPROVE || approvals.length === 0) return;
+
+  const approval = approvals[0];
+  const resolved = await api("POST", `/api/approvals/${encodeURIComponent(approval.id)}/resolve`, apiKey, {
+    decision: "approve",
+    reason: "Approved by controlled Agent OS integration test.",
+  });
+  if (!resolved.ok) throw new Error(`Approval resolution failed: ${JSON.stringify(resolved.data)}`);
+  console.log("resolved_approval", resolved.data.approval || resolved.data);
+}
+
+async function reconciliationFlow(jobId) {
+  const apiKey = requireValue(BUYER_KEY, "AGORAGENTIC_API_KEY");
+  const result = await api("GET", `/api/jobs/${encodeURIComponent(jobId)}/reconciliation`, apiKey);
+  if (!result.ok) throw new Error(`Reconciliation failed: ${JSON.stringify(result.data)}`);
+  console.log("job_reconciliation", result.data.reconciliation || result.data);
+}
+
+const mode = process.argv[2] || "buyer";
+if (mode === "buyer") {
+  await buyerFlow();
+} else if (mode === "supervisor") {
+  await supervisorFlow();
+} else if (mode === "reconciliation") {
+  await reconciliationFlow(requireValue(process.argv[3], "job id argument"));
+} else {
+  throw new Error("Usage: node agent_os_node.mjs buyer|supervisor|reconciliation <job_id>");
+}

--- a/agent-os/agent_os_python.py
+++ b/agent-os/agent_os_python.py
@@ -1,0 +1,200 @@
+"""Agoragentic Agent OS control-plane example.
+
+Public boundary:
+- Uses only public API endpoints.
+- Approval and reconciliation calls are free control-plane calls.
+- Paid settlement happens only when /api/execute succeeds against a paid listing.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any, Dict, Optional
+
+import requests
+
+
+BASE_URL = os.environ.get("AGORAGENTIC_BASE_URL", "https://agoragentic.com")
+BUYER_KEY = os.environ.get("AGORAGENTIC_API_KEY", "")
+SUPERVISOR_KEY = os.environ.get("AGORAGENTIC_SUPERVISOR_API_KEY", "")
+CAPABILITY_ID = os.environ.get("AGORAGENTIC_CAPABILITY_ID", "")
+AUTO_APPROVE = os.environ.get("AGORAGENTIC_AUTO_APPROVE") == "true"
+DEFAULT_INPUT: Dict[str, Any] = {
+    "text": "Summarize this Agent OS control-plane request.",
+}
+
+
+def require_value(value: str, name: str) -> str:
+    if not value:
+        raise RuntimeError(f"Missing {name}")
+    return value
+
+
+def parse_input() -> Dict[str, Any]:
+    raw = os.environ.get("AGORAGENTIC_INPUT_JSON")
+    if not raw:
+        return DEFAULT_INPUT
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"AGORAGENTIC_INPUT_JSON must be valid JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise RuntimeError("AGORAGENTIC_INPUT_JSON must decode to an object")
+    return value
+
+
+def api(method: str, path: str, api_key: str = "", body: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    response = requests.request(
+        method,
+        f"{BASE_URL}{path}",
+        headers=headers,
+        json=body,
+        timeout=60,
+    )
+    try:
+        data = response.json()
+    except ValueError:
+        data = {"raw": response.text}
+    return {"status": response.status_code, "ok": response.ok, "data": data}
+
+
+def create_quote(capability_id: str, input_data: Dict[str, Any], api_key: str) -> Dict[str, Any]:
+    result = api(
+        "POST",
+        "/api/commerce/quotes",
+        api_key,
+        {"capability_id": capability_id, "units": 1, "input": input_data},
+    )
+    if not result["ok"]:
+        raise RuntimeError(f"Quote failed: {json.dumps(result['data'])}")
+    return result["data"]["quote"]
+
+
+def procurement_check(quote: Dict[str, Any], input_data: Dict[str, Any], api_key: str) -> Dict[str, Any]:
+    return api(
+        "POST",
+        "/api/commerce/procurement/check",
+        api_key,
+        {
+            "capability_id": quote["capability"]["id"],
+            "quoted_cost_usdc": quote["quoted_price_usdc"],
+            "input": input_data,
+        },
+    )
+
+
+def execute_with_quote(quote: Dict[str, Any], input_data: Dict[str, Any], api_key: str) -> Dict[str, Any]:
+    capability = quote["capability"]
+    return api(
+        "POST",
+        "/api/execute",
+        api_key,
+        {
+            "quote_id": quote["quote_id"],
+            "task": capability.get("category") or capability.get("name") or capability["id"],
+            "input": input_data,
+        },
+    )
+
+
+def buyer_flow() -> None:
+    api_key = require_value(BUYER_KEY, "AGORAGENTIC_API_KEY")
+    capability_id = require_value(CAPABILITY_ID, "AGORAGENTIC_CAPABILITY_ID")
+    input_data = parse_input()
+
+    quote = create_quote(capability_id, input_data, api_key)
+    print("quote", json.dumps({
+        "quote_id": quote["quote_id"],
+        "execution_ready": quote["execution_ready"],
+        "price": quote["quoted_price_usdc"],
+    }, indent=2))
+
+    procurement = procurement_check(quote, input_data, api_key)
+    print("procurement", json.dumps(
+        procurement["data"].get("procurement_check", {}).get("decision", procurement["data"]),
+        indent=2,
+    ))
+
+    execution = execute_with_quote(quote, input_data, api_key)
+    if execution["status"] == 202 or execution["data"].get("error") == "pending_approval":
+        approval = execution["data"].get("approval") or {}
+        print("approval_required", json.dumps({
+            "approval_id": approval.get("approval_id") or approval.get("id"),
+            "approvals_url": execution["data"].get("approvals_url") or "GET /api/approvals?role=buyer",
+            "retry": "Retry this same quote_id and input after supervisor approval.",
+        }, indent=2))
+        return
+    if not execution["ok"]:
+        raise RuntimeError(f"Execution failed: {json.dumps(execution['data'])}")
+
+    print("execution", json.dumps({
+        "invocation_id": execution["data"].get("invocation_id"),
+        "status": execution["data"].get("status"),
+        "cost": execution["data"].get("cost"),
+        "receipt": execution["data"].get("receipt_id") or execution["data"].get("receipt"),
+        "approval": execution["data"].get("approval"),
+    }, indent=2))
+
+
+def supervisor_flow() -> None:
+    api_key = require_value(SUPERVISOR_KEY, "AGORAGENTIC_SUPERVISOR_API_KEY")
+    queue = api("GET", "/api/approvals?role=supervisor&status=pending&limit=10", api_key)
+    if not queue["ok"]:
+        raise RuntimeError(f"Approval queue failed: {json.dumps(queue['data'])}")
+
+    approvals = (
+        queue["data"].get("supervisor_queue", {}).get("approvals")
+        or queue["data"].get("approvals")
+        or []
+    )
+    print("pending_approvals", json.dumps([{
+        "id": approval.get("id"),
+        "buyer_id": approval.get("buyer_id"),
+        "capability_id": approval.get("capability_id"),
+        "cost_usdc": approval.get("cost_usdc"),
+        "status": approval.get("status"),
+    } for approval in approvals], indent=2))
+
+    if not AUTO_APPROVE or not approvals:
+        return
+
+    approval = approvals[0]
+    resolved = api(
+        "POST",
+        f"/api/approvals/{approval['id']}/resolve",
+        api_key,
+        {"decision": "approve", "reason": "Approved by controlled Agent OS integration test."},
+    )
+    if not resolved["ok"]:
+        raise RuntimeError(f"Approval resolution failed: {json.dumps(resolved['data'])}")
+    print("resolved_approval", json.dumps(resolved["data"].get("approval", resolved["data"]), indent=2))
+
+
+def reconciliation_flow(job_id: str) -> None:
+    api_key = require_value(BUYER_KEY, "AGORAGENTIC_API_KEY")
+    result = api("GET", f"/api/jobs/{job_id}/reconciliation", api_key)
+    if not result["ok"]:
+        raise RuntimeError(f"Reconciliation failed: {json.dumps(result['data'])}")
+    print("job_reconciliation", json.dumps(result["data"].get("reconciliation", result["data"]), indent=2))
+
+
+def main() -> None:
+    mode = sys.argv[1] if len(sys.argv) > 1 else "buyer"
+    if mode == "buyer":
+        buyer_flow()
+    elif mode == "supervisor":
+        supervisor_flow()
+    elif mode == "reconciliation":
+        reconciliation_flow(require_value(sys.argv[2] if len(sys.argv) > 2 else "", "job id argument"))
+    else:
+        raise RuntimeError("Usage: python agent_os_python.py buyer|supervisor|reconciliation <job_id>")
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations.json
+++ b/integrations.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.3.0",
-  "updated_at": "2026-04-02",
+  "version": "2.4.0",
+  "updated_at": "2026-04-11",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
   "packages": {
@@ -90,9 +90,43 @@
       "id": "agoragentic_passport",
       "description": "Check or verify NFT identity passport",
       "cost": "free"
+    },
+    {
+      "id": "agoragentic_quote",
+      "description": "Create a durable quote before paid execution",
+      "cost": "free"
+    },
+    {
+      "id": "agoragentic_procurement_check",
+      "description": "Preflight a purchase against wallet, budget, policy, and approval state",
+      "cost": "free"
+    },
+    {
+      "id": "agoragentic_approval_queue",
+      "description": "List buyer or supervisor purchase approvals",
+      "cost": "free"
+    },
+    {
+      "id": "agoragentic_resolve_approval",
+      "description": "Approve or deny one supervised purchase request",
+      "cost": "free"
+    },
+    {
+      "id": "agoragentic_job_reconciliation",
+      "description": "Inspect per-job spend, success rate, and receipt linkage",
+      "cost": "free"
     }
   ],
   "integrations": [
+    {
+      "id": "agent-os",
+      "name": "Agent OS Control Plane",
+      "language": "javascript",
+      "status": "ready",
+      "path": "agent-os/agent_os_node.mjs",
+      "install": "node 18+ or pip install requests",
+      "docs": "agent-os/README.md"
+    },
     {
       "id": "langchain",
       "name": "LangChain",
@@ -305,6 +339,7 @@
     "glama": "glama.json",
     "a2a_card": "a2a/agent-card.json",
     "acp_spec": "specs/ACP-SPEC.md",
+    "agent_os": "agent-os/README.md",
     "live_api": "https://agoragentic.com",
     "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json"
   }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4,7 +4,7 @@
 
 ## What This Repo Is
 
-This repository contains drop-in integrations connecting 20 agent frameworks to the Agoragentic capability router. The router lets agents autonomously discover, browse, invoke, and pay for services — settled in USDC on Base L2.
+This repository contains drop-in integrations connecting 21 agent framework and Agent OS surfaces to the Agoragentic capability router. The router lets agents autonomously discover, browse, invoke, and pay for services, with free control-plane endpoints and paid execution settled in USDC on Base L2.
 
 The two published packages are:
 - **Python SDK**: `pip install agoragentic` (PyPI, Python ≥3.8)
@@ -19,9 +19,9 @@ Every integration uses the same auth pattern:
 - How to get one: `POST https://agoragentic.com/api/quickstart` with `{"name": "your-agent"}`
 - Or: call the `agoragentic_register` tool at runtime — the agent can self-register
 
-## Tool Catalog (v2.0)
+## Tool Catalog (v2.1)
 
-All integrations expose the same 13 canonical tools:
+Core integrations expose these canonical tools:
 
 | ID | Description | Cost |
 |----|-------------|------|
@@ -38,6 +38,11 @@ All integrations expose the same 13 canonical tools:
 | agoragentic_secret_store | Store an encrypted credential (AES-256) | Free |
 | agoragentic_secret_retrieve | Retrieve a decrypted credential | Free |
 | agoragentic_passport | Check or verify NFT identity passport | Free |
+| agoragentic_quote | Create a durable quote before paid execution | Free |
+| agoragentic_procurement_check | Preflight a purchase against wallet, budget, policy, and approval state | Free |
+| agoragentic_approval_queue | List buyer or supervisor purchase approvals | Free |
+| agoragentic_resolve_approval | Approve or deny one supervised purchase request | Free |
+| agoragentic_job_reconciliation | Inspect per-job spend, success rate, and receipt linkage | Free |
 
 ## Integration Matrix
 
@@ -75,6 +80,12 @@ All integrations expose the same 13 canonical tools:
 |-----------|------|---------|
 | Dify | dify/agoragentic_provider.json | Import JSON into Dify provider settings |
 | A2A Protocol (Google) | a2a/agent-card.json | No install — discovery spec |
+
+### Specialized Integrations (1)
+
+| Surface | File | Install |
+|---------|------|---------|
+| Agent OS Control Plane | agent-os/agent_os_node.mjs | node 18+ or pip install requests |
 
 ## MCP Client Install Configs
 
@@ -149,6 +160,7 @@ Full spec: specs/ACP-SPEC.md
 |-------|----------|
 | Machine index | integrations.json |
 | JSON Schema | integrations.schema.json |
+| Agent OS control plane | agent-os/README.md |
 | Agent instructions | AGENTS.md |
 | Capability desc | SKILL.md |
 | Thin LLM bootstrap | llms.txt |

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Agoragentic Integrations
 
-> Drop-in adapters connecting 20 agent frameworks to the Agoragentic capability router. USDC settlement on Base L2.
+> Drop-in adapters connecting 21 agent framework and Agent OS surfaces to the Agoragentic capability router. USDC settlement on Base L2.
 
 ## Packages
 - Python: `pip install agoragentic` (PyPI, ≥3.8)
@@ -11,14 +11,16 @@
 - Get key: POST https://agoragentic.com/api/quickstart
 - Or call agoragentic_register at runtime
 
-## Integrations (20)
+## Integrations (21)
 - LangChain, CrewAI, AutoGen, OpenAI Agents SDK, Google ADK, pydantic-ai, smolagents, Agno, MetaGPT, LlamaIndex, AutoGPT, SuperAGI, CAMEL (Python)
 - MCP, Vercel AI, Mastra, Bee Agent, ElizaOS (JS/TS)
 - Dify, A2A (JSON)
+- Agent OS Control Plane (public API examples for quote, procurement, approvals, execute, reconciliation)
 
 ## Machine Index
 - integrations.json — structured index of all integrations, tools, packages
 - integrations.schema.json — JSON Schema for validation
+- agent-os/README.md — public Agent OS control-plane guide
 - AGENTS.md — agent instruction file
 - SKILL.md — capability description
 - a2a/agent-card.json — A2A protocol card


### PR DESCRIPTION
## Summary
- Add public Agent OS control-plane examples for Node and Python.
- Add an Agent OS README documenting quote -> procurement -> approval -> execute -> reconciliation flow.
- Register the Agent OS surface in integrations.json, llms.txt, and llms-full.txt so agents can discover it programmatically.
- Add Python bytecode ignore rules for the new example surface.

## Boundary
- This exports only public API usage patterns and does not expose private ranking, settlement internals, database state, or implementation details.
- Control-plane calls remain free; monetization stays on paid execution/settlement through Agoragentic.

## Validation
- node --check agent-os/agent_os_node.mjs
- python -m py_compile agent-os/agent_os_python.py
- JSON.parse(integrations.json)
- manifest path check for agent-os README/examples
- git diff --check on the seven scoped files

## Notes
- Built from the force-updated origin/main branch to avoid carrying unrelated dirty local integration work or the old-history branch.