### PR TITLE
[codex] Release Micro ECF durable context workflow

### DIFF
--- a/ACP_REGISTRY.md
+++ b/ACP_REGISTRY.md
@@ -1,0 +1,70 @@
+# ACP Registry Positioning
+
+Agoragentic already has an ACP Registry entry. Keep that entry focused on Agent OS.
+
+## Current Problem
+
+The public registry copy can drift toward old marketplace-only language:
+
+```text
+Agent marketplace with 174+ AI capabilities. Browse, invoke, and pay for agent services settled in USDC on Base L2.
+```
+
+That is no longer the clearest product spine. The registry should describe Agoragentic as Agent OS plus router/marketplace execution rails.
+
+## Desired Registry Copy
+
+Name:
+
+```text
+Agoragentic Agent OS
+```
+
+Description:
+
+```text
+Deploy and operate autonomous agents with runtime policy, marketplace routing, receipts, x402/USDC settlement, and governed Agent OS handoff surfaces.
+```
+
+Distribution should stay on the ACP adapter package if it remains the active adapter:
+
+```json
+{
+  "npx": {
+    "package": "agoragentic-mcp",
+    "args": ["--acp"]
+  }
+}
+```
+
+Pin the version to the published ACP adapter package version, not the Agent OS CLI version.
+
+## Micro ECF Boundary
+
+Do not register Micro ECF as a separate ACP agent until it has an ACP-native server mode.
+
+Micro ECF should be described as:
+
+```text
+Local context and policy artifacts that can prepare an Agent OS harness export.
+```
+
+ACP Registry entry:
+
+```text
+Agoragentic Agent OS ACP adapter
+```
+
+Micro ECF:
+
+```text
+Local install / repo artifacts / optional MCP / Agent OS harness export
+```
+
+## Submit Checklist
+
+1. Verify the current published `agoragentic-mcp` version.
+2. Update the ACP registry `agent.json` description to Agent OS language.
+3. Keep the repository URL as `https://github.com/rhein1/agoragentic-integrations`.
+4. Do not claim Micro ECF speaks ACP unless the adapter is implemented.
+5. Link Micro ECF from this repo README as the local harness/context handoff path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,8 @@ specs/ACP-SPEC.md           ← Agent Commerce Protocol spec
 <framework>/README.md      ← per-framework install + quickstart
 agent-os/README.md         ← public Agent OS deployment/control-plane examples
 micro-ecf/README.md        ← local policy and Agent OS harness export
+micro-ecf/FRAMEWORKS.md    ← using Micro ECF with existing agent frameworks
+ACP_REGISTRY.md            ← ACP registry positioning and update checklist
 ```
 
 ## How to Use This Repo
@@ -53,7 +55,7 @@ micro-ecf/README.md        ← local policy and Agent OS harness export
 
 Use `agent-os/README.md`. Agent OS is a hosted deployment and control layer, not a local operating system install. The public export covers launch previews, account checks, quote creation, procurement checks, supervisor approvals, quote-locked execution, receipts, and reconciliation without exposing private platform internals.
 
-Use `micro-ecf/README.md` when you need local context, tool, budget, approval, memory, or swarm policy before moving a local/self-hosted agent toward hosted Agent OS deployment. Use `micro-ecf/LLM_INSTALL.md` when an IDE LLM is installing Micro ECF for a developer; it must run `micro-ecf plan` first and only run `micro-ecf install --yes` after explicit approval. The package-ready entrypoint is `micro-ecf/bin/micro-ecf.mjs`; the future npm install path is `npx agoragentic-micro-ecf init`. After install, compatible IDE agents should rely on the generated `AGENTS.md`; arbitrary new chats should receive the generated `MICRO_ECF_LLM_BOOTSTRAP.md`; IDEs with persistent local tools can use `micro-ecf serve-mcp --root .micro-ecf`.
+Use `micro-ecf/README.md` when you need local context, tool, budget, approval, memory, or swarm policy before moving a local/self-hosted agent toward hosted Agent OS deployment. Use `micro-ecf/LLM_INSTALL.md` when an IDE LLM is installing Micro ECF for a developer; it must run `micro-ecf plan` first and only run `micro-ecf install --yes` after explicit approval. The package-ready entrypoint is `micro-ecf/bin/micro-ecf.mjs`; the npm install path is `npx agoragentic-micro-ecf@latest init`. After install, compatible IDE agents should rely on generated `AGENTS.md` plus `ECF.md`; arbitrary new chats should receive generated `MICRO_ECF_LLM_BOOTSTRAP.md`; IDEs with persistent local tools can use `micro-ecf serve-mcp --root .micro-ecf`. Use `micro-ecf doctor`, `micro-ecf scan`, and `micro-ecf lint ECF.md` before relying on installed artifacts.
 
 ## Canonical Tool IDs
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,9 @@ Install and build local context artifacts:
 npx agoragentic-micro-ecf@latest explain
 npx agoragentic-micro-ecf@latest plan --dir ./my-agent
 npx agoragentic-micro-ecf@latest install --dir ./my-agent --yes
+npx agoragentic-micro-ecf@latest doctor --dir ./my-agent
+npx agoragentic-micro-ecf@latest scan --dir ./my-agent
+npx agoragentic-micro-ecf@latest lint ./my-agent/ECF.md
 npx agoragentic-micro-ecf@latest index ./my-agent/docs --output-dir ./my-agent/.micro-ecf
 npx agoragentic-micro-ecf@latest build-packet --policy ./my-agent/.micro-ecf/policy.json --source-map ./my-agent/.micro-ecf/source-map.json --output-dir ./my-agent/.micro-ecf
 ```
@@ -199,6 +202,8 @@ The safe flow is consent-gated: `micro-ecf plan --dir .` first, then `micro-ecf 
 
 After install, Micro ECF is persistent as repo artifacts, not hidden global chat memory. Compatible IDE agents should read the generated `AGENTS.md`; any new LLM chat that does not auto-load repo instructions should receive `MICRO_ECF_LLM_BOOTSTRAP.md`; IDEs with persistent local tools can run `micro-ecf serve-mcp --root .micro-ecf`.
 
+`ECF.md` is the persistent agent-readable Micro ECF contract. It gives new chats a durable policy file before they inspect generated `.micro-ecf/*` artifacts.
+
 Use [`micro-ecf/POST_INSTALL.md`](./micro-ecf/POST_INSTALL.md) for the after-install workflow.
 
 Optional context providers can be declared in `context_providers[]`. Existing RAG or database MCP providers should use `type: "retrieval_context"` when they return cited context evidence. A local GitNexus MCP provider should use `type: "code_graph"`, `provider: "gitnexus"`, `mode: "local_mcp"`, and `required_for_action_classes: ["code_change"]` when code-change actions should receive pre-action impact review.
@@ -206,6 +211,8 @@ Optional context providers can be declared in `context_providers[]`. Existing RA
 Provider guide and examples:
 
 - [`micro-ecf/PROVIDER_WRAPPING.md`](./micro-ecf/PROVIDER_WRAPPING.md)
+- [`micro-ecf/FRAMEWORKS.md`](./micro-ecf/FRAMEWORKS.md)
+- [`micro-ecf/AGENT_OS_EVIDENCE_EVAL_BACKLOG.md`](./micro-ecf/AGENT_OS_EVIDENCE_EVAL_BACKLOG.md)
 - [`micro-ecf/examples/context-provider-rag.policy.json`](./micro-ecf/examples/context-provider-rag.policy.json)
 - [`micro-ecf/examples/context-provider-gitnexus.policy.json`](./micro-ecf/examples/context-provider-gitnexus.policy.json)
 - [`micro-ecf/examples/context-provider-database-mcp.policy.json`](./micro-ecf/examples/context-provider-database-mcp.policy.json)
@@ -232,6 +239,7 @@ Your Agent  →  Integration (tools/MCP)  →  Agent OS + Agoragentic API
 | Machine-readable index | [`integrations.json`](./integrations.json) |
 | JSON Schema | [`integrations.schema.json`](./integrations.schema.json) |
 | Agent instructions | [`AGENTS.md`](./AGENTS.md) |
+| ACP registry positioning | [`ACP_REGISTRY.md`](./ACP_REGISTRY.md) |
 | LLM bootstrap | [`llms.txt`](./llms.txt) |
 | LLM full context | [`llms-full.txt`](./llms-full.txt) |
 | Capability description | [`SKILL.md`](./SKILL.md) |
@@ -240,6 +248,8 @@ Your Agent  →  Integration (tools/MCP)  →  Agent OS + Agoragentic API
 | Micro ECF Syrin guide | [`micro-ecf/SYRIN_USER_GUIDE.md`](./micro-ecf/SYRIN_USER_GUIDE.md) |
 | Micro ECF post-install | [`micro-ecf/POST_INSTALL.md`](./micro-ecf/POST_INSTALL.md) |
 | Micro ECF provider wrapping | [`micro-ecf/PROVIDER_WRAPPING.md`](./micro-ecf/PROVIDER_WRAPPING.md) |
+| Micro ECF framework guide | [`micro-ecf/FRAMEWORKS.md`](./micro-ecf/FRAMEWORKS.md) |
+| Agent OS evidence/eval backlog | [`micro-ecf/AGENT_OS_EVIDENCE_EVAL_BACKLOG.md`](./micro-ecf/AGENT_OS_EVIDENCE_EVAL_BACKLOG.md) |
 | Changelog | [`CHANGELOG.md`](./CHANGELOG.md) |
 | Citation | [`CITATION.cff`](./CITATION.cff) |
 | A2A agent card | [`a2a/agent-card.json`](./a2a/agent-card.json) |

--- a/SKILL.md
+++ b/SKILL.md
@@ -184,6 +184,9 @@ For the Syrin user launch path and visual roadmap, use `micro-ecf/SYRIN_USER_GUI
 npx agoragentic-micro-ecf@latest explain
 npx agoragentic-micro-ecf@latest plan --dir ./my-agent
 npx agoragentic-micro-ecf@latest install --dir ./my-agent --yes
+npx agoragentic-micro-ecf@latest doctor --dir ./my-agent
+npx agoragentic-micro-ecf@latest scan --dir ./my-agent
+npx agoragentic-micro-ecf@latest lint ./my-agent/ECF.md
 npx agoragentic-micro-ecf@latest index ./my-agent/docs --output-dir ./my-agent/.micro-ecf
 npx agoragentic-micro-ecf@latest build-packet --policy ./my-agent/.micro-ecf/policy.json --source-map ./my-agent/.micro-ecf/source-map.json --output-dir ./my-agent/.micro-ecf
 npx agoragentic-micro-ecf@latest export --agent-os --policy ./my-agent/.micro-ecf/policy.json --output ./my-agent/.micro-ecf/harness-export.json
@@ -193,7 +196,7 @@ AGORAGENTIC_API_KEY=amk_your_key npx agoragentic-os@latest deploy create --file 
 ```
 
 The output includes `agent_os_preview_request` for hosted Agent OS preview. `deploy readiness` and `deploy preview` are no-spend checks. `deploy create` records a hosted deployment request; runtime provisioning, funding, public API exposure, marketplace selling, and x402 monetization remain separate gated steps.
-It also does not include Full ECF, router ranking, trust/fraud scoring, hosted provisioning, wallet settlement, x402 settlement, private connectors, operator prompts, or enterprise governance internals.
+It also does not include Full ECF, router ranking, trust/fraud scoring, hosted provisioning, wallet settlement, x402 settlement, private connectors, operator prompts, or enterprise governance internals. Generated `ECF.md` is the persistent agent-readable policy contract for future chats; generated `MICRO_ECF_LLM_BOOTSTRAP.md` is the paste/attach fallback for chats that do not auto-load repo instructions.
 
 Use the public harness docs when a local or self-hosted agent needs to present a stable deployment contract:
 
@@ -547,7 +550,7 @@ These are readable without an API key:
 curl https://agoragentic.com/skill.md                         # canonical skill file
 curl https://agoragentic.com/start/                           # nontechnical launch path
 curl https://agoragentic.com/developers/                      # technical builder path
-curl https://agoragentic.com/micro-ecf/                       # open governance layer
+curl https://agoragentic.com/micro-ecf/                       # local context wedge
 curl https://agoragentic.com/agoragentic-harness/             # harness docs
 curl https://agoragentic.com/agent-os-harness.json            # harness contract
 curl https://agoragentic.com/llms.txt                         # high-level overview

--- a/integrations.json
+++ b/integrations.json
@@ -24,7 +24,7 @@
     },
     "agent_os_cli": {
       "name": "agoragentic-os",
-      "install": "npx agoragentic-os@1.6.4 doctor",
+      "install": "npx agoragentic-os@1.6.5 doctor",
       "registry": "https://www.npmjs.com/package/agoragentic-os",
       "min_node": "18"
     },
@@ -261,7 +261,7 @@
       "language": "javascript",
       "status": "beta",
       "path": "micro-ecf/bin/micro-ecf.mjs",
-      "install": "npx agoragentic-micro-ecf plan --dir . && npx agoragentic-micro-ecf install --dir . --yes",
+      "install": "npx agoragentic-micro-ecf plan --dir . && npx agoragentic-micro-ecf install --dir . --yes && npx agoragentic-micro-ecf doctor --dir .",
       "docs": "micro-ecf/README.md"
     },
     {
@@ -514,8 +514,12 @@
     "acp_spec": "specs/ACP-SPEC.md",
     "agent_os": "agent-os/README.md",
     "agent_os_public_export": "agent-os/README.md",
+    "acp_registry_positioning": "ACP_REGISTRY.md",
     "micro_ecf": "micro-ecf/README.md",
     "micro_ecf_llm_install": "micro-ecf/LLM_INSTALL.md",
+    "micro_ecf_ecf_md": "Generated ECF.md in installed projects",
+    "micro_ecf_frameworks": "micro-ecf/FRAMEWORKS.md",
+    "agent_os_evidence_eval_backlog": "micro-ecf/AGENT_OS_EVIDENCE_EVAL_BACKLOG.md",
     "agent_os_harness": "https://agoragentic.com/agent-os-harness.json",
     "agent_os_overview": "https://agoragentic.com/agent-os/",
     "agent_os_quickstart": "https://agoragentic.com/guides/agent-os-quickstart/",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4,7 +4,7 @@
 
 ## What This Repo Is
 
-This repository contains drop-in integrations connecting agent frameworks, protocol adapters, Micro ECF harness packets, and Agent OS deployment examples to Agoragentic. Agoragentic is Agent OS for deployed agents and swarms. Micro ECF is the open governance layer. The marketplace is the transaction rail where deployed agents buy, sell, invoke, and settle work in USDC on Base L2.
+This repository contains drop-in integrations connecting agent frameworks, protocol adapters, Micro ECF harness packets, and Agent OS deployment examples to Agoragentic. Agoragentic is Agent OS for deployed agents and swarms. Micro ECF is the local context wedge. Agent OS is the deployment product. Full ECF is the private enterprise runtime engine. The marketplace is the transaction rail where deployed agents buy, sell, invoke, and settle work in USDC on Base L2.
 
 The published packages are:
 - **Python SDK**: `pip install agoragentic` (PyPI, Python ≥3.8)
@@ -96,11 +96,11 @@ Framework adapters, Agent OS control-plane examples, and marketplace integration
 | Export | File | Install |
 |--------|------|---------|
 | Agent OS Control Plane | agent-os/agent_os_node.mjs | npm install agoragentic or pip install agoragentic |
-| Micro ECF Harness Export | micro-ecf/README.md | npx agoragentic-micro-ecf@latest export --agent-os |
+| Micro ECF Harness Export | micro-ecf/README.md | npx agoragentic-micro-ecf@latest doctor --dir . |
 
 Agent OS is the hosted operating layer for deployed agents and swarms, not a local OS installation. External agents use the public SDK/API surface for launch previews, account checks, quote creation, procurement checks, supervisor approvals, quote-locked execution, receipts, and reconciliation. The examples in `agent-os/` are no-spend by default and only execute when `AGORAGENTIC_EXECUTE=true`.
 
-Micro ECF is the open local policy layer for context, tools, budgets, approvals, memory, and swarm boundaries. The harness export produces a stable `agent_os_preview_request` for hosted Agent OS preview. Use `npx agoragentic-os@latest deploy readiness --file .micro-ecf/harness-export.json`, then `deploy preview`, and only use `deploy create` when the owner is ready to record a hosted deployment request. Micro ECF does not execute hosted work, activate billing, provision runtime, publish marketplace listings, settle x402, or expose Full ECF internals.
+Micro ECF is the local context wedge for context, tools, budgets, approvals, memory, and swarm boundaries. It generates `ECF.md` as a persistent agent-readable policy contract, then `.micro-ecf/*` source maps, context packets, policy summaries, and Agent OS harness exports. Use `micro-ecf scan --dir .`, `micro-ecf doctor --dir .`, and `micro-ecf lint ECF.md` before relying on the artifacts. The harness export produces a stable `agent_os_preview_request` for hosted Agent OS preview. Use `npx agoragentic-os@latest deploy readiness --file .micro-ecf/harness-export.json`, then `deploy preview`, and only use `deploy create` when the owner is ready to record a hosted deployment request. Micro ECF does not execute hosted work, activate billing, provision runtime, publish marketplace listings, settle x402, or expose Full ECF internals.
 
 ## MCP Client Install Configs
 
@@ -177,8 +177,11 @@ Full spec: specs/ACP-SPEC.md
 | JSON Schema | integrations.schema.json |
 | Agent instructions | AGENTS.md |
 | Capability desc | SKILL.md |
+| ACP registry positioning | ACP_REGISTRY.md |
 | Agent OS export | agent-os/README.md |
 | Syrin Micro ECF guide | micro-ecf/SYRIN_USER_GUIDE.md |
+| Micro ECF framework guide | micro-ecf/FRAMEWORKS.md |
+| Agent OS evidence/eval backlog | micro-ecf/AGENT_OS_EVIDENCE_EVAL_BACKLOG.md |
 | Thin LLM bootstrap | llms.txt |
 | Full LLM context | llms-full.txt (this file) |
 | A2A card | a2a/agent-card.json |

--- a/llms.txt
+++ b/llms.txt
@@ -33,8 +33,12 @@
 - micro-ecf/SYRIN_USER_GUIDE.md — Syrin user launch guide with visual roadmap and Discord-ready install text
 - micro-ecf/LLM_INSTALL.md — consent-gated IDE LLM install instructions: explain, plan, ask approval, then install --yes
 - micro-ecf/POST_INSTALL.md — post-install workflow for new chats, artifact refresh, MCP use, and Agent OS deploy readiness/preview/create handoff
+- micro-ecf/FRAMEWORKS.md — using Micro ECF with OpenHands, CrewAI, LangGraph, Letta, browser-use, GPT Researcher, Syrin, and IDE agents
+- micro-ecf/AGENT_OS_EVIDENCE_EVAL_BACKLOG.md — future evidence/eval layer backlog for Agent OS and Full ECF
+- ACP_REGISTRY.md — ACP Registry copy and submission boundary
+- ECF.md — generated per-project Micro ECF contract with machine-readable front matter and human-readable policy rationale
 - MICRO_ECF_LLM_BOOTSTRAP.md — generated per-project paste/attach handoff for new chats that do not auto-load repo instructions
-- micro-ecf/bin/micro-ecf.mjs — package-ready local CLI: init, index, build-packet, export, serve-mcp
+- micro-ecf/bin/micro-ecf.mjs — package-ready local CLI: init, scan, doctor, lint, diff, spec, index, build-packet, export, serve-mcp
 
 ## Live API
 - Manifest: https://agoragentic.com/.well-known/agent-marketplace.json

--- a/micro-ecf/AGENT_OS_EVIDENCE_EVAL_BACKLOG.md
+++ b/micro-ecf/AGENT_OS_EVIDENCE_EVAL_BACKLOG.md
@@ -1,0 +1,71 @@
+# Agent OS Evidence And Eval Backlog
+
+This is a backlog note, not a live product claim.
+
+Future AGI-style eval, trace, guardrail, and simulation platforms validate a real buyer expectation: serious agent deployments need evidence, not only runtime features.
+
+Agoragentic should not become a generic eval platform. The Agent OS value is governed deployment: runtime, budgets, receipts, marketplace access, approvals, and reconciliation. The evidence layer should prove those actions happened safely.
+
+## Target Evidence Loop
+
+```text
+Agent OS run/event
+-> policy decision
+-> context/source packet reference
+-> tool/provider trace reference
+-> receipt or no-spend proof
+-> eval/guardrail result
+-> audit-ready report
+```
+
+## What Micro ECF Can Produce Now
+
+- `ECF.md`
+- `.micro-ecf/policy.json`
+- `.micro-ecf/source-map.json`
+- `.micro-ecf/context-packet.json`
+- `.micro-ecf/policy-summary.json`
+- `.micro-ecf/deployment-preview.json`
+- `.micro-ecf/harness-export.json`
+
+These are local evidence artifacts. They show what was allowed, blocked, summarized, cited, and exported before Agent OS preview.
+
+## What Agent OS Should Add Later
+
+- run trace references
+- policy decision records
+- approval records
+- budget and spend checks
+- receipt links
+- provider/tool evidence references
+- eval fixture export
+- guardrail result export
+- simulation result import
+- post-run report
+
+## What Full ECF Should Add Later
+
+- tenant-scoped evidence packets
+- separate audit-log storage
+- access review exports
+- customer-controlled trace retention
+- approved-provider eval reports
+- compliance evidence bundles for scoped pilots
+
+## Product Boundary
+
+Do not put eval-provider internals, hosted traces, enterprise evidence storage, or customer audit systems into open Micro ECF.
+
+Micro ECF should export local fixtures and provenance. Agent OS should bind those fixtures to deployment events. Full ECF should provide the private enterprise evidence plane.
+
+## Go / No-Go For Productization
+
+Only productize a deeper evidence layer when it can show:
+
+- which context packet was used
+- which policy decision allowed or blocked the action
+- which tools/providers were called
+- what was spent, if anything
+- where the receipt is
+- whether guardrails/evals passed
+- whether a human or supervisor approved high-risk steps

--- a/micro-ecf/FRAMEWORKS.md
+++ b/micro-ecf/FRAMEWORKS.md
@@ -1,0 +1,105 @@
+# Using Micro ECF With Existing Agent Frameworks
+
+Micro ECF does not replace your agent framework.
+
+Use it as the local context and policy boundary around agents built with frameworks such as OpenHands, CrewAI, LangGraph, Letta, browser-use, GPT Researcher, OpenAI Agents SDK, AutoGen, Syrin, Codex, Cursor, Claude, Gemini, or any MCP-compatible IDE agent.
+
+## The Pattern
+
+```text
+your agent framework
+-> local repo/docs/db/tools
+-> Micro ECF context and policy boundary
+-> Agent OS harness export
+-> Agent OS readiness / preview / deployment request
+```
+
+Micro ECF answers:
+
+```text
+What may this agent read, cite, use, package, and export?
+```
+
+Your framework still owns:
+
+```text
+planning
+tool use
+memory implementation
+browser automation
+coding actions
+research workflow
+model calls
+```
+
+Agent OS owns:
+
+```text
+hosted runtime
+wallet budgets
+receipts
+marketplace access
+x402 monetization
+approval gates
+deployment requests
+```
+
+## Framework Notes
+
+| Framework | How Micro ECF Helps |
+|-----------|---------------------|
+| OpenHands / coding agents | Provides `ECF.md`, source maps, blocked-source rules, and Agent OS harness export before a coding agent becomes a deployment. |
+| CrewAI | Gives each crew a local context boundary and policy summary before task delegation. |
+| LangGraph | Defines allowed context and provider evidence for stateful graph nodes without changing LangGraph state management. |
+| Letta | Keeps local memory/retrieval boundaries explicit; Micro ECF does not become the memory backend. |
+| browser-use | Declares browser/context/tool boundaries before browser-action agents export into Agent OS. |
+| GPT Researcher | Preserves source/citation expectations and blocks secret/private local sources before research outputs become deployment context. |
+| OpenAI Agents SDK | Supplies local policy and harness files around tools, handoffs, and sessions. |
+| AutoGen | Makes multi-agent context, tool, budget, and approval boundaries explicit before coordinated work. |
+| Syrin | Provides the local context wedge before Syrin users hand off to Agent OS readiness, preview, and deployment request flows. |
+| Codex / Cursor / Claude / Gemini | Gives new chats a persistent `ECF.md` plus generated bootstrap instructions so the assistant knows when Micro ECF is actually in use. |
+
+## Minimal Setup
+
+```bash
+npx agoragentic-micro-ecf@latest explain
+npx agoragentic-micro-ecf@latest plan --dir .
+# review the plan, then approve
+npx agoragentic-micro-ecf@latest install --dir . --yes
+npx agoragentic-micro-ecf@latest doctor --dir .
+```
+
+After significant repo changes:
+
+```bash
+npx agoragentic-micro-ecf@latest scan --dir .
+npx agoragentic-micro-ecf@latest index . --output-dir .micro-ecf
+npx agoragentic-micro-ecf@latest build-packet --policy .micro-ecf/policy.json --source-map .micro-ecf/source-map.json --output-dir .micro-ecf
+npx agoragentic-micro-ecf@latest export --agent-os --policy .micro-ecf/policy.json --output .micro-ecf/harness-export.json
+```
+
+Then use Agent OS:
+
+```bash
+AGORAGENTIC_API_KEY=amk_your_key npx agoragentic-os@latest deploy readiness --file .micro-ecf/harness-export.json
+AGORAGENTIC_API_KEY=amk_your_key npx agoragentic-os@latest deploy preview --file .micro-ecf/harness-export.json
+```
+
+`readiness` and `preview` are no-spend checks. A live deployment request, wallet funding, runtime provisioning, public API exposure, marketplace selling, and x402 monetization are separate Agent OS steps.
+
+## Boundaries
+
+Micro ECF does not include:
+
+- semantic/vector retrieval
+- hosted RAG answers
+- live hosted runtime
+- wallet settlement
+- x402 settlement
+- router ranking
+- trust/fraud scoring internals
+- hosted provisioning
+- private connectors
+- Full ECF enterprise runtime internals
+
+If a framework already has retrieval or memory, declare it as a `context_providers[]` entry. The provider brings evidence; Micro ECF wraps that evidence with policy, provenance, and action-risk boundaries.

--- a/micro-ecf/LLM_INSTALL.md
+++ b/micro-ecf/LLM_INSTALL.md
@@ -39,6 +39,8 @@ Micro ECF is a lightweight local context layer for builders who want safer agent
 
 It helps because the LLM gets a stable, local map of what it can safely know, cite, and use. It also creates policy artifacts that make the boundary explicit before the agent touches tools, data, money, or hosted deployment.
 
+Micro ECF also creates `ECF.md`, a persistent agent-readable contract with machine-readable front matter and human-readable policy rationale. New chats should read `ECF.md` before relying on `.micro-ecf/*` artifacts.
+
 Micro ECF is not a semantic RAG engine, vector store, hosted answer pipeline, or Full ECF runtime. If the developer already has RAG, GitNexus, database tools, or MCP context providers, Micro ECF wraps those providers with policy, provenance, budget, and action-risk boundaries.
 
 ## Consent Gate
@@ -57,6 +59,7 @@ When the package is not installed globally, use the `npx agoragentic-micro-ecf@l
 `install --yes` creates local artifacts only:
 
 ```text
+ECF.md
 AGENTS.md
 MICRO_ECF_LLM_BOOTSTRAP.md
 .micro-ecf/policy.json
@@ -74,7 +77,7 @@ Micro ECF is persistent in the repo, not automatically persistent inside every n
 Use these rules:
 
 - If the IDE assistant auto-loads repo instructions, `AGENTS.md` should tell it to read the Micro ECF artifacts at the start of non-trivial work.
-- If the new chat does not auto-load repo instructions, paste or attach `MICRO_ECF_LLM_BOOTSTRAP.md` at the start of the conversation.
+- If the new chat does not auto-load repo instructions, paste or attach `MICRO_ECF_LLM_BOOTSTRAP.md` at the start of the conversation and tell it to read `ECF.md`.
 - If the IDE supports persistent MCP servers, configure `micro-ecf serve-mcp --root .micro-ecf` once so the assistant can query Micro ECF as a local tool.
 - The assistant should answer clearly whether it read Micro ECF artifacts, used direct repo reads, used MCP, or did not use Micro ECF in that conversation.
 
@@ -109,4 +112,12 @@ Only after approval should it run:
 
 ```bash
 micro-ecf install --dir . --yes
+```
+
+After install, it should verify:
+
+```bash
+micro-ecf doctor --dir .
+micro-ecf scan --dir .
+micro-ecf lint ECF.md
 ```

--- a/micro-ecf/POST_INSTALL.md
+++ b/micro-ecf/POST_INSTALL.md
@@ -11,6 +11,7 @@ Use this checklist after `micro-ecf install --dir . --yes`.
 Confirm these files exist:
 
 ```text
+ECF.md
 AGENTS.md
 MICRO_ECF_LLM_BOOTSTRAP.md
 .micro-ecf/policy.json
@@ -25,6 +26,13 @@ If they are missing, rerun a read-only plan first:
 
 ```bash
 micro-ecf plan --dir .
+```
+
+Verify the installed boundary:
+
+```bash
+micro-ecf doctor --dir .
+micro-ecf lint ECF.md
 ```
 
 Only reinstall after explicit approval:
@@ -42,6 +50,7 @@ Pick the handoff path your IDE or assistant supports.
 If the IDE auto-loads repo instruction files, `AGENTS.md` tells the assistant to read:
 
 ```text
+ECF.md
 .micro-ecf/policy-summary.json
 .micro-ecf/context-packet.json
 .micro-ecf/source-map.json
@@ -88,6 +97,7 @@ A good assistant should answer one of:
 When docs, source files, schemas, or local DB summaries change, refresh the artifacts:
 
 ```bash
+micro-ecf scan --dir .
 micro-ecf index . --output-dir .micro-ecf
 micro-ecf build-packet --policy .micro-ecf/policy.json --source-map .micro-ecf/source-map.json --output-dir .micro-ecf
 micro-ecf export --agent-os --policy .micro-ecf/policy.json --output .micro-ecf/harness-export.json

--- a/micro-ecf/README.md
+++ b/micro-ecf/README.md
@@ -88,6 +88,7 @@ Good inputs:
 Generated outputs:
 
 ```text
+ECF.md
 .micro-ecf/context-packet.json
 .micro-ecf/policy-summary.json
 .micro-ecf/source-map.json
@@ -118,6 +119,27 @@ It does not contain:
 - Full ECF private context graph internals
 
 Use direct source reads, your own RAG, GitNexus, or another MCP/context provider as the source of truth for deep retrieval. Use Micro ECF to govern what those systems may expose or act on.
+
+## ECF.md
+
+`ECF.md` is the persistent agent-readable Micro ECF contract for a local project. It follows the same practical pattern as other agent-readable project contracts: machine-readable front matter plus human-readable rationale.
+
+Use it when a new Codex, Cursor, Claude, Gemini, database, or IDE agent conversation needs to know:
+
+- what Micro ECF is doing in this repo
+- which sources are allowed
+- which sources are blocked
+- how to verify Micro ECF is installed
+- when to use `.micro-ecf/*` artifacts
+- when to export an Agent OS Harness packet
+
+Commands:
+
+```bash
+micro-ecf lint ECF.md
+micro-ecf diff ECF.md ECF-next.md
+micro-ecf spec
+```
 
 ## What Micro ECF Does Not Include
 
@@ -192,6 +214,9 @@ The binary is intentionally simple:
 
 ```bash
 micro-ecf init
+micro-ecf scan
+micro-ecf doctor
+micro-ecf lint ECF.md
 micro-ecf plan
 micro-ecf install --yes
 micro-ecf index ./docs
@@ -206,6 +231,13 @@ Initialize a local project:
 
 ```bash
 npx agoragentic-micro-ecf@latest init --dir ./my-agent
+```
+
+Verify the local install and inspect the context boundary without writing:
+
+```bash
+npx agoragentic-micro-ecf@latest doctor --dir ./my-agent
+npx agoragentic-micro-ecf@latest scan --dir ./my-agent
 ```
 
 Index bounded local context:
@@ -276,6 +308,10 @@ The MCP server reads and writes local `.micro-ecf` artifacts only. It does not c
 Micro ECF can attach optional context providers for pre-action impact review. A provider brings its own retrieval, graph, or database engine; Micro ECF records the provider contract, policy boundary, and evidence shape so Agent OS can evaluate blast radius before an agent acts.
 
 Full guide: [`PROVIDER_WRAPPING.md`](./PROVIDER_WRAPPING.md).
+
+Framework guide: [`FRAMEWORKS.md`](./FRAMEWORKS.md).
+
+Evidence/eval backlog: [`AGENT_OS_EVIDENCE_EVAL_BACKLOG.md`](./AGENT_OS_EVIDENCE_EVAL_BACKLOG.md).
 
 Supported provider types:
 

--- a/micro-ecf/bin/micro-ecf.mjs
+++ b/micro-ecf/bin/micro-ecf.mjs
@@ -6,14 +6,19 @@ import {
   DEFAULT_BASE_URL,
   DEFAULT_OUTPUT_DIR,
   buildArtifacts,
+  buildEcfSpec,
   buildExplanation,
   buildInstallPlan,
+  diffEcfMd,
+  doctorProject,
   exportAgentOsHarness,
   indexSources,
   installProject,
   initProject,
+  lintEcfMd,
   readJson,
   readPolicy,
+  scanProject,
   searchSourceMap,
   writeJson,
 } from '../src/core.mjs';
@@ -45,6 +50,11 @@ Usage:
   micro-ecf explain
   micro-ecf plan [--dir .] [--output-dir .micro-ecf]
   micro-ecf install [--dir .] [--output-dir .micro-ecf] [--yes]
+  micro-ecf scan [--dir .] [--policy .micro-ecf/policy.json]
+  micro-ecf doctor [--dir .] [--output-dir .micro-ecf]
+  micro-ecf lint [ECF.md]
+  micro-ecf diff <before ECF.md> <after ECF.md>
+  micro-ecf spec [--json]
   micro-ecf index <path> [--policy .micro-ecf/policy.json] [--output-dir .micro-ecf]
   micro-ecf build-packet [--policy .micro-ecf/policy.json] [--source-map .micro-ecf/source-map.json] [--output-dir .micro-ecf]
   micro-ecf export --agent-os [--policy .micro-ecf/policy.json] [--output .micro-ecf/harness-export.json]
@@ -91,6 +101,22 @@ function commandInstall(flags) {
     maxFiles: flags['max-files'],
     maxFileBytes: flags['max-file-bytes'],
     baseUrl: flags['base-url'] || DEFAULT_BASE_URL,
+  });
+}
+
+function commandScan(flags) {
+  return scanProject({
+    targetDir: flags.dir || flags._[0] || process.cwd(),
+    policyPath: flags.policy || null,
+    maxFiles: flags['max-files'],
+    maxFileBytes: flags['max-file-bytes'],
+  });
+}
+
+function commandDoctor(flags) {
+  return doctorProject({
+    targetDir: flags.dir || process.cwd(),
+    outputDir: flags['output-dir'] || null,
   });
 }
 
@@ -167,6 +193,16 @@ async function main() {
   else if (command === 'explain') output(buildExplanation());
   else if (command === 'plan') output(commandPlan(flags));
   else if (command === 'install') output(commandInstall(flags));
+  else if (command === 'scan') output(commandScan(flags));
+  else if (command === 'doctor') output(commandDoctor(flags));
+  else if (command === 'lint') output(lintEcfMd(flags._[0] || 'ECF.md'));
+  else if (command === 'diff') {
+    if (!flags._[0] || !flags._[1]) throw new Error('diff requires two ECF.md file paths.');
+    output(diffEcfMd(flags._[0], flags._[1]));
+  } else if (command === 'spec') {
+    const spec = buildEcfSpec({ format: flags.json ? 'json' : 'markdown' });
+    output(spec, flags.json === true);
+  }
   else if (command === 'index') output(commandIndex(flags));
   else if (command === 'build-packet') output(commandBuildPacket(flags));
   else if (command === 'export') output(commandExport(flags));

--- a/micro-ecf/package.json
+++ b/micro-ecf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agoragentic-micro-ecf",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Local-first context layer and policy packets for safer agents before Agent OS deployment preview.",
   "type": "module",
   "license": "Apache-2.0",
@@ -18,6 +18,8 @@
     "LLM_INSTALL.md",
     "POST_INSTALL.md",
     "PROVIDER_WRAPPING.md",
+    "FRAMEWORKS.md",
+    "AGENT_OS_EVIDENCE_EVAL_BACKLOG.md",
     "LICENSE",
     "policy.example.json",
     "export-agent-os-harness.mjs"

--- a/micro-ecf/src/core.mjs
+++ b/micro-ecf/src/core.mjs
@@ -218,11 +218,14 @@ export function initProject({ targetDir = process.cwd(), force = false } = {}) {
   fs.mkdirSync(outputDir, { recursive: true });
 
   const policyPath = path.join(outputDir, 'policy.json');
+  const ecfMdPath = path.join(root, 'ECF.md');
   const agentsPath = path.join(root, 'AGENTS.md');
   const bootstrapPath = path.join(root, 'MICRO_ECF_LLM_BOOTSTRAP.md');
   const projectName = path.basename(root) || 'local-agent';
+  const policy = createDefaultPolicy(projectName);
 
-  writeIfAllowed(policyPath, createDefaultPolicy(projectName), force);
+  writeIfAllowed(policyPath, policy, force);
+  writeTextIfAllowed(ecfMdPath, buildEcfMd(policy), force);
   writeTextIfAllowed(agentsPath, buildAgentsMd(projectName), force);
   writeTextIfAllowed(bootstrapPath, buildLlmBootstrapMd(projectName), force);
 
@@ -230,9 +233,11 @@ export function initProject({ targetDir = process.cwd(), force = false } = {}) {
     ok: true,
     output_dir: relativePortable(process.cwd(), outputDir),
     policy: relativePortable(process.cwd(), policyPath),
+    ecf_md: relativePortable(process.cwd(), ecfMdPath),
     agents_md: relativePortable(process.cwd(), agentsPath),
     llm_bootstrap: relativePortable(process.cwd(), bootstrapPath),
     next_steps: [
+      'micro-ecf doctor --dir .',
       `micro-ecf index ${portablePath(root)}`,
       'micro-ecf build-packet',
       'micro-ecf export --agent-os',
@@ -247,12 +252,14 @@ export function buildExplanation() {
     what_it_does: [
       'Builds bounded local source maps from repos, docs, local files, and database-summary exports.',
       'Builds citation-ready context packets from source summaries and provenance without exporting raw source content.',
+      'Creates ECF.md as a persistent agent-readable local policy contract.',
       'Applies local policy boundaries for allowed context, blocked sources, tools, budgets, approvals, memory, and swarms.',
       'Can declare external context providers such as RAG, code graphs, database tools, or MCP servers so Agent OS can apply governance around them.',
       'Exports an Agent OS Harness file for no-spend deployment preview.',
     ],
     why_it_helps: [
       'Your IDE LLM gets a stable map of what it can safely know and cite.',
+      'New chats get ECF.md plus generated bootstrap instructions instead of relying on hidden memory.',
       'Secret-looking files, private keys, wallet seeds, credentials, node_modules, and .git internals are blocked by default.',
       'Existing RAG, GitNexus, database, or MCP context systems can be wrapped with explicit policy/provenance boundaries instead of hidden prompt assumptions.',
       'Agent OS receives a structured preview packet instead of an informal prompt or screenshot.',
@@ -292,6 +299,7 @@ export function buildInstallPlan({ targetDir = process.cwd(), outputDir = null, 
     },
     proposed_local_actions: [
       'Create or reuse .micro-ecf/policy.json with local-only context/tool/budget/approval/memory/swarm boundaries.',
+      'Create or reuse ECF.md with a persistent agent-readable Micro ECF policy contract.',
       'Create or reuse AGENTS.md with Micro ECF local safety rules for IDE agents that auto-load repo instructions.',
       'Create or reuse MICRO_ECF_LLM_BOOTSTRAP.md as the drag/paste handoff for any new LLM chat that does not auto-load repo instructions.',
       'Index allowed local text/code/docs/database-summary files into .micro-ecf/source-map.json.',
@@ -300,6 +308,7 @@ export function buildInstallPlan({ targetDir = process.cwd(), outputDir = null, 
       'Export .micro-ecf/harness-export.json for Agent OS preview.',
     ],
     files_that_may_be_created_or_updated: [
+      rel(path.join(root, 'ECF.md')),
       rel(path.join(root, 'AGENTS.md')),
       rel(path.join(root, 'MICRO_ECF_LLM_BOOTSTRAP.md')),
       rel(path.join(resolvedOutput, 'policy.json')),
@@ -398,6 +407,69 @@ function writeTextIfAllowed(filePath, value, force) {
   fs.writeFileSync(filePath, value);
 }
 
+export function buildEcfMd(policy = createDefaultPolicy('local-agent')) {
+  validatePolicy(policy);
+  const projectName = policy.agent_manifest.name || 'local-agent';
+  const allowedSources = asList(policy.context_policy.allowed_sources);
+  const blockedSources = [
+    ...asList(policy.context_policy.denied_sources),
+    '.env',
+    'private_keys',
+    'wallet_seeds',
+    'raw_credentials',
+    'node_modules',
+    '.git internals',
+  ];
+  const providers = asList(policy.context_providers).map((provider) => ({
+    type: provider.type,
+    provider: provider.provider,
+    required: provider.required === true,
+  }));
+
+  return `---
+version: "0.1"
+project: "${escapeYaml(projectName)}"
+scope: "local_project"
+allowed_sources:
+${formatYamlList(allowedSources)}
+blocked_sources:
+${formatYamlList(blockedSources)}
+${providers.length
+  ? `context_providers:\n${providers.map((provider) => `  - type: "${escapeYaml(provider.type)}"\n    provider: "${escapeYaml(provider.provider)}"\n    required: ${provider.required ? 'true' : 'false'}`).join('\n')}`
+  : 'context_providers: []'}
+agent_os:
+  export_harness: true
+  deploy_preview: true
+  live_deploy_requires_owner_approval: true
+---
+
+# ${projectName} Micro ECF Contract
+
+## Overview
+
+This project uses Micro ECF as a local context wedge and policy boundary before Agent OS preview. Micro ECF prepares local context and policy artifacts; it does not deploy, spend, publish, provision, settle x402 payments, or expose Full ECF internals.
+
+## Context Boundaries
+
+Allowed source classes are declared in the front matter. Blocked source classes include secrets, private keys, wallet seeds, raw credentials, dependency folders, Git internals, and any local policy block patterns in \`.micro-ecf/policy.json\`.
+
+## Agent Workflow
+
+1. Run \`micro-ecf doctor --dir .\` before relying on existing artifacts.
+2. Run \`micro-ecf scan --dir .\` when you need a read-only view of included and blocked sources.
+3. Read \`.micro-ecf/policy-summary.json\`, \`.micro-ecf/context-packet.json\`, and \`.micro-ecf/source-map.json\` before broad exploration.
+4. Use direct source reads as source-of-truth verification before editing code.
+5. Use \`.micro-ecf/harness-export.json\` only for Agent OS readiness, preview, or deployment-request handoff.
+
+## Do Not
+
+- Do not read or export blocked source classes.
+- Do not claim Micro ECF is a semantic RAG engine, hosted answer pipeline, or Full ECF runtime.
+- Do not deploy, spend, publish, provision, or call hosted providers from Micro ECF.
+- Do not put router ranking, wallet settlement, x402 settlement, trust/fraud internals, operator prompts, or enterprise governance internals in local Micro ECF artifacts.
+`;
+}
+
 function buildAgentsMd(projectName) {
   return `# ${projectName} Agent Boundary
 
@@ -406,13 +478,14 @@ This project uses Micro ECF as a local context wedge and policy boundary before 
 ## New Conversation Rule
 
 At the start of any non-trivial IDE-agent conversation, check whether .micro-ecf artifacts exist.
-If they exist, read .micro-ecf/policy-summary.json, .micro-ecf/context-packet.json, and .micro-ecf/source-map.json before broad codebase exploration.
+If they exist, read ECF.md, .micro-ecf/policy-summary.json, .micro-ecf/context-packet.json, and .micro-ecf/source-map.json before broad codebase exploration.
 Tell the developer whether you are using Micro ECF artifacts, direct repo reads, or both.
 If this assistant cannot auto-load repo instructions, ask the developer to paste or attach MICRO_ECF_LLM_BOOTSTRAP.md.
 
 ## Local Rules
 
 - Do not read or export .env files, private keys, wallet seeds, raw credentials, or customer-private folders.
+- Use ECF.md as the persistent agent-readable policy contract.
 - Use .micro-ecf/context-packet.json for citation-ready local context summaries.
 - Use .micro-ecf/policy-summary.json for allowed tools, blocked sources, approvals, and budget limits.
 - Use .micro-ecf/harness-export.json only for Agent OS preview; it does not deploy, spend, publish, or provision anything.
@@ -439,11 +512,12 @@ Micro ECF is not Full ECF. It does not include private enterprise runtime intern
 ## New Chat Startup Checklist
 
 1. Check whether .micro-ecf/ exists.
-2. If present, read .micro-ecf/policy-summary.json first to understand allowed tools, blocked sources, budget limits, approvals, memory, and swarm rules.
-3. Read .micro-ecf/context-packet.json for citation-ready source summaries, provenance, and source IDs.
-4. Read .micro-ecf/source-map.json before using broad search so source paths, blocked paths, hashes, and provenance are visible.
-5. Use direct repo/file reads as the source of truth when implementing code. Micro ECF guides what to inspect; it does not replace source verification.
-6. Tell the developer exactly whether you are using Micro ECF artifacts, direct repo reads, a configured Micro ECF MCP server, or none of them.
+2. If present, read ECF.md as the persistent Micro ECF contract.
+3. Read .micro-ecf/policy-summary.json to understand allowed tools, blocked sources, budget limits, approvals, memory, and swarm rules.
+4. Read .micro-ecf/context-packet.json for citation-ready source summaries, provenance, and source IDs.
+5. Read .micro-ecf/source-map.json before using broad search so source paths, blocked paths, hashes, and provenance are visible.
+6. Use direct repo/file reads as the source of truth when implementing code. Micro ECF guides what to inspect; it does not replace source verification.
+7. Tell the developer exactly whether you are using Micro ECF artifacts, direct repo reads, a configured Micro ECF MCP server, or none of them.
 
 ## If Micro ECF Is Missing Or Stale
 
@@ -472,6 +546,7 @@ When asked "are you using Micro ECF?", answer in one of these forms:
 ## Useful Files
 
 - AGENTS.md: persistent repo instructions for IDE agents that auto-load repo guidance.
+- ECF.md: persistent Micro ECF policy contract for agents.
 - MICRO_ECF_LLM_BOOTSTRAP.md: paste or attach this file into any new chat that does not auto-load repo guidance.
 - .micro-ecf/policy.json: editable local policy source.
 - .micro-ecf/policy-summary.json: readable policy summary for LLMs.
@@ -707,6 +782,285 @@ export function buildPolicySummary(policy) {
     learning_memory_boundary: buildLearningMemoryBoundary(),
     swarm: policy.swarm_policy,
   };
+}
+
+export function scanProject({ targetDir = process.cwd(), policyPath = null, maxFiles, maxFileBytes } = {}) {
+  const root = path.resolve(targetDir);
+  const resolvedPolicy = policyPath
+    ? path.resolve(policyPath)
+    : path.join(root, DEFAULT_OUTPUT_DIR, 'policy.json');
+  const sourceMap = indexSources(root, {
+    policyPath: fs.existsSync(resolvedPolicy) ? resolvedPolicy : null,
+    maxFiles,
+    maxFileBytes,
+  });
+  const sensitiveBlocked = sourceMap.blocked.filter((entry) => String(entry.reason || '').includes('secret')
+    || String(entry.reason || '').includes('sensitive')
+    || String(entry.path || '').toLowerCase().includes('.env'));
+  const policy = fs.existsSync(resolvedPolicy) ? readPolicy(resolvedPolicy).policy : null;
+
+  return {
+    ok: true,
+    no_writes_performed: true,
+    root: relativePortable(process.cwd(), root),
+    policy: fs.existsSync(resolvedPolicy) ? relativePortable(process.cwd(), resolvedPolicy) : null,
+    stats: {
+      included_sources: sourceMap.stats.included_sources,
+      blocked_paths: sourceMap.stats.blocked_paths,
+      sensitive_blocked_paths: sensitiveBlocked.length,
+      context_providers: asList(policy?.context_providers).length,
+    },
+    included_preview: sourceMap.sources.slice(0, 20).map((source) => ({
+      path: source.path,
+      type: source.type,
+      hash: source.hash,
+    })),
+    blocked_preview: sourceMap.blocked.slice(0, 20),
+    boundary: {
+      local_only: true,
+      raw_content_exported: false,
+      no_spend: true,
+      no_deploy: true,
+      no_full_ecf_internals: true,
+    },
+  };
+}
+
+export function doctorProject({ targetDir = process.cwd(), outputDir = null } = {}) {
+  const root = path.resolve(targetDir);
+  const resolvedOutput = path.resolve(outputDir || path.join(root, DEFAULT_OUTPUT_DIR));
+  const checks = [];
+
+  const requireFile = (name, filePath) => {
+    const exists = fs.existsSync(filePath);
+    checks.push({
+      name,
+      ok: exists,
+      path: relativePortable(process.cwd(), filePath),
+      severity: exists ? 'ok' : 'error',
+    });
+    return exists;
+  };
+
+  const ecfPath = path.join(root, 'ECF.md');
+  const policyPath = path.join(resolvedOutput, 'policy.json');
+  requireFile('ecf_md', ecfPath);
+  requireFile('agents_md', path.join(root, 'AGENTS.md'));
+  requireFile('llm_bootstrap', path.join(root, 'MICRO_ECF_LLM_BOOTSTRAP.md'));
+  requireFile('policy', policyPath);
+  requireFile('source_map', path.join(resolvedOutput, 'source-map.json'));
+  requireFile('context_packet', path.join(resolvedOutput, 'context-packet.json'));
+  requireFile('policy_summary', path.join(resolvedOutput, 'policy-summary.json'));
+  requireFile('deployment_preview', path.join(resolvedOutput, 'deployment-preview.json'));
+  requireFile('harness_export', path.join(resolvedOutput, 'harness-export.json'));
+
+  if (fs.existsSync(policyPath)) {
+    try {
+      readPolicy(policyPath);
+      checks.push({ name: 'policy_valid', ok: true, severity: 'ok' });
+    } catch (err) {
+      checks.push({ name: 'policy_valid', ok: false, severity: 'error', message: err.message });
+    }
+  }
+
+  if (fs.existsSync(ecfPath)) {
+    const lint = lintEcfMd(ecfPath);
+    checks.push({
+      name: 'ecf_md_lint',
+      ok: lint.ok,
+      severity: lint.ok ? 'ok' : 'error',
+      findings: lint.findings,
+    });
+  }
+
+  const errors = checks.filter((check) => check.ok !== true && check.severity === 'error');
+  return {
+    ok: errors.length === 0,
+    root: relativePortable(process.cwd(), root),
+    output_dir: relativePortable(process.cwd(), resolvedOutput),
+    checks,
+    next_steps: errors.length === 0
+      ? ['micro-ecf scan --dir .', 'micro-ecf export --agent-os']
+      : ['micro-ecf plan --dir .', 'micro-ecf install --dir . --yes'],
+  };
+}
+
+export function lintEcfMd(filePath = 'ECF.md') {
+  const resolved = path.resolve(filePath);
+  const findings = [];
+  if (!fs.existsSync(resolved)) {
+    return {
+      ok: false,
+      file: relativePortable(process.cwd(), resolved),
+      findings: [{ severity: 'error', path: 'file', message: 'ECF.md does not exist.' }],
+      summary: { errors: 1, warnings: 0, info: 0 },
+    };
+  }
+
+  const text = fs.readFileSync(resolved, 'utf8');
+  const parsed = parseEcfMd(text);
+  if (!parsed.frontMatter) {
+    findings.push({ severity: 'error', path: 'front_matter', message: 'ECF.md must start with YAML front matter delimited by ---.' });
+  }
+
+  const requiredKeys = ['version', 'project', 'scope', 'allowed_sources', 'blocked_sources', 'agent_os'];
+  for (const key of requiredKeys) {
+    if (parsed.tokens[key] === undefined) {
+      findings.push({ severity: key === 'agent_os' ? 'warning' : 'error', path: key, message: `Missing required ECF.md token: ${key}.` });
+    }
+  }
+
+  for (const heading of ['## Overview', '## Context Boundaries', '## Agent Workflow', '## Do Not']) {
+    if (!text.includes(heading)) {
+      findings.push({ severity: 'warning', path: 'markdown', message: `Missing recommended section: ${heading}.` });
+    }
+  }
+
+  const summary = summarizeFindings(findings);
+  return {
+    ok: summary.errors === 0,
+    file: relativePortable(process.cwd(), resolved),
+    tokens: parsed.tokens,
+    findings,
+    summary,
+  };
+}
+
+export function diffEcfMd(beforePath, afterPath) {
+  const before = lintEcfMd(beforePath);
+  const after = lintEcfMd(afterPath);
+  const beforeTokens = before.tokens || {};
+  const afterTokens = after.tokens || {};
+  const keys = new Set([...Object.keys(beforeTokens), ...Object.keys(afterTokens)]);
+  const changes = [];
+  for (const key of keys) {
+    if (JSON.stringify(beforeTokens[key]) !== JSON.stringify(afterTokens[key])) {
+      changes.push({
+        token: key,
+        before: beforeTokens[key] ?? null,
+        after: afterTokens[key] ?? null,
+      });
+    }
+  }
+  return {
+    ok: before.ok && after.ok,
+    regression: after.summary.errors > before.summary.errors,
+    changes,
+    before: before.summary,
+    after: after.summary,
+  };
+}
+
+export function buildEcfSpec({ format = 'markdown' } = {}) {
+  const spec = {
+    name: 'ECF.md',
+    status: 'micro-ecf-v0.1',
+    purpose: 'Persistent agent-readable local context and governance contract for Micro ECF projects.',
+    required_front_matter: ['version', 'project', 'scope', 'allowed_sources', 'blocked_sources', 'agent_os'],
+    recommended_sections: ['Overview', 'Context Boundaries', 'Agent Workflow', 'Do Not'],
+    generated_artifacts: [
+      'ECF.md',
+      'AGENTS.md',
+      'MICRO_ECF_LLM_BOOTSTRAP.md',
+      '.micro-ecf/policy.json',
+      '.micro-ecf/source-map.json',
+      '.micro-ecf/context-packet.json',
+      '.micro-ecf/policy-summary.json',
+      '.micro-ecf/deployment-preview.json',
+      '.micro-ecf/harness-export.json',
+    ],
+    boundary: {
+      local_only: true,
+      no_spend: true,
+      no_deploy: true,
+      no_full_ecf_internals: true,
+    },
+  };
+
+  if (format === 'json') return spec;
+  return `# ECF.md Spec
+
+ECF.md is the persistent agent-readable Micro ECF contract for a local project.
+
+Required front matter:
+
+${spec.required_front_matter.map((key) => `- ${key}`).join('\n')}
+
+Recommended sections:
+
+${spec.recommended_sections.map((key) => `- ${key}`).join('\n')}
+
+Boundary:
+
+- local-only
+- no spend
+- no deployment or provisioning
+- no Full ECF, router ranking, settlement, trust/fraud, or enterprise governance internals
+`;
+}
+
+function parseEcfMd(text) {
+  const lines = String(text || '').replace(/\r\n/g, '\n').split('\n');
+  if (lines[0] !== '---') return { frontMatter: '', tokens: {} };
+  const endIndex = lines.indexOf('---', 1);
+  if (endIndex === -1) return { frontMatter: '', tokens: {} };
+
+  const frontMatterLines = lines.slice(1, endIndex);
+  const tokens = {};
+  let currentKey = null;
+  for (const rawLine of frontMatterLines) {
+    const line = rawLine.trimEnd();
+    if (!line.trim()) continue;
+    const topLevel = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (topLevel) {
+      currentKey = topLevel[1];
+      const rawValue = topLevel[2];
+      if (rawValue === '') {
+        tokens[currentKey] = [];
+      } else if (rawValue === '[]') {
+        tokens[currentKey] = [];
+      } else {
+        tokens[currentKey] = parseScalar(rawValue);
+      }
+      continue;
+    }
+    const listItem = line.match(/^\s+-\s*(.*)$/);
+    if (listItem && currentKey) {
+      if (!Array.isArray(tokens[currentKey])) tokens[currentKey] = [];
+      tokens[currentKey].push(parseScalar(listItem[1]));
+    }
+  }
+
+  return {
+    frontMatter: frontMatterLines.join('\n'),
+    tokens,
+  };
+}
+
+function parseScalar(value) {
+  const trimmed = String(value || '').trim();
+  if (trimmed === 'true') return true;
+  if (trimmed === 'false') return false;
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) return trimmed.slice(1, -1);
+  return trimmed;
+}
+
+function summarizeFindings(findings) {
+  return {
+    errors: findings.filter((finding) => finding.severity === 'error').length,
+    warnings: findings.filter((finding) => finding.severity === 'warning').length,
+    info: findings.filter((finding) => finding.severity === 'info').length,
+  };
+}
+
+function formatYamlList(values) {
+  const list = asList(values);
+  if (!list.length) return '  []';
+  return list.map((value) => `  - "${escapeYaml(value)}"`).join('\n');
+}
+
+function escapeYaml(value) {
+  return String(value ?? '').replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 
 export function buildContextPacket(policy, sourceMap) {

--- a/micro-ecf/test/cli.test.mjs
+++ b/micro-ecf/test/cli.test.mjs
@@ -39,16 +39,30 @@ test('micro-ecf CLI initializes, indexes, builds, and exports bounded local arti
     const init = run(['init', '--dir', tmp], microEcfRoot);
     assert.equal(init.ok, true);
     assert.ok(fs.existsSync(path.join(tmp, '.micro-ecf', 'policy.json')));
+    assert.ok(fs.existsSync(path.join(tmp, 'ECF.md')));
     assert.ok(fs.existsSync(path.join(tmp, 'AGENTS.md')));
     assert.ok(fs.existsSync(path.join(tmp, 'MICRO_ECF_LLM_BOOTSTRAP.md')));
 
+    const lint = run(['lint', path.join(tmp, 'ECF.md')], microEcfRoot);
+    assert.equal(lint.ok, true);
+    assert.equal(lint.tokens.project, path.basename(tmp));
+
+    const doctor = run(['doctor', '--dir', tmp], microEcfRoot);
+    assert.equal(doctor.ok, false);
+    assert.ok(doctor.checks.some((check) => check.name === 'source_map' && check.ok === false));
+
+    const scan = run(['scan', '--dir', tmp], microEcfRoot);
+    assert.equal(scan.ok, true);
+    assert.equal(scan.no_writes_performed, true);
+    assert.ok(scan.stats.sensitive_blocked_paths >= 1);
+
     const index = run(['index', tmp, '--output-dir', path.join(tmp, '.micro-ecf')], microEcfRoot);
     assert.equal(index.ok, true);
-    assert.equal(index.stats.included_sources, 4);
+    assert.equal(index.stats.included_sources, 5);
     assert.ok(index.stats.blocked_paths >= 1);
 
     const sourceMap = readJson(path.join(tmp, '.micro-ecf', 'source-map.json'));
-    assert.deepEqual(sourceMap.sources.map((source) => source.path).sort(), ['AGENTS.md', 'MICRO_ECF_LLM_BOOTSTRAP.md', 'docs/api.md', 'src/agent.js']);
+    assert.deepEqual(sourceMap.sources.map((source) => source.path).sort(), ['AGENTS.md', 'ECF.md', 'MICRO_ECF_LLM_BOOTSTRAP.md', 'docs/api.md', 'src/agent.js']);
     assert.ok(sourceMap.blocked.some((entry) => entry.path === '.env'));
     assert.equal(JSON.stringify(sourceMap).includes('do-not-export'), false);
     assert.equal(JSON.stringify(sourceMap).includes(tmp.replace(/\\/g, '/')), false);
@@ -62,7 +76,7 @@ test('micro-ecf CLI initializes, indexes, builds, and exports bounded local arti
     const contextPacket = readJson(path.join(tmp, '.micro-ecf', 'context-packet.json'));
     assert.equal(contextPacket.schema, 'agoragentic.micro-ecf.context-packet.v1');
     assert.equal(contextPacket.export_boundary.raw_content_exported, false);
-    assert.equal(contextPacket.citations.length, 4);
+    assert.equal(contextPacket.citations.length, 5);
 
     const preview = readJson(path.join(tmp, '.micro-ecf', 'deployment-preview.json'));
     assert.equal(preview.marketplace_policy.can_buy, false);
@@ -73,6 +87,9 @@ test('micro-ecf CLI initializes, indexes, builds, and exports bounded local arti
 
     const exported = run(['export', '--agent-os', '--policy', path.join(tmp, '.micro-ecf', 'policy.json'), '--output', path.join(tmp, '.micro-ecf', 'harness-export.json')], microEcfRoot);
     assert.equal(exported.ok, true);
+
+    const healthy = run(['doctor', '--dir', tmp], microEcfRoot);
+    assert.equal(healthy.ok, true);
 
     const harness = readJson(path.join(tmp, '.micro-ecf', 'harness-export.json'));
     assert.equal(harness.schema, 'agoragentic.agent-os.harness.v1');
@@ -112,6 +129,7 @@ test('LLM install flow is read-only until explicit approval', () => {
     assert.equal(plan.approval_required, true);
     assert.equal(plan.no_writes_performed, true);
     assert.ok(plan.files_that_may_be_created_or_updated.some((file) => file.endsWith('MICRO_ECF_LLM_BOOTSTRAP.md')));
+    assert.ok(plan.files_that_may_be_created_or_updated.some((file) => file.endsWith('ECF.md')));
     assert.ok(plan.files_that_may_be_created_or_updated.some((file) => file.endsWith('.micro-ecf/harness-export.json')));
     assert.equal(fs.existsSync(path.join(tmp, '.micro-ecf')), false);
 
@@ -124,12 +142,14 @@ test('LLM install flow is read-only until explicit approval', () => {
     assert.equal(installed.ok, true);
     assert.equal(installed.approved, true);
     assert.ok(fs.existsSync(path.join(tmp, 'AGENTS.md')));
+    assert.ok(fs.existsSync(path.join(tmp, 'ECF.md')));
     assert.ok(fs.existsSync(path.join(tmp, 'MICRO_ECF_LLM_BOOTSTRAP.md')));
     assert.ok(fs.existsSync(path.join(tmp, '.micro-ecf', 'context-packet.json')));
     assert.ok(fs.existsSync(path.join(tmp, '.micro-ecf', 'policy-summary.json')));
     assert.ok(fs.existsSync(path.join(tmp, '.micro-ecf', 'harness-export.json')));
 
     const bootstrap = fs.readFileSync(path.join(tmp, 'MICRO_ECF_LLM_BOOTSTRAP.md'), 'utf8');
+    assert.match(bootstrap, /ECF\.md/);
     assert.match(bootstrap, /Expected Assistant Disclosure/);
     assert.match(bootstrap, /are you using Micro ECF/);
     assert.match(bootstrap, /not a semantic RAG engine/i);
@@ -142,6 +162,10 @@ test('LLM install flow is read-only until explicit approval', () => {
     assert.equal(harness.public_boundary.full_ecf_runtime_included, false);
     assert.equal(harness.public_boundary.learning_memory_review_only, true);
     assert.equal(harness.public_boundary.memory_can_authorize_live_actions, false);
+
+    const spec = run(['spec', '--json'], microEcfRoot);
+    assert.equal(spec.name, 'ECF.md');
+    assert.ok(spec.required_front_matter.includes('allowed_sources'));
   } finally {
     fs.rmSync(tmp, { recursive: true, force: true });
   }
@@ -157,6 +181,8 @@ test('package metadata keeps Micro ECF local-first and Apache licensed', () => {
   assert.ok(packageJson.files.includes('assets/'));
   assert.ok(packageJson.files.includes('POST_INSTALL.md'));
   assert.ok(packageJson.files.includes('PROVIDER_WRAPPING.md'));
+  assert.ok(packageJson.files.includes('FRAMEWORKS.md'));
+  assert.ok(packageJson.files.includes('AGENT_OS_EVIDENCE_EVAL_BACKLOG.md'));
 });
 
 test('context provider docs and examples keep Micro ECF as a governance wrapper', () => {

--- a/skills/agoragentic/SKILL.md
+++ b/skills/agoragentic/SKILL.md
@@ -28,7 +28,7 @@ Do **not** use this skill when:
 
 Agoragentic is **Agent OS for deployed agents and swarms**.
 
-Micro ECF is the open governance layer for local context, tool, budget, approval, memory, and swarm policy. The marketplace is the transaction rail where deployed agents buy, sell, invoke, and settle work.
+Micro ECF is the local context wedge for builders. Agent OS is the deployment product. Full ECF is the private enterprise runtime engine. The marketplace is the transaction rail where deployed agents buy, sell, invoke, and settle work.
 
 Instead of hardcoding provider IDs, retries, billing logic, and fallback rules, agents can call a task like:
 
@@ -449,7 +449,7 @@ These are readable without an API key:
 curl https://agoragentic.com/llms.txt                        # high-level overview
 curl https://agoragentic.com/start/                          # nontechnical launch path
 curl https://agoragentic.com/developers/                     # technical builder path
-curl https://agoragentic.com/micro-ecf/                      # open governance layer
+curl https://agoragentic.com/micro-ecf/                      # local context wedge
 curl https://agoragentic.com/agoragentic-harness/            # harness docs
 curl https://agoragentic.com/agent-os-harness.json           # harness contract
 curl https://agoragentic.com/.well-known/agent.json           # core agent metadata


### PR DESCRIPTION
## Summary

- Adds the Micro ECF durable `ECF.md` contract plus local `scan`, `doctor`, `lint`, `diff`, and `spec` workflows.
- Updates Micro ECF docs, LLM install/post-install guidance, framework integration notes, ACP registry positioning, and Agent OS evidence/eval backlog.
- Aligns public discovery surfaces and package metadata for `agoragentic-micro-ecf@0.1.1` while preserving the local-only boundary and excluding Full ECF, settlement, hosted provisioning, and private governance internals.

## Validation

- `npm test` in `micro-ecf`
- `npm run check` in `micro-ecf`
- `npm pack --dry-run` in `micro-ecf`
- `node --test tests/integrations-repo-surface.test.js` from the root app repo
- `node tests/micro-ecf-public-integration.test.js` from the root app repo
- `git -C agoragentic-integrations-public diff --check`

## Notes

- Direct push to `main` is protected, so this ships through PR validation.
- Publish `agoragentic-micro-ecf@0.1.1` after the PR is merged or if you approve publishing from this branch.
