### PR TITLE
[codex] document Micro ECF to ECF Core upgrade path

### DIFF
--- a/micro-ecf/ECF_CORE_UPGRADE.md
+++ b/micro-ecf/ECF_CORE_UPGRADE.md
@@ -1,0 +1,79 @@
+# From Micro ECF To ECF Core
+
+Micro ECF and ECF Core are intentionally different.
+
+```text
+Micro ECF
+-> lightweight local packet wedge
+-> static project artifacts
+-> Agent OS Harness export
+
+ECF Core
+-> open-source self-hosted context-governance runtime
+-> richer local compilation/eval
+-> grounding eval and active MCP context serving
+
+Agent OS
+-> hosted deployment product
+-> runtime, budgets, APIs, receipts, marketplace access, x402
+```
+
+## Stay On Micro ECF When
+
+- you have one small repo, docs folder, or database summary
+- you need `ECF.md`, source maps, policy summaries, and context packets
+- you only need an Agent OS Harness export
+- static generated artifacts are enough for your IDE assistant
+- you do not need richer grounding eval or active context serving
+
+## Upgrade To ECF Core When
+
+- the project has enough context that static packets are not enough
+- you want deterministic grounding eval before Agent OS preview
+- you want active local MCP serving over compiled context
+- you want adapter contracts for docs, OpenAPI, SQLite summaries, or MCP descriptors
+- you want a separate open-source runtime that can be used without Agoragentic Cloud
+
+Install ECF Core:
+
+```bash
+npm install -g agoragentic-ecf-core
+ecf-core init .
+ecf-core compile . --agent-os
+ecf-core eval . --grounding
+ecf-core agent-os-preview .ecf-core
+ecf-core validate .ecf-core
+```
+
+Optional local MCP serving:
+
+```bash
+ecf-core serve-mcp .ecf-core
+```
+
+## Move To Agent OS When
+
+Use Agent OS when you want the agent to become a deployed product:
+
+- hosted runtime
+- wallet budgets
+- generated APIs
+- receipts
+- marketplace participation
+- x402 monetization
+- owner approval gates
+- reconciliation
+
+Micro ECF and ECF Core do not deploy agents. They prepare local context and policy evidence.
+
+## Boundary
+
+Neither Micro ECF nor ECF Core includes:
+
+- Full ECF private internals
+- hosted Agent OS provisioning
+- wallet or x402 settlement
+- marketplace ranking
+- private connectors
+- tenant-isolated enterprise runtime
+- SOC 2 or audit claims

--- a/micro-ecf/POST_INSTALL.md
+++ b/micro-ecf/POST_INSTALL.md
@@ -122,7 +122,28 @@ AGORAGENTIC_API_KEY=amk_your_key npx agoragentic-os@latest deploy create --file 
 
 Use `readiness` and `preview` for no-spend checks. Use `deploy create` only when the owner is ready to record a hosted deployment request. Runtime provisioning, funding, public API exposure, marketplace selling, and x402 monetization remain separate gated steps.
 
-## 6. Keep The Boundary Clear
+## 6. Upgrade To ECF Core When Static Packets Are Not Enough
+
+Micro ECF is the lightweight local packet wedge. If a project needs richer self-hosted context governance, deterministic grounding eval, or active local MCP context serving, move to ECF Core instead of overbuilding Micro ECF.
+
+```bash
+npm install -g agoragentic-ecf-core
+ecf-core init .
+ecf-core compile . --agent-os
+ecf-core eval . --grounding
+ecf-core agent-os-preview .ecf-core
+ecf-core validate .ecf-core
+```
+
+Optional active local context serving:
+
+```bash
+ecf-core serve-mcp .ecf-core
+```
+
+See [`ECF_CORE_UPGRADE.md`](./ECF_CORE_UPGRADE.md).
+
+## 7. Keep The Boundary Clear
 
 Micro ECF is local-first and open-source. It can prepare source maps, context packets, policy summaries, and Agent OS Harness exports.
 

--- a/micro-ecf/README.md
+++ b/micro-ecf/README.md
@@ -21,6 +21,7 @@ Micro ECF runs locally and does not require Agoragentic Cloud. When you want liv
 Use the Syrin guide when you want the shortest path from local Micro ECF artifacts to hosted Agent OS readiness:
 
 - [Syrin User Guide: Micro ECF To Agent OS](./SYRIN_USER_GUIDE.md)
+- [When to upgrade from Micro ECF to ECF Core](./ECF_CORE_UPGRADE.md)
 - [Roadmap overview image](./assets/roadmap/roadmap-overview.png)
 
 ![Micro ECF to Agent OS roadmap](assets/roadmap/roadmap-overview.png)
@@ -36,8 +37,9 @@ Use this product rule everywhere:
 
 ```text
 Micro ECF is the local context wedge.
+ECF Core is the open-source self-hosted context-governance runtime.
 Agent OS is the deployment product.
-Full ECF is the enterprise runtime engine.
+Full ECF is private/internal infrastructure.
 ```
 
 Architecture rule:
@@ -396,7 +398,8 @@ Funnel:
 5. Micro ECF exports Agent OS Harness files.
 6. Builder previews deployment on Agoragentic.
 7. If they want runtime, wallets, APIs, receipts, marketplace, or x402 monetization, they move to Agent OS.
-8. If they need private enterprise context, tenant isolation, access control, audit logs, approved tools, and compliance evidence, they move to Agent OS Enterprise / Full ECF.
+8. If they outgrow static local artifacts but still do not need hosted deployment, they move to ECF Core.
+9. Full ECF remains private/internal infrastructure and is not included in Micro ECF or ECF Core.
 ```
 
 Canonical hosted contracts:

--- a/micro-ecf/SYRIN_USER_GUIDE.md
+++ b/micro-ecf/SYRIN_USER_GUIDE.md
@@ -6,8 +6,9 @@ Product boundary:
 
 ```text
 Micro ECF = local context and policy packets
+ECF Core = open-source self-hosted context governance when static packets are not enough
 Agent OS = hosted deployment, budgets, APIs, receipts, marketplace access
-Full ECF = private enterprise governance/runtime
+Full ECF = private/internal Agoragentic infrastructure
 ```
 
 Micro ECF does not deploy, spend funds, publish listings, provision runtime, settle x402, expose secrets, or expose Full ECF internals.
@@ -98,6 +99,18 @@ AGORAGENTIC_API_KEY=amk_your_key npx agoragentic-os@latest deploy preview --file
 ```
 
 Stop here if you only want a no-spend readiness check.
+
+If you want deeper local eval before this handoff, use ECF Core:
+
+```bash
+npm install -g agoragentic-ecf-core
+ecf-core init .
+ecf-core compile . --agent-os
+ecf-core eval . --grounding
+ecf-core agent-os-preview .ecf-core
+```
+
+Use Micro ECF for the light local wedge. Use ECF Core when you need a self-hosted context-governance runtime. Use Agent OS only when you are ready for hosted deployment flow.
 
 When the owner is ready to record the hosted deployment request:
 

--- a/micro-ecf/package.json
+++ b/micro-ecf/package.json
@@ -19,6 +19,7 @@
     "POST_INSTALL.md",
     "PROVIDER_WRAPPING.md",
     "FRAMEWORKS.md",
+    "ECF_CORE_UPGRADE.md",
     "AGENT_OS_EVIDENCE_EVAL_BACKLOG.md",
     "LICENSE",
     "policy.example.json",

--- a/micro-ecf/test/cli.test.mjs
+++ b/micro-ecf/test/cli.test.mjs
@@ -182,6 +182,7 @@ test('package metadata keeps Micro ECF local-first and Apache licensed', () => {
   assert.ok(packageJson.files.includes('POST_INSTALL.md'));
   assert.ok(packageJson.files.includes('PROVIDER_WRAPPING.md'));
   assert.ok(packageJson.files.includes('FRAMEWORKS.md'));
+  assert.ok(packageJson.files.includes('ECF_CORE_UPGRADE.md'));
   assert.ok(packageJson.files.includes('AGENT_OS_EVIDENCE_EVAL_BACKLOG.md'));
 });
 
@@ -195,6 +196,11 @@ test('context provider docs and examples keep Micro ECF as a governance wrapper'
   assert.match(guide, /does not replace your RAG/i);
   assert.match(guide, /raw_secret_content_allowed/);
   assert.match(guide, /fail closed/i);
+  const upgrade = fs.readFileSync(path.join(microEcfRoot, 'ECF_CORE_UPGRADE.md'), 'utf8');
+  assert.match(upgrade, /Micro ECF/);
+  assert.match(upgrade, /ECF Core/);
+  assert.match(upgrade, /Agent OS/);
+  assert.match(upgrade, /Full ECF private internals/);
 
   const examples = [
     ['context-provider-rag.policy.json', 'retrieval_context', 'local_rag'],


### PR DESCRIPTION
## Summary
- add a Micro ECF -> ECF Core upgrade guide
- link the upgrade guide from README, Syrin guide, and post-install docs
- include the guide in package metadata and add regression coverage

## Boundary
- Micro ECF remains the lightweight local packet wedge
- ECF Core is positioned as the open-source self-hosted context-governance runtime
- Agent OS remains the hosted deployment product
- Full ECF remains private/internal and is not exposed

## Validation
- npm test in micro-ecf
- npm run check in micro-ecf
- git diff --check
