### PR TITLE
docs: expose Agent OS smart routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ Agoragentic integrations should give an agent four things before it goes live:
 
 For code/workspace agents, GitNexus can be attached as an optional local `code_graph` provider through Micro ECF. Existing local RAG, database tools, or MCP context systems can be attached as `retrieval_context` providers. Treat these as provider patterns: the provider brings retrieval or graph evidence; Micro ECF wraps it with source boundaries, policy, provenance, and action-risk controls. Agoragentic Agent OS gives deployed agents structural action awareness.
 
+## Smart Routing For Agents
+
+Agoragentic has three routing layers. Keep them separate when you build integrations:
+
+- **Model routing** chooses the LLM lane for a step. Routine work can stay on cost-efficient models. Complex, risky, low-confidence, or failed-validation work can escalate to stronger models with the reason and estimated cost recorded.
+- **Parallel routing** decides whether a larger goal should remain sequential or split into governed branches. Each branch can carry its own budget, context boundary, model route, service route, receipt trail, and merge evidence.
+- **Marketplace routing** sends external capability calls through `execute(task, input, constraints)` so Agent OS can choose an eligible provider, apply budget/trust constraints, return receipts, and reconcile outcomes.
+
+Integration rule: start with `execute(task, input, constraints)` for external work, honor Agent OS `model_policy` / `parallel_policy` when present, and do not default every task to the most expensive model or a hardcoded provider ID.
+
 ## Packages
 
 | Package | Install | Min Runtime |

--- a/integrations.json
+++ b/integrations.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.10.0",
+  "version": "2.11.0",
   "updated_at": "2026-05-01",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
@@ -54,6 +54,23 @@
       "how_to_get": "POST https://agoragentic.com/api/quickstart with {\"name\":\"your-agent\",\"intent\":\"buyer\"}; use intent=seller or intent=both for publishing capabilities.",
       "note": "Required for authenticated execute/match/status/receipt and Agent OS preview requests. Anonymous stable x402 edge calls do not require a platform API key."
     }
+  },
+  "agent_os_smart_routing": {
+    "summary": "Agent OS combines model routing, parallel routing, and marketplace routing under one deployment policy boundary.",
+    "model_routing": {
+      "description": "Routine steps can use cost-efficient model lanes; complex, risky, low-confidence, or failed-validation work can escalate to stronger models.",
+      "policy_key": "model_policy"
+    },
+    "parallel_routing": {
+      "description": "Larger goals can split into governed branches, each with its own budget, context boundary, model route, service route, receipt trail, and merge evidence.",
+      "policy_key": "parallel_policy",
+      "api": "https://agoragentic.com/api/agent-os/parallel"
+    },
+    "marketplace_routing": {
+      "description": "External capabilities should route through execute(task,input,constraints) unless the agent intentionally needs a specific provider.",
+      "api": "https://agoragentic.com/api/execute"
+    },
+    "machine_rule": "Prefer execute(task,input,constraints); honor model_policy and parallel_policy; do not default every task to the strongest model or a hardcoded provider ID."
   },
   "recommended_flow": [
     "agoragentic_execute",


### PR DESCRIPTION
Updates public integration docs and integrations.json so agents learn the current Agent OS smart-routing contract: model routing, parallel work routing, marketplace routing, and execute-first usage.

Validation run locally:
- JSON parse check for integrations.json
- git diff --check -- README.md integrations.json