### PR TITLE
Add claude-view local provider contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ For code/workspace agents, GitNexus can be attached as an optional local `code_g
 | [**oh-my-claudecode**](oh-my-claudecode/) | JavaScript | ✅ Ready | `oh-my-claudecode/README.md` | [README](oh-my-claudecode/README.md) |
 | [**DashClaw**](dashclaw/) | JavaScript | ✅ Ready | `dashclaw/agoragentic_dashclaw.mjs` | [README](dashclaw/README.md) |
 | [**RepoBrain Local Provider**](repobrain/) | JSON | Beta | `repobrain/repobrain.retrieve_context.manifest.json` | [README](repobrain/README.md) |
+| [**claude-view Local Provider**](claude-view/) | JSON | Beta | `claude-view/claude_view.get_live_summary.manifest.json` | [README](claude-view/README.md) |
 | [**Scrumboy**](scrumboy/) | JSON | Beta | `scrumboy/scrumboy.discover_tools.manifest.json` | [README](scrumboy/README.md) |
 | [**Syrin**](syrin/) | Python | ✅ Ready | `syrin/agoragentic_syrin.py` | [README](syrin/README.md) |
 | [**Agent OS Control Plane**](agent-os/) | JavaScript/Python | ✅ Ready | `agent-os/agent_os_node.mjs` | [README](agent-os/README.md) |

--- a/claude-view/README.md
+++ b/claude-view/README.md
@@ -1,0 +1,74 @@
+# Agoragentic + claude-view
+
+claude-view can act as a local Claude Code session observability provider for Agoragentic Agent OS and Micro ECF.
+
+Use this contract when an agent owner wants a read-only summary of local Claude Code activity before reviewing work, approving follow-ups, or deciding whether an Agent OS worker needs escalation.
+
+## Integration Model
+
+```text
+Owner or supervising agent
+  -> claude_view.get_live_summary
+  -> local claude-view runtime
+  -> bounded session/cost/subagent summary
+  -> Agent OS report, approval packet, or operator inbox
+```
+
+claude-view owns local session monitoring. Micro ECF owns source boundaries, local policy, and context-packet export. Agent OS owns hosted deployment preview, receipts, approvals, and governed execution when the agent later calls `execute()`.
+
+## Listing Contract
+
+This integration is represented as a local-provider listing contract:
+
+- Listing ID: `claude_view.get_live_summary`
+- Listing type: `service`
+- Pricing model: `free`
+- Runtime mode: local/self-hosted
+- Public endpoint: none by default
+- Primary use: return bounded live summaries of local Claude Code sessions, costs, models, and subagent activity
+
+See [`claude_view.get_live_summary.manifest.json`](./claude_view.get_live_summary.manifest.json) for the machine-readable contract.
+
+## Request Shape
+
+```json
+{
+  "project": "agent-marketplace",
+  "include_costs": true,
+  "include_subagents": true
+}
+```
+
+## Response Shape
+
+```json
+{
+  "sessions": [
+    {
+      "id": "session_123",
+      "project": "agent-marketplace",
+      "status": "active",
+      "last_message": "running tests",
+      "model": "claude-sonnet",
+      "cost": 0.42,
+      "subagents": []
+    }
+  ],
+  "metadata": {
+    "provider": "claude-view",
+    "mode": "local_only"
+  }
+}
+```
+
+## Guardrails
+
+- Keep the runtime local unless the owner explicitly exposes a bounded summary endpoint.
+- Do not publish raw transcripts, API keys, environment variables, private paths, or secret material in listing metadata.
+- Return bounded summaries, not full session logs.
+- Treat this as observability evidence only. It does not authorize code changes, public outreach, wallet movement, or deployment.
+- Route any external paid work through `execute(task, input, constraints)` after procurement and approval checks.
+
+## Status
+
+Beta integration contract. This is intended for maintainer review and local-provider registration before any hosted or public endpoint is advertised.

--- a/claude-view/claude_view.get_live_summary.manifest.json
+++ b/claude-view/claude_view.get_live_summary.manifest.json
@@ -1,0 +1,125 @@
+{
+  "schema": "agoragentic.integration.local-provider.v1",
+  "id": "claude_view.get_live_summary",
+  "name": "claude-view Live Session Summary",
+  "description": "Return a bounded read-only summary of local Claude Code sessions from a claude-view runtime.",
+  "provider": {
+    "name": "claude-view",
+    "runtime": "local",
+    "endpoint_url": null,
+    "requires_owner_hosting": true
+  },
+  "listing": {
+    "category": "developer-tools",
+    "listing_type": "service",
+    "pricing_model": "free",
+    "tags": [
+      "claude-code",
+      "monitoring",
+      "sessions",
+      "agent-observability",
+      "local-first"
+    ]
+  },
+  "input_schema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "project": {
+        "type": "string",
+        "description": "Optional project or workspace filter for local Claude Code sessions."
+      },
+      "include_costs": {
+        "type": "boolean",
+        "default": true
+      },
+      "include_subagents": {
+        "type": "boolean",
+        "default": true
+      }
+    }
+  },
+  "output_schema": {
+    "type": "object",
+    "additionalProperties": true,
+    "required": [
+      "sessions",
+      "metadata"
+    ],
+    "properties": {
+      "sessions": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": [
+            "id",
+            "status"
+          ],
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "project": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "last_message": {
+              "type": "string",
+              "maxLength": 800
+            },
+            "model": {
+              "type": "string"
+            },
+            "cost": {
+              "type": "number",
+              "minimum": 0
+            },
+            "subagents": {
+              "type": "array"
+            }
+          }
+        }
+      },
+      "metadata": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": [
+          "provider",
+          "mode"
+        ],
+        "properties": {
+          "provider": {
+            "type": "string",
+            "const": "claude-view"
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "local_only"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "sandbox_probe": {
+    "input": {
+      "project": "agent-marketplace",
+      "include_costs": true,
+      "include_subagents": true
+    },
+    "expected": {
+      "sessions": "array",
+      "metadata.provider": "claude-view"
+    }
+  },
+  "guardrails": [
+    "Do not publish raw transcripts, environment variables, API keys, local credential paths, or secret material.",
+    "Return bounded summaries rather than full session logs.",
+    "Keep the provider local/self-hosted unless the owner explicitly exposes a bounded summary endpoint.",
+    "Use this output as observability evidence only; it does not authorize code mutation, deployment, outreach, wallet movement, or spend."
+  ]
+}

--- a/integrations.json
+++ b/integrations.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.10.0",
-  "updated_at": "2026-05-01",
+  "version": "2.11.0",
+  "updated_at": "2026-05-02",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
   "packages": {
@@ -494,6 +494,15 @@
       "path": "repobrain/repobrain.retrieve_context.manifest.json",
       "install": "Use RepoBrain locally with Micro ECF; no hosted install required",
       "docs": "repobrain/README.md"
+    },
+    {
+      "id": "claude-view",
+      "name": "claude-view Local Provider",
+      "language": "json",
+      "status": "beta",
+      "path": "claude-view/claude_view.get_live_summary.manifest.json",
+      "install": "Run claude-view locally; no hosted endpoint required",
+      "docs": "claude-view/README.md"
     },
     {
       "id": "scrumboy",

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,7 @@
 - LangChain, CrewAI, AutoGen, OpenAI Agents SDK, Google ADK, pydantic-ai, smolagents, Agno, MetaGPT, LlamaIndex, AutoGPT, SuperAGI, CAMEL, Syrin (Python)
 - MCP, Vercel AI, Mastra, Bee Agent, ElizaOS, oh-my-claudecode, DashClaw (JS/TS)
 - Agent Client Protocol: acp/agent.json and `npx agoragentic-mcp --acp`
-- Dify, A2A, RepoBrain Local Provider, Scrumboy (JSON)
+- Dify, A2A, RepoBrain Local Provider, claude-view Local Provider, Scrumboy (JSON)
 - LangSmith: langsmith/README.md (observability)
 - Agent OS Control Plane: agent-os/README.md (public quote, procurement, approval, execute, and reconciliation flow)
 - Micro ECF: micro-ecf/README.md (local context/policy packets and Agent OS Harness export)


### PR DESCRIPTION
Adds a beta local-provider contract for claude-view as a read-only Claude Code session summary surface.\n\nScope:\n- local/self-hosted provider only\n- free v1 listing contract\n- no public hosted endpoint by default\n- bounded session summaries, not raw transcripts or mutation authority\n\nValidation:\n- Parsed integrations.json and claude-view manifest\n- Verified every integration path/docs target exists\n- git diff --check