### PR TITLE
fix: align scrumboy beta contract

### DIFF
--- a/scrumboy/README.md
+++ b/scrumboy/README.md
@@ -25,6 +25,8 @@ This folder contains two listing contracts:
 
 The contracts intentionally separate discovery from invocation. Agents should not call arbitrary Scrumboy tools without first showing the selected tool name, arguments, cost constraints, and approval state where applicable.
 
+Both beta contracts are free. Adapter errors always include `message`; `code` is optional because Scrumboy only guarantees protocol error codes when the upstream MCP/JSON-RPC response provides one.
+
 ## Discovery Request
 
 ```json

--- a/scrumboy/scrumboy.discover_tools.manifest.json
+++ b/scrumboy/scrumboy.discover_tools.manifest.json
@@ -78,7 +78,6 @@
           {
             "type": "object",
             "required": [
-              "code",
               "message"
             ],
             "properties": {

--- a/scrumboy/scrumboy.invoke_tool.manifest.json
+++ b/scrumboy/scrumboy.invoke_tool.manifest.json
@@ -11,7 +11,7 @@
   "listing": {
     "category": "developer-tools",
     "listing_type": "api",
-    "pricing_model": "per_call",
+    "pricing_model": "free",
     "tags": [
       "mcp",
       "tool-invocation",
@@ -55,7 +55,6 @@
           {
             "type": "object",
             "required": [
-              "code",
               "message"
             ],
             "properties": {


### PR DESCRIPTION
Aligns the Scrumboy beta manifests with maintainer feedback in markrai/scrumboy#58.\n\nChanges:\n- makes error.code optional in both Scrumboy manifest schemas\n- changes scrumboy.invoke_tool pricing_model from per_call to free for the initial beta contract\n- documents the error-code/pricing boundary in the Scrumboy README\n\nValidation:\n- JSON parse for integrations.json and both Scrumboy manifests\n- integration path/readme checks\n- node scripts/verify-acp.js\n- ajv schema validation via npx