### PR TITLE
[codex] Add OpenFang commerce bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Agoragentic has three routing layers. Keep them separate when you build integrat
 
 Integration rule: start with `execute(task, input, constraints)` for external work, honor Agent OS `model_policy` / `parallel_policy` when present, and do not default every task to the most expensive model or a hardcoded provider ID.
 
+## Local Runtime Commerce Bridges
+
+Local agent runtimes can keep their own execution model while using Agoragentic for cross-agent commerce. The OpenFang bridge maps local Hand manifests and capability grants into Agoragentic intent contracts, then uses `execute(task, input, constraints)` for routed buying, receipts, and optional seller listing drafts.
+
 ## Packages
 
 | Package | Install | Min Runtime |
@@ -96,6 +100,7 @@ Integration rule: start with `execute(task, input, constraints)` for external wo
 | [**LangSmith**](langsmith/) | Node.js/Python | ✅ Ready | `langsmith/README.md` | [README](langsmith/README.md) |
 | [**oh-my-claudecode**](oh-my-claudecode/) | JavaScript | ✅ Ready | `oh-my-claudecode/README.md` | [README](oh-my-claudecode/README.md) |
 | [**DashClaw**](dashclaw/) | JavaScript | ✅ Ready | `dashclaw/agoragentic_dashclaw.mjs` | [README](dashclaw/README.md) |
+| [**OpenFang**](openfang/) | JavaScript | Beta | `openfang/agoragentic_openfang.mjs` | [README](openfang/README.md) |
 | [**RepoBrain Local Provider**](repobrain/) | JSON | Beta | `repobrain/repobrain.retrieve_context.manifest.json` | [README](repobrain/README.md) |
 | [**claude-view Local Provider**](claude-view/) | JSON | Beta | `claude-view/claude_view.get_live_summary.manifest.json` | [README](claude-view/README.md) |
 | [**Scrumboy**](scrumboy/) | JSON | Beta | `scrumboy/scrumboy.discover_tools.manifest.json` | [README](scrumboy/README.md) |
@@ -262,6 +267,7 @@ Your Agent  →  Integration (tools/MCP)  →  Agent OS + Agoragentic API
 | LLM full context | [`llms-full.txt`](./llms-full.txt) |
 | Capability description | [`SKILL.md`](./SKILL.md) |
 | Agent OS public export | [`agent-os/README.md`](./agent-os/README.md) |
+| OpenFang bridge | [`openfang/README.md`](./openfang/README.md) |
 | Micro ECF | [`micro-ecf/README.md`](./micro-ecf/README.md) |
 | Micro ECF Syrin guide | [`micro-ecf/SYRIN_USER_GUIDE.md`](./micro-ecf/SYRIN_USER_GUIDE.md) |
 | Micro ECF post-install | [`micro-ecf/POST_INSTALL.md`](./micro-ecf/POST_INSTALL.md) |

--- a/integrations.json
+++ b/integrations.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.11.0",
-  "updated_at": "2026-05-02",
+  "version": "2.12.0",
+  "updated_at": "2026-05-11",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
   "packages": {
@@ -83,6 +83,21 @@
     "agoragentic_edge_receipt",
     "agoragentic_x402_test"
   ],
+  "agent_os_smart_routing": {
+    "model_routing": {
+      "policy_key": "model_policy",
+      "description": "Choose cheaper models for simple work, balanced models for normal reasoning, and stronger models only when risk, validation failure, or policy requires escalation."
+    },
+    "parallel_routing": {
+      "policy_key": "parallel_policy",
+      "description": "Keep a goal sequential or split it into bounded branches with context slices, consequence review, budgets, receipts, and a merge path."
+    },
+    "marketplace_routing": {
+      "entrypoint": "execute(task,input,constraints)",
+      "description": "Route external work through provider matching, trust constraints, cost caps, receipts, and settlement instead of hardcoded provider IDs."
+    },
+    "machine_rule": "Prefer execute(task,input,constraints) for external work; honor model_policy and parallel_policy when present."
+  },
   "tools": [
     {
       "id": "agoragentic_quote",
@@ -277,6 +292,15 @@
       "path": "agent-os/agent_os_node.mjs",
       "install": "node 18+ or pip install requests",
       "docs": "agent-os/README.md"
+    },
+    {
+      "id": "openfang",
+      "name": "OpenFang",
+      "language": "javascript",
+      "status": "beta",
+      "path": "openfang/agoragentic_openfang.mjs",
+      "install": "node 18+; use with a local OpenFang Hand manifest",
+      "docs": "openfang/README.md"
     },
     {
       "id": "micro-ecf",
@@ -556,6 +580,8 @@
     "agent_client_protocol_adapter": "acp/agent.json",
     "agent_os": "agent-os/README.md",
     "agent_os_public_export": "agent-os/README.md",
+    "openfang": "openfang/README.md",
+    "openfang_bridge_manifest": "openfang/openfang.agoragentic-hand-bridge.manifest.json",
     "acp_registry_positioning": "ACP_REGISTRY.md",
     "micro_ecf": "micro-ecf/README.md",
     "micro_ecf_llm_install": "micro-ecf/LLM_INSTALL.md",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -69,7 +69,7 @@ Framework adapters, Agent OS control-plane examples, and marketplace integration
 | CAMEL | camel/agoragentic_camel.py | pip install agoragentic camel-ai |
 | Syrin | syrin/agoragentic_syrin.py | pip install syrin requests |
 
-### JavaScript/TypeScript Integrations (7)
+### JavaScript/TypeScript Integrations (9)
 
 | Framework | File | Install |
 |-----------|------|---------|
@@ -81,6 +81,7 @@ Framework adapters, Agent OS control-plane examples, and marketplace integration
 | LangSmith | langsmith/README.md | npm install agoragentic langsmith |
 | oh-my-claudecode | oh-my-claudecode/README.md | npx agoragentic-mcp |
 | DashClaw | dashclaw/agoragentic_dashclaw.mjs | npm install dashclaw agoragentic |
+| OpenFang | openfang/agoragentic_openfang.mjs | node 18+ with a local OpenFang Hand manifest |
 
 ### Config-Only Integrations (4)
 
@@ -179,6 +180,7 @@ Full spec: specs/ACP-SPEC.md
 | Capability desc | SKILL.md |
 | ACP registry positioning | ACP_REGISTRY.md |
 | Agent OS export | agent-os/README.md |
+| OpenFang bridge | openfang/README.md |
 | Syrin Micro ECF guide | micro-ecf/SYRIN_USER_GUIDE.md |
 | Micro ECF framework guide | micro-ecf/FRAMEWORKS.md |
 | Agent OS evidence/eval backlog | micro-ecf/AGENT_OS_EVIDENCE_EVAL_BACKLOG.md |

--- a/llms.txt
+++ b/llms.txt
@@ -16,7 +16,7 @@
 
 ## Integrations
 - LangChain, CrewAI, AutoGen, OpenAI Agents SDK, Google ADK, pydantic-ai, smolagents, Agno, MetaGPT, LlamaIndex, AutoGPT, SuperAGI, CAMEL, Syrin (Python)
-- MCP, Vercel AI, Mastra, Bee Agent, ElizaOS, oh-my-claudecode, DashClaw (JS/TS)
+- MCP, Vercel AI, Mastra, Bee Agent, ElizaOS, oh-my-claudecode, DashClaw, OpenFang (JS/TS)
 - Agent Client Protocol: acp/agent.json and `npx agoragentic-mcp --acp`
 - Dify, A2A, RepoBrain Local Provider, claude-view Local Provider, Scrumboy (JSON)
 - LangSmith: langsmith/README.md (observability)
@@ -32,6 +32,7 @@
 - acp/agent.json — Agent Client Protocol adapter manifest
 - glama.json — Glama registry
 - agent-os/README.md — Agent OS public control-plane export
+- openfang/README.md — OpenFang Hand bridge for routed buying, receipts, and seller listing drafts
 - micro-ecf/README.md — local Micro ECF policy layer and Agent OS Harness export
 - micro-ecf/SYRIN_USER_GUIDE.md — Syrin user launch guide with visual roadmap and Discord-ready install text
 - micro-ecf/LLM_INSTALL.md — consent-gated IDE LLM install instructions: explain, plan, ask approval, then install --yes

--- a/openfang/README.md
+++ b/openfang/README.md
@@ -1,0 +1,111 @@
+# OpenFang + Agoragentic
+
+OpenFang is a local Rust Agent OS for autonomous Hands, workflows, memory, channels, MCP/A2A, and sandboxed tool execution. Agoragentic is the hosted Triptych OS (Agent OS) and Router / Marketplace layer for agent commerce: buying work, selling capabilities, metering, receipts, settlement, and reconciliation.
+
+This adapter keeps that boundary explicit:
+
+- OpenFang runs the local Hand.
+- Agoragentic routes external paid work through `POST /api/execute`.
+- Agoragentic returns receipts and settlement metadata.
+- OpenFang Hands can be converted into seller listing drafts, but publication is never automatic.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `agoragentic_openfang.mjs` | Dependency-free Node bridge for match, execute, receipts, and listing drafts |
+| `openfang.agoragentic-hand-bridge.manifest.json` | Machine-readable bridge contract and authority boundary |
+| `example-hand.json` | Minimal OpenFang-style Hand manifest for local testing |
+| `agoragentic_openfang.test.mjs` | Node test coverage for policy mapping, dry-run, and draft-only publication |
+
+## Install
+
+Requires Node 18+ for built-in `fetch`.
+
+```bash
+export AGORAGENTIC_API_KEY="amk_your_key"
+```
+
+Get a key with:
+
+```bash
+curl -s https://agoragentic.com/api/quickstart \
+  -H "Content-Type: application/json" \
+  -d '{"name":"openfang-hand","intent":"buyer"}'
+```
+
+## Buyer: no-spend match
+
+Preview matching providers before spend:
+
+```bash
+OPENFANG_HAND_MANIFEST=./openfang/example-hand.json \
+AGORAGENTIC_TASK="summarize this report for an operations team" \
+node openfang/agoragentic_openfang.mjs match
+```
+
+This calls `GET /api/execute/match` only. No paid execution occurs.
+
+## Buyer: execute through Agoragentic
+
+Execution is opt-in and must set `AGORAGENTIC_EXECUTE=true`:
+
+```bash
+OPENFANG_HAND_MANIFEST=./openfang/example-hand.json \
+AGORAGENTIC_TASK="summarize this report for an operations team" \
+AGORAGENTIC_INPUT_JSON='{"text":"Agent OS turns local agents into governed buyers and sellers."}' \
+AGORAGENTIC_MAX_COST_USDC=0.10 \
+AGORAGENTIC_EXECUTE=true \
+node openfang/agoragentic_openfang.mjs execute
+```
+
+The request goes through `POST /api/execute`, keeps provider selection routed by task intent, and attempts to fetch the resulting receipt.
+
+## Seller: create a listing draft
+
+Create a draft payload for exposing an OpenFang Hand as an Agoragentic seller capability:
+
+```bash
+OPENFANG_HAND_MANIFEST=./openfang/example-hand.json \
+OPENFANG_HAND_ENDPOINT_URL="https://example.com/openfang/hand/researcher" \
+node openfang/agoragentic_openfang.mjs listing-draft
+```
+
+Publication is blocked by default. To publish, set both the mode and the explicit gate:
+
+```bash
+OPENFANG_HAND_MANIFEST=./openfang/example-hand.json \
+OPENFANG_HAND_ENDPOINT_URL="https://example.com/openfang/hand/researcher" \
+AGORAGENTIC_PUBLISH_LISTING=true \
+node openfang/agoragentic_openfang.mjs publish-listing
+```
+
+## Capability grant mapping
+
+| OpenFang concept | Agoragentic mapping |
+|------------------|---------------------|
+| `max_call_cost_usdc` | `constraints.max_cost` and wallet policy |
+| `max_daily_cost_usdc` | daily spend policy metadata |
+| `approval_required_above_usdc` | owner approval threshold |
+| `tools[]` | allowed tool names in the intent contract |
+| `allowed_domains[]` / `network_allowlist[]` | network boundary metadata |
+| `allow_private_data` | data policy flag, false by default |
+| `allow_secret_access` | data policy flag, false by default |
+| Hand manifest metadata | listing draft metadata and receipt provenance |
+
+## Security boundary
+
+- Dry-run is the default mode.
+- No provider IDs are hardcoded.
+- No wallet custody or private key handling is included.
+- No Full ECF internals are exposed.
+- No hosted runtime provisioning is included.
+- Listing publication requires explicit opt-in.
+- Paid execution requires explicit opt-in.
+
+## Tests
+
+```bash
+node --check openfang/agoragentic_openfang.mjs
+node --test openfang/agoragentic_openfang.test.mjs
+```

--- a/openfang/agoragentic_openfang.mjs
+++ b/openfang/agoragentic_openfang.mjs
@@ -105,7 +105,7 @@ export function mapOpenFangGrantsToAgoragenticPolicy(grants = {}, options = {}) 
     source_runtime: "openfang",
     spend: {
       max_call_cost_usdc: maxCostUsdc,
-      max_daily_cost_usdc: Number(grants.max_daily_cost_usdc ?? options.maxDailyCostUsdc ?? maxCostUsdc),
+      max_daily_cost_usdc: Number(options.maxDailyCostUsdc ?? grants.max_daily_cost_usdc ?? maxCostUsdc),
       approval_required_above_usdc: approvalAboveUsdc,
       currency: "USDC",
       settlement_network: "base",
@@ -212,8 +212,9 @@ export function createOpenFangAgoragenticBridge({
 } = {}) {
   async function match({ task, constraints = {} } = {}) {
     const params = new URLSearchParams({ task: requireTask(task) });
-    if (constraints.max_cost_usdc ?? constraints.max_cost) {
-      params.set("max_cost", String(constraints.max_cost_usdc ?? constraints.max_cost));
+    const maxCost = constraints.max_cost_usdc ?? constraints.max_cost;
+    if (maxCost !== undefined && maxCost !== null) {
+      params.set("max_cost", String(maxCost));
     }
     return httpJson({
       apiBase,

--- a/openfang/agoragentic_openfang.mjs
+++ b/openfang/agoragentic_openfang.mjs
@@ -1,0 +1,386 @@
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_API_BASE = "https://agoragentic.com";
+const DEFAULT_MAX_COST_USDC = 0.10;
+
+function cleanApiBase(apiBase = DEFAULT_API_BASE) {
+  return String(apiBase || DEFAULT_API_BASE).replace(/\/+$/, "");
+}
+
+function requireTask(task) {
+  const value = String(task || "").trim();
+  if (!value) throw new Error("task is required");
+  return value;
+}
+
+function parseJson(value, fallback = {}) {
+  if (value == null || value === "") return fallback;
+  if (typeof value === "object") return value;
+  return JSON.parse(value);
+}
+
+function redactHeaders(headers = {}) {
+  const out = { ...headers };
+  if (out.Authorization) out.Authorization = "Bearer amk_...";
+  if (out.authorization) out.authorization = "Bearer amk_...";
+  return out;
+}
+
+async function httpJson({
+  apiBase,
+  apiKey,
+  method = "GET",
+  path,
+  body,
+  fetchImpl = globalThis.fetch,
+}) {
+  if (typeof fetchImpl !== "function") {
+    throw new Error("fetch is required; use Node 18+ or pass fetchImpl");
+  }
+
+  const headers = {
+    "Content-Type": "application/json",
+    "User-Agent": "agoragentic-openfang-bridge/0.1",
+  };
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+  const res = await fetchImpl(`${cleanApiBase(apiBase)}${path}`, {
+    method,
+    headers,
+    body: body == null ? undefined : JSON.stringify(body),
+  });
+  const text = await res.text();
+  const data = text ? JSON.parse(text) : {};
+
+  if (!res.ok) {
+    const err = new Error(data.error || data.message || `HTTP ${res.status}`);
+    err.status = res.status;
+    err.response = data;
+    err.request = { method, path, headers: redactHeaders(headers) };
+    throw err;
+  }
+
+  return data;
+}
+
+export function normalizeOpenFangHand(hand = {}) {
+  const id = hand.id || hand.hand_id || hand.name || "openfang-hand";
+  const grants = hand.capability_grants || hand.grants || hand.permissions || {};
+  const workflows = hand.workflows || hand.workflow_policy || {};
+
+  return {
+    id: String(id),
+    name: String(hand.name || id),
+    description: String(hand.description || hand.summary || "OpenFang Hand"),
+    runtime: "openfang",
+    version: hand.version || null,
+    channels: Array.isArray(hand.channels) ? hand.channels : [],
+    workflows,
+    capability_grants: grants,
+    memory: hand.memory || hand.memory_policy || null,
+    sandbox: hand.sandbox || hand.sandbox_policy || null,
+  };
+}
+
+export function mapOpenFangGrantsToAgoragenticPolicy(grants = {}, options = {}) {
+  const maxCostUsdc = Number(
+    options.maxCostUsdc ??
+    grants.max_cost_usdc ??
+    grants.max_call_cost_usdc ??
+    DEFAULT_MAX_COST_USDC,
+  );
+  const approvalAboveUsdc = Number(
+    options.approvalAboveUsdc ??
+    grants.approval_required_above_usdc ??
+    maxCostUsdc,
+  );
+
+  const allowedDomains = [
+    ...(Array.isArray(grants.allowed_domains) ? grants.allowed_domains : []),
+    ...(Array.isArray(grants.network_allowlist) ? grants.network_allowlist : []),
+  ];
+
+  return {
+    source_runtime: "openfang",
+    spend: {
+      max_call_cost_usdc: maxCostUsdc,
+      max_daily_cost_usdc: Number(grants.max_daily_cost_usdc ?? options.maxDailyCostUsdc ?? maxCostUsdc),
+      approval_required_above_usdc: approvalAboveUsdc,
+      currency: "USDC",
+      settlement_network: "base",
+    },
+    tools: {
+      allowed_tools: Array.isArray(grants.tools) ? grants.tools : [],
+      allowed_domains: [...new Set(allowedDomains)],
+      network_required: Boolean(grants.network || allowedDomains.length),
+    },
+    data: {
+      allow_private_data: Boolean(grants.allow_private_data),
+      allow_secret_access: Boolean(grants.allow_secret_access),
+      requires_context_boundary: true,
+    },
+    approvals: {
+      require_human_for_spend: approvalAboveUsdc <= maxCostUsdc,
+      require_human_for_listing_publication: true,
+      require_human_for_external_side_effects: true,
+    },
+  };
+}
+
+export function buildOpenFangIntentContract({
+  hand = {},
+  task,
+  input = {},
+  constraints = {},
+} = {}) {
+  const normalizedHand = normalizeOpenFangHand(hand);
+  const policy = mapOpenFangGrantsToAgoragenticPolicy(
+    normalizedHand.capability_grants,
+    {
+      maxCostUsdc: constraints.max_cost_usdc ?? constraints.max_cost,
+      approvalAboveUsdc: constraints.approval_required_above_usdc,
+      maxDailyCostUsdc: constraints.max_daily_cost_usdc,
+    },
+  );
+
+  return {
+    schema: "agoragentic.openfang.intent-contract.v1",
+    source_runtime: "openfang",
+    hand: normalizedHand,
+    intent: {
+      task: requireTask(task),
+      input_shape: Array.isArray(input) ? "array" : typeof input,
+      input_keys: input && typeof input === "object" && !Array.isArray(input) ? Object.keys(input).sort() : [],
+    },
+    policy,
+    execution: {
+      preferred_entrypoint: "POST /api/execute",
+      avoid_provider_hardcoding: true,
+      require_receipt: true,
+      require_reconciliation: true,
+    },
+  };
+}
+
+export function buildListingDraftFromOpenFangHand({
+  hand = {},
+  endpointUrl,
+  pricePerUnit = DEFAULT_MAX_COST_USDC,
+  category = "workflows",
+  inputSchema,
+  outputSchema,
+} = {}) {
+  const normalizedHand = normalizeOpenFangHand(hand);
+  if (!endpointUrl) {
+    throw new Error("endpointUrl is required to expose an OpenFang Hand as a seller listing");
+  }
+
+  return {
+    name: normalizedHand.name,
+    description: normalizedHand.description,
+    category,
+    listing_type: "service",
+    pricing_model: "per_call",
+    price_per_unit: Number(pricePerUnit),
+    endpoint_url: endpointUrl,
+    tags: ["openfang", "hand", "agent-os", "receipts"],
+    input_schema: inputSchema || {
+      type: "object",
+      additionalProperties: true,
+      description: "Input forwarded to the OpenFang Hand endpoint.",
+    },
+    output_schema: outputSchema || {
+      type: "object",
+      additionalProperties: true,
+      description: "OpenFang Hand result plus Agoragentic receipt metadata.",
+    },
+    metadata: {
+      source_runtime: "openfang",
+      hand_id: normalizedHand.id,
+      hand_name: normalizedHand.name,
+      requires_receipts: true,
+      requires_owner_approval_for_publication: true,
+    },
+  };
+}
+
+export function createOpenFangAgoragenticBridge({
+  apiKey = process.env.AGORAGENTIC_API_KEY,
+  apiBase = process.env.AGORAGENTIC_API_BASE || DEFAULT_API_BASE,
+  fetchImpl = globalThis.fetch,
+} = {}) {
+  async function match({ task, constraints = {} } = {}) {
+    const params = new URLSearchParams({ task: requireTask(task) });
+    if (constraints.max_cost_usdc ?? constraints.max_cost) {
+      params.set("max_cost", String(constraints.max_cost_usdc ?? constraints.max_cost));
+    }
+    return httpJson({
+      apiBase,
+      apiKey,
+      fetchImpl,
+      path: `/api/execute/match?${params.toString()}`,
+    });
+  }
+
+  async function execute({
+    hand = {},
+    task,
+    input = {},
+    constraints = {},
+    execute: shouldExecute = false,
+  } = {}) {
+    const contract = buildOpenFangIntentContract({ hand, task, input, constraints });
+    if (!shouldExecute) {
+      const preview = await match({ task, constraints });
+      return {
+        mode: "dry_run",
+        no_spend: true,
+        contract,
+        preview,
+      };
+    }
+
+    const result = await httpJson({
+      apiBase,
+      apiKey,
+      fetchImpl,
+      method: "POST",
+      path: "/api/execute",
+      body: {
+        task: requireTask(task),
+        input,
+        constraints: {
+          ...constraints,
+          max_cost: constraints.max_cost_usdc ?? constraints.max_cost ?? contract.policy.spend.max_call_cost_usdc,
+        },
+        intent_contract: contract,
+      },
+    });
+
+    const receiptId = result.receipt_id || result.receipt?.receipt_id || result.invocation_id;
+    const receipt = receiptId ? await getReceipt(receiptId).catch(() => null) : null;
+    return {
+      mode: "executed",
+      contract,
+      result,
+      receipt,
+    };
+  }
+
+  async function getStatus(invocationId) {
+    if (!invocationId) throw new Error("invocationId is required");
+    return httpJson({ apiBase, apiKey, fetchImpl, path: `/api/execute/status/${encodeURIComponent(invocationId)}` });
+  }
+
+  async function getReceipt(receiptId) {
+    if (!receiptId) throw new Error("receiptId is required");
+    return httpJson({ apiBase, apiKey, fetchImpl, path: `/api/commerce/receipts/${encodeURIComponent(receiptId)}` });
+  }
+
+  async function publishListing({
+    hand = {},
+    endpointUrl,
+    pricePerUnit,
+    category,
+    publish = false,
+  } = {}) {
+    const draft = buildListingDraftFromOpenFangHand({ hand, endpointUrl, pricePerUnit, category });
+    if (!publish) {
+      return {
+        mode: "draft_only",
+        no_publication: true,
+        draft,
+      };
+    }
+    return httpJson({
+      apiBase,
+      apiKey,
+      fetchImpl,
+      method: "POST",
+      path: "/api/capabilities",
+      body: draft,
+    });
+  }
+
+  return {
+    match,
+    execute,
+    status: getStatus,
+    receipt: getReceipt,
+    publishListing,
+    buildIntentContract: buildOpenFangIntentContract,
+    buildListingDraft: buildListingDraftFromOpenFangHand,
+  };
+}
+
+function loadHandManifest(path) {
+  if (!path) return {};
+  return JSON.parse(fs.readFileSync(path, "utf8"));
+}
+
+function parseCli(argv = process.argv.slice(2)) {
+  const opts = {
+    mode: "match",
+    handPath: process.env.OPENFANG_HAND_MANIFEST || null,
+    task: process.env.AGORAGENTIC_TASK || "echo",
+    input: parseJson(process.env.AGORAGENTIC_INPUT_JSON, { text: "OpenFang Hand dry run" }),
+    maxCostUsdc: Number(process.env.AGORAGENTIC_MAX_COST_USDC || DEFAULT_MAX_COST_USDC),
+    endpointUrl: process.env.OPENFANG_HAND_ENDPOINT_URL || null,
+    pricePerUnit: Number(process.env.OPENFANG_LISTING_PRICE_USDC || DEFAULT_MAX_COST_USDC),
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "match" || arg === "execute" || arg === "listing-draft" || arg === "publish-listing") {
+      opts.mode = arg;
+    } else if (arg === "--hand" && argv[i + 1]) {
+      opts.handPath = argv[++i];
+    } else if (arg === "--task" && argv[i + 1]) {
+      opts.task = argv[++i];
+    } else if (arg === "--input-json" && argv[i + 1]) {
+      opts.input = parseJson(argv[++i], {});
+    } else if (arg === "--max-cost" && argv[i + 1]) {
+      opts.maxCostUsdc = Number(argv[++i]);
+    } else if (arg === "--endpoint-url" && argv[i + 1]) {
+      opts.endpointUrl = argv[++i];
+    } else if (arg === "--price" && argv[i + 1]) {
+      opts.pricePerUnit = Number(argv[++i]);
+    }
+  }
+  return opts;
+}
+
+async function runCli() {
+  const opts = parseCli();
+  const hand = loadHandManifest(opts.handPath);
+  const bridge = createOpenFangAgoragenticBridge();
+
+  if (opts.mode === "listing-draft" || opts.mode === "publish-listing") {
+    const out = await bridge.publishListing({
+      hand,
+      endpointUrl: opts.endpointUrl,
+      pricePerUnit: opts.pricePerUnit,
+      publish: opts.mode === "publish-listing" && process.env.AGORAGENTIC_PUBLISH_LISTING === "true",
+    });
+    console.log(JSON.stringify(out, null, 2));
+    return;
+  }
+
+  const out = await bridge.execute({
+    hand,
+    task: opts.task,
+    input: opts.input,
+    constraints: { max_cost_usdc: opts.maxCostUsdc },
+    execute: opts.mode === "execute" && process.env.AGORAGENTIC_EXECUTE === "true",
+  });
+  console.log(JSON.stringify(out, null, 2));
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  runCli().catch((err) => {
+    console.error(err.message || err);
+    if (err.status) console.error(JSON.stringify(err.response || {}, null, 2));
+    process.exit(1);
+  });
+}

--- a/openfang/agoragentic_openfang.test.mjs
+++ b/openfang/agoragentic_openfang.test.mjs
@@ -1,0 +1,119 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildListingDraftFromOpenFangHand,
+  buildOpenFangIntentContract,
+  createOpenFangAgoragenticBridge,
+  mapOpenFangGrantsToAgoragenticPolicy,
+} from "./agoragentic_openfang.mjs";
+
+function jsonResponse(data, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    async text() {
+      return JSON.stringify(data);
+    },
+  };
+}
+
+const hand = {
+  id: "researcher.hand",
+  name: "Researcher Hand",
+  description: "Researches a topic and returns a cited brief.",
+  capability_grants: {
+    max_call_cost_usdc: 0.15,
+    max_daily_cost_usdc: 1.5,
+    approval_required_above_usdc: 0.15,
+    tools: ["web_search", "citation_check"],
+    allowed_domains: ["agoragentic.com"],
+    network_allowlist: ["example.com"],
+    network: true,
+  },
+};
+
+test("maps OpenFang grants to bounded Agoragentic policy", () => {
+  const policy = mapOpenFangGrantsToAgoragenticPolicy(hand.capability_grants);
+
+  assert.equal(policy.source_runtime, "openfang");
+  assert.equal(policy.spend.max_call_cost_usdc, 0.15);
+  assert.equal(policy.spend.max_daily_cost_usdc, 1.5);
+  assert.equal(policy.spend.settlement_network, "base");
+  assert.deepEqual(policy.tools.allowed_tools, ["web_search", "citation_check"]);
+  assert.deepEqual(policy.tools.allowed_domains.sort(), ["agoragentic.com", "example.com"]);
+  assert.equal(policy.data.allow_private_data, false);
+  assert.equal(policy.approvals.require_human_for_listing_publication, true);
+});
+
+test("builds an intent contract without provider hardcoding", () => {
+  const contract = buildOpenFangIntentContract({
+    hand,
+    task: "summarize this source",
+    input: { text: "hello" },
+    constraints: { max_cost_usdc: 0.12 },
+  });
+
+  assert.equal(contract.schema, "agoragentic.openfang.intent-contract.v1");
+  assert.equal(contract.source_runtime, "openfang");
+  assert.equal(contract.hand.id, "researcher.hand");
+  assert.equal(contract.intent.task, "summarize this source");
+  assert.equal(contract.policy.spend.max_call_cost_usdc, 0.12);
+  assert.equal(contract.execution.preferred_entrypoint, "POST /api/execute");
+  assert.equal(contract.execution.avoid_provider_hardcoding, true);
+  assert.equal(contract.execution.require_receipt, true);
+});
+
+test("dry-run execute calls match only and never spends", async () => {
+  const calls = [];
+  const bridge = createOpenFangAgoragenticBridge({
+    apiKey: "amk_test",
+    fetchImpl: async (url, options = {}) => {
+      calls.push({ url: String(url), method: options.method || "GET" });
+      return jsonResponse({ matches: [{ id: "cap_test" }] });
+    },
+  });
+
+  const result = await bridge.execute({
+    hand,
+    task: "summarize this source",
+    input: { text: "hello" },
+    execute: false,
+  });
+
+  assert.equal(result.mode, "dry_run");
+  assert.equal(result.no_spend, true);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].method, "GET");
+  assert.match(calls[0].url, /\/api\/execute\/match\?/);
+});
+
+test("listing draft does not publish unless explicitly requested", async () => {
+  const calls = [];
+  const bridge = createOpenFangAgoragenticBridge({
+    apiKey: "amk_test",
+    fetchImpl: async (url, options = {}) => {
+      calls.push({ url: String(url), method: options.method || "GET" });
+      return jsonResponse({ ok: true });
+    },
+  });
+
+  const result = await bridge.publishListing({
+    hand,
+    endpointUrl: "https://example.com/openfang/researcher",
+    pricePerUnit: 0.25,
+    publish: false,
+  });
+
+  assert.equal(result.mode, "draft_only");
+  assert.equal(result.no_publication, true);
+  assert.equal(calls.length, 0);
+  assert.equal(result.draft.metadata.source_runtime, "openfang");
+  assert.equal(result.draft.price_per_unit, 0.25);
+});
+
+test("listing draft requires an endpoint URL", () => {
+  assert.throws(
+    () => buildListingDraftFromOpenFangHand({ hand }),
+    /endpointUrl is required/,
+  );
+});

--- a/openfang/agoragentic_openfang.test.mjs
+++ b/openfang/agoragentic_openfang.test.mjs
@@ -63,6 +63,17 @@ test("builds an intent contract without provider hardcoding", () => {
   assert.equal(contract.execution.require_receipt, true);
 });
 
+test("runtime daily budget override tightens manifest daily cap", () => {
+  const contract = buildOpenFangIntentContract({
+    hand,
+    task: "summarize this source",
+    input: { text: "hello" },
+    constraints: { max_daily_cost_usdc: 0.25 },
+  });
+
+  assert.equal(contract.policy.spend.max_daily_cost_usdc, 0.25);
+});
+
 test("dry-run execute calls match only and never spends", async () => {
   const calls = [];
   const bridge = createOpenFangAgoragenticBridge({
@@ -85,6 +96,28 @@ test("dry-run execute calls match only and never spends", async () => {
   assert.equal(calls.length, 1);
   assert.equal(calls[0].method, "GET");
   assert.match(calls[0].url, /\/api\/execute\/match\?/);
+});
+
+test("dry-run match preserves zero max cost for free-only previews", async () => {
+  const calls = [];
+  const bridge = createOpenFangAgoragenticBridge({
+    apiKey: "amk_test",
+    fetchImpl: async (url, options = {}) => {
+      calls.push({ url: String(url), method: options.method || "GET" });
+      return jsonResponse({ matches: [] });
+    },
+  });
+
+  await bridge.execute({
+    hand,
+    task: "free-only preview",
+    input: {},
+    constraints: { max_cost_usdc: 0 },
+    execute: false,
+  });
+
+  assert.equal(calls.length, 1);
+  assert.match(calls[0].url, /max_cost=0/);
 });
 
 test("listing draft does not publish unless explicitly requested", async () => {

--- a/openfang/example-hand.json
+++ b/openfang/example-hand.json
@@ -1,0 +1,30 @@
+{
+  "id": "researcher.hand",
+  "name": "OpenFang Researcher Hand",
+  "version": "0.1.0",
+  "description": "Local OpenFang Hand that researches a topic, checks source quality, and returns a cited brief.",
+  "channels": ["telegram", "slack"],
+  "workflows": {
+    "mode": "sequential",
+    "supports_scheduled_runs": true,
+    "supports_fan_out": true
+  },
+  "capability_grants": {
+    "max_call_cost_usdc": 0.1,
+    "max_daily_cost_usdc": 1,
+    "approval_required_above_usdc": 0.1,
+    "tools": ["web_search", "summarize", "citation_check"],
+    "allowed_domains": ["agoragentic.com"],
+    "network": true,
+    "allow_private_data": false,
+    "allow_secret_access": false
+  },
+  "memory": {
+    "type": "sqlite_vector",
+    "exports_raw_memory": false
+  },
+  "sandbox": {
+    "type": "wasm",
+    "requires_capability_grants": true
+  }
+}

--- a/openfang/openfang.agoragentic-hand-bridge.manifest.json
+++ b/openfang/openfang.agoragentic-hand-bridge.manifest.json
@@ -1,0 +1,42 @@
+{
+  "schema": "agoragentic.openfang.bridge.v1",
+  "name": "OpenFang to Agoragentic Bridge",
+  "status": "beta",
+  "source_runtime": "openfang",
+  "target_layer": "agoragentic_router_marketplace",
+  "summary": "Bridge local OpenFang Hands into Agoragentic for routed buying, receipts, and optional seller listing drafts.",
+  "agoragentic_entrypoints": {
+    "match": "GET https://agoragentic.com/api/execute/match",
+    "buyer_execute": "POST https://agoragentic.com/api/execute",
+    "receipt": "GET https://agoragentic.com/api/commerce/receipts/{receipt_id}",
+    "seller_listing": "POST https://agoragentic.com/api/capabilities"
+  },
+  "openfang_mapping": {
+    "hand": "agoragentic intent contract source_runtime.openfang.hand",
+    "capability_grants": "agoragentic spend, tool, data, and approval policy metadata",
+    "workflow": "task intent and execution constraints",
+    "audit_trail": "agoragentic receipt and reconciliation references"
+  },
+  "required_env": ["AGORAGENTIC_API_KEY"],
+  "optional_env": [
+    "AGORAGENTIC_API_BASE",
+    "OPENFANG_HAND_MANIFEST",
+    "AGORAGENTIC_TASK",
+    "AGORAGENTIC_INPUT_JSON",
+    "AGORAGENTIC_MAX_COST_USDC",
+    "AGORAGENTIC_EXECUTE",
+    "OPENFANG_HAND_ENDPOINT_URL",
+    "OPENFANG_LISTING_PRICE_USDC",
+    "AGORAGENTIC_PUBLISH_LISTING"
+  ],
+  "authority_boundary": {
+    "dry_run_default": true,
+    "requires_execute_opt_in": true,
+    "requires_listing_publish_opt_in": true,
+    "no_wallet_custody": true,
+    "no_private_key_handling": true,
+    "no_hosted_runtime_provisioning": true,
+    "no_full_ecf_access": true,
+    "no_provider_hardcoding": true
+  }
+}


### PR DESCRIPTION
Adds a beta OpenFang integration that maps local Hand manifests and capability grants into Agoragentic intent contracts. The bridge defaults to no-spend match, requires explicit opt-in for paid /api/execute calls, fetches receipts when available, and creates draft-only seller listing payloads unless publication is explicitly enabled. Updates README, integrations.json, llms.txt, and llms-full.txt so the integration is discoverable. Validation: node --check openfang/agoragentic_openfang.mjs; node --test openfang/agoragentic_openfang.test.mjs; integrations.json validated against integrations.schema.json.