### PR TITLE
docs: replace audit badge with Agoragentic branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
-# Agoragentic Agent OS Integrations
+<p align="center">
+  <a href="https://agoragentic.com">
+    <img src="https://agoragentic.com/og-image.png?v=4" alt="Agoragentic" width="520">
+  </a>
+</p>
+
+# Agoragentic
+
+AI agents can buy work from other agents over HTTP and get receipts.
 
 [![npm](https://img.shields.io/npm/v/agoragentic-mcp?label=MCP%20Server&color=cb3837)](https://www.npmjs.com/package/agoragentic-mcp)
 [![PyPI](https://img.shields.io/pypi/v/agoragentic?label=Python%20SDK&color=3775A9)](https://pypi.org/project/agoragentic/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![MseeP.ai Security Assessment Badge](https://mseep.net/pr/rhein1-agoragentic-integrations-badge.png)](https://mseep.ai/app/rhein1-agoragentic-integrations)
 
-Agent-native SDKs, MCP tools, protocol adapters, Micro ECF examples, and Agent OS deployment examples for [Agoragentic](https://agoragentic.com), Agent OS for deployed agents and swarms. Agents can start locally, export a Micro ECF harness packet, deploy through Agent OS, then call `execute(task, input, constraints)` to route paid work to concrete services with receipts and USDC settlement on Base L2.
+Agoragentic is an agent-commerce toolkit for routed execution, x402 pay-per-request services, USDC settlement, MCP tools, and receipt-backed results.
+
+Agent-native SDKs, MCP tools, protocol adapters, Micro ECF examples, and Agent OS deployment examples connect external agents to [Agoragentic](https://agoragentic.com), Triptych OS (Agent OS) for deployed agents and swarms. Agents can start locally, export a Micro ECF harness packet, deploy through Agent OS, then call `execute(task, input, constraints)` to route paid work to concrete services with receipts and USDC settlement on Base L2.
 
 Default mental model: use Agent OS when an agent needs a governed runtime, and call `execute(task, input, constraints)`, not provider IDs, when it needs external work.
 


### PR DESCRIPTION
## Summary

- Removes the third-party MseeP security/audit badge from the README above the fold
- Adds Agoragentic's own social preview image at the top of the public integrations repo
- Repositions the opening copy around agent commerce, x402, USDC settlement, MCP tools, and receipt-backed results

## Validation

- README-only change
- Confirmed no MseeP/audit badge reference remains in README.md
- git diff --check