### PR TITLE
docs: sharpen Agoragentic README brand banner

### DIFF
--- a/assets/agoragentic-agent-commerce-banner.svg
+++ b/assets/agoragentic-agent-commerce-banner.svg
@@ -1,80 +1,109 @@
 <svg width="1200" height="520" viewBox="0 0 1200 520" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
   <title id="title">Agoragentic agent commerce banner</title>
-  <desc id="desc">Agent commerce visual showing routed execution, x402 and USDC payment rails, and receipt-backed results.</desc>
+  <desc id="desc">Agoragentic orange and navy brand banner for agent commerce, execute routing, x402, Base USDC settlement, and receipts.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="520" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#F7F0DF"/>
-      <stop offset="0.47" stop-color="#E9F5EA"/>
-      <stop offset="1" stop-color="#D9EEF5"/>
+      <stop stop-color="#070D18"/>
+      <stop offset="0.46" stop-color="#111A2A"/>
+      <stop offset="1" stop-color="#070D18"/>
     </linearGradient>
-    <linearGradient id="ink" x1="110" y1="72" x2="1032" y2="484" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#10231E"/>
-      <stop offset="1" stop-color="#1C3B35"/>
+    <radialGradient id="emberTop" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(612 0) rotate(90) scale(286 520)">
+      <stop stop-color="#E8613A" stop-opacity="0.68"/>
+      <stop offset="0.42" stop-color="#E8613A" stop-opacity="0.18"/>
+      <stop offset="1" stop-color="#E8613A" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="emberRight" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(982 166) rotate(128) scale(304 240)">
+      <stop stop-color="#FF7A45" stop-opacity="0.44"/>
+      <stop offset="1" stop-color="#FF7A45" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="mark" x1="104" y1="64" x2="185" y2="146" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FF8A5F"/>
+      <stop offset="1" stop-color="#E8613A"/>
     </linearGradient>
-    <linearGradient id="green" x1="642" y1="86" x2="1002" y2="420" gradientUnits="userSpaceOnUse">
-      <stop stop-color="#29D37D"/>
-      <stop offset="1" stop-color="#0B8F65"/>
+    <linearGradient id="chip" x1="0" y1="0" x2="1" y2="1">
+      <stop stop-color="#2A3445"/>
+      <stop offset="1" stop-color="#111A2A"/>
     </linearGradient>
     <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%" color-interpolation-filters="sRGB">
-      <feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#10231E" flood-opacity="0.14"/>
+      <feDropShadow dx="0" dy="24" stdDeviation="26" flood-color="#000000" flood-opacity="0.38"/>
     </filter>
-    <pattern id="grid" width="36" height="36" patternUnits="userSpaceOnUse">
-      <path d="M36 0H0V36" stroke="#10231E" stroke-opacity="0.06" stroke-width="1"/>
+    <pattern id="microGrid" width="48" height="48" patternUnits="userSpaceOnUse">
+      <path d="M48 0H0V48" stroke="#FFFFFF" stroke-opacity="0.035" stroke-width="1"/>
     </pattern>
   </defs>
 
-  <rect width="1200" height="520" rx="36" fill="url(#bg)"/>
-  <rect width="1200" height="520" rx="36" fill="url(#grid)"/>
+  <rect width="1200" height="520" rx="34" fill="url(#bg)"/>
+  <rect width="1200" height="520" rx="34" fill="url(#emberTop)"/>
+  <rect width="1200" height="520" rx="34" fill="url(#emberRight)"/>
+  <rect width="1200" height="520" rx="34" fill="url(#microGrid)"/>
 
-  <path d="M-60 436C130 356 184 497 338 410C497 319 515 158 702 156C866 154 929 272 1268 134" stroke="#10231E" stroke-opacity="0.08" stroke-width="80"/>
-  <path d="M-25 430C148 348 210 476 352 391C495 305 535 143 702 146C863 149 939 261 1234 151" stroke="#0B8F65" stroke-opacity="0.18" stroke-width="10"/>
+  <g stroke="#E8613A" stroke-opacity="0.28" stroke-width="2" fill="none">
+    <path d="M-20 165H178L254 241H436"/>
+    <path d="M0 232H214L282 300H503"/>
+    <path d="M0 306H180L237 363H452"/>
+    <path d="M1200 138H1030L959 209H769"/>
+    <path d="M1200 222H1016L956 282H746"/>
+    <path d="M1200 322H1018L946 394H716"/>
+    <path d="M577 -22V118L523 172V260"/>
+    <path d="M643 -20V126L704 187V292"/>
+  </g>
+  <g fill="#E8613A" fill-opacity="0.42">
+    <circle cx="178" cy="165" r="5"/>
+    <circle cx="436" cy="241" r="5"/>
+    <circle cx="503" cy="300" r="5"/>
+    <circle cx="769" cy="209" r="5"/>
+    <circle cx="746" cy="282" r="5"/>
+    <circle cx="716" cy="394" r="5"/>
+    <circle cx="523" cy="260" r="5"/>
+    <circle cx="704" cy="292" r="5"/>
+  </g>
 
-  <g transform="translate(78 70)">
-    <rect x="0" y="0" width="1044" height="380" rx="34" fill="#FFFDF5" fill-opacity="0.84" stroke="#10231E" stroke-opacity="0.1" filter="url(#shadow)"/>
-    <circle cx="66" cy="66" r="34" fill="url(#ink)"/>
-    <path d="M51 83L65 45L82 83H73L70 75H58L55 83H51ZM61 67H67L64 58L61 67Z" fill="#F7F0DF"/>
-    <text x="118" y="59" font-family="Verdana, DejaVu Sans, Arial, sans-serif" font-size="22" font-weight="700" fill="#10231E">AGORAGENTIC</text>
-    <text x="118" y="88" font-family="Verdana, DejaVu Sans, Arial, sans-serif" font-size="15" font-weight="600" letter-spacing="2.5" fill="#0B8F65">AGENT COMMERCE WITH RECEIPTS</text>
+  <g transform="translate(88 64)">
+    <rect width="1024" height="392" rx="36" fill="#0B1220" fill-opacity="0.78" stroke="#FFFFFF" stroke-opacity="0.08" filter="url(#shadow)"/>
 
-    <text x="48" y="175" font-family="Verdana, DejaVu Sans, Arial, sans-serif" font-size="54" font-weight="800" fill="#10231E">Agents buy work.</text>
-    <text x="48" y="234" font-family="Verdana, DejaVu Sans, Arial, sans-serif" font-size="54" font-weight="800" fill="#10231E">HTTP returns proof.</text>
-    <text x="52" y="282" font-family="Verdana, DejaVu Sans, Arial, sans-serif" font-size="21" font-weight="500" fill="#34514A">Route tasks with execute(). Pay by x402 or USDC. Settle on Base. Keep receipts.</text>
-
-    <g transform="translate(50 318)">
-      <rect width="138" height="38" rx="19" fill="#10231E"/>
-      <text x="22" y="25" font-family="Verdana, DejaVu Sans, Arial, sans-serif" font-size="14" font-weight="700" fill="#F7F0DF">execute()</text>
-      <rect x="154" width="112" height="38" rx="19" fill="#FFB545"/>
-      <text x="179" y="25" font-family="Verdana, DejaVu Sans, Arial, sans-serif" font-size="14" font-weight="700" fill="#10231E">x402</text>
-      <rect x="282" width="118" height="38" rx="19" fill="#D9EEF5"/>
-      <text x="308" y="25" font-family="Verdana, DejaVu Sans, Arial, sans-serif" font-size="14" font-weight="700" fill="#10231E">USDC</text>
-      <rect x="416" width="132" height="38" rx="19" fill="#DFF4E7"/>
-      <text x="439" y="25" font-family="Verdana, DejaVu Sans, Arial, sans-serif" font-size="14" font-weight="700" fill="#10231E">receipts</text>
+    <g transform="translate(50 44)">
+      <rect x="0" y="0" width="68" height="68" rx="17" fill="url(#mark)"/>
+      <rect x="18" y="18" width="32" height="32" rx="7" fill="#0B1220"/>
+      <circle cx="47" cy="49" r="6" fill="#FFB18D"/>
+      <text x="90" y="28" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="23" font-weight="800" fill="#F6F7FB">agora<tspan fill="#B9C0CD">gentic</tspan></text>
+      <text x="91" y="57" font-family="JetBrains Mono, Consolas, monospace" font-size="13" font-weight="700" letter-spacing="2.5" fill="#FF8A5F">AGENT COMMERCE WITH RECEIPTS</text>
     </g>
 
-    <g transform="translate(664 82)">
-      <rect x="0" y="32" width="280" height="214" rx="28" fill="#10231E"/>
-      <rect x="24" y="62" width="232" height="154" rx="20" fill="#16352E"/>
-      <circle cx="70" cy="139" r="35" fill="#29D37D"/>
-      <path d="M55 141L66 152L87 124" stroke="#10231E" stroke-width="9" stroke-linecap="round" stroke-linejoin="round"/>
-      <text x="116" y="128" font-family="Verdana, DejaVu Sans, Arial, sans-serif" font-size="20" font-weight="800" fill="#F7F0DF">receipt</text>
-      <text x="116" y="157" font-family="Verdana, DejaVu Sans, Arial, sans-serif" font-size="14" font-weight="600" fill="#A9DCCB">paid route settled</text>
-      <path d="M50 195H230" stroke="#F7F0DF" stroke-opacity="0.24" stroke-width="8" stroke-linecap="round"/>
-      <path d="M50 213H184" stroke="#F7F0DF" stroke-opacity="0.18" stroke-width="8" stroke-linecap="round"/>
+    <g transform="translate(52 154)">
+      <text x="0" y="0" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="58" font-weight="850" fill="#F6F7FB">One execute() call.</text>
+      <text x="0" y="68" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="58" font-weight="850" fill="#F6F7FB">Proof comes back.</text>
+      <text x="2" y="120" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="21" font-weight="500" fill="#B9C0CD">Route paid agent work. Settle on Base. Keep receipts.</text>
+    </g>
 
-      <g transform="translate(-86 0)">
-        <rect x="0" y="0" width="156" height="82" rx="22" fill="#FFFDF5" stroke="#10231E" stroke-opacity="0.12"/>
-        <text x="24" y="35" font-family="Verdana, DejaVu Sans, Arial, sans-serif" font-size="15" font-weight="800" fill="#10231E">buyer</text>
-        <text x="24" y="59" font-family="Verdana, DejaVu Sans, Arial, sans-serif" font-size="13" font-weight="600" fill="#0B8F65">agent</text>
-      </g>
-      <g transform="translate(210 0)">
-        <rect x="0" y="0" width="156" height="82" rx="22" fill="#FFFDF5" stroke="#10231E" stroke-opacity="0.12"/>
-        <text x="24" y="35" font-family="Verdana, DejaVu Sans, Arial, sans-serif" font-size="15" font-weight="800" fill="#10231E">seller</text>
-        <text x="24" y="59" font-family="Verdana, DejaVu Sans, Arial, sans-serif" font-size="13" font-weight="600" fill="#0B8F65">agent</text>
-      </g>
-      <path d="M84 40C122 30 160 30 198 40" stroke="#FFB545" stroke-width="9" stroke-linecap="round"/>
-      <path d="M198 40L183 26M198 40L180 53" stroke="#FFB545" stroke-width="7" stroke-linecap="round"/>
-      <path d="M198 253C160 263 122 263 84 253" stroke="#29D37D" stroke-width="9" stroke-linecap="round"/>
-      <path d="M84 253L99 239M84 253L102 266" stroke="#29D37D" stroke-width="7" stroke-linecap="round"/>
+    <g transform="translate(54 318)">
+      <rect x="0" y="0" width="128" height="40" rx="20" fill="#E8613A"/>
+      <text x="27" y="26" font-family="JetBrains Mono, Consolas, monospace" font-size="14" font-weight="800" fill="#0B1220">execute</text>
+      <rect x="144" y="0" width="92" height="40" rx="20" fill="#202A3B" stroke="#E8613A" stroke-opacity="0.55"/>
+      <text x="172" y="26" font-family="JetBrains Mono, Consolas, monospace" font-size="14" font-weight="800" fill="#F6F7FB">x402</text>
+      <rect x="252" y="0" width="136" height="40" rx="20" fill="#202A3B" stroke="#E8613A" stroke-opacity="0.55"/>
+      <text x="282" y="26" font-family="JetBrains Mono, Consolas, monospace" font-size="14" font-weight="800" fill="#F6F7FB">Base USDC</text>
+      <rect x="404" y="0" width="116" height="40" rx="20" fill="#F6F7FB"/>
+      <text x="432" y="26" font-family="JetBrains Mono, Consolas, monospace" font-size="14" font-weight="800" fill="#0B1220">receipt</text>
+    </g>
+
+    <g transform="translate(724 108)">
+      <rect x="0" y="42" width="226" height="208" rx="26" fill="#101827" stroke="#FFFFFF" stroke-opacity="0.08"/>
+      <rect x="24" y="70" width="178" height="132" rx="18" fill="#F6F7FB"/>
+      <text x="46" y="108" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18" font-weight="800" fill="#0B1220">receipt</text>
+      <text x="46" y="136" font-family="JetBrains Mono, Consolas, monospace" font-size="13" font-weight="700" fill="#E8613A">settled on Base</text>
+      <path d="M47 166H151" stroke="#0B1220" stroke-opacity="0.18" stroke-width="8" stroke-linecap="round"/>
+      <path d="M47 188H126" stroke="#0B1220" stroke-opacity="0.14" stroke-width="8" stroke-linecap="round"/>
+      <circle cx="162" cy="112" r="27" fill="#E8613A"/>
+      <path d="M150 112L159 121L176 99" stroke="#0B1220" stroke-width="7" stroke-linecap="round" stroke-linejoin="round"/>
+
+      <rect x="-52" y="0" width="128" height="72" rx="20" fill="url(#chip)" stroke="#E8613A" stroke-opacity="0.42"/>
+      <text x="-22" y="31" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="800" fill="#F6F7FB">buyer</text>
+      <text x="-22" y="53" font-family="JetBrains Mono, Consolas, monospace" font-size="12" font-weight="700" fill="#B9C0CD">agent</text>
+      <rect x="146" y="0" width="128" height="72" rx="20" fill="url(#chip)" stroke="#E8613A" stroke-opacity="0.42"/>
+      <text x="176" y="31" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="15" font-weight="800" fill="#F6F7FB">seller</text>
+      <text x="176" y="53" font-family="JetBrains Mono, Consolas, monospace" font-size="12" font-weight="700" fill="#B9C0CD">agent</text>
+      <path d="M78 35C98 20 125 20 146 35" stroke="#E8613A" stroke-width="8" stroke-linecap="round"/>
+      <path d="M146 35L132 24M146 35L130 46" stroke="#E8613A" stroke-width="6" stroke-linecap="round"/>
     </g>
   </g>
 </svg>


### PR DESCRIPTION
## Summary

- Replaces the merged README banner artwork with a darker Agoragentic-owned agent-commerce brand card
- Keeps the current commerce-first README copy and existing asset path
- Removes the weak audit/bird visual direction in favor of execute/x402/Base USDC/receipt proof rails

## Validation

- Parsed SVG as XML locally
- Rendered the SVG in headless Chrome for visual QA