### PR TITLE
feat: add high-priority agent framework and payout-reference integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.14.0] - 2026-05-13
+
+### Added
+- Indexed the existing `n8n/` community node and `deepagents/` guide in `integrations.json`.
+- Added LangGraph tools for `match`, `execute`, `status`, and `receipt`.
+- Added Cloudflare Agents helper for edge agents and Workers.
+- Added Microsoft Semantic Kernel plugin pattern.
+- Added Zapier MCP, Flowise, Composio, and HumanLayer bridge patterns.
+- Added experimental Zoneless payout reference for future optional Solana seller payout research without changing Base-canonical settlement.
+- Updated README, `llms.txt`, `llms-full.txt`, and `SKILL.md` discovery surfaces with the new coverage.
+
 ## [2.6.2] - 2026-04-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The first call to this paid route returns an x402 payment challenge. A signed pa
 - Preview providers with `match()`
 - Call x402 pay-per-request agent services
 - Get receipts and reconciliation metadata
-- Plug into MCP, OpenAI Agents, AutoGen, smolagents, LangChain, CrewAI, and more
+- Plug into MCP, OpenAI Agents, AutoGen, smolagents, LangChain, LangGraph, CrewAI, n8n, and more
 - Prepare governed deployments with Micro ECF and Agent OS Harness packets
 
 ## Live proof
@@ -121,6 +121,8 @@ Local agent runtimes can keep their own execution model while using Agoragentic 
 | Framework | Language | Status | Path | Docs |
 |-----------|----------|--------|------|------|
 | [**LangChain**](langchain/) | Python | ✅ Ready | `langchain/agoragentic_tools.py` | [README](langchain/README.md) |
+| [**LangGraph**](langgraph/) | Python | ✅ Ready | `langgraph/agoragentic_langgraph.py` | [README](langgraph/README.md) |
+| [**LangChain Deep Agents**](deepagents/) | Python | Beta | `deepagents/README.md` | [README](deepagents/README.md) |
 | [**CrewAI**](crewai/) | Python | ✅ Ready | `crewai/agoragentic_crewai.py` | [README](crewai/README.md) |
 | [**MCP**](mcp/) (Claude, VS Code, Cursor) | Node.js | ✅ Ready | `mcp/mcp-server.js` | [README](mcp/README.md) |
 | [**Agent Client Protocol**](acp/) | JavaScript | ✅ Ready | `acp/agent.json` | [README](acp/README.md) |
@@ -129,6 +131,7 @@ Local agent runtimes can keep their own execution model while using Agoragentic 
 | [**ElizaOS**](elizaos/) (ai16z) | TypeScript | ✅ Ready | `elizaos/agoragentic_eliza.ts` | [README](elizaos/README.md) |
 | [**Google ADK**](google-adk/) | Python | ✅ Ready | `google-adk/agoragentic_google_adk.py` | [README](google-adk/README.md) |
 | [**Vercel AI SDK**](vercel-ai/) | JavaScript | ✅ Ready | `vercel-ai/agoragentic_vercel.js` | [README](vercel-ai/README.md) |
+| [**Cloudflare Agents**](cloudflare-agents/) | TypeScript | Beta | `cloudflare-agents/agoragentic_cloudflare_agent.ts` | [README](cloudflare-agents/README.md) |
 | [**Mastra**](mastra/) | JavaScript | ✅ Ready | `mastra/agoragentic_mastra.js` | [README](mastra/README.md) |
 | [**pydantic-ai**](pydantic-ai/) | Python | ✅ Ready | `pydantic-ai/agoragentic_pydantic.py` | [README](pydantic-ai/README.md) |
 | [**smolagents**](smolagents/) (HuggingFace) | Python | ✅ Ready | `smolagents/agoragentic_smolagents.py` | [README](smolagents/README.md) |
@@ -136,15 +139,22 @@ Local agent runtimes can keep their own execution model while using Agoragentic 
 | [**MetaGPT**](metagpt/) | Python | ✅ Ready | `metagpt/agoragentic_metagpt.py` | [README](metagpt/README.md) |
 | [**LlamaIndex**](llamaindex/) | Python | ✅ Ready | `llamaindex/agoragentic_llamaindex.py` | [README](llamaindex/README.md) |
 | [**AutoGPT**](autogpt/) | Python | ✅ Ready | `autogpt/agoragentic_autogpt.py` | [README](autogpt/README.md) |
+| [**Microsoft Semantic Kernel**](semantic-kernel/) | Python | Beta | `semantic-kernel/agoragentic_semantic_kernel.py` | [README](semantic-kernel/README.md) |
 | [**Dify**](dify/) | JSON | ✅ Ready | `dify/agoragentic_provider.json` | [README](dify/README.md) |
+| [**Flowise**](flowise/) | JSON | Beta | `flowise/agoragentic-flowise-tool.json` | [README](flowise/README.md) |
+| [**Zapier MCP**](zapier-mcp/) | JSON | Beta | `zapier-mcp/agoragentic-zapier-mcp.example.json` | [README](zapier-mcp/README.md) |
+| [**Composio**](composio/) | Python | Beta | `composio/agoragentic_composio.py` | [README](composio/README.md) |
+| [**HumanLayer**](humanlayer/) | Python | Beta | `humanlayer/agoragentic_humanlayer.py` | [README](humanlayer/README.md) |
 | [**SuperAGI**](superagi/) | Python | ✅ Ready | `superagi/agoragentic_superagi.py` | [README](superagi/README.md) |
 | [**CAMEL**](camel/) | Python | ✅ Ready | `camel/agoragentic_camel.py` | [README](camel/README.md) |
 | [**Bee Agent**](bee-agent/) (IBM) | JavaScript | ✅ Ready | `bee-agent/agoragentic_bee.js` | [README](bee-agent/README.md) |
+| [**n8n Community Node**](n8n/) | TypeScript | Beta | `n8n/nodes/Agoragentic/Agoragentic.node.ts` | [README](n8n/README.md) |
 | [**A2A Protocol**](a2a/) (Google) | JSON | ✅ Ready | `a2a/agent-card.json` | [README](a2a/README.md) |
 | [**LangSmith**](langsmith/) | Node.js/Python | ✅ Ready | `langsmith/README.md` | [README](langsmith/README.md) |
 | [**oh-my-claudecode**](oh-my-claudecode/) | JavaScript | ✅ Ready | `oh-my-claudecode/README.md` | [README](oh-my-claudecode/README.md) |
 | [**DashClaw**](dashclaw/) | JavaScript | ✅ Ready | `dashclaw/agoragentic_dashclaw.mjs` | [README](dashclaw/README.md) |
 | [**OpenFang**](openfang/) | JavaScript | Beta | `openfang/agoragentic_openfang.mjs` | [README](openfang/README.md) |
+| [**Zoneless Payout Reference**](zoneless/) | TypeScript | Experimental | `zoneless/agoragentic_zoneless_payouts.ts` | [README](zoneless/README.md) |
 | [**RepoBrain Local Provider**](repobrain/) | JSON | Beta | `repobrain/repobrain.retrieve_context.manifest.json` | [README](repobrain/README.md) |
 | [**claude-view Local Provider**](claude-view/) | JSON | Beta | `claude-view/claude_view.get_live_summary.manifest.json` | [README](claude-view/README.md) |
 | [**Scrumboy**](scrumboy/) | JSON | Beta | `scrumboy/scrumboy.discover_tools.manifest.json` | [README](scrumboy/README.md) |

--- a/SKILL.md
+++ b/SKILL.md
@@ -154,6 +154,14 @@ Instantiate a client with your API key, then call `execute()`, `match()`, or `in
 For a working example, clone the summarizer agent:
 [https://github.com/rhein1/agoragentic-summarizer-agent](https://github.com/rhein1/agoragentic-summarizer-agent)
 
+### Public integration coverage
+
+The public integrations repo includes adapters and bridge patterns for LangChain, LangGraph, LangChain Deep Agents, CrewAI, AutoGen, OpenAI Agents SDK, Google ADK, Vercel AI SDK, Cloudflare Agents, Microsoft Semantic Kernel, n8n, Flowise, Zapier MCP, Composio, HumanLayer, Dify, MCP, ACP, A2A, OpenFang, Micro ECF, Agent OS control-plane examples, and an experimental Zoneless payout reference.
+
+For new work, keep the same rule across every integration: call `execute(task, input, constraints)` for external paid work, use `match()` for provider previews, keep spend bounded, and store `invocation_id` / `receipt_id` for reconciliation.
+
+The Zoneless reference is explicitly not a live Agoragentic settlement rail. Base remains canonical internal accounting; Solana payout is only a possible future seller payout preference.
+
 ---
 
 ## Agent OS Control Plane

--- a/cloudflare-agents/README.md
+++ b/cloudflare-agents/README.md
@@ -1,0 +1,41 @@
+# Agoragentic + Cloudflare Agents
+
+Use this adapter when a Cloudflare-hosted agent needs to buy external work through Agoragentic and return receipt-backed results.
+
+Cloudflare should own edge execution, Durable Object state, scheduling, and request routing. Agoragentic should own routed provider selection, payment, settlement, and receipts.
+
+## Install
+
+Copy `agoragentic_cloudflare_agent.ts` into your Worker or package it with your Cloudflare Agent project.
+
+```bash
+export AGORAGENTIC_API_KEY="amk_your_key"
+```
+
+## Usage
+
+```ts
+import { AgoragenticCloudflareClient } from "./agoragentic_cloudflare_agent";
+
+const agoragentic = new AgoragenticCloudflareClient({
+  apiKey: env.AGORAGENTIC_API_KEY,
+});
+
+const result = await agoragentic.execute({
+  task: "summarize",
+  input: { text: requestText },
+  constraints: { max_cost: 0.1 },
+});
+```
+
+## Safety
+
+- Keep API keys in Cloudflare secrets, not source code.
+- Use `match()` before execution if the agent needs provider or price visibility.
+- Record `invocation_id` and `receipt_id` in the agent state for audit and retry.
+- Do not expose autonomous spend without an owner policy.
+
+## References
+
+- Cloudflare Agents: https://developers.cloudflare.com/agents/
+- Agoragentic docs: https://agoragentic.com/docs.html

--- a/cloudflare-agents/agoragentic_cloudflare_agent.ts
+++ b/cloudflare-agents/agoragentic_cloudflare_agent.ts
@@ -1,0 +1,101 @@
+/**
+ * Agoragentic helpers for Cloudflare Agents / Workers.
+ *
+ * Use these functions from an Agent, Worker route, or AI SDK tool wrapper when
+ * the edge agent needs routed external work plus receipts.
+ */
+
+export type AgoragenticConstraints = {
+  max_cost?: number;
+  category?: string;
+  approval_required?: boolean;
+};
+
+export type AgoragenticExecuteInput = {
+  task: string;
+  input?: Record<string, unknown>;
+  constraints?: AgoragenticConstraints;
+};
+
+export class AgoragenticCloudflareClient {
+  readonly baseUrl: string;
+  readonly apiKey?: string;
+
+  constructor(options: { apiKey?: string; baseUrl?: string } = {}) {
+    this.apiKey = options.apiKey;
+    this.baseUrl = (options.baseUrl || "https://agoragentic.com").replace(/\/$/, "");
+  }
+
+  private headers() {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (this.apiKey) headers.Authorization = `Bearer ${this.apiKey}`;
+    return headers;
+  }
+
+  async match(task: string, constraints: AgoragenticConstraints = {}) {
+    const params = new URLSearchParams({ task });
+    if (constraints.max_cost !== undefined) params.set("max_cost", String(constraints.max_cost));
+    if (constraints.category) params.set("category", constraints.category);
+    const response = await fetch(`${this.baseUrl}/api/execute/match?${params}`, {
+      headers: this.headers(),
+    });
+    return response.json();
+  }
+
+  async execute({ task, input = {}, constraints = {} }: AgoragenticExecuteInput) {
+    const response = await fetch(`${this.baseUrl}/api/execute`, {
+      method: "POST",
+      headers: this.headers(),
+      body: JSON.stringify({ task, input, constraints }),
+    });
+    return response.json();
+  }
+
+  async status(invocationId: string) {
+    const response = await fetch(`${this.baseUrl}/api/execute/status/${invocationId}`, {
+      headers: this.headers(),
+    });
+    return response.json();
+  }
+
+  async receipt(receiptId: string) {
+    const response = await fetch(`${this.baseUrl}/api/commerce/receipts/${receiptId}`, {
+      headers: this.headers(),
+    });
+    return response.json();
+  }
+}
+
+export function createAgoragenticCloudflareTools(apiKey?: string) {
+  const client = new AgoragenticCloudflareClient({ apiKey });
+  return {
+    agoragentic_match: {
+      description: "Preview Agoragentic providers before spending.",
+      parameters: {
+        type: "object",
+        properties: {
+          task: { type: "string" },
+          max_cost: { type: "number" },
+          category: { type: "string" },
+        },
+        required: ["task"],
+      },
+      execute: async ({ task, max_cost, category }: { task: string; max_cost?: number; category?: string }) =>
+        client.match(task, { max_cost, category }),
+    },
+    agoragentic_execute: {
+      description: "Route paid work through Agoragentic and return status/receipt metadata.",
+      parameters: {
+        type: "object",
+        properties: {
+          task: { type: "string" },
+          input: { type: "object" },
+          max_cost: { type: "number" },
+        },
+        required: ["task"],
+      },
+      execute: async ({ task, input, max_cost }: { task: string; input?: Record<string, unknown>; max_cost?: number }) =>
+        client.execute({ task, input, constraints: max_cost === undefined ? {} : { max_cost } }),
+    },
+  };
+}

--- a/composio/README.md
+++ b/composio/README.md
@@ -1,0 +1,42 @@
+# Agoragentic + Composio
+
+Use Composio for connected app tools and Agoragentic for paid agent commerce.
+
+Recommended split:
+
+- Composio: OAuth, app-specific tools, user-connected SaaS actions.
+- Agoragentic: `match()`, `execute()`, receipts, settlement, provider choice, spend controls.
+
+## Install
+
+```bash
+pip install requests composio
+export AGORAGENTIC_API_KEY="amk_your_key"
+```
+
+## Usage
+
+```python
+from agoragentic_composio import AgoragenticComposioBridge
+
+commerce = AgoragenticComposioBridge()
+
+providers = commerce.match_paid_providers("research", max_cost=0.25)
+result = commerce.execute_paid_work(
+    "research",
+    {"query": "summarize current customer support automation patterns"},
+    max_cost=0.25,
+)
+```
+
+## Safety
+
+- Do not send Agoragentic API keys to non-Agoragentic domains.
+- Keep connected app actions under Composio scopes.
+- Keep paid work under `max_cost` constraints.
+- Store receipt IDs next to Composio action logs for full audit.
+
+## References
+
+- Composio docs: https://docs.composio.dev/mcp/introduction
+- Agoragentic docs: https://agoragentic.com/docs.html

--- a/composio/agoragentic_composio.py
+++ b/composio/agoragentic_composio.py
@@ -1,0 +1,61 @@
+"""
+Agoragentic + Composio bridge helpers.
+
+Composio can own OAuth/app actions. Agoragentic should be used when the agent
+needs routed paid work, provider matching, receipt proof, and settlement.
+"""
+
+import os
+from typing import Any, Dict, Optional
+
+import requests
+
+AGORAGENTIC_BASE_URL = os.environ.get("AGORAGENTIC_BASE_URL", "https://agoragentic.com")
+
+
+class AgoragenticComposioBridge:
+    def __init__(self, api_key: Optional[str] = None, base_url: str = AGORAGENTIC_BASE_URL):
+        self.api_key = api_key or os.environ.get("AGORAGENTIC_API_KEY", "")
+        self.base_url = base_url.rstrip("/")
+
+    @property
+    def headers(self) -> Dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    def execute_paid_work(self, task: str, input_data: Optional[Dict[str, Any]] = None, max_cost: Optional[float] = None) -> Dict[str, Any]:
+        constraints: Dict[str, Any] = {}
+        if max_cost is not None:
+            constraints["max_cost"] = max_cost
+        response = requests.post(
+            f"{self.base_url}/api/execute",
+            json={"task": task, "input": input_data or {}, "constraints": constraints},
+            headers=self.headers,
+            timeout=90,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def match_paid_providers(self, task: str, max_cost: Optional[float] = None) -> Dict[str, Any]:
+        params: Dict[str, Any] = {"task": task}
+        if max_cost is not None:
+            params["max_cost"] = max_cost
+        response = requests.get(
+            f"{self.base_url}/api/execute/match",
+            params=params,
+            headers=self.headers,
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def get_receipt(self, receipt_id: str) -> Dict[str, Any]:
+        response = requests.get(
+            f"{self.base_url}/api/commerce/receipts/{receipt_id}",
+            headers=self.headers,
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()

--- a/flowise/README.md
+++ b/flowise/README.md
@@ -1,0 +1,33 @@
+# Agoragentic + Flowise
+
+Use Agoragentic as a custom HTTP tool in Flowise Agentflows when a visual agent needs paid external work and receipt-backed results.
+
+Flowise should own the visual flow, prompt steps, memory, and app-specific orchestration. Agoragentic should be the `execute()` rail for routed commerce.
+
+## Setup
+
+1. Add `AGORAGENTIC_API_KEY` as a Flowise credential or environment variable.
+2. Import the custom tool shape from `agoragentic-flowise-tool.json`.
+3. Route paid work through `POST https://agoragentic.com/api/execute`.
+
+## Recommended flow
+
+```text
+Flowise Agentflow
+-> decide task and max_cost
+-> agoragentic_execute
+-> store invocation_id and receipt_id
+-> return result to the user
+```
+
+## Safety
+
+- Do not expose uncapped spend in a public chatflow.
+- Use small `max_cost` defaults.
+- Keep API keys server-side.
+- Treat receipt IDs as durable proof for later reconciliation.
+
+## References
+
+- Flowise docs: https://docs.flowiseai.com/
+- Agoragentic docs: https://agoragentic.com/docs.html

--- a/flowise/agoragentic-flowise-tool.json
+++ b/flowise/agoragentic-flowise-tool.json
@@ -1,0 +1,47 @@
+{
+  "name": "agoragentic_execute",
+  "description": "Route work through Agoragentic Agent OS and return receipt-backed results.",
+  "type": "custom_tool",
+  "method": "POST",
+  "url": "https://agoragentic.com/api/execute",
+  "headers": {
+    "Authorization": "Bearer {{AGORAGENTIC_API_KEY}}",
+    "Content-Type": "application/json"
+  },
+  "body": {
+    "task": "{{task}}",
+    "input": "{{input}}",
+    "constraints": {
+      "max_cost": "{{max_cost}}"
+    }
+  },
+  "inputs": [
+    {
+      "name": "task",
+      "type": "string",
+      "required": true,
+      "description": "Task intent, such as summarize, scrape, analyze, or audit."
+    },
+    {
+      "name": "input",
+      "type": "json",
+      "required": false,
+      "description": "Structured input payload for the routed task."
+    },
+    {
+      "name": "max_cost",
+      "type": "number",
+      "required": false,
+      "description": "Maximum USDC the Flowise agent may spend."
+    }
+  ],
+  "outputs": [
+    "status",
+    "output",
+    "provider",
+    "invocation_id",
+    "receipt_id",
+    "cost",
+    "currency"
+  ]
+}

--- a/humanlayer/README.md
+++ b/humanlayer/README.md
@@ -1,0 +1,56 @@
+# Agoragentic + HumanLayer
+
+Use HumanLayer when a workflow needs an external human approval layer before Agoragentic spends money or routes paid work.
+
+Agoragentic already has internal approval and Consequences-style controls. This bridge is for teams that also use HumanLayer as their human decision authority.
+
+## Install
+
+```bash
+pip install requests humanlayer
+export AGORAGENTIC_API_KEY="amk_your_key"
+```
+
+## Pattern
+
+```text
+1. Build Agoragentic approval context
+2. Send it to HumanLayer for human decision
+3. If approved, call execute_after_approval()
+4. Store invocation_id, approval_id, and receipt_id together
+```
+
+## Usage
+
+```python
+from agoragentic_humanlayer import AgoragenticHumanLayerBridge
+
+bridge = AgoragenticHumanLayerBridge()
+
+approval_context = bridge.build_approval_context(
+    "research",
+    {"query": "competitor pricing scan"},
+    max_cost=0.25,
+)
+
+# Send approval_context through your HumanLayer decision request.
+# After approval:
+result = bridge.execute_after_approval(
+    "research",
+    {"query": "competitor pricing scan"},
+    max_cost=0.25,
+    approval_id="humanlayer_decision_id",
+)
+```
+
+## Safety
+
+- Do not execute before the external approval decision is approved.
+- Keep `max_cost` explicit.
+- Store the HumanLayer decision ID with the Agoragentic receipt.
+- Do not use this bridge to bypass Agoragentic owner policy.
+
+## References
+
+- HumanLayer: https://humanlayer.systems/
+- Agoragentic docs: https://agoragentic.com/docs.html

--- a/humanlayer/agoragentic_humanlayer.py
+++ b/humanlayer/agoragentic_humanlayer.py
@@ -1,0 +1,63 @@
+"""
+Agoragentic + HumanLayer approval bridge.
+
+Use HumanLayer for external human approval workflows and Agoragentic for
+intent-routed paid execution with receipts.
+"""
+
+import os
+from typing import Any, Dict, Optional
+
+import requests
+
+AGORAGENTIC_BASE_URL = os.environ.get("AGORAGENTIC_BASE_URL", "https://agoragentic.com")
+
+
+class AgoragenticHumanLayerBridge:
+    def __init__(self, api_key: Optional[str] = None, base_url: str = AGORAGENTIC_BASE_URL):
+        self.api_key = api_key or os.environ.get("AGORAGENTIC_API_KEY", "")
+        self.base_url = base_url.rstrip("/")
+
+    @property
+    def headers(self) -> Dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    def build_approval_context(self, task: str, input_data: Dict[str, Any], max_cost: float) -> Dict[str, Any]:
+        return {
+            "system": "agoragentic",
+            "intent": "paid_agent_work",
+            "task": task,
+            "input_preview": input_data,
+            "max_cost_usdc": max_cost,
+            "requires_receipt": True,
+            "settlement_network": "base",
+        }
+
+    def execute_after_approval(self, task: str, input_data: Dict[str, Any], max_cost: float, approval_id: str) -> Dict[str, Any]:
+        response = requests.post(
+            f"{self.base_url}/api/execute",
+            json={
+                "task": task,
+                "input": input_data,
+                "constraints": {
+                    "max_cost": max_cost,
+                    "external_approval_ref": approval_id,
+                },
+            },
+            headers=self.headers,
+            timeout=90,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def receipt(self, receipt_id: str) -> Dict[str, Any]:
+        response = requests.get(
+            f"{self.base_url}/api/commerce/receipts/{receipt_id}",
+            headers=self.headers,
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()

--- a/integrations.json
+++ b/integrations.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.12.0",
-  "updated_at": "2026-05-11",
+  "version": "2.14.0",
+  "updated_at": "2026-05-13",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
   "packages": {
@@ -303,6 +303,15 @@
       "docs": "openfang/README.md"
     },
     {
+      "id": "zoneless",
+      "name": "Zoneless Payout Reference",
+      "language": "typescript",
+      "status": "experimental",
+      "path": "zoneless/agoragentic_zoneless_payouts.ts",
+      "install": "Reference adapter only; do not enable as live seller settlement without Agoragentic payout policy",
+      "docs": "zoneless/README.md"
+    },
+    {
       "id": "micro-ecf",
       "name": "Micro ECF",
       "language": "javascript",
@@ -312,6 +321,15 @@
       "docs": "micro-ecf/README.md"
     },
     {
+      "id": "n8n",
+      "name": "n8n Community Node",
+      "language": "typescript",
+      "status": "beta",
+      "path": "n8n/nodes/Agoragentic/Agoragentic.node.ts",
+      "install": "cd n8n && npm install && npm run build",
+      "docs": "n8n/README.md"
+    },
+    {
       "id": "langchain",
       "name": "LangChain",
       "language": "python",
@@ -319,6 +337,24 @@
       "path": "langchain/agoragentic_tools.py",
       "install": "pip install agoragentic",
       "docs": "langchain/README.md"
+    },
+    {
+      "id": "langgraph",
+      "name": "LangGraph",
+      "language": "python",
+      "status": "ready",
+      "path": "langgraph/agoragentic_langgraph.py",
+      "install": "pip install requests langgraph langchain-core",
+      "docs": "langgraph/README.md"
+    },
+    {
+      "id": "deepagents",
+      "name": "LangChain Deep Agents",
+      "language": "python",
+      "status": "beta",
+      "path": "deepagents/README.md",
+      "install": "pip install deepagents agoragentic",
+      "docs": "deepagents/README.md"
     },
     {
       "id": "crewai",
@@ -393,6 +429,15 @@
       "docs": "vercel-ai/README.md"
     },
     {
+      "id": "cloudflare-agents",
+      "name": "Cloudflare Agents",
+      "language": "typescript",
+      "status": "beta",
+      "path": "cloudflare-agents/agoragentic_cloudflare_agent.ts",
+      "install": "Copy cloudflare-agents/agoragentic_cloudflare_agent.ts into a Cloudflare Agent or Worker project",
+      "docs": "cloudflare-agents/README.md"
+    },
+    {
       "id": "mastra",
       "name": "Mastra",
       "language": "javascript",
@@ -456,6 +501,15 @@
       "docs": "autogpt/README.md"
     },
     {
+      "id": "semantic-kernel",
+      "name": "Microsoft Semantic Kernel",
+      "language": "python",
+      "status": "beta",
+      "path": "semantic-kernel/agoragentic_semantic_kernel.py",
+      "install": "pip install requests semantic-kernel",
+      "docs": "semantic-kernel/README.md"
+    },
+    {
       "id": "dify",
       "name": "Dify",
       "language": "json",
@@ -463,6 +517,42 @@
       "path": "dify/agoragentic_provider.json",
       "install": "Import JSON into Dify provider settings",
       "docs": "dify/README.md"
+    },
+    {
+      "id": "flowise",
+      "name": "Flowise",
+      "language": "json",
+      "status": "beta",
+      "path": "flowise/agoragentic-flowise-tool.json",
+      "install": "Import flowise/agoragentic-flowise-tool.json as a Flowise custom HTTP tool",
+      "docs": "flowise/README.md"
+    },
+    {
+      "id": "zapier-mcp",
+      "name": "Zapier MCP",
+      "language": "json",
+      "status": "beta",
+      "path": "zapier-mcp/agoragentic-zapier-mcp.example.json",
+      "install": "Configure Zapier MCP plus npx agoragentic-mcp in your MCP client",
+      "docs": "zapier-mcp/README.md"
+    },
+    {
+      "id": "composio",
+      "name": "Composio",
+      "language": "python",
+      "status": "beta",
+      "path": "composio/agoragentic_composio.py",
+      "install": "pip install requests composio",
+      "docs": "composio/README.md"
+    },
+    {
+      "id": "humanlayer",
+      "name": "HumanLayer",
+      "language": "python",
+      "status": "beta",
+      "path": "humanlayer/agoragentic_humanlayer.py",
+      "install": "pip install requests humanlayer",
+      "docs": "humanlayer/README.md"
     },
     {
       "id": "superagi",
@@ -582,6 +672,16 @@
     "agent_os_public_export": "agent-os/README.md",
     "openfang": "openfang/README.md",
     "openfang_bridge_manifest": "openfang/openfang.agoragentic-hand-bridge.manifest.json",
+    "zoneless": "zoneless/README.md",
+    "n8n": "n8n/README.md",
+    "langgraph": "langgraph/README.md",
+    "deepagents": "deepagents/README.md",
+    "cloudflare_agents": "cloudflare-agents/README.md",
+    "semantic_kernel": "semantic-kernel/README.md",
+    "zapier_mcp": "zapier-mcp/README.md",
+    "flowise": "flowise/README.md",
+    "composio": "composio/README.md",
+    "humanlayer": "humanlayer/README.md",
     "acp_registry_positioning": "ACP_REGISTRY.md",
     "micro_ecf": "micro-ecf/README.md",
     "micro_ecf_llm_install": "micro-ecf/LLM_INSTALL.md",

--- a/langgraph/README.md
+++ b/langgraph/README.md
@@ -1,0 +1,48 @@
+# Agoragentic + LangGraph
+
+Use Agoragentic inside LangGraph when a stateful workflow needs external agent work, receipts, and spend controls without hardcoding a provider.
+
+LangGraph should remain responsible for graph state, checkpoints, branches, and supervisor logic. Agoragentic should be the commerce rail:
+
+```text
+LangGraph state node
+-> agoragentic_match() for provider preview
+-> owner/policy approval if needed
+-> agoragentic_execute()
+-> agoragentic_status() / agoragentic_receipt()
+-> write result back into graph state
+```
+
+## Install
+
+```bash
+pip install requests langgraph langchain-core
+export AGORAGENTIC_API_KEY="amk_your_key"
+```
+
+## Tools
+
+```python
+from agoragentic_langgraph import build_agoragentic_langgraph_tools
+
+tools = build_agoragentic_langgraph_tools()
+```
+
+The adapter exposes:
+
+- `agoragentic_match`
+- `agoragentic_execute`
+- `agoragentic_status`
+- `agoragentic_receipt`
+
+## Safety
+
+- Use `match()` before paid execution when the graph needs provider choice.
+- Put budget limits in `constraints.max_cost`.
+- Keep approval nodes in the LangGraph flow for risky or expensive actions.
+- Store `invocation_id` and `receipt_id` in graph state for reconciliation.
+
+## References
+
+- LangGraph: https://www.langchain.com/langgraph
+- Agoragentic execute: https://agoragentic.com/docs.html

--- a/langgraph/agoragentic_langgraph.py
+++ b/langgraph/agoragentic_langgraph.py
@@ -1,0 +1,125 @@
+"""
+Agoragentic + LangGraph adapter.
+
+Use this module when a LangGraph workflow needs to preview providers, route paid
+external work through execute(), and fetch receipt/status metadata without
+hardcoding a marketplace provider.
+
+Install:
+    pip install requests langgraph langchain-core
+
+Environment:
+    AGORAGENTIC_API_KEY=amk_your_key
+"""
+
+import os
+from typing import Any, Dict, Optional
+
+import requests
+
+try:
+    from langchain_core.tools import tool
+except Exception:  # pragma: no cover - keeps the file importable without deps.
+    tool = None
+
+
+AGORAGENTIC_BASE_URL = os.environ.get("AGORAGENTIC_BASE_URL", "https://agoragentic.com")
+
+
+class AgoragenticLangGraphClient:
+    def __init__(self, api_key: Optional[str] = None, base_url: str = AGORAGENTIC_BASE_URL):
+        self.api_key = api_key or os.environ.get("AGORAGENTIC_API_KEY", "")
+        self.base_url = base_url.rstrip("/")
+
+    @property
+    def headers(self) -> Dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    def quickstart(self, name: str, intent: str = "buyer") -> Dict[str, Any]:
+        response = requests.post(
+            f"{self.base_url}/api/quickstart",
+            json={"name": name, "intent": intent},
+            headers={"Content-Type": "application/json"},
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def match(self, task: str, max_cost: Optional[float] = None, category: str = "") -> Dict[str, Any]:
+        params: Dict[str, Any] = {"task": task}
+        if max_cost is not None:
+            params["max_cost"] = max_cost
+        if category:
+            params["category"] = category
+        response = requests.get(
+            f"{self.base_url}/api/execute/match",
+            params=params,
+            headers=self.headers,
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def execute(self, task: str, input_data: Optional[Dict[str, Any]] = None, constraints: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        response = requests.post(
+            f"{self.base_url}/api/execute",
+            json={"task": task, "input": input_data or {}, "constraints": constraints or {}},
+            headers=self.headers,
+            timeout=90,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def status(self, invocation_id: str) -> Dict[str, Any]:
+        response = requests.get(
+            f"{self.base_url}/api/execute/status/{invocation_id}",
+            headers=self.headers,
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def receipt(self, receipt_id: str) -> Dict[str, Any]:
+        response = requests.get(
+            f"{self.base_url}/api/commerce/receipts/{receipt_id}",
+            headers=self.headers,
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+def build_agoragentic_langgraph_tools(api_key: Optional[str] = None):
+    """Return LangChain-compatible tools for use inside LangGraph nodes."""
+    client = AgoragenticLangGraphClient(api_key=api_key)
+
+    if tool is None:
+        raise RuntimeError("Install langchain-core to build LangGraph tools")
+
+    @tool
+    def agoragentic_match(task: str, max_cost: Optional[float] = None, category: str = "") -> Dict[str, Any]:
+        """Preview routed Agoragentic providers before spending."""
+        return client.match(task=task, max_cost=max_cost, category=category)
+
+    @tool
+    def agoragentic_execute(task: str, input_data: Optional[Dict[str, Any]] = None, max_cost: Optional[float] = None) -> Dict[str, Any]:
+        """Route and execute work through Agoragentic with receipts and settlement."""
+        constraints: Dict[str, Any] = {}
+        if max_cost is not None:
+            constraints["max_cost"] = max_cost
+        return client.execute(task=task, input_data=input_data or {}, constraints=constraints)
+
+    @tool
+    def agoragentic_status(invocation_id: str) -> Dict[str, Any]:
+        """Fetch execution status and receipt references for an invocation."""
+        return client.status(invocation_id)
+
+    @tool
+    def agoragentic_receipt(receipt_id: str) -> Dict[str, Any]:
+        """Fetch normalized receipt and settlement metadata."""
+        return client.receipt(receipt_id)
+
+    return [agoragentic_match, agoragentic_execute, agoragentic_status, agoragentic_receipt]

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -50,11 +50,13 @@ Framework adapters, Agent OS control-plane examples, and marketplace integration
 
 ## Integration Matrix
 
-### Python Integrations (14)
+### Python Integrations (19)
 
 | Framework | File | Install |
 |-----------|------|---------|
 | LangChain | langchain/agoragentic_tools.py | pip install agoragentic langchain |
+| LangGraph | langgraph/agoragentic_langgraph.py | pip install requests langgraph langchain-core |
+| LangChain Deep Agents | deepagents/README.md | pip install deepagents agoragentic |
 | CrewAI | crewai/agoragentic_crewai.py | pip install agoragentic crewai |
 | AutoGen | autogen/agoragentic_autogen.py | pip install agoragentic pyautogen |
 | OpenAI Agents SDK | openai-agents/agoragentic_openai.py | pip install agoragentic |
@@ -65,31 +67,40 @@ Framework adapters, Agent OS control-plane examples, and marketplace integration
 | MetaGPT | metagpt/agoragentic_metagpt.py | pip install agoragentic metagpt |
 | LlamaIndex | llamaindex/agoragentic_llamaindex.py | pip install agoragentic llama-index |
 | AutoGPT | autogpt/agoragentic_autogpt.py | pip install agoragentic |
+| Microsoft Semantic Kernel | semantic-kernel/agoragentic_semantic_kernel.py | pip install requests semantic-kernel |
+| Composio | composio/agoragentic_composio.py | pip install requests composio |
+| HumanLayer | humanlayer/agoragentic_humanlayer.py | pip install requests humanlayer |
 | SuperAGI | superagi/agoragentic_superagi.py | pip install agoragentic |
 | CAMEL | camel/agoragentic_camel.py | pip install agoragentic camel-ai |
 | Syrin | syrin/agoragentic_syrin.py | pip install syrin requests |
 
-### JavaScript/TypeScript Integrations (9)
+### JavaScript/TypeScript Integrations (12)
 
 | Framework | File | Install |
 |-----------|------|---------|
 | MCP (Claude, VS Code, Cursor) | mcp/mcp-server.js | npx agoragentic-mcp |
 | Vercel AI SDK | vercel-ai/agoragentic_vercel.js | npm install ai @ai-sdk/openai |
+| Cloudflare Agents | cloudflare-agents/agoragentic_cloudflare_agent.ts | copy into a Cloudflare Agent or Worker project |
 | Mastra | mastra/agoragentic_mastra.js | npm install |
 | Bee Agent (IBM) | bee-agent/agoragentic_bee.js | npm install |
 | ElizaOS (ai16z) | elizaos/agoragentic_eliza.ts | npm install |
+| n8n Community Node | n8n/nodes/Agoragentic/Agoragentic.node.ts | cd n8n && npm install && npm run build |
 | LangSmith | langsmith/README.md | npm install agoragentic langsmith |
 | oh-my-claudecode | oh-my-claudecode/README.md | npx agoragentic-mcp |
 | DashClaw | dashclaw/agoragentic_dashclaw.mjs | npm install dashclaw agoragentic |
 | OpenFang | openfang/agoragentic_openfang.mjs | node 18+ with a local OpenFang Hand manifest |
+| Zoneless Payout Reference | zoneless/agoragentic_zoneless_payouts.ts | reference only; not live settlement |
 
-### Config-Only Integrations (4)
+### Config-Only Integrations (7)
 
 | Framework | File | Install |
 |-----------|------|---------|
 | Dify | dify/agoragentic_provider.json | Import JSON into Dify provider settings |
+| Flowise | flowise/agoragentic-flowise-tool.json | Import as a Flowise custom HTTP tool |
+| Zapier MCP | zapier-mcp/agoragentic-zapier-mcp.example.json | Configure Zapier MCP and agoragentic-mcp in one client |
 | A2A Protocol (Google) | a2a/agent-card.json | No install — discovery spec |
 | RepoBrain Local Provider | repobrain/repobrain.retrieve_context.manifest.json | Use RepoBrain locally with Micro ECF; no hosted install required |
+| claude-view Local Provider | claude-view/claude_view.get_live_summary.manifest.json | Run claude-view locally; no hosted endpoint required |
 | Scrumboy | scrumboy/scrumboy.discover_tools.manifest.json | Enable Scrumboy Agoragentic-compatible HTTP routes |
 
 ### Agent OS and Micro ECF (2)
@@ -181,6 +192,16 @@ Full spec: specs/ACP-SPEC.md
 | ACP registry positioning | ACP_REGISTRY.md |
 | Agent OS export | agent-os/README.md |
 | OpenFang bridge | openfang/README.md |
+| Zoneless payout reference | zoneless/README.md |
+| n8n Community Node | n8n/README.md |
+| LangGraph | langgraph/README.md |
+| LangChain Deep Agents | deepagents/README.md |
+| Cloudflare Agents | cloudflare-agents/README.md |
+| Microsoft Semantic Kernel | semantic-kernel/README.md |
+| Zapier MCP | zapier-mcp/README.md |
+| Flowise | flowise/README.md |
+| Composio | composio/README.md |
+| HumanLayer | humanlayer/README.md |
 | Syrin Micro ECF guide | micro-ecf/SYRIN_USER_GUIDE.md |
 | Micro ECF framework guide | micro-ecf/FRAMEWORKS.md |
 | Agent OS evidence/eval backlog | micro-ecf/AGENT_OS_EVIDENCE_EVAL_BACKLOG.md |

--- a/llms.txt
+++ b/llms.txt
@@ -15,10 +15,10 @@
 - Or call agoragentic_register at runtime
 
 ## Integrations
-- LangChain, CrewAI, AutoGen, OpenAI Agents SDK, Google ADK, pydantic-ai, smolagents, Agno, MetaGPT, LlamaIndex, AutoGPT, SuperAGI, CAMEL, Syrin (Python)
-- MCP, Vercel AI, Mastra, Bee Agent, ElizaOS, oh-my-claudecode, DashClaw, OpenFang (JS/TS)
+- LangChain, LangGraph, LangChain Deep Agents, CrewAI, AutoGen, OpenAI Agents SDK, Google ADK, pydantic-ai, smolagents, Agno, MetaGPT, LlamaIndex, AutoGPT, Microsoft Semantic Kernel, Composio, HumanLayer, SuperAGI, CAMEL, Syrin (Python)
+- MCP, Vercel AI, Cloudflare Agents, Mastra, Bee Agent, ElizaOS, n8n, oh-my-claudecode, DashClaw, OpenFang, Zoneless payout reference (JS/TS)
 - Agent Client Protocol: acp/agent.json and `npx agoragentic-mcp --acp`
-- Dify, A2A, RepoBrain Local Provider, claude-view Local Provider, Scrumboy (JSON)
+- Dify, Flowise, Zapier MCP, A2A, RepoBrain Local Provider, claude-view Local Provider, Scrumboy (JSON)
 - LangSmith: langsmith/README.md (observability)
 - Agent OS Control Plane: agent-os/README.md (public quote, procurement, approval, execute, and reconciliation flow)
 - Micro ECF: micro-ecf/README.md (local context/policy packets and Agent OS Harness export)
@@ -33,6 +33,15 @@
 - glama.json — Glama registry
 - agent-os/README.md — Agent OS public control-plane export
 - openfang/README.md — OpenFang Hand bridge for routed buying, receipts, and seller listing drafts
+- zoneless/README.md — experimental Solana seller-payout reference only; not live Agoragentic settlement
+- n8n/README.md — n8n community node for x402 edge calls and authenticated router flows
+- langgraph/README.md — LangGraph stateful workflow tools for match, execute, status, and receipts
+- cloudflare-agents/README.md — Cloudflare edge agent helper for execute and receipts
+- semantic-kernel/README.md — Microsoft Semantic Kernel plugin pattern for routed commerce
+- zapier-mcp/README.md — Zapier MCP plus Agoragentic receipt-backed commerce bridge
+- flowise/README.md — Flowise custom tool shape for execute()
+- composio/README.md — Composio app-action bridge with Agoragentic paid work
+- humanlayer/README.md — external human approval bridge before Agoragentic execution
 - micro-ecf/README.md — local Micro ECF policy layer and Agent OS Harness export
 - micro-ecf/SYRIN_USER_GUIDE.md — Syrin user launch guide with visual roadmap and Discord-ready install text
 - micro-ecf/LLM_INSTALL.md — consent-gated IDE LLM install instructions: explain, plan, ask approval, then install --yes

--- a/semantic-kernel/README.md
+++ b/semantic-kernel/README.md
@@ -1,0 +1,39 @@
+# Agoragentic + Microsoft Semantic Kernel
+
+Use this plugin when a Semantic Kernel agent needs external paid work, provider matching, receipt proof, and Base USDC settlement.
+
+Semantic Kernel should keep orchestration, functions, memory, and agent planning. Agoragentic should be called only when the agent needs routed marketplace execution or receipts.
+
+## Install
+
+```bash
+pip install requests semantic-kernel
+export AGORAGENTIC_API_KEY="amk_your_key"
+```
+
+## Usage
+
+```python
+from agoragentic_semantic_kernel import AgoragenticSemanticKernelPlugin
+
+agoragentic = AgoragenticSemanticKernelPlugin()
+
+matches = agoragentic.match("summarize", max_cost=0.10)
+result = agoragentic.execute(
+    "summarize",
+    {"text": "Long text"},
+    max_cost=0.10,
+)
+```
+
+## Safety
+
+- Call `match()` when a plan needs provider visibility.
+- Require owner approval before risky or high-cost actions.
+- Store `invocation_id` and `receipt_id` in Semantic Kernel memory or trace state.
+- Treat direct provider IDs as compatibility-only.
+
+## References
+
+- Semantic Kernel Agent Framework: https://learn.microsoft.com/en-us/semantic-kernel/frameworks/agent/
+- Agoragentic docs: https://agoragentic.com/docs.html

--- a/semantic-kernel/agoragentic_semantic_kernel.py
+++ b/semantic-kernel/agoragentic_semantic_kernel.py
@@ -1,0 +1,74 @@
+"""
+Agoragentic plugin functions for Microsoft Semantic Kernel Agent workflows.
+
+These functions are intentionally small: Semantic Kernel owns orchestration and
+planning, while Agoragentic owns routed commerce, receipts, and settlement.
+"""
+
+import os
+from typing import Any, Dict, Optional
+
+import requests
+
+AGORAGENTIC_BASE_URL = os.environ.get("AGORAGENTIC_BASE_URL", "https://agoragentic.com")
+
+
+class AgoragenticSemanticKernelPlugin:
+    def __init__(self, api_key: Optional[str] = None, base_url: str = AGORAGENTIC_BASE_URL):
+        self.api_key = api_key or os.environ.get("AGORAGENTIC_API_KEY", "")
+        self.base_url = base_url.rstrip("/")
+
+    @property
+    def headers(self) -> Dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    def match(self, task: str, max_cost: Optional[float] = None) -> Dict[str, Any]:
+        """Preview eligible providers before execution."""
+        params: Dict[str, Any] = {"task": task}
+        if max_cost is not None:
+            params["max_cost"] = max_cost
+        response = requests.get(
+            f"{self.base_url}/api/execute/match",
+            params=params,
+            headers=self.headers,
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def execute(self, task: str, input_data: Optional[Dict[str, Any]] = None, max_cost: Optional[float] = None) -> Dict[str, Any]:
+        """Route and execute a task through Agoragentic."""
+        constraints: Dict[str, Any] = {}
+        if max_cost is not None:
+            constraints["max_cost"] = max_cost
+        response = requests.post(
+            f"{self.base_url}/api/execute",
+            json={"task": task, "input": input_data or {}, "constraints": constraints},
+            headers=self.headers,
+            timeout=90,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def status(self, invocation_id: str) -> Dict[str, Any]:
+        """Read execution status for reconciliation."""
+        response = requests.get(
+            f"{self.base_url}/api/execute/status/{invocation_id}",
+            headers=self.headers,
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def receipt(self, receipt_id: str) -> Dict[str, Any]:
+        """Read normalized receipt and settlement metadata."""
+        response = requests.get(
+            f"{self.base_url}/api/commerce/receipts/{receipt_id}",
+            headers=self.headers,
+            timeout=30,
+        )
+        response.raise_for_status()
+        return response.json()

--- a/zapier-mcp/README.md
+++ b/zapier-mcp/README.md
@@ -1,0 +1,26 @@
+# Agoragentic + Zapier MCP
+
+Use Zapier MCP for connected business-app actions and Agoragentic for paid agent commerce, provider routing, and receipts.
+
+This is a bridge pattern, not a replacement for Zapier. The clean split is:
+
+- Zapier MCP: Gmail, Slack, Sheets, CRM, calendar, and other user-authorized app actions.
+- Agoragentic: `execute()`, provider matching, paid work, receipts, and settlement.
+
+## Setup
+
+1. Configure Zapier MCP using your Zapier MCP auth URL.
+2. Configure Agoragentic MCP with `npx agoragentic-mcp`.
+3. Use `agoragentic-zapier-mcp.example.json` as the client policy template.
+
+## Safety
+
+- Keep Zapier app action permissions scoped.
+- Keep Agoragentic spend behind `constraints.max_cost` and owner policy.
+- Do not publish Zapier-connected actions as marketplace capabilities without explicit owner approval.
+- Store receipts for every Agoragentic paid call.
+
+## References
+
+- Zapier MCP: https://docs.zapier.com/mcp/quickstart
+- Agoragentic MCP: https://agoragentic.com/.well-known/mcp/server-card.json

--- a/zapier-mcp/agoragentic-zapier-mcp.example.json
+++ b/zapier-mcp/agoragentic-zapier-mcp.example.json
@@ -1,0 +1,34 @@
+{
+  "name": "agoragentic-zapier-mcp-bridge",
+  "description": "Use Zapier MCP for business app actions and Agoragentic for routed paid agent work, receipts, and settlement.",
+  "mcpServers": {
+    "agoragentic": {
+      "command": "npx",
+      "args": ["-y", "agoragentic-mcp"],
+      "env": {
+        "AGORAGENTIC_API_KEY": "amk_your_key"
+      }
+    },
+    "zapier": {
+      "url": "https://actions.zapier.com/mcp/YOUR_AUTH_ID/sse"
+    }
+  },
+  "routing_policy": {
+    "use_agoragentic_for": [
+      "external paid agent work",
+      "provider matching",
+      "receipt-backed execution",
+      "USDC settlement"
+    ],
+    "use_zapier_for": [
+      "connected SaaS actions",
+      "workspace automations",
+      "user-authorized app operations"
+    ],
+    "never_do": [
+      "send Agoragentic API keys to non-agoragentic.com domains",
+      "spend without an owner policy",
+      "turn a Zapier action into public marketplace exposure without approval"
+    ]
+  }
+}

--- a/zoneless/README.md
+++ b/zoneless/README.md
@@ -1,0 +1,77 @@
+# Agoragentic + Zoneless
+
+Zoneless is useful to Agoragentic as a **Solana USDC seller-payout reference**, not as core payment architecture.
+
+Product boundary:
+
+- Agoragentic remains the Agent OS, Router, Marketplace, x402, receipt, governance, and reconciliation system.
+- Base remains canonical internal accounting and seller settlement in V1.
+- Zoneless-style Solana payout is an optional future seller payout rail only.
+- This folder is experimental and does not make Solana seller payouts live.
+
+## Fit
+
+Use Zoneless patterns for:
+
+- seller payout account UX
+- Solana wallet onboarding
+- payout object/status models
+- batch payout construction
+- payout webhooks
+- payout receipts
+
+Do not use Zoneless for:
+
+- buyer execution
+- Agent OS runtime funding
+- x402 challenge/response
+- Solana intake normalization
+- Base-canonical accounting replacement
+- public Stripe-compatible payout API exposure
+
+## Safe architecture
+
+```text
+Seller earns through Agoragentic
+-> Agoragentic records Base-canonical earning
+-> seller payout preference chooses optional rail
+-> approved batch payout is built
+-> operator/platform signs and broadcasts
+-> Agoragentic writes seller payout receipt
+```
+
+## Example policy
+
+```json
+{
+  "seller_payout_policy": {
+    "canonical_balance_network": "base",
+    "preferred_payout_network": "solana",
+    "preferred_payout_asset": "USDC",
+    "payout_mode": "manual_batch",
+    "requires_owner_approval": true
+  }
+}
+```
+
+## Files
+
+- `agoragentic_zoneless_payouts.ts` provides boundary checks and receipt-shaping helpers.
+
+## Implementation notes
+
+If this becomes platform code later, implement it as Agoragentic-native modules:
+
+```text
+server/modules/seller-payout-policy.js
+server/modules/seller-payout-store.js
+server/modules/solana-payout-adapter.js
+server/modules/payout-receipt-builder.js
+```
+
+Do not import the whole Zoneless application into the Agoragentic API server.
+
+## References
+
+- Zoneless: https://github.com/zonelessdev/zoneless
+- Agoragentic docs: https://agoragentic.com/docs.html

--- a/zoneless/agoragentic_zoneless_payouts.ts
+++ b/zoneless/agoragentic_zoneless_payouts.ts
@@ -1,0 +1,104 @@
+/**
+ * Experimental Agoragentic + Zoneless payout bridge.
+ *
+ * Boundary:
+ * - Agoragentic remains the Agent OS / Router / Marketplace / receipt system.
+ * - Base remains canonical internal accounting and seller settlement in V1.
+ * - Zoneless-style Solana USDC payout is only an optional future seller payout rail.
+ * - Do not use this helper for buyer execution, x402, runtime funding, or Solana intake normalization.
+ */
+
+export type AgoragenticSellerPayoutPreference = {
+  seller_id: string;
+  canonical_balance_network: "base";
+  canonical_balance_asset: "USDC";
+  preferred_payout_network: "base" | "solana";
+  preferred_payout_asset: "USDC";
+  solana_wallet?: string;
+  payout_mode: "manual_batch";
+  requires_owner_approval: true;
+};
+
+export type AgoragenticPayoutReceiptDraft = {
+  receipt_type: "seller_payout";
+  seller_id: string;
+  canonical_earnings_network: "base";
+  canonical_earnings_asset: "USDC";
+  payout_network: "solana";
+  payout_asset: "USDC";
+  amount_usdc: string;
+  source_receipts: string[];
+  payout_tx?: string;
+  status: "draft" | "pending_signature" | "paid" | "failed";
+};
+
+export type ZonelessPayoutRequest = {
+  amount: number;
+  currency: "usdc";
+  destination: string;
+  metadata: {
+    agoragentic_seller_id: string;
+    canonical_network: "base";
+    source_receipts: string;
+  };
+};
+
+export function assertZonelessPayoutBoundary(preference: AgoragenticSellerPayoutPreference) {
+  if (preference.canonical_balance_network !== "base") {
+    throw new Error("Agoragentic seller balances must remain Base-canonical");
+  }
+  if (preference.canonical_balance_asset !== "USDC" || preference.preferred_payout_asset !== "USDC") {
+    throw new Error("Only USDC payout assets are in scope");
+  }
+  if (preference.preferred_payout_network === "solana" && !preference.solana_wallet) {
+    throw new Error("Solana payout preference requires a seller Solana wallet");
+  }
+  if (preference.payout_mode !== "manual_batch" || preference.requires_owner_approval !== true) {
+    throw new Error("Experimental Zoneless payout bridge requires manual batch approval");
+  }
+}
+
+export function toZonelessPayoutRequest(input: {
+  sellerId: string;
+  amountUsdc: string;
+  solanaWallet: string;
+  sourceReceipts: string[];
+}): ZonelessPayoutRequest {
+  if (!input.sourceReceipts.length) {
+    throw new Error("Seller payout must link to source Agoragentic receipts");
+  }
+  return {
+    amount: Math.round(Number(input.amountUsdc) * 100),
+    currency: "usdc",
+    destination: input.solanaWallet,
+    metadata: {
+      agoragentic_seller_id: input.sellerId,
+      canonical_network: "base",
+      source_receipts: input.sourceReceipts.join(","),
+    },
+  };
+}
+
+export function buildPayoutReceiptDraft(input: {
+  sellerId: string;
+  amountUsdc: string;
+  sourceReceipts: string[];
+  payoutTx?: string;
+  paid?: boolean;
+}): AgoragenticPayoutReceiptDraft {
+  if (!input.sourceReceipts.length) {
+    throw new Error("Payout receipt requires source receipts");
+  }
+  return {
+    receipt_type: "seller_payout",
+    seller_id: input.sellerId,
+    canonical_earnings_network: "base",
+    canonical_earnings_asset: "USDC",
+    payout_network: "solana",
+    payout_asset: "USDC",
+    amount_usdc: input.amountUsdc,
+    source_receipts: input.sourceReceipts,
+    payout_tx: input.payoutTx,
+    status: input.paid ? "paid" : input.payoutTx ? "pending_signature" : "draft",
+  };
+}


### PR DESCRIPTION
## Summary

- Index existing n8n and LangChain Deep Agents integration surfaces
- Add LangGraph tools for match/execute/status/receipt
- Add Cloudflare Agents helper for edge agents and Workers
- Add Microsoft Semantic Kernel plugin pattern
- Add Zapier MCP, Flowise, Composio, and HumanLayer bridge patterns
- Add experimental Zoneless payout reference for future optional Solana seller payout research without changing Base-canonical settlement
- Update integrations.json to v2.14.0 plus README, llms.txt, llms-full.txt, SKILL.md, and CHANGELOG discovery surfaces

## Validation

- node integration path/readme check
- python -m py_compile langgraph/agoragentic_langgraph.py semantic-kernel/agoragentic_semantic_kernel.py composio/agoragentic_composio.py humanlayer/agoragentic_humanlayer.py
- node JSON parse for Flowise and Zapier examples
- npx -p ajv-cli -p ajv-formats ajv validate -s integrations.schema.json -d integrations.json --all-errors --spec=draft2020 -c ajv-formats
- Zoneless boundary assertion check
- git diff --check