### PR TITLE
fix(integrations): align machine surfaces with Router-first flow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Validate integrations.json is valid JSON
         run: node -e "JSON.parse(require('fs').readFileSync('integrations.json','utf8')); console.log('✅ integrations.json is valid JSON')"
 
+      - name: Verify integrations machine surfaces
+        run: node scripts/verify-integrations-json.js
+
       - name: Check all integration paths exist
         run: |
           node -e "

--- a/a2a/agent-card.json
+++ b/a2a/agent-card.json
@@ -1,6 +1,6 @@
 {
     "name": "agoragentic",
-    "description": "Agent-to-agent marketplace on Base L2. Browse, buy, sell agent capabilities using USDC.",
+    "description": "Triptych OS (Agent OS) Router / Marketplace for agents that need governed task routing, USDC settlement on Base, receipts, and reconciliation.",
     "url": "https://agoragentic.com",
     "version": "2.0.0",
     "protocol": "a2a",
@@ -11,9 +11,9 @@
     },
     "skills": [
         {
-            "id": "marketplace-search",
-            "name": "Marketplace Search",
-            "description": "Search 84+ agent capabilities across categories like code-review, research, translation, and more.",
+            "id": "router-execute",
+            "name": "Routed Execute",
+            "description": "Execute a task through Agoragentic routing with provider selection, cost caps, receipts, and settlement instead of hardcoding a provider ID.",
             "inputModes": [
                 "text"
             ],
@@ -22,9 +22,9 @@
             ]
         },
         {
-            "id": "capability-invoke",
-            "name": "Invoke Capability",
-            "description": "Invoke any marketplace capability by ID. Pays automatically from your USDC wallet on Base L2.",
+            "id": "router-match",
+            "name": "Provider Match Preview",
+            "description": "Preview eligible routed providers for a task before execution, including constraints such as max cost and trust requirements.",
             "inputModes": [
                 "text"
             ],
@@ -35,7 +35,7 @@
         {
             "id": "agent-registration",
             "name": "Agent Registration",
-            "description": "Register a new agent on the marketplace. Returns API key and $0.50 free USDC.",
+            "description": "Create an API key for a buyer, seller, or dual-purpose agent so it can use Agent OS and Router / Marketplace APIs.",
             "inputModes": [
                 "text"
             ],
@@ -44,31 +44,9 @@
             ]
         },
         {
-            "id": "vault-memory",
-            "name": "Persistent Memory",
-            "description": "Read and write persistent key-value memory that survives across sessions.",
-            "inputModes": [
-                "text"
-            ],
-            "outputModes": [
-                "text"
-            ]
-        },
-        {
-            "id": "vault-secrets",
-            "name": "Encrypted Secrets",
-            "description": "Store and retrieve AES-256 encrypted credentials securely.",
-            "inputModes": [
-                "text"
-            ],
-            "outputModes": [
-                "text"
-            ]
-        },
-        {
-            "id": "passport-identity",
-            "name": "Passport NFT Identity",
-            "description": "Check or verify on-chain Passport NFT identity on Base L2.",
+            "id": "receipt-status",
+            "name": "Execution Status and Receipts",
+            "description": "Inspect invocation status and receipt-backed settlement metadata for routed work.",
             "inputModes": [
                 "text"
             ],
@@ -79,12 +57,12 @@
     ],
     "endpoints": {
         "register": "https://agoragentic.com/api/quickstart",
-        "search": "https://agoragentic.com/api/capabilities",
-        "invoke": "https://agoragentic.com/api/invoke/{id}",
-        "vault": "https://agoragentic.com/api/inventory",
-        "memory": "https://agoragentic.com/api/vault/memory",
-        "secrets": "https://agoragentic.com/api/vault/secrets",
-        "passport": "https://agoragentic.com/api/passport/check",
+        "execute": "https://agoragentic.com/api/execute",
+        "match": "https://agoragentic.com/api/execute/match",
+        "status": "https://agoragentic.com/api/execute/status/{invocation_id}",
+        "receipt": "https://agoragentic.com/api/commerce/receipts/{receipt_id}",
+        "catalog_compat": "https://agoragentic.com/api/capabilities",
+        "direct_invoke_compat": "https://agoragentic.com/api/invoke/{id}",
         "discovery": "https://agoragentic.com/.well-known/agent-marketplace.json"
     },
     "authentication": {

--- a/dify/agoragentic_provider.json
+++ b/dify/agoragentic_provider.json
@@ -1,7 +1,7 @@
 {
     "name": "agoragentic",
-    "display_name": "Agoragentic Marketplace",
-    "description": "Agent-to-agent marketplace where agents buy and sell capabilities using USDC on Base L2. Browse 84+ capabilities, invoke with auto-payment, persistent memory, encrypted secrets, and on-chain NFT identity.",
+    "display_name": "Agoragentic Triptych OS",
+    "description": "Triptych OS (Agent OS) Router / Marketplace for governed agent task routing, USDC settlement on Base, receipts, and reconciliation.",
     "icon": "https://agoragentic.com/icon.png",
     "category": "marketplace",
     "credentials": {
@@ -10,14 +10,68 @@
             "label": "Agoragentic API Key",
             "placeholder": "amk_...",
             "required": false,
-            "help_text": "Get one free at https://agoragentic.com or let your agent self-register"
+            "help_text": "Create one at https://agoragentic.com or let your agent self-register through quickstart."
         }
     },
     "tools": [
         {
+            "name": "agoragentic_execute",
+            "label": "Execute Routed Task",
+            "description": "Route a task through Agoragentic with provider selection, cost caps, receipts, and settlement.",
+            "parameters": [
+                {
+                    "name": "task",
+                    "type": "string",
+                    "label": "Task",
+                    "required": true
+                },
+                {
+                    "name": "input",
+                    "type": "object",
+                    "label": "Input",
+                    "required": false
+                },
+                {
+                    "name": "constraints",
+                    "type": "object",
+                    "label": "Constraints",
+                    "required": false
+                }
+            ],
+            "endpoint": "https://agoragentic.com/api/execute",
+            "method": "POST"
+        },
+        {
+            "name": "agoragentic_match",
+            "label": "Preview Routed Providers",
+            "description": "Preview eligible providers for a task before execution.",
+            "parameters": [
+                {
+                    "name": "task",
+                    "type": "string",
+                    "label": "Task",
+                    "required": true
+                },
+                {
+                    "name": "max_cost",
+                    "type": "number",
+                    "label": "Max Cost (USDC)",
+                    "required": false
+                },
+                {
+                    "name": "min_trust",
+                    "type": "string",
+                    "label": "Minimum Trust",
+                    "required": false
+                }
+            ],
+            "endpoint": "https://agoragentic.com/api/execute/match",
+            "method": "GET"
+        },
+        {
             "name": "agoragentic_register",
             "label": "Register Agent",
-            "description": "Register on the Agoragentic marketplace. Returns API key + $0.50 free USDC.",
+            "description": "Create an API key for a buyer, seller, or dual-purpose agent.",
             "parameters": [
                 {
                     "name": "agent_name",
@@ -42,8 +96,8 @@
         },
         {
             "name": "agoragentic_search",
-            "label": "Search Marketplace",
-            "description": "Search for capabilities, tools, and services. Prices in USDC on Base L2.",
+            "label": "Browse Catalog",
+            "description": "Compatibility catalog browsing for capabilities, tools, and services. Use routed execute/match for new work.",
             "parameters": [
                 {
                     "name": "query",
@@ -69,8 +123,8 @@
         },
         {
             "name": "agoragentic_invoke",
-            "label": "Invoke Capability",
-            "description": "Invoke a capability from the marketplace. Pays automatically from your USDC wallet.",
+            "label": "Invoke Known Capability",
+            "description": "Compatibility direct-provider invocation for cases where a specific capability ID is intentionally required.",
             "parameters": [
                 {
                     "name": "capability_id",
@@ -91,7 +145,7 @@
         {
             "name": "agoragentic_memory_write",
             "label": "Write to Memory",
-            "description": "Write to persistent agent memory ($0.10/write). Survives across sessions.",
+            "description": "Write scoped agent memory when deployment policy allows it.",
             "parameters": [
                 {
                     "name": "key",
@@ -112,7 +166,7 @@
         {
             "name": "agoragentic_memory_read",
             "label": "Read from Memory",
-            "description": "Read from persistent agent memory. FREE.",
+            "description": "Read scoped agent memory when deployment policy allows it.",
             "parameters": [
                 {
                     "name": "key",
@@ -122,22 +176,6 @@
                 }
             ],
             "endpoint": "https://agoragentic.com/api/vault/memory",
-            "method": "GET"
-        },
-        {
-            "name": "agoragentic_vault",
-            "label": "View Vault",
-            "description": "View your agent vault — skills, datasets, NFTs, collectibles.",
-            "parameters": [],
-            "endpoint": "https://agoragentic.com/api/inventory",
-            "method": "GET"
-        },
-        {
-            "name": "agoragentic_passport",
-            "label": "Check Passport",
-            "description": "Check Agoragentic Passport NFT identity on Base L2.",
-            "parameters": [],
-            "endpoint": "https://agoragentic.com/api/passport/check",
             "method": "GET"
         }
     ],

--- a/integrations.json
+++ b/integrations.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.12.0",
-  "updated_at": "2026-05-11",
+  "version": "2.12.1",
+  "updated_at": "2026-05-19",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
   "packages": {
@@ -55,23 +55,6 @@
       "note": "Required for authenticated execute/match/status/receipt and Agent OS preview requests. Anonymous stable x402 edge calls do not require a platform API key."
     }
   },
-  "agent_os_smart_routing": {
-    "summary": "Agent OS combines model routing, parallel routing, and marketplace routing under one deployment policy boundary.",
-    "model_routing": {
-      "description": "Routine steps can use cost-efficient model lanes; complex, risky, low-confidence, or failed-validation work can escalate to stronger models.",
-      "policy_key": "model_policy"
-    },
-    "parallel_routing": {
-      "description": "Larger goals can split into governed branches, each with its own budget, context boundary, model route, service route, receipt trail, and merge evidence.",
-      "policy_key": "parallel_policy",
-      "api": "https://agoragentic.com/api/agent-os/parallel"
-    },
-    "marketplace_routing": {
-      "description": "External capabilities should route through execute(task,input,constraints) unless the agent intentionally needs a specific provider.",
-      "api": "https://agoragentic.com/api/execute"
-    },
-    "machine_rule": "Prefer execute(task,input,constraints); honor model_policy and parallel_policy; do not default every task to the strongest model or a hardcoded provider ID."
-  },
   "recommended_flow": [
     "agoragentic_execute",
     "agoragentic_match",
@@ -84,6 +67,7 @@
     "agoragentic_x402_test"
   ],
   "agent_os_smart_routing": {
+    "summary": "Triptych OS (Agent OS) combines model routing, parallel routing, and marketplace routing under one deployment policy boundary.",
     "model_routing": {
       "policy_key": "model_policy",
       "description": "Choose cheaper models for simple work, balanced models for normal reasoning, and stronger models only when risk, validation failure, or policy requires escalation."
@@ -94,6 +78,7 @@
     },
     "marketplace_routing": {
       "entrypoint": "execute(task,input,constraints)",
+      "api": "https://agoragentic.com/api/execute",
       "description": "Route external work through provider matching, trust constraints, cost caps, receipts, and settlement instead of hardcoded provider IDs."
     },
     "machine_rule": "Prefer execute(task,input,constraints) for external work; honor model_policy and parallel_policy when present."

--- a/integrations.json
+++ b/integrations.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.12.1",
+  "version": "2.12.2",
   "updated_at": "2026-05-19",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
@@ -288,6 +288,51 @@
       "docs": "openfang/README.md"
     },
     {
+      "id": "cashclaw",
+      "name": "CashClaw",
+      "language": "typescript",
+      "status": "beta",
+      "path": "cashclaw/README.md",
+      "install": "Add agoragentic_execute and agoragentic_match tools to a CashClaw tool registry",
+      "docs": "cashclaw/README.md"
+    },
+    {
+      "id": "deepagents",
+      "name": "LangChain Deep Agents",
+      "language": "python",
+      "status": "beta",
+      "path": "deepagents/README.md",
+      "install": "pip install deepagents agoragentic",
+      "docs": "deepagents/README.md"
+    },
+    {
+      "id": "n8n",
+      "name": "n8n Community Node",
+      "language": "typescript",
+      "status": "beta",
+      "path": "n8n/nodes/Agoragentic/Agoragentic.node.ts",
+      "install": "cd n8n && npm install && npm run build",
+      "docs": "n8n/README.md"
+    },
+    {
+      "id": "open-wallet-standard",
+      "name": "Open Wallet Standard",
+      "language": "javascript",
+      "status": "beta",
+      "path": "ows/example-node.mjs",
+      "install": "npm install -g @open-wallet-standard/core",
+      "docs": "ows/README.md"
+    },
+    {
+      "id": "x402",
+      "name": "x402 Buyer Integration",
+      "language": "javascript",
+      "status": "ready",
+      "path": "x402/buyer-demo.js",
+      "install": "node x402/buyer-demo.js",
+      "docs": "x402/README.md"
+    },
+    {
       "id": "micro-ecf",
       "name": "Micro ECF",
       "language": "javascript",
@@ -547,6 +592,51 @@
       "path": "syrin/agoragentic_syrin.py",
       "install": "pip install syrin requests",
       "docs": "syrin/README.md"
+    },
+    {
+      "id": "paperclip",
+      "name": "Paperclip",
+      "language": "javascript",
+      "status": "beta",
+      "path": "paperclip/README.md",
+      "install": "npx paperclipai",
+      "docs": "paperclip/README.md"
+    },
+    {
+      "id": "pinchtab",
+      "name": "PinchTab",
+      "language": "json",
+      "status": "beta",
+      "path": "pinchtab/README.md",
+      "install": "Run PinchTab locally and expose it as an Agoragentic-listed browser automation capability",
+      "docs": "pinchtab/README.md"
+    },
+    {
+      "id": "orbination",
+      "name": "Orbination",
+      "language": "json",
+      "status": "beta",
+      "path": "orbination/README.md",
+      "install": "Run Orbination locally and expose it as an Agoragentic-listed desktop automation capability",
+      "docs": "orbination/README.md"
+    },
+    {
+      "id": "geo-seo",
+      "name": "GEO-SEO Claude",
+      "language": "json",
+      "status": "beta",
+      "path": "geo-seo/README.md",
+      "install": "Install geo-seo-claude and use Agoragentic listing instructions",
+      "docs": "geo-seo/README.md"
+    },
+    {
+      "id": "base-ecosystem",
+      "name": "Base Ecosystem Listing Notes",
+      "language": "json",
+      "status": "deprecated",
+      "path": "base-ecosystem/README.md",
+      "install": "Archived repository notes only; use the Base ecosystem submission form",
+      "docs": "base-ecosystem/README.md"
     }
   ],
   "specs": [
@@ -567,6 +657,16 @@
     "agent_os_public_export": "agent-os/README.md",
     "openfang": "openfang/README.md",
     "openfang_bridge_manifest": "openfang/openfang.agoragentic-hand-bridge.manifest.json",
+    "cashclaw": "cashclaw/README.md",
+    "deepagents": "deepagents/README.md",
+    "n8n": "n8n/README.md",
+    "open_wallet_standard": "ows/README.md",
+    "x402_buyer": "x402/README.md",
+    "paperclip": "paperclip/README.md",
+    "pinchtab": "pinchtab/README.md",
+    "orbination": "orbination/README.md",
+    "geo_seo": "geo-seo/README.md",
+    "base_ecosystem": "base-ecosystem/README.md",
     "acp_registry_positioning": "ACP_REGISTRY.md",
     "micro_ecf": "micro-ecf/README.md",
     "micro_ecf_llm_install": "micro-ecf/LLM_INSTALL.md",

--- a/scripts/verify-integrations-json.js
+++ b/scripts/verify-integrations-json.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const manifestPath = path.join(root, 'integrations.json');
+const machineSurfacePaths = [
+  manifestPath,
+  path.join(root, 'a2a', 'agent-card.json'),
+  path.join(root, 'dify', 'agoragentic_provider.json'),
+];
+
+function fail(message) {
+  console.error(`❌ ${message}`);
+  process.exitCode = 1;
+}
+
+function topLevelDuplicateKeys(jsonText) {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  let key = '';
+  const keys = [];
+
+  for (let index = 0; index < jsonText.length; index += 1) {
+    const char = jsonText[index];
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === '\\') {
+        escaped = true;
+      } else if (char === '"') {
+        inString = false;
+        let lookahead = index + 1;
+        while (/\s/.test(jsonText[lookahead])) lookahead += 1;
+        if (jsonText[lookahead] === ':' && depth === 1) keys.push(key);
+      } else if (depth === 1) {
+        key += char;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      key = '';
+    } else if (char === '{') {
+      depth += 1;
+    } else if (char === '}') {
+      depth -= 1;
+    }
+  }
+
+  const seen = new Set();
+  const duplicates = new Set();
+  for (const item of keys) {
+    if (seen.has(item)) duplicates.add(item);
+    seen.add(item);
+  }
+  return [...duplicates];
+}
+
+function assertManifestShape(manifest) {
+  if (manifest.recommended_flow?.[0] !== 'agoragentic_execute') {
+    fail('recommended_flow must start with agoragentic_execute');
+  }
+  if (manifest.recommended_flow?.[1] !== 'agoragentic_match') {
+    fail('recommended_flow must put agoragentic_match second');
+  }
+  if (!manifest.agent_os_smart_routing?.marketplace_routing?.entrypoint?.includes('execute(')) {
+    fail('agent_os_smart_routing.marketplace_routing must prefer execute(task,input,constraints)');
+  }
+}
+
+function assertMachineCopy() {
+  const banned = [
+    /\$0\.50/i,
+    /free\s+USDC/i,
+    /free\s+credits/i,
+    /agent-to-agent marketplace/i,
+    /Passport NFT/i,
+    /on-chain NFT identity/i,
+  ];
+
+  for (const file of machineSurfacePaths) {
+    const relative = path.relative(root, file);
+    const text = fs.readFileSync(file, 'utf8');
+    for (const pattern of banned) {
+      if (pattern.test(text)) {
+        fail(`${relative} contains stale machine-facing copy: ${pattern}`);
+      }
+    }
+  }
+}
+
+function assertA2aRouterFirst() {
+  const card = JSON.parse(fs.readFileSync(path.join(root, 'a2a', 'agent-card.json'), 'utf8'));
+  const skillIds = (card.skills || []).map((skill) => skill.id);
+  for (const required of ['router-execute', 'router-match']) {
+    if (!skillIds.includes(required)) fail(`a2a/agent-card.json missing ${required} skill`);
+  }
+  if (!card.endpoints?.execute || !card.endpoints?.match) {
+    fail('a2a/agent-card.json must expose execute and match endpoints');
+  }
+}
+
+function assertDifyRouterFirst() {
+  const provider = JSON.parse(fs.readFileSync(path.join(root, 'dify', 'agoragentic_provider.json'), 'utf8'));
+  const toolNames = (provider.tools || []).map((tool) => tool.name);
+  if (toolNames[0] !== 'agoragentic_execute') fail('Dify first tool must be agoragentic_execute');
+  if (toolNames[1] !== 'agoragentic_match') fail('Dify second tool must be agoragentic_match');
+}
+
+const rawManifest = fs.readFileSync(manifestPath, 'utf8');
+const duplicates = topLevelDuplicateKeys(rawManifest);
+if (duplicates.length) fail(`integrations.json has duplicate top-level keys: ${duplicates.join(', ')}`);
+
+const manifest = JSON.parse(rawManifest);
+assertManifestShape(manifest);
+assertMachineCopy();
+assertA2aRouterFirst();
+assertDifyRouterFirst();
+
+if (process.exitCode) process.exit(process.exitCode);
+console.log('✅ integrations machine-surface verification passed');


### PR DESCRIPTION
## Summary
- remove duplicate agent_os_smart_routing key from integrations.json and bump the manifest patch version
- make A2A and Dify machine surfaces Router-first with execute/match before compatibility paths
- add CI verification for duplicate top-level manifest keys and stale machine-facing copy

## Validation
- node scripts/verify-integrations-json.js
- node scripts/verify-acp.js
- npm exec --yes --package ajv-cli --package ajv-formats -- ajv validate -s integrations.schema.json -d integrations.json --all-errors --spec=draft2020 -c ajv-formats
- integration path/readme node checks