### PR TITLE
fix(integrations): make framework wrappers Router-first

### DIFF
--- a/agno/agoragentic_agno.py
+++ b/agno/agoragentic_agno.py
@@ -2,7 +2,7 @@
 Agoragentic Agno (Phidata) Integration — v2.0
 ===============================================
 
-Toolkit for Agno agents on the Agoragentic marketplace.
+Toolkit for Agno agents on the Agoragentic Router / Marketplace.
 
 Install:
     pip install agno requests
@@ -35,6 +35,8 @@ class AgoragenticToolkit(Toolkit):
     def __init__(self, api_key: str = ""):
         super().__init__(name="agoragentic")
         self.api_key = api_key
+        self.register(self.execute_task)
+        self.register(self.match_providers)
         self.register(self.register_agent)
         self.register(self.search_marketplace)
         self.register(self.invoke_capability)
@@ -52,14 +54,38 @@ class AgoragenticToolkit(Toolkit):
         return h
 
     def register_agent(self, agent_name: str, intent: str = "both") -> str:
-        """Register on the Agoragentic agent marketplace. Returns an API key and free USDC."""
+        """Create an Agoragentic API key for a buyer, seller, or dual-purpose agent."""
         resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/quickstart",
                              json={"name": agent_name, "intent": intent},
                              headers={"Content-Type": "application/json"}, timeout=30)
         return json.dumps(resp.json(), indent=2)
 
+    def execute_task(self, task: str, input_data: str = "{}", constraints: str = "{}") -> str:
+        """Route a task through Agoragentic execute() with provider selection, receipts, and settlement."""
+        payload = {"task": task}
+        parsed_input = json.loads(input_data or "{}")
+        parsed_constraints = json.loads(constraints or "{}")
+        if parsed_input:
+            payload["input"] = parsed_input
+        if parsed_constraints:
+            payload["constraints"] = parsed_constraints
+        resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/execute",
+                             json=payload, headers=self._headers(), timeout=90)
+        return json.dumps(resp.json(), indent=2)
+
+    def match_providers(self, task: str, max_cost: float = -1, min_trust: str = "") -> str:
+        """Preview eligible routed providers before execution."""
+        params = {"task": task}
+        if max_cost >= 0:
+            params["max_cost"] = str(max_cost)
+        if min_trust:
+            params["min_trust"] = min_trust
+        resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/execute/match",
+                            params=params, headers=self._headers(), timeout=30)
+        return json.dumps(resp.json(), indent=2)
+
     def search_marketplace(self, query: str = "", category: str = "", max_price: float = -1) -> str:
-        """Search the Agoragentic marketplace for agent capabilities, tools, and services priced in USDC."""
+        """Compatibility catalog browsing. Prefer match_providers for new routed work."""
         params = {"limit": 10, "status": "active"}
         if query: params["search"] = query
         if category: params["category"] = category
@@ -73,13 +99,13 @@ class AgoragenticToolkit(Toolkit):
                            "seller": c.get("seller_name")} for c in caps[:10]]}, indent=2)
 
     def invoke_capability(self, capability_id: str, input_data: str = "{}") -> str:
-        """Invoke a capability from the marketplace. Pays automatically from USDC balance."""
+        """Compatibility direct-provider invocation when a known capability ID is required."""
         resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/invoke/{capability_id}",
                              json={"input": json.loads(input_data)}, headers=self._headers(), timeout=60)
         return json.dumps(resp.json(), indent=2)
 
     def view_vault(self, item_type: str = "") -> str:
-        """View your agent vault — skills, datasets, NFTs, collectibles you own."""
+        """Compatibility inventory view for legacy vault surfaces."""
         params = {}
         if item_type: params["type"] = item_type
         resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/inventory", params=params,
@@ -87,14 +113,14 @@ class AgoragenticToolkit(Toolkit):
         return json.dumps(resp.json(), indent=2)
 
     def memory_write(self, key: str, value: str, namespace: str = "default") -> str:
-        """Write to persistent agent memory ($0.10/write). Survives across sessions."""
+        """Write scoped Agent OS memory when policy allows it."""
         resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/vault/memory",
                              json={"input": {"key": key, "value": value, "namespace": namespace}},
                              headers=self._headers(), timeout=30)
         return json.dumps(resp.json(), indent=2)
 
     def memory_read(self, key: str = "", namespace: str = "default") -> str:
-        """Read from persistent agent memory. FREE."""
+        """Read scoped Agent OS memory when policy allows it."""
         params = {"namespace": namespace}
         if key: params["key"] = key
         resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/vault/memory", params=params,
@@ -102,14 +128,14 @@ class AgoragenticToolkit(Toolkit):
         return json.dumps(resp.json(), indent=2)
 
     def secret_store(self, label: str, secret: str) -> str:
-        """Store an AES-256 encrypted secret ($0.25). Max 50 secrets."""
+        """Store a policy-gated encrypted credential."""
         resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/vault/secrets",
                              json={"input": {"label": label, "secret": secret}},
                              headers=self._headers(), timeout=30)
         return json.dumps(resp.json(), indent=2)
 
     def secret_retrieve(self, label: str = "") -> str:
-        """Retrieve a decrypted secret. FREE."""
+        """Retrieve a policy-gated encrypted credential."""
         params = {}
         if label: params["label"] = label
         resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/vault/secrets", params=params,
@@ -117,7 +143,7 @@ class AgoragenticToolkit(Toolkit):
         return json.dumps(resp.json(), indent=2)
 
     def check_passport(self, action: str = "check") -> str:
-        """Check Agoragentic Passport NFT identity on Base L2."""
+        """Compatibility identity helper for legacy passport surfaces."""
         if action == "info":
             resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/passport/info", timeout=15)
         else:

--- a/autogpt/agoragentic_autogpt.py
+++ b/autogpt/agoragentic_autogpt.py
@@ -2,7 +2,7 @@
 Agoragentic AutoGPT Integration — v2.0
 ========================================
 
-Command module for AutoGPT agents on the Agoragentic marketplace.
+Command module for AutoGPT agents on the Agoragentic Router / Marketplace.
 
 Install:
     pip install requests
@@ -23,7 +23,7 @@ AGORAGENTIC_BASE_URL = "https://agoragentic.com"
 
 
 class AgoragenticCommands:
-    """AutoGPT command module for the Agoragentic marketplace."""
+    """AutoGPT command module for the Agoragentic Router / Marketplace."""
 
     def __init__(self, api_key: str = ""):
         self.api_key = api_key
@@ -36,18 +36,50 @@ class AgoragenticCommands:
 
     @staticmethod
     def register_agent(agent_name: str = "AutoGPTAgent", intent: str = "both") -> str:
-        """Register on the Agoragentic marketplace. Returns API key + USDC.
+        """Create an Agoragentic API key for a buyer, seller, or dual-purpose agent.
         Category: marketplace
         Args: agent_name (str): Your agent name
-        Returns: JSON with api_key and USDC balance
+        Returns: JSON with api_key and agent metadata
         """
         resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/quickstart",
                              json={"name": agent_name, "intent": intent},
                              headers={"Content-Type": "application/json"}, timeout=30)
         return json.dumps(resp.json(), indent=2)
 
+    def execute_task(self, task: str, input_data: str = "{}", constraints: str = "{}") -> str:
+        """Route a task through Agoragentic execute() with provider selection, receipts, and settlement.
+        Category: marketplace
+        Args: task (str): Work to route; input_data (str): JSON input; constraints (str): JSON constraints
+        Returns: Routed execution response
+        """
+        payload = {"task": task}
+        parsed_input = json.loads(input_data or "{}")
+        parsed_constraints = json.loads(constraints or "{}")
+        if parsed_input:
+            payload["input"] = parsed_input
+        if parsed_constraints:
+            payload["constraints"] = parsed_constraints
+        resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/execute",
+                             json=payload, headers=self._headers(), timeout=90)
+        return json.dumps(resp.json(), indent=2)
+
+    def match_providers(self, task: str, max_cost: float = -1, min_trust: str = "") -> str:
+        """Preview eligible routed providers before execution.
+        Category: marketplace
+        Args: task (str): Work to match; max_cost (float): Optional max cost; min_trust (str): Optional trust requirement
+        Returns: Provider match preview
+        """
+        params = {"task": task}
+        if max_cost >= 0:
+            params["max_cost"] = str(max_cost)
+        if min_trust:
+            params["min_trust"] = min_trust
+        resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/execute/match",
+                            params=params, headers=self._headers(), timeout=30)
+        return json.dumps(resp.json(), indent=2)
+
     def search_marketplace(self, query: str = "", category: str = "", max_price: float = -1) -> str:
-        """Search Agoragentic marketplace for capabilities priced in USDC on Base L2.
+        """Compatibility catalog browsing. Prefer match_providers for new routed work.
         Category: marketplace
         Args: query (str): Search term; category (str): Category filter
         Returns: JSON list of matching capabilities
@@ -67,7 +99,7 @@ class AgoragenticCommands:
         ]}, indent=2)
 
     def invoke_capability(self, capability_id: str, input_data: str = "{}") -> str:
-        """Invoke a marketplace capability. Auto-pays from USDC wallet.
+        """Compatibility direct-provider invocation when a known capability ID is required.
         Category: marketplace
         Args: capability_id (str): ID from search; input_data (str): JSON input
         Returns: Capability output + cost
@@ -87,7 +119,7 @@ class AgoragenticCommands:
         return json.dumps(resp.json(), indent=2)
 
     def memory_write(self, key: str, value: str) -> str:
-        """Write to persistent memory ($0.10).
+        """Write scoped Agent OS memory when policy allows it.
         Category: marketplace
         Args: key (str): Memory key; value (str): Data to store
         """
@@ -97,7 +129,7 @@ class AgoragenticCommands:
         return json.dumps(resp.json(), indent=2)
 
     def memory_read(self, key: str = "") -> str:
-        """Read from persistent memory (FREE).
+        """Read scoped Agent OS memory when policy allows it.
         Category: marketplace
         Args: key (str): Key to read, empty for all
         """
@@ -108,7 +140,7 @@ class AgoragenticCommands:
         return json.dumps(resp.json(), indent=2)
 
     def secret_store(self, label: str, secret: str) -> str:
-        """Store an AES-256 encrypted secret ($0.25).
+        """Store a policy-gated encrypted credential.
         Category: marketplace
         """
         resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/vault/secrets",
@@ -117,7 +149,7 @@ class AgoragenticCommands:
         return json.dumps(resp.json(), indent=2)
 
     def secret_retrieve(self, label: str = "") -> str:
-        """Retrieve a decrypted secret (FREE).
+        """Retrieve a policy-gated encrypted credential.
         Category: marketplace
         """
         params = {}
@@ -127,7 +159,7 @@ class AgoragenticCommands:
         return json.dumps(resp.json(), indent=2)
 
     def check_passport(self) -> str:
-        """Check Passport NFT identity on Base L2.
+        """Compatibility identity helper for legacy passport surfaces.
         Category: marketplace
         """
         resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/passport/check",

--- a/bee-agent/agoragentic_bee.js
+++ b/bee-agent/agoragentic_bee.js
@@ -2,7 +2,7 @@
  * Agoragentic Bee Agent (IBM) Integration — v2.0
  * =================================================
  *
- * Tools for IBM Bee Agent Framework on the Agoragentic marketplace.
+ * Tools for IBM Bee Agent Framework on the Agoragentic Router / Marketplace.
  *
  * Install:
  *   npm install bee-agent-framework
@@ -25,9 +25,47 @@ async function apiCall(method, path, apiKey, body = null) {
 
 export function getAgoragenticTools(apiKey = "") {
     return {
+        agoragentic_execute: {
+            name: "agoragentic_execute",
+            description: "Route a task through Agoragentic execute() with provider selection, receipts, and settlement.",
+            inputSchema: {
+                type: "object",
+                properties: {
+                    task: { type: "string", description: "Task to route through Agoragentic" },
+                    input: { type: "object", description: "Task input payload" },
+                    constraints: { type: "object", description: "Optional budget, trust, or routing constraints" }
+                },
+                required: ["task"]
+            },
+            handler: async ({ task, input = {}, constraints = {} }) => {
+                const payload = { task };
+                if (Object.keys(input).length) payload.input = input;
+                if (Object.keys(constraints).length) payload.constraints = constraints;
+                return apiCall("POST", "/api/execute", apiKey, payload);
+            }
+        },
+        agoragentic_match: {
+            name: "agoragentic_match",
+            description: "Preview eligible routed providers before execution.",
+            inputSchema: {
+                type: "object",
+                properties: {
+                    task: { type: "string", description: "Task to match" },
+                    max_cost: { type: "number", description: "Optional max cost in USDC" },
+                    min_trust: { type: "string", description: "Optional minimum trust requirement" }
+                },
+                required: ["task"]
+            },
+            handler: async ({ task, max_cost = -1, min_trust = "" }) => {
+                const params = new URLSearchParams({ task });
+                if (max_cost >= 0) params.set("max_cost", String(max_cost));
+                if (min_trust) params.set("min_trust", min_trust);
+                return apiCall("GET", `/api/execute/match?${params}`, apiKey);
+            }
+        },
         agoragentic_register: {
             name: "agoragentic_register",
-            description: "Register on the Agoragentic agent marketplace. Returns API key + free USDC.",
+            description: "Create an Agoragentic API key for a buyer, seller, or dual-purpose agent.",
             inputSchema: {
                 type: "object",
                 properties: {
@@ -42,7 +80,7 @@ export function getAgoragenticTools(apiKey = "") {
         },
         agoragentic_search: {
             name: "agoragentic_search",
-            description: "Search the Agoragentic marketplace for capabilities priced in USDC.",
+            description: "Compatibility catalog browsing. Prefer agoragentic_match for new routed work.",
             inputSchema: {
                 type: "object",
                 properties: {
@@ -59,7 +97,7 @@ export function getAgoragenticTools(apiKey = "") {
         },
         agoragentic_invoke: {
             name: "agoragentic_invoke",
-            description: "Invoke a marketplace capability. Auto-pays from USDC wallet.",
+            description: "Compatibility direct-provider invocation when a known capability ID is required.",
             inputSchema: {
                 type: "object",
                 properties: {
@@ -74,13 +112,13 @@ export function getAgoragenticTools(apiKey = "") {
         },
         agoragentic_vault: {
             name: "agoragentic_vault",
-            description: "View agent vault — skills, datasets, NFTs.",
+            description: "Compatibility inventory view for legacy vault surfaces.",
             inputSchema: { type: "object", properties: {} },
             handler: async () => apiCall("GET", "/api/inventory", apiKey)
         },
         agoragentic_memory_write: {
             name: "agoragentic_memory_write",
-            description: "Write to persistent memory (FREE).",
+            description: "Write scoped Agent OS memory when policy allows it.",
             inputSchema: {
                 type: "object",
                 properties: { key: { type: "string" }, value: { type: "string" } },
@@ -92,7 +130,7 @@ export function getAgoragenticTools(apiKey = "") {
         },
         agoragentic_memory_read: {
             name: "agoragentic_memory_read",
-            description: "Read from persistent memory (FREE).",
+            description: "Read scoped Agent OS memory when policy allows it.",
             inputSchema: { type: "object", properties: { key: { type: "string" } } },
             handler: async ({ key = "" }) => {
                 const params = key ? `?key=${key}&namespace=default` : "?namespace=default";
@@ -101,7 +139,7 @@ export function getAgoragenticTools(apiKey = "") {
         },
         agoragentic_passport: {
             name: "agoragentic_passport",
-            description: "Check Passport NFT identity on Base L2.",
+            description: "Compatibility identity helper for legacy passport surfaces.",
             inputSchema: { type: "object", properties: {} },
             handler: async () => apiCall("GET", "/api/passport/check", apiKey)
         }

--- a/camel/agoragentic_camel.py
+++ b/camel/agoragentic_camel.py
@@ -2,7 +2,7 @@
 Agoragentic CAMEL Integration — v2.0
 ======================================
 
-Tools for CAMEL-AI agent framework on the Agoragentic marketplace.
+Tools for CAMEL-AI agent framework on the Agoragentic Router / Marketplace.
 
 Install:
     pip install camel-ai requests
@@ -35,15 +35,41 @@ def _headers(api_key: str):
 
 
 def agoragentic_register(agent_name: str, intent: str = "both") -> str:
-    """Register on the Agoragentic marketplace. Returns API key + $0.50 free USDC."""
+    """Create an Agoragentic API key for a buyer, seller, or dual-purpose agent."""
     resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/quickstart",
                          json={"name": agent_name, "intent": intent},
                          headers={"Content-Type": "application/json"}, timeout=30)
     return json.dumps(resp.json(), indent=2)
 
 
+def agoragentic_execute(task: str, input_data: str = "{}", constraints: str = "{}", api_key: str = "") -> str:
+    """Route a task through Agoragentic execute() with provider selection, receipts, and settlement."""
+    payload = {"task": task}
+    parsed_input = json.loads(input_data or "{}")
+    parsed_constraints = json.loads(constraints or "{}")
+    if parsed_input:
+        payload["input"] = parsed_input
+    if parsed_constraints:
+        payload["constraints"] = parsed_constraints
+    resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/execute",
+                         json=payload, headers=_headers(api_key), timeout=90)
+    return json.dumps(resp.json(), indent=2)
+
+
+def agoragentic_match(task: str, max_cost: float = -1, min_trust: str = "", api_key: str = "") -> str:
+    """Preview eligible routed providers before execution."""
+    params = {"task": task}
+    if max_cost >= 0:
+        params["max_cost"] = str(max_cost)
+    if min_trust:
+        params["min_trust"] = min_trust
+    resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/execute/match",
+                        params=params, headers=_headers(api_key), timeout=30)
+    return json.dumps(resp.json(), indent=2)
+
+
 def agoragentic_search(query: str = "", category: str = "", api_key: str = "") -> str:
-    """Search the Agoragentic marketplace for capabilities priced in USDC on Base L2."""
+    """Compatibility catalog browsing. Prefer agoragentic_match for new routed work."""
     params = {"limit": 10, "status": "active"}
     if query: params["search"] = query
     if category: params["category"] = category
@@ -58,7 +84,7 @@ def agoragentic_search(query: str = "", category: str = "", api_key: str = "") -
 
 
 def agoragentic_invoke(capability_id: str, input_data: str = "{}", api_key: str = "") -> str:
-    """Invoke a marketplace capability. Auto-pays from USDC wallet."""
+    """Compatibility direct-provider invocation when a known capability ID is required."""
     resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/invoke/{capability_id}",
                          json={"input": json.loads(input_data)},
                          headers=_headers(api_key), timeout=60)
@@ -66,14 +92,14 @@ def agoragentic_invoke(capability_id: str, input_data: str = "{}", api_key: str 
 
 
 def agoragentic_vault(api_key: str = "") -> str:
-    """View your agent vault — skills, datasets, NFTs, collectibles you own."""
+    """Compatibility inventory view for legacy vault surfaces."""
     resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/inventory",
                         headers=_headers(api_key), timeout=15)
     return json.dumps(resp.json(), indent=2)
 
 
 def agoragentic_memory_write(key: str, value: str, api_key: str = "") -> str:
-    """Write to persistent agent memory ($0.10/write). Survives across sessions."""
+    """Write scoped Agent OS memory when policy allows it."""
     resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/vault/memory",
                          json={"input": {"key": key, "value": value}},
                          headers=_headers(api_key), timeout=30)
@@ -81,7 +107,7 @@ def agoragentic_memory_write(key: str, value: str, api_key: str = "") -> str:
 
 
 def agoragentic_memory_read(key: str = "", api_key: str = "") -> str:
-    """Read from persistent agent memory. FREE."""
+    """Read scoped Agent OS memory when policy allows it."""
     params = {"namespace": "default"}
     if key: params["key"] = key
     resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/vault/memory",
@@ -90,7 +116,7 @@ def agoragentic_memory_read(key: str = "", api_key: str = "") -> str:
 
 
 def agoragentic_passport(api_key: str = "") -> str:
-    """Check Agoragentic Passport NFT identity on Base L2."""
+    """Compatibility identity helper for legacy passport surfaces."""
     resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/passport/check",
                         headers=_headers(api_key), timeout=15)
     return json.dumps(resp.json(), indent=2)
@@ -100,6 +126,8 @@ def get_agoragentic_tools(api_key: str = ""):
     """Get all Agoragentic tools wrapped as CAMEL FunctionTools."""
     import functools
     fns = [
+        functools.partial(agoragentic_execute, api_key=api_key),
+        functools.partial(agoragentic_match, api_key=api_key),
         agoragentic_register,
         functools.partial(agoragentic_search, api_key=api_key),
         functools.partial(agoragentic_invoke, api_key=api_key),

--- a/elizaos/agoragentic_eliza.ts
+++ b/elizaos/agoragentic_eliza.ts
@@ -2,7 +2,7 @@
  * Agoragentic ElizaOS Plugin — v2.0
  * ===================================
  *
- * Plugin for ElizaOS (ai16z) agents to interact with the Agoragentic marketplace.
+ * Plugin for ElizaOS (ai16z) agents to interact with the Agoragentic Router / Marketplace.
  * Crypto-native agents with existing USDC wallets are a perfect fit.
  *
  * Install:
@@ -28,13 +28,13 @@ async function apiCall(method: string, path: string, apiKey: string | null, body
 
 const registerAction = {
     name: "AGORAGENTIC_REGISTER",
-    description: "Register on the Agoragentic agent marketplace to get an API key and free USDC.",
+    description: "Create an Agoragentic API key for a buyer, seller, or dual-purpose agent.",
     similes: ["register on marketplace", "join agoragentic", "get api key", "sign up marketplace"],
     validate: async () => true,
     handler: async (runtime: any, message: any) => {
         const agentName = runtime.character?.name || "ElizaAgent";
         const data = await apiCall("POST", "/api/quickstart", null, {
-            name: agentName, type: "both"
+            name: agentName, intent: "both"
         });
         if (data.api_key) {
             await runtime.cacheManager?.set("agoragentic_api_key", data.api_key);
@@ -48,9 +48,58 @@ const registerAction = {
     ]
 };
 
+const executeAction = {
+    name: "AGORAGENTIC_EXECUTE",
+    description: "Route a task through Agoragentic execute() with provider selection, receipts, and settlement.",
+    similes: ["execute task", "route task", "buy routed work", "run through agoragentic"],
+    validate: async (runtime: any) => {
+        const key = await runtime.cacheManager?.get("agoragentic_api_key") ||
+            runtime.getSetting?.("AGORAGENTIC_API_KEY");
+        return !!key;
+    },
+    handler: async (runtime: any, message: any) => {
+        const apiKey = await runtime.cacheManager?.get("agoragentic_api_key") ||
+            runtime.getSetting?.("AGORAGENTIC_API_KEY") || "";
+        const task = message.content?.task || message.content?.text || "";
+        if (!task) return { text: "Please provide a task to execute through Agoragentic." };
+        const data = await apiCall("POST", "/api/execute", apiKey, {
+            task,
+            input: message.content?.input || {},
+            constraints: message.content?.constraints || {}
+        });
+        return { text: JSON.stringify(data, null, 2).slice(0, 1200) };
+    },
+    examples: [
+        [{ user: "user", content: { text: "Execute this research task through Agoragentic" } },
+        { user: "agent", content: { text: "I'll route that task through Agoragentic execute()." } }]
+    ]
+};
+
+const matchAction = {
+    name: "AGORAGENTIC_MATCH",
+    description: "Preview eligible routed providers before execution.",
+    similes: ["match providers", "preview providers", "find routed providers", "provider match"],
+    validate: async () => true,
+    handler: async (runtime: any, message: any) => {
+        const apiKey = await runtime.cacheManager?.get("agoragentic_api_key") ||
+            runtime.getSetting?.("AGORAGENTIC_API_KEY") || "";
+        const task = message.content?.task || message.content?.text?.replace(/match|preview|providers/gi, "").trim() || "";
+        if (!task) return { text: "Please provide a task to match." };
+        const params = new URLSearchParams({ task });
+        if (message.content?.max_cost) params.set("max_cost", String(message.content.max_cost));
+        if (message.content?.min_trust) params.set("min_trust", message.content.min_trust);
+        const data = await apiCall("GET", `/api/execute/match?${params}`, apiKey);
+        return { text: JSON.stringify(data, null, 2).slice(0, 1200) };
+    },
+    examples: [
+        [{ user: "user", content: { text: "Match providers for a summarization task" } },
+        { user: "agent", content: { text: "I'll preview eligible routed providers." } }]
+    ]
+};
+
 const searchAction = {
     name: "AGORAGENTIC_SEARCH",
-    description: "Search the Agoragentic marketplace for agent capabilities, tools, and services.",
+    description: "Compatibility catalog browsing. Prefer AGORAGENTIC_MATCH for new routed work.",
     similes: ["search marketplace", "find tools", "browse capabilities", "look for services"],
     validate: async () => true,
     handler: async (runtime: any, message: any) => {
@@ -73,7 +122,7 @@ const searchAction = {
 
 const invokeAction = {
     name: "AGORAGENTIC_INVOKE",
-    description: "Invoke a capability from the Agoragentic marketplace. Pays from USDC balance.",
+    description: "Compatibility direct-provider invocation when a known capability ID is required.",
     similes: ["invoke capability", "use tool", "call service", "buy capability"],
     validate: async (runtime: any) => {
         const key = await runtime.cacheManager?.get("agoragentic_api_key") ||
@@ -99,7 +148,7 @@ const invokeAction = {
 
 const memoryWriteAction = {
     name: "AGORAGENTIC_MEMORY_WRITE",
-    description: "Write to persistent agent memory on Agoragentic ($0.10/write). Survives across sessions.",
+    description: "Write scoped Agent OS memory when policy allows it.",
     similes: ["save to memory", "remember this", "store data", "persist"],
     validate: async (runtime: any) => !!(await runtime.cacheManager?.get("agoragentic_api_key") || runtime.getSetting?.("AGORAGENTIC_API_KEY")),
     handler: async (runtime: any, message: any) => {
@@ -114,7 +163,7 @@ const memoryWriteAction = {
 
 const vaultAction = {
     name: "AGORAGENTIC_VAULT",
-    description: "View your agent vault — skills, datasets, NFTs, collectibles you own on Agoragentic.",
+    description: "Compatibility inventory view for legacy vault surfaces.",
     similes: ["check vault", "my inventory", "what do i own", "show vault"],
     validate: async (runtime: any) => !!(await runtime.cacheManager?.get("agoragentic_api_key") || runtime.getSetting?.("AGORAGENTIC_API_KEY")),
     handler: async (runtime: any, message: any) => {
@@ -128,8 +177,8 @@ const vaultAction = {
 
 const passportAction = {
     name: "AGORAGENTIC_PASSPORT",
-    description: "Check your Agoragentic Passport NFT identity on Base L2.",
-    similes: ["check passport", "my identity", "passport status", "nft identity"],
+    description: "Compatibility identity helper for legacy passport surfaces.",
+    similes: ["check passport", "my identity", "passport status"],
     validate: async () => true,
     handler: async (runtime: any) => {
         const apiKey = await runtime.cacheManager?.get("agoragentic_api_key") || runtime.getSetting?.("AGORAGENTIC_API_KEY") || "";
@@ -143,8 +192,8 @@ const passportAction = {
 
 export const agoragenticPlugin = {
     name: "agoragentic",
-    description: "Agoragentic agent marketplace — buy, sell, and trade agent capabilities using USDC on Base L2",
-    actions: [registerAction, searchAction, invokeAction, memoryWriteAction, vaultAction, passportAction],
+    description: "Agoragentic Router / Marketplace for governed agent task routing, receipts, and USDC settlement on Base L2",
+    actions: [executeAction, matchAction, registerAction, searchAction, invokeAction, memoryWriteAction, vaultAction, passportAction],
     evaluators: [],
     providers: [],
     services: []

--- a/google-adk/agoragentic_google_adk.py
+++ b/google-adk/agoragentic_google_adk.py
@@ -2,7 +2,7 @@
 Agoragentic Google ADK Integration — v2.0
 ==========================================
 
-Tools for Google Agent Development Kit agents on the Agoragentic marketplace.
+Tools for Google Agent Development Kit agents on the Agoragentic Router / Marketplace.
 
 Install:
     pip install google-adk requests
@@ -28,15 +28,39 @@ def _headers(api_key: str):
 
 
 def agoragentic_register(agent_name: str, intent: str = "both") -> dict:
-    """Register on the Agoragentic agent-to-agent marketplace. Returns an API key and free USDC."""
+    """Create an Agoragentic API key for a buyer, seller, or dual-purpose agent."""
     resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/quickstart",
                          json={"name": agent_name, "intent": intent},
                          headers={"Content-Type": "application/json"}, timeout=30)
     return resp.json()
 
 
+def agoragentic_execute(api_key: str, task: str, input_data: dict = None, constraints: dict = None) -> dict:
+    """Route a task through Agoragentic execute() with provider selection, receipts, and settlement."""
+    payload = {"task": task}
+    if input_data:
+        payload["input"] = input_data
+    if constraints:
+        payload["constraints"] = constraints
+    resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/execute",
+                         json=payload, headers=_headers(api_key), timeout=90)
+    return resp.json()
+
+
+def agoragentic_match(api_key: str, task: str, max_cost: float = -1, min_trust: str = "") -> dict:
+    """Preview eligible routed providers before execution."""
+    params = {"task": task}
+    if max_cost >= 0:
+        params["max_cost"] = str(max_cost)
+    if min_trust:
+        params["min_trust"] = min_trust
+    resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/execute/match",
+                        params=params, headers=_headers(api_key), timeout=30)
+    return resp.json()
+
+
 def agoragentic_search(api_key: str, query: str = "", category: str = "", max_price: float = -1) -> dict:
-    """Search the Agoragentic marketplace for agent capabilities, tools, and services. Prices in USDC on Base L2."""
+    """Compatibility catalog browsing. Prefer agoragentic_match for new routed work."""
     params = {"limit": 10, "status": "active"}
     if query: params["search"] = query
     if category: params["category"] = category
@@ -51,14 +75,14 @@ def agoragentic_search(api_key: str, query: str = "", category: str = "", max_pr
 
 
 def agoragentic_invoke(api_key: str, capability_id: str, input_data: dict = None) -> dict:
-    """Invoke a capability from the Agoragentic marketplace. Payment is automatic from your USDC wallet."""
+    """Compatibility direct-provider invocation when a known capability ID is required."""
     resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/invoke/{capability_id}",
                          json={"input": input_data or {}}, headers=_headers(api_key), timeout=60)
     return resp.json()
 
 
 def agoragentic_vault(api_key: str, item_type: str = "") -> dict:
-    """View your agent vault inventory — skills, datasets, NFTs, collectibles."""
+    """Compatibility inventory view for legacy vault surfaces."""
     params = {}
     if item_type: params["type"] = item_type
     resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/inventory", params=params,
@@ -67,7 +91,7 @@ def agoragentic_vault(api_key: str, item_type: str = "") -> dict:
 
 
 def agoragentic_memory_write(api_key: str, key: str, value: str, namespace: str = "default") -> dict:
-    """Write to persistent agent memory ($0.10/write). Data survives across sessions, IDEs, and machines."""
+    """Write scoped Agent OS memory when policy allows it."""
     resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/vault/memory",
                          json={"input": {"key": key, "value": value, "namespace": namespace}},
                          headers=_headers(api_key), timeout=30)
@@ -75,7 +99,7 @@ def agoragentic_memory_write(api_key: str, key: str, value: str, namespace: str 
 
 
 def agoragentic_memory_read(api_key: str, key: str = "", namespace: str = "default") -> dict:
-    """Read from persistent agent memory. FREE. Omit key to list all keys."""
+    """Read scoped Agent OS memory when policy allows it."""
     params = {"namespace": namespace}
     if key: params["key"] = key
     resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/vault/memory", params=params,
@@ -84,7 +108,7 @@ def agoragentic_memory_read(api_key: str, key: str = "", namespace: str = "defau
 
 
 def agoragentic_secret_store(api_key: str, label: str, secret: str) -> dict:
-    """Store an AES-256 encrypted secret in your vault ($0.25). Max 50 secrets."""
+    """Store a policy-gated encrypted credential."""
     resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/vault/secrets",
                          json={"input": {"label": label, "secret": secret}},
                          headers=_headers(api_key), timeout=30)
@@ -92,7 +116,7 @@ def agoragentic_secret_store(api_key: str, label: str, secret: str) -> dict:
 
 
 def agoragentic_secret_retrieve(api_key: str, label: str = "") -> dict:
-    """Retrieve a decrypted secret from your vault. FREE."""
+    """Retrieve a policy-gated encrypted credential."""
     params = {}
     if label: params["label"] = label
     resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/vault/secrets", params=params,
@@ -101,7 +125,7 @@ def agoragentic_secret_retrieve(api_key: str, label: str = "") -> dict:
 
 
 def agoragentic_passport(api_key: str = "", action: str = "check") -> dict:
-    """Check or verify Agoragentic Passport NFT identity on Base L2."""
+    """Compatibility identity helper for legacy passport surfaces."""
     if action == "info":
         resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/passport/info", timeout=15)
     else:
@@ -114,6 +138,8 @@ def get_agoragentic_tools(api_key: str = ""):
     """Get all Agoragentic tools for Google ADK agents. Returns a list of callables."""
     import functools
     bound = {
+        "agoragentic_execute": functools.partial(agoragentic_execute, api_key),
+        "agoragentic_match": functools.partial(agoragentic_match, api_key),
         "agoragentic_register": agoragentic_register,
         "agoragentic_search": functools.partial(agoragentic_search, api_key),
         "agoragentic_invoke": functools.partial(agoragentic_invoke, api_key),

--- a/llamaindex/agoragentic_llamaindex.py
+++ b/llamaindex/agoragentic_llamaindex.py
@@ -2,7 +2,7 @@
 Agoragentic LlamaIndex Integration — v2.0
 ===========================================
 
-ToolSpec for LlamaIndex agents on the Agoragentic marketplace.
+ToolSpec for LlamaIndex agents on the Agoragentic Router / Marketplace.
 
 Install:
     pip install llama-index requests
@@ -36,6 +36,8 @@ class AgoragenticToolSpec(BaseToolSpec):
     """Agoragentic marketplace tool spec for LlamaIndex agents."""
 
     spec_functions = [
+        "agoragentic_execute",
+        "agoragentic_match",
         "agoragentic_register",
         "agoragentic_search",
         "agoragentic_invoke",
@@ -57,14 +59,38 @@ class AgoragenticToolSpec(BaseToolSpec):
         return h
 
     def agoragentic_register(self, agent_name: str, intent: str = "both") -> str:
-        """Register on the Agoragentic marketplace. Returns API key + $0.50 free USDC."""
+        """Create an Agoragentic API key for a buyer, seller, or dual-purpose agent."""
         resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/quickstart",
                              json={"name": agent_name, "intent": intent},
                              headers={"Content-Type": "application/json"}, timeout=30)
         return json.dumps(resp.json(), indent=2)
 
+    def agoragentic_execute(self, task: str, input_data: str = "{}", constraints: str = "{}") -> str:
+        """Route a task through Agoragentic execute() with provider selection, receipts, and settlement."""
+        payload = {"task": task}
+        parsed_input = json.loads(input_data or "{}")
+        parsed_constraints = json.loads(constraints or "{}")
+        if parsed_input:
+            payload["input"] = parsed_input
+        if parsed_constraints:
+            payload["constraints"] = parsed_constraints
+        resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/execute",
+                             json=payload, headers=self._headers(), timeout=90)
+        return json.dumps(resp.json(), indent=2)
+
+    def agoragentic_match(self, task: str, max_cost: float = -1, min_trust: str = "") -> str:
+        """Preview eligible routed providers before execution."""
+        params = {"task": task}
+        if max_cost >= 0:
+            params["max_cost"] = str(max_cost)
+        if min_trust:
+            params["min_trust"] = min_trust
+        resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/execute/match",
+                            params=params, headers=self._headers(), timeout=30)
+        return json.dumps(resp.json(), indent=2)
+
     def agoragentic_search(self, query: str = "", category: str = "", max_price: float = -1) -> str:
-        """Search the Agoragentic marketplace for capabilities, tools, and services priced in USDC."""
+        """Compatibility catalog browsing. Prefer agoragentic_match for new routed work."""
         params = {"limit": 10, "status": "active"}
         if query: params["search"] = query
         if category: params["category"] = category
@@ -80,14 +106,14 @@ class AgoragenticToolSpec(BaseToolSpec):
         ]}, indent=2)
 
     def agoragentic_invoke(self, capability_id: str, input_data: str = "{}") -> str:
-        """Invoke a capability from the marketplace. Pays automatically from USDC balance."""
+        """Compatibility direct-provider invocation when a known capability ID is required."""
         resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/invoke/{capability_id}",
                              json={"input": json.loads(input_data)},
                              headers=self._headers(), timeout=60)
         return json.dumps(resp.json(), indent=2)
 
     def agoragentic_vault(self, item_type: str = "") -> str:
-        """View your agent vault — skills, datasets, NFTs, collectibles."""
+        """Compatibility inventory view for legacy vault surfaces."""
         params = {}
         if item_type: params["type"] = item_type
         resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/inventory",
@@ -95,14 +121,14 @@ class AgoragenticToolSpec(BaseToolSpec):
         return json.dumps(resp.json(), indent=2)
 
     def agoragentic_memory_write(self, key: str, value: str, namespace: str = "default") -> str:
-        """Write to persistent agent memory ($0.10/write). Survives across sessions."""
+        """Write scoped Agent OS memory when policy allows it."""
         resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/vault/memory",
                              json={"input": {"key": key, "value": value, "namespace": namespace}},
                              headers=self._headers(), timeout=30)
         return json.dumps(resp.json(), indent=2)
 
     def agoragentic_memory_read(self, key: str = "", namespace: str = "default") -> str:
-        """Read from persistent agent memory. FREE."""
+        """Read scoped Agent OS memory when policy allows it."""
         params = {"namespace": namespace}
         if key: params["key"] = key
         resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/vault/memory",
@@ -110,14 +136,14 @@ class AgoragenticToolSpec(BaseToolSpec):
         return json.dumps(resp.json(), indent=2)
 
     def agoragentic_secret_store(self, label: str, secret: str) -> str:
-        """Store an AES-256 encrypted secret ($0.25)."""
+        """Store a policy-gated encrypted credential."""
         resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/vault/secrets",
                              json={"input": {"label": label, "secret": secret}},
                              headers=self._headers(), timeout=30)
         return json.dumps(resp.json(), indent=2)
 
     def agoragentic_secret_retrieve(self, label: str = "") -> str:
-        """Retrieve a decrypted secret. FREE."""
+        """Retrieve a policy-gated encrypted credential."""
         params = {}
         if label: params["label"] = label
         resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/vault/secrets",
@@ -125,7 +151,7 @@ class AgoragenticToolSpec(BaseToolSpec):
         return json.dumps(resp.json(), indent=2)
 
     def agoragentic_passport(self, action: str = "check") -> str:
-        """Check Agoragentic Passport NFT identity on Base L2."""
+        """Compatibility identity helper for legacy passport surfaces."""
         path = "/api/passport/info" if action == "info" else "/api/passport/check"
         resp = requests.get(f"{AGORAGENTIC_BASE_URL}{path}",
                             headers=self._headers(), timeout=15)

--- a/mastra/agoragentic_mastra.js
+++ b/mastra/agoragentic_mastra.js
@@ -2,7 +2,7 @@
  * Agoragentic Mastra Integration — v2.0
  * ========================================
  *
- * Integration for Mastra framework agents on the Agoragentic marketplace.
+ * Integration for Mastra framework agents on the Agoragentic Router / Marketplace.
  *
  * Install:
  *   npm install @mastra/core
@@ -34,16 +34,38 @@ export class AgoragenticIntegration {
     getTools() {
         const apiKey = this.apiKey;
         return {
+            agoragentic_execute: {
+                label: "Execute Routed Task",
+                description: "Route a task through Agoragentic execute() with provider selection, receipts, and settlement.",
+                schema: { type: "object", properties: { task: { type: "string" }, input: { type: "object" }, constraints: { type: "object" } }, required: ["task"] },
+                executor: async ({ task, input = {}, constraints = {} }) => {
+                    const payload = { task };
+                    if (Object.keys(input).length) payload.input = input;
+                    if (Object.keys(constraints).length) payload.constraints = constraints;
+                    return apiCall("POST", "/api/execute", apiKey, payload);
+                }
+            },
+            agoragentic_match: {
+                label: "Preview Routed Providers",
+                description: "Preview eligible routed providers before execution.",
+                schema: { type: "object", properties: { task: { type: "string" }, max_cost: { type: "number" }, min_trust: { type: "string" } }, required: ["task"] },
+                executor: async ({ task, max_cost = -1, min_trust = "" }) => {
+                    const params = new URLSearchParams({ task });
+                    if (max_cost >= 0) params.set("max_cost", String(max_cost));
+                    if (min_trust) params.set("min_trust", min_trust);
+                    return apiCall("GET", `/api/execute/match?${params}`, apiKey);
+                }
+            },
             agoragentic_register: {
                 label: "Register on Agoragentic",
-                description: "Register on the Agoragentic marketplace. Returns API key + free USDC.",
+                description: "Create an Agoragentic API key for a buyer, seller, or dual-purpose agent.",
                 schema: { type: "object", properties: { agent_name: { type: "string" }, intent: { type: "string", default: "both" } }, required: ["agent_name"] },
                 executor: async ({ agent_name, intent = "both" }) =>
                     apiCall("POST", "/api/quickstart", null, { name: agent_name, intent: intent })
             },
             agoragentic_search: {
                 label: "Search Marketplace",
-                description: "Search capabilities, tools, services. Prices in USDC on Base L2.",
+                description: "Compatibility catalog browsing. Prefer agoragentic_match for new routed work.",
                 schema: { type: "object", properties: { query: { type: "string" }, category: { type: "string" }, max_price: { type: "number" } } },
                 executor: async ({ query = "", category = "" }) => {
                     const params = new URLSearchParams({ limit: "10", status: "active" });
@@ -54,14 +76,14 @@ export class AgoragenticIntegration {
             },
             agoragentic_invoke: {
                 label: "Invoke Capability",
-                description: "Invoke a marketplace capability. Auto-pays from USDC wallet.",
+                description: "Compatibility direct-provider invocation when a known capability ID is required.",
                 schema: { type: "object", properties: { capability_id: { type: "string" }, input_data: { type: "object" } }, required: ["capability_id"] },
                 executor: async ({ capability_id, input_data = {} }) =>
                     apiCall("POST", `/api/invoke/${capability_id}`, apiKey, { input: input_data })
             },
             agoragentic_vault: {
                 label: "View Vault",
-                description: "View agent vault — skills, datasets, NFTs, collectibles.",
+                description: "Compatibility inventory view for legacy vault surfaces.",
                 schema: { type: "object", properties: { item_type: { type: "string" } } },
                 executor: async ({ item_type = "" }) => {
                     const params = item_type ? `?type=${item_type}` : "";
@@ -70,14 +92,14 @@ export class AgoragenticIntegration {
             },
             agoragentic_memory_write: {
                 label: "Write to Memory",
-                description: "Persistent agent memory (FREE). Survives sessions.",
+                description: "Write scoped Agent OS memory when policy allows it.",
                 schema: { type: "object", properties: { key: { type: "string" }, value: { type: "string" } }, required: ["key", "value"] },
                 executor: async ({ key, value }) =>
                     apiCall("POST", "/api/vault/memory", apiKey, { input: { key, value } })
             },
             agoragentic_memory_read: {
                 label: "Read from Memory",
-                description: "Read persistent memory. FREE.",
+                description: "Read scoped Agent OS memory when policy allows it.",
                 schema: { type: "object", properties: { key: { type: "string" } } },
                 executor: async ({ key = "" }) => {
                     const params = key ? `?key=${key}` : "";
@@ -86,14 +108,14 @@ export class AgoragenticIntegration {
             },
             agoragentic_secret_store: {
                 label: "Store Secret",
-                description: "AES-256 encrypted secret storage ($0.25).",
+                description: "Store a policy-gated encrypted credential.",
                 schema: { type: "object", properties: { label: { type: "string" }, secret: { type: "string" } }, required: ["label", "secret"] },
                 executor: async ({ label, secret }) =>
                     apiCall("POST", "/api/vault/secrets", apiKey, { input: { label, secret } })
             },
             agoragentic_secret_retrieve: {
                 label: "Retrieve Secret",
-                description: "Decrypt and retrieve a secret. FREE.",
+                description: "Retrieve a policy-gated encrypted credential.",
                 schema: { type: "object", properties: { label: { type: "string" } } },
                 executor: async ({ label = "" }) => {
                     const params = label ? `?label=${label}` : "";
@@ -102,7 +124,7 @@ export class AgoragenticIntegration {
             },
             agoragentic_passport: {
                 label: "Check Passport",
-                description: "Passport NFT identity on Base L2.",
+                description: "Compatibility identity helper for legacy passport surfaces.",
                 schema: { type: "object", properties: { action: { type: "string" } } },
                 executor: async ({ action = "check" }) => {
                     const path = action === "info" ? "/api/passport/info" : "/api/passport/check";

--- a/metagpt/agoragentic_metagpt.py
+++ b/metagpt/agoragentic_metagpt.py
@@ -2,19 +2,19 @@
 Agoragentic MetaGPT Integration — v2.0
 ========================================
 
-Action for MetaGPT agents on the Agoragentic marketplace.
+Actions for MetaGPT agents on the Agoragentic Router / Marketplace.
 
 Install:
     pip install metagpt requests
 
 Usage:
     from metagpt.roles import Role
-    from agoragentic_metagpt import AgoragenticSearch, AgoragenticInvoke
+    from agoragentic_metagpt import AgoragenticExecute, AgoragenticMatch
 
     class MarketplaceAgent(Role):
         def __init__(self, **kwargs):
             super().__init__(**kwargs)
-            self.set_actions([AgoragenticSearch, AgoragenticInvoke])
+            self.set_actions([AgoragenticExecute, AgoragenticMatch])
 """
 
 import json
@@ -47,10 +47,42 @@ class AgoragenticRegister(Action):
     name: str = "AgoragenticRegister"
 
     async def run(self, agent_name: str = "MetaGPTAgent", intent: str = "both") -> str:
-        """Register on the Agoragentic marketplace. Returns API key + free USDC."""
+        """Create an Agoragentic API key for a buyer, seller, or dual-purpose agent."""
         resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/quickstart",
                              json={"name": agent_name, "intent": intent},
                              headers={"Content-Type": "application/json"}, timeout=30)
+        return json.dumps(resp.json(), indent=2)
+
+
+class AgoragenticExecute(Action):
+    name: str = "AgoragenticExecute"
+
+    async def run(self, task: str = "", api_key: str = "", input_data: str = "{}", constraints: str = "{}") -> str:
+        """Route a task through Agoragentic execute() with provider selection, receipts, and settlement."""
+        payload = {"task": task}
+        parsed_input = json.loads(input_data or "{}")
+        parsed_constraints = json.loads(constraints or "{}")
+        if parsed_input:
+            payload["input"] = parsed_input
+        if parsed_constraints:
+            payload["constraints"] = parsed_constraints
+        resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/execute",
+                             json=payload, headers=_headers(api_key), timeout=90)
+        return json.dumps(resp.json(), indent=2)
+
+
+class AgoragenticMatch(Action):
+    name: str = "AgoragenticMatch"
+
+    async def run(self, task: str = "", api_key: str = "", max_cost: float = -1, min_trust: str = "") -> str:
+        """Preview eligible routed providers before execution."""
+        params = {"task": task}
+        if max_cost >= 0:
+            params["max_cost"] = str(max_cost)
+        if min_trust:
+            params["min_trust"] = min_trust
+        resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/execute/match",
+                            params=params, headers=_headers(api_key), timeout=30)
         return json.dumps(resp.json(), indent=2)
 
 
@@ -58,7 +90,7 @@ class AgoragenticSearch(Action):
     name: str = "AgoragenticSearch"
 
     async def run(self, query: str = "", api_key: str = "", category: str = "") -> str:
-        """Search the Agoragentic marketplace for capabilities."""
+        """Compatibility catalog browsing. Prefer AgoragenticMatch for new routed work."""
         params = {"limit": 10, "status": "active"}
         if query:
             params["search"] = query
@@ -78,7 +110,7 @@ class AgoragenticInvoke(Action):
     name: str = "AgoragenticInvoke"
 
     async def run(self, capability_id: str = "", api_key: str = "", input_data: str = "{}") -> str:
-        """Invoke a capability from the marketplace."""
+        """Compatibility direct-provider invocation when a known capability ID is required."""
         resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/invoke/{capability_id}",
                              json={"input": json.loads(input_data)},
                              headers=_headers(api_key), timeout=60)
@@ -89,7 +121,7 @@ class AgoragenticMemoryWrite(Action):
     name: str = "AgoragenticMemoryWrite"
 
     async def run(self, key: str = "", value: str = "", api_key: str = "") -> str:
-        """Write to persistent agent memory ($0.10/write)."""
+        """Write scoped Agent OS memory when policy allows it."""
         resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/vault/memory",
                              json={"input": {"key": key, "value": value}},
                              headers=_headers(api_key), timeout=30)
@@ -100,7 +132,7 @@ class AgoragenticMemoryRead(Action):
     name: str = "AgoragenticMemoryRead"
 
     async def run(self, key: str = "", api_key: str = "") -> str:
-        """Read from persistent agent memory. FREE."""
+        """Read scoped Agent OS memory when policy allows it."""
         params = {"namespace": "default"}
         if key:
             params["key"] = key
@@ -113,7 +145,7 @@ class AgoragenticVault(Action):
     name: str = "AgoragenticVault"
 
     async def run(self, api_key: str = "") -> str:
-        """View your agent vault — skills, datasets, NFTs, collectibles."""
+        """Compatibility inventory view for legacy vault surfaces."""
         resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/inventory",
                             headers=_headers(api_key), timeout=15)
         return json.dumps(resp.json(), indent=2)
@@ -123,7 +155,7 @@ class AgoragenticPassport(Action):
     name: str = "AgoragenticPassport"
 
     async def run(self, api_key: str = "", action: str = "check") -> str:
-        """Check Agoragentic Passport NFT identity on Base L2."""
+        """Compatibility identity helper for legacy passport surfaces."""
         path = "/api/passport/info" if action == "info" else "/api/passport/check"
         resp = requests.get(f"{AGORAGENTIC_BASE_URL}{path}",
                             headers=_headers(api_key), timeout=15)
@@ -132,6 +164,7 @@ class AgoragenticPassport(Action):
 
 def get_all_actions():
     """Return all Agoragentic actions for MetaGPT."""
-    return [AgoragenticRegister, AgoragenticSearch, AgoragenticInvoke,
+    return [AgoragenticExecute, AgoragenticMatch, AgoragenticRegister,
+            AgoragenticSearch, AgoragenticInvoke,
             AgoragenticMemoryWrite, AgoragenticMemoryRead,
             AgoragenticVault, AgoragenticPassport]

--- a/openai-agents/agoragentic_openai.py
+++ b/openai-agents/agoragentic_openai.py
@@ -2,7 +2,7 @@
 Agoragentic OpenAI Agents SDK Integration — v2.0
 ==================================================
 
-Tools for the OpenAI Agents SDK to interact with the Agoragentic marketplace.
+Tools for the OpenAI Agents SDK to interact with the Agoragentic Router / Marketplace.
 
 Install:
     pip install openai-agents requests
@@ -39,7 +39,7 @@ def _make_tools(api_key: str):
 
     @function_tool
     def agoragentic_register(agent_name: str, intent: str = "both") -> str:
-        """Register on the Agoragentic agent marketplace. Returns an API key and free USDC."""
+        """Create an Agoragentic API key for a buyer, seller, or dual-purpose agent."""
         try:
             resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/quickstart",
                                  json={"name": agent_name, "intent": intent},
@@ -53,8 +53,40 @@ def _make_tools(api_key: str):
             return json.dumps({"error": str(e)})
 
     @function_tool
+    def agoragentic_execute(task: str, input_data: str = "{}", constraints: str = "{}") -> str:
+        """Route a task through Agoragentic execute() with provider selection, receipts, and settlement."""
+        try:
+            payload = {"task": task}
+            parsed_input = json.loads(input_data or "{}")
+            parsed_constraints = json.loads(constraints or "{}")
+            if parsed_input:
+                payload["input"] = parsed_input
+            if parsed_constraints:
+                payload["constraints"] = parsed_constraints
+            resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/execute",
+                                 json=payload, headers=_headers(api_key), timeout=90)
+            return json.dumps(resp.json(), indent=2)
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    @function_tool
+    def agoragentic_match(task: str, max_cost: float = -1, min_trust: str = "") -> str:
+        """Preview eligible routed providers before execution."""
+        try:
+            params = {"task": task}
+            if max_cost >= 0:
+                params["max_cost"] = str(max_cost)
+            if min_trust:
+                params["min_trust"] = min_trust
+            resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/execute/match",
+                                params=params, headers=_headers(api_key), timeout=30)
+            return json.dumps(resp.json(), indent=2)
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    @function_tool
     def agoragentic_search(query: str = "", category: str = "", max_price: float = -1) -> str:
-        """Search the Agoragentic marketplace for agent capabilities, tools, and services priced in USDC."""
+        """Compatibility catalog browsing. Prefer agoragentic_match for new routed work."""
         try:
             params = {"limit": 10, "status": "active"}
             if query: params["search"] = query
@@ -71,7 +103,7 @@ def _make_tools(api_key: str):
 
     @function_tool
     def agoragentic_invoke(capability_id: str, input_data: str = "{}") -> str:
-        """Invoke a marketplace capability. Pays automatically from your USDC wallet balance."""
+        """Compatibility direct-provider invocation when a known capability ID is required."""
         try:
             resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/invoke/{capability_id}",
                                  json={"input": json.loads(input_data)}, headers=_headers(api_key), timeout=60)
@@ -85,7 +117,7 @@ def _make_tools(api_key: str):
 
     @function_tool
     def agoragentic_vault(item_type: str = "") -> str:
-        """View your agent vault inventory — skills, datasets, NFTs, collectibles you own."""
+        """Compatibility inventory view for legacy vault surfaces."""
         try:
             params = {}
             if item_type: params["type"] = item_type
@@ -96,7 +128,7 @@ def _make_tools(api_key: str):
 
     @function_tool
     def agoragentic_memory_write(key: str, value: str, namespace: str = "default") -> str:
-        """Write to persistent agent memory ($0.10/write). Data survives across sessions."""
+        """Write scoped Agent OS memory when policy allows it."""
         try:
             resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/vault/memory",
                                  json={"input": {"key": key, "value": value, "namespace": namespace}},
@@ -107,7 +139,7 @@ def _make_tools(api_key: str):
 
     @function_tool
     def agoragentic_memory_read(key: str = "", namespace: str = "default") -> str:
-        """Read from persistent agent memory. FREE. Omit key to list all."""
+        """Read scoped Agent OS memory when policy allows it."""
         try:
             params = {"namespace": namespace}
             if key: params["key"] = key
@@ -118,7 +150,7 @@ def _make_tools(api_key: str):
 
     @function_tool
     def agoragentic_secret_store(label: str, secret: str) -> str:
-        """Store an AES-256 encrypted secret in your vault ($0.25). 50 secrets max."""
+        """Store a policy-gated encrypted credential."""
         try:
             resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/vault/secrets",
                                  json={"input": {"label": label, "secret": secret}},
@@ -129,7 +161,7 @@ def _make_tools(api_key: str):
 
     @function_tool
     def agoragentic_secret_retrieve(label: str = "") -> str:
-        """Retrieve a decrypted secret from your vault. FREE."""
+        """Retrieve a policy-gated encrypted credential."""
         try:
             params = {}
             if label: params["label"] = label
@@ -140,7 +172,7 @@ def _make_tools(api_key: str):
 
     @function_tool
     def agoragentic_passport(action: str = "check") -> str:
-        """Check your Agoragentic Passport NFT identity status on Base L2."""
+        """Compatibility identity helper for legacy passport surfaces."""
         try:
             if action == "info":
                 resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/passport/info", timeout=15)
@@ -150,7 +182,8 @@ def _make_tools(api_key: str):
         except Exception as e:
             return json.dumps({"error": str(e)})
 
-    return [agoragentic_register, agoragentic_search, agoragentic_invoke,
+    return [agoragentic_execute, agoragentic_match, agoragentic_register,
+            agoragentic_search, agoragentic_invoke,
             agoragentic_vault, agoragentic_memory_write, agoragentic_memory_read,
             agoragentic_secret_store, agoragentic_secret_retrieve, agoragentic_passport]
 

--- a/superagi/agoragentic_superagi.py
+++ b/superagi/agoragentic_superagi.py
@@ -2,7 +2,7 @@
 Agoragentic SuperAGI Integration — v2.0
 =========================================
 
-Tool module for SuperAGI agents on the Agoragentic marketplace.
+Tool module for SuperAGI agents on the Agoragentic Router / Marketplace.
 
 Install:
     pip install requests
@@ -42,9 +42,57 @@ class SearchInput(BaseModel):
     api_key: str = Field(default="", description="Agoragentic API key (amk_...)")
 
 
+class ExecuteInput(BaseModel):
+    task: str = Field(description="Task to route through Agoragentic")
+    input_data: str = Field(default="{}", description="JSON input payload")
+    constraints: str = Field(default="{}", description="JSON budget, trust, or routing constraints")
+    api_key: str = Field(default="", description="Agoragentic API key")
+
+
+class AgoragenticExecuteTool(BaseTool):
+    name = "Agoragentic Execute"
+    description = "Route a task through Agoragentic execute() with provider selection, receipts, and settlement."
+    args_schema: Type[BaseModel] = ExecuteInput
+
+    def _execute(self, task: str, input_data: str = "{}", constraints: str = "{}", api_key: str = "") -> str:
+        payload = {"task": task}
+        parsed_input = json.loads(input_data or "{}")
+        parsed_constraints = json.loads(constraints or "{}")
+        if parsed_input:
+            payload["input"] = parsed_input
+        if parsed_constraints:
+            payload["constraints"] = parsed_constraints
+        resp = requests.post(f"{AGORAGENTIC_BASE_URL}/api/execute",
+                             json=payload, headers=_headers(api_key), timeout=90)
+        return json.dumps(resp.json(), indent=2)
+
+
+class MatchInput(BaseModel):
+    task: str = Field(description="Task to match")
+    max_cost: float = Field(default=-1, description="Optional max cost in USDC")
+    min_trust: str = Field(default="", description="Optional minimum trust requirement")
+    api_key: str = Field(default="", description="Agoragentic API key")
+
+
+class AgoragenticMatchTool(BaseTool):
+    name = "Agoragentic Match"
+    description = "Preview eligible routed providers before execution."
+    args_schema: Type[BaseModel] = MatchInput
+
+    def _execute(self, task: str, max_cost: float = -1, min_trust: str = "", api_key: str = "") -> str:
+        params = {"task": task}
+        if max_cost >= 0:
+            params["max_cost"] = str(max_cost)
+        if min_trust:
+            params["min_trust"] = min_trust
+        resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/execute/match",
+                            params=params, headers=_headers(api_key), timeout=30)
+        return json.dumps(resp.json(), indent=2)
+
+
 class AgoragenticSearchTool(BaseTool):
     name = "Agoragentic Search"
-    description = "Search the Agoragentic agent marketplace for capabilities priced in USDC on Base L2."
+    description = "Compatibility catalog browsing. Prefer Agoragentic Match for new routed work."
     args_schema: Type[BaseModel] = SearchInput
 
     def _execute(self, query: str = "", category: str = "", api_key: str = "") -> str:
@@ -68,7 +116,7 @@ class InvokeInput(BaseModel):
 
 class AgoragenticInvokeTool(BaseTool):
     name = "Agoragentic Invoke"
-    description = "Invoke a capability from the Agoragentic marketplace. Pays from USDC balance."
+    description = "Compatibility direct-provider invocation when a known capability ID is required."
     args_schema: Type[BaseModel] = InvokeInput
 
     def _execute(self, capability_id: str, input_data: str = "{}", api_key: str = "") -> str:
@@ -85,7 +133,7 @@ class RegisterInput(BaseModel):
 
 class AgoragenticRegisterTool(BaseTool):
     name = "Agoragentic Register"
-    description = "Register on the Agoragentic marketplace. Get API key + $0.50 free USDC."
+    description = "Create an Agoragentic API key for a buyer, seller, or dual-purpose agent."
     args_schema: Type[BaseModel] = RegisterInput
 
     def _execute(self, agent_name: str, intent: str = "both") -> str:
@@ -103,7 +151,7 @@ class MemoryInput(BaseModel):
 
 class AgoragenticMemoryTool(BaseTool):
     name = "Agoragentic Memory"
-    description = "Read/write persistent agent memory. Write: $0.10, Read: FREE."
+    description = "Read or write scoped Agent OS memory when policy allows it."
     args_schema: Type[BaseModel] = MemoryInput
 
     def _execute(self, key: str, value: str = "", api_key: str = "") -> str:

--- a/vercel-ai/agoragentic_vercel.js
+++ b/vercel-ai/agoragentic_vercel.js
@@ -2,7 +2,7 @@
  * Agoragentic Vercel AI SDK Integration — v2.0
  * ===============================================
  *
- * Tools for Vercel AI SDK 6 agents on the Agoragentic marketplace.
+ * Tools for Vercel AI SDK 6 agents on the Agoragentic Router / Marketplace.
  *
  * Install:
  *   npm install ai @ai-sdk/openai
@@ -32,8 +32,44 @@ async function apiCall(method, path, apiKey, body = null) {
 
 export function getAgoragenticTools(apiKey = "") {
     return {
+        agoragentic_execute: {
+            description: "Route a task through Agoragentic execute() with provider selection, receipts, and settlement.",
+            parameters: {
+                type: "object",
+                properties: {
+                    task: { type: "string", description: "Task to route through Agoragentic" },
+                    input: { type: "object", description: "Task input payload" },
+                    constraints: { type: "object", description: "Optional budget, trust, or routing constraints" }
+                },
+                required: ["task"]
+            },
+            execute: async ({ task, input = {}, constraints = {} }) => {
+                const payload = { task };
+                if (Object.keys(input).length) payload.input = input;
+                if (Object.keys(constraints).length) payload.constraints = constraints;
+                return apiCall("POST", "/api/execute", apiKey, payload);
+            }
+        },
+        agoragentic_match: {
+            description: "Preview eligible routed providers before execution.",
+            parameters: {
+                type: "object",
+                properties: {
+                    task: { type: "string", description: "Task to match" },
+                    max_cost: { type: "number", description: "Optional max cost in USDC" },
+                    min_trust: { type: "string", description: "Optional minimum trust requirement" }
+                },
+                required: ["task"]
+            },
+            execute: async ({ task, max_cost = -1, min_trust = "" }) => {
+                const params = new URLSearchParams({ task });
+                if (max_cost >= 0) params.set("max_cost", String(max_cost));
+                if (min_trust) params.set("min_trust", min_trust);
+                return apiCall("GET", `/api/execute/match?${params}`, apiKey);
+            }
+        },
         agoragentic_register: {
-            description: "Register on the Agoragentic agent marketplace. Returns API key and free USDC.",
+            description: "Create an Agoragentic API key for a buyer, seller, or dual-purpose agent.",
             parameters: {
                 type: "object",
                 properties: {
@@ -47,7 +83,7 @@ export function getAgoragenticTools(apiKey = "") {
             }
         },
         agoragentic_search: {
-            description: "Search the Agoragentic marketplace for capabilities, tools, and services priced in USDC.",
+            description: "Compatibility catalog browsing. Prefer agoragentic_match for new routed work.",
             parameters: {
                 type: "object",
                 properties: {
@@ -72,7 +108,7 @@ export function getAgoragenticTools(apiKey = "") {
             }
         },
         agoragentic_invoke: {
-            description: "Invoke a marketplace capability. Pays automatically from USDC balance.",
+            description: "Compatibility direct-provider invocation when a known capability ID is required.",
             parameters: {
                 type: "object",
                 properties: {
@@ -86,7 +122,7 @@ export function getAgoragenticTools(apiKey = "") {
             }
         },
         agoragentic_vault: {
-            description: "View your agent vault — skills, datasets, NFTs, collectibles.",
+            description: "Compatibility inventory view for legacy vault surfaces.",
             parameters: { type: "object", properties: { item_type: { type: "string" } } },
             execute: async ({ item_type = "" }) => {
                 const params = item_type ? `?type=${item_type}` : "";
@@ -94,7 +130,7 @@ export function getAgoragenticTools(apiKey = "") {
             }
         },
         agoragentic_memory_write: {
-            description: "Write to persistent agent memory (FREE). Survives across sessions.",
+            description: "Write scoped Agent OS memory when policy allows it.",
             parameters: {
                 type: "object",
                 properties: {
@@ -108,7 +144,7 @@ export function getAgoragenticTools(apiKey = "") {
             }
         },
         agoragentic_memory_read: {
-            description: "Read from persistent agent memory. FREE.",
+            description: "Read scoped Agent OS memory when policy allows it.",
             parameters: { type: "object", properties: { key: { type: "string" }, namespace: { type: "string" } } },
             execute: async ({ key = "", namespace = "default" }) => {
                 const params = new URLSearchParams({ namespace });
@@ -117,7 +153,7 @@ export function getAgoragenticTools(apiKey = "") {
             }
         },
         agoragentic_secret_store: {
-            description: "Store an AES-256 encrypted secret ($0.25).",
+            description: "Store a policy-gated encrypted credential.",
             parameters: {
                 type: "object",
                 properties: { label: { type: "string" }, secret: { type: "string" } },
@@ -128,7 +164,7 @@ export function getAgoragenticTools(apiKey = "") {
             }
         },
         agoragentic_secret_retrieve: {
-            description: "Retrieve a decrypted secret. FREE.",
+            description: "Retrieve a policy-gated encrypted credential.",
             parameters: { type: "object", properties: { label: { type: "string" } } },
             execute: async ({ label = "" }) => {
                 const params = label ? `?label=${label}` : "";
@@ -136,7 +172,7 @@ export function getAgoragenticTools(apiKey = "") {
             }
         },
         agoragentic_passport: {
-            description: "Check Passport NFT identity on Base L2.",
+            description: "Compatibility identity helper for legacy passport surfaces.",
             parameters: { type: "object", properties: { action: { type: "string", enum: ["check", "info"] } } },
             execute: async ({ action = "check" }) => {
                 const path = action === "info" ? "/api/passport/info" : "/api/passport/check";


### PR DESCRIPTION
## Summary
- add first-class routed execute/match helpers to OpenAI Agents, Google ADK, Vercel AI, Mastra, Agno, LlamaIndex, CAMEL, Bee Agent, ElizaOS, MetaGPT, AutoGPT, and SuperAGI wrappers
- keep direct invoke/search/vault/passport helpers as compatibility paths instead of primary paths
- remove stale free-USDC, dollar-credit, and Passport NFT copy from the updated wrappers
- fix ElizaOS quickstart payload to send intent instead of type

## Validation
- python -m py_compile for all modified Python wrappers
- node --check for modified JavaScript wrappers
- npm exec --yes --package typescript -- tsc --noEmit --allowJs false --target ES2020 --module ESNext --lib ES2020,DOM --skipLibCheck elizaos/agoragentic_eliza.ts
- import smoke checks for modified Python wrappers
- dynamic import smoke checks for Vercel, Mastra, and Bee wrappers
- stale-copy scan for free USDC, free credits, .50, Passport NFT, on-chain NFT identity, agent-to-agent marketplace, auto-pays, and FREE