### PR TITLE
docs: clarify Agent OS hosted boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ Agent-native SDKs, MCP tools, protocol adapters, Micro ECF examples, and Agent O
 
 Default mental model: use Agent OS when an agent needs a governed runtime, and call `execute(task, input, constraints)`, not provider IDs, when it needs external work.
 
+## Downloadable vs Hosted
+
+Downloadable/local from this repo:
+
+- SDK examples, MCP/ACP adapters, framework wrappers, Agent OS public examples, and Micro ECF tooling
+- Harness packets and preview requests that describe an agent before hosted launch
+
+Hosted/private on Agoragentic:
+
+- Triptych OS / Agent OS control plane, deployment treasury, receipts, reconciliation, Router / Marketplace ranking, and x402/USDC settlement
+- private Full ECF, hosted runtime internals, trust/fraud scoring, and payout orchestration
+
+Self-hosted agents use this repo to call Agoragentic over HTTPS, MCP, A2A, or SDKs. They do not download or run the full Agent OS control plane locally.
+
 Canonical product routes:
 
 - [Agent OS](https://agoragentic.com/agent-os/) - deploy agents and swarms with budgets, wallets, APIs, receipts, and marketplace access

--- a/SKILL.md
+++ b/SKILL.md
@@ -28,9 +28,11 @@ Do **not** use this skill when:
 
 ## What This Is
 
-Agoragentic is **Agent OS for deployed agents and swarms**.
+Agoragentic is **Triptych OS (Agent OS) for deployed agents and swarms**.
 
 Micro ECF is the local context wedge for builders. Agent OS is the deployment product. Full ECF is the private enterprise runtime engine. The marketplace is the transaction rail where deployed agents buy, sell, invoke, and settle work.
+
+Downloadable/local integration surfaces are SDKs, MCP/ACP adapters, framework wrappers, Micro ECF tooling, examples, and public contracts. The full Triptych OS / Agent OS control plane, Router / Marketplace ranking, x402/USDC settlement, receipts, reconciliation, trust mutation, and Full ECF internals are hosted or private.
 
 Instead of hardcoding provider IDs, retries, billing logic, and fallback rules, agents can call a task like:
 

--- a/agent-os/README.md
+++ b/agent-os/README.md
@@ -4,6 +4,8 @@ Use Agoragentic as an agent-native operating layer for paid tool execution: quot
 
 This is the public integration boundary. It uses only public API endpoints and does not expose Agoragentic internals, private ranking logic, database state, or settlement implementation details.
 
+Downloadable here means client examples and public API contracts only. The Triptych OS / Agent OS control plane, Router / Marketplace ranking, x402/USDC settlement, hosted receipts, reconciliation, trust mutation, and private Full ECF internals remain hosted or private.
+
 ## Public API Surface
 
 | Step | Endpoint | Cost | Purpose |

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,8 @@
 # Agoragentic Integrations
 
-> Drop-in adapters connecting agent frameworks, protocol adapters, observability hooks, Micro ECF policy exports, and Agent OS deployment examples to Agoragentic. Agoragentic is Agent OS for deployed agents and swarms; Micro ECF is the local context wedge; the marketplace is the transaction rail; USDC settlement runs on Base L2.
+> Drop-in adapters connecting agent frameworks, protocol adapters, observability hooks, Micro ECF policy exports, and Agent OS deployment examples to Agoragentic. Agoragentic is Triptych OS (Agent OS) for deployed agents and swarms; Micro ECF is the local context wedge; the marketplace is the transaction rail; USDC settlement runs on Base L2.
+>
+> Downloadable here means SDKs, MCP/ACP adapters, framework wrappers, Micro ECF tooling, examples, and public contracts. The full Triptych OS / Agent OS control plane, Router / Marketplace ranking, x402/USDC settlement, receipts, reconciliation, trust mutation, and Full ECF internals are hosted or private.
 
 ## Packages
 - Python: `pip install agoragentic` (PyPI, ≥3.8)


### PR DESCRIPTION
## Summary
- Clarifies what is downloadable/local from the integrations repo versus hosted/private on Agoragentic.
- Makes explicit that self-hosted agents use SDK/MCP/A2A/HTTP integrations and do not download the full Triptych OS / Agent OS control plane.
- Aligns README, SKILL.md, Agent OS public examples, and llms.txt.

## Validation
- node scripts/verify-integrations-json.js
- node scripts/verify-acp.js
- ajv validate -s integrations.schema.json -d integrations.json --all-errors --spec=draft2020 -c ajv-formats
- git diff --check