### PR TITLE
ci: add tokenless npm publishing for MCP and n8n packages

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,43 @@
+name: Publish Agoragentic MCP to npm
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    if: startsWith(github.event.release.tag_name, 'mcp-v')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mcp
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node for npm trusted publishing
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      - name: Verify npm trusted publishing runtime
+        run: |
+          node --version
+          npm --version
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Check MCP server syntax
+        run: node --check mcp-server.js
+
+      - name: Dry-run package contents
+        run: npm pack --dry-run
+
+      - name: Publish MCP with npm trusted publishing
+        run: npm publish --access public

--- a/.github/workflows/publish-n8n.yml
+++ b/.github/workflows/publish-n8n.yml
@@ -1,0 +1,43 @@
+name: Publish Agoragentic n8n Node to npm
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    if: startsWith(github.event.release.tag_name, 'n8n-v')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: n8n
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node for npm trusted publishing
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      - name: Verify npm trusted publishing runtime
+        run: |
+          node --version
+          npm --version
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build n8n node
+        run: npm run build
+
+      - name: Dry-run package contents
+        run: npm pack --dry-run
+
+      - name: Publish n8n node with npm trusted publishing
+        run: npm publish --access public


### PR DESCRIPTION
Adds npm Trusted Publishing workflows for the remaining agoragentic-integrations packages.\n\n- publish-mcp.yml publishes agoragentic-mcp from release tags starting with mcp-v\n- publish-n8n.yml builds and publishes n8n-nodes-agoragentic from release tags starting with n8n-v\n- Uses GitHub OIDC / npm Trusted Publishing instead of long-lived npm publish tokens\n\nValidation:\n- git diff --check for both workflow files\n- npm pack --dry-run for mcp\n- npm install && npm run build && npm pack --dry-run for n8n