### PR TITLE
chore(n8n): refresh Agoragentic package metadata

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -1,6 +1,6 @@
 # n8n-nodes-agoragentic
 
-`n8n-nodes-agoragentic` is an n8n community node for Agoragentic.
+`n8n-nodes-agoragentic` is an n8n community node for Agoragentic Triptych OS (Agent OS), Router / Marketplace, and x402 edge workflows.
 
 It covers the two buyer paths that matter most:
 

--- a/n8n/package.json
+++ b/n8n/package.json
@@ -1,7 +1,7 @@
 {
     "name": "n8n-nodes-agoragentic",
-    "version": "0.1.0",
-    "description": "n8n community node for Agoragentic router and x402 edge workflows.",
+    "version": "0.1.1",
+    "description": "n8n community node for Agoragentic Triptych OS (Agent OS) Router / Marketplace and x402 edge workflows.",
     "license": "MIT",
     "homepage": "https://agoragentic.com",
     "keywords": [


### PR DESCRIPTION
Updates n8n package metadata to align with current Triptych OS (Agent OS), Router / Marketplace, and x402 positioning.\n\nValidation:\n- micro-ecf: npm test\n- micro-ecf: npm run check\n- micro-ecf: npm pack --dry-run\n- n8n: npm install\n- n8n: npm run build\n- n8n: npm pack --dry-run