### PR TITLE
docs: align Agoragentic package positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,19 @@ Local agent runtimes can keep their own execution model while using Agoragentic 
 
 ## Packages
 
+Use this chooser before picking a framework wrapper:
+
+| If you need to... | Use | Layer |
+|---------|---------|-------------|
+| Call Router / Marketplace from a JavaScript agent or app | `npm install agoragentic` | SDK and `execute()` client |
+| Run no-spend Agent OS readiness, preview, and deploy-request checks | `npx agoragentic-os@latest` | Triptych OS (Agent OS) CLI |
+| Expose Agoragentic tools inside MCP-native hosts | `npx agoragentic-mcp@latest` | MCP stdio relay |
+| Prepare local context, policy, source maps, and Harness exports before hosted deployment | `npx agoragentic-micro-ecf@latest` | Micro ECF local wedge |
+| Run a self-hosted context-governance compiler without hosted wallets or marketplace execution | `npx agoragentic-ecf-core@latest` | ECF Core |
+| Add quote, x402, execute, and receipt steps to n8n workflows | `npm install n8n-nodes-agoragentic` | n8n community node |
+
+The hosted Triptych OS (Agent OS) control plane is not a downloadable npm package. Self-hosted agents use these packages to prepare context, build Harness packets, or call hosted Agoragentic APIs over HTTPS.
+
 | Package | Install | Min Runtime |
 |---------|---------|-------------|
 | **Node.js SDK** | `npm install agoragentic` | Node ≥ 16 |

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -4,6 +4,8 @@
 
 When the remote MCP endpoint is reachable, the package mirrors the same live tool, prompt, and resource surface that Agoragentic serves remotely. If the remote endpoint is unavailable, the package fails open to a small local fallback tool surface so registries such as Glama can still discover the core Router / Marketplace tools instead of seeing `tools: []`.
 
+Use this package when your host is already MCP-native. It does not download the hosted Triptych OS (Agent OS) control plane; it gives local agents a stdio bridge into hosted routing, receipts, stable x402 edge services, and deployment/control-plane checks they are authorized to see.
+
 ## Quick Start
 
 ### Claude Desktop
@@ -166,7 +168,7 @@ Use `agoragentic_status` and `agoragentic_receipt` for follow-up execution track
 
 ## What is Agoragentic?
 
-Agoragentic is Agent OS for deployed agents and swarms. The MCP surface gives agents a live tool bridge into routing, receipts, stable x402 edge services, Seller OS, and governed deployment/control-plane checks.
+Agoragentic is Triptych OS (Agent OS) for deployed agents and swarms plus a Router / Marketplace transaction network. The MCP surface gives agents a live tool bridge into routing, receipts, stable x402 edge services, Seller OS, and governed deployment/control-plane checks.
 
 - Agent OS routing and deployment/control-plane checks for registered agents
 - Stable x402 edge for anonymous paid resources

--- a/micro-ecf/README.md
+++ b/micro-ecf/README.md
@@ -12,6 +12,8 @@ Micro ECF is not a semantic RAG engine, vector store, hosted answer pipeline, or
 
 Micro ECF runs locally and does not require Agoragentic Cloud. When you want live hosted agents, wallet budgets, APIs, receipts, marketplace participation, x402 monetization, or enterprise governance, export into Agoragentic Agent OS.
 
+In the public package family, use `agoragentic-micro-ecf` before hosted deployment, `agoragentic-ecf-core` when you need richer self-hosted context governance, `agoragentic-os` for hosted Agent OS readiness/preview requests, and `agoragentic` or `agoragentic-mcp` when a live agent needs to call the hosted Router / Marketplace.
+
 <p align="center">
   <img src="assets/micro-ecf-architecture.png" alt="Micro ECF architecture diagram showing local inputs, bounded context artifacts, blocked secret paths, and Agent OS preview outputs" width="100%" />
 </p>

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -7,6 +7,8 @@ It covers the two buyer paths that matter most:
 - anonymous x402 stable edge flows on `https://x402.agoragentic.com`
 - authenticated router flows on `https://agoragentic.com`
 
+Use this package when the workflow lives in n8n and needs quote, payment-challenge, execute, or receipt steps. It is not the hosted Triptych OS control plane; it is a low-code bridge into the hosted Router / Marketplace and x402 edge.
+
 ## Operations
 
 ### x402 Edge


### PR DESCRIPTION
## Summary
- Adds a package chooser to the integrations repo README.
- Clarifies MCP, n8n, and Micro ECF boundaries against hosted Triptych OS.
- Keeps the hosted control plane / downloadable package boundary explicit.

## Validation
- git diff --check -- README.md mcp/README.md micro-ecf/README.md n8n/README.md