### PR TITLE
[codex] Add Premortem Golden Loop agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `harness-core/`, the package-ready local no-spend Harness Core scaffold for `init`, `validate`, `proof`, `export --to agent-os`, `listing check`, and adapter discovery.
 - Added Harness Core schemas, tests, and a Trusted Publishing release workflow gated by `harness-core-v*` release tags.
+- Added `premortem-golden-loop/`, a free local OSS agent release premortem, no-spend Golden Loop readiness, and safe self-heal scaffold CLI.
+- Added Premortem Golden Loop discovery pointers in `integrations.json`, `README.md`, `llms.txt`, `llms-full.txt`, and `SKILL.md`.
 - Added high-priority adapters for LangGraph, Cloudflare Agents, Microsoft Semantic Kernel, Zapier MCP, Flowise, Composio, and HumanLayer.
 - Added an experimental Zoneless payout reference as documentation-only research while keeping Base settlement canonical.
 - Folded the integration manifest to version `2.15.0` with all public integration surfaces indexed.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The first call to this paid route returns an x402 payment challenge. A signed pa
 - Plug into MCP, OpenAI Agents, AutoGen, smolagents, LangChain, CrewAI, and more
 - Prepare governed deployments with Micro ECF and Agent OS Harness packets
 - Run local no-spend Harness Core proof, receipt, export, and listing-readiness checks before hosted launch
+- Run local release premortems, no-spend Golden Loop readiness checks, and additive self-heal plans before publishing an OSS agent
 
 ## Live proof
 
@@ -126,6 +127,7 @@ Use this chooser before picking a framework wrapper:
 | Expose Agoragentic tools inside MCP-native hosts | `npx agoragentic-mcp@latest` | MCP stdio relay |
 | Prepare local context, policy, source maps, and Harness exports before hosted deployment | `npx agoragentic-micro-ecf@latest` | Micro ECF local wedge |
 | Build no-spend local proof, receipt, Agent OS export, and listing-readiness artifacts | `node harness-core/bin/agoragentic-harness.mjs` | Harness Core source scaffold |
+| Run a local release premortem and safe self-heal plan before publishing an OSS agent | `node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs` | Premortem Golden Loop source scaffold |
 | Run a self-hosted context-governance compiler without hosted wallets or marketplace execution | `npx agoragentic-ecf-core@latest` | ECF Core |
 | Add quote, x402, execute, and receipt steps to n8n workflows | `npm install n8n-nodes-agoragentic` | n8n community node |
 
@@ -138,6 +140,7 @@ The hosted Triptych OS (Agent OS) control plane is not a downloadable npm packag
 | **MCP Server** | `npx agoragentic-mcp` | Node ≥ 18 |
 | **ACP Adapter** | `npx agoragentic-mcp --acp` | Node ≥ 18 |
 | **Micro ECF** | `npx agoragentic-micro-ecf@latest init` | Node ≥ 18 |
+| **Premortem Golden Loop Agent** | `node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs run --repo .` | Node ≥ 18 |
 
 ## Available Integrations
 
@@ -152,6 +155,7 @@ The hosted Triptych OS (Agent OS) control plane is not a downloadable npm packag
 | [**x402 Buyer Integration**](x402/) | Javascript | ✅ Ready | `x402/buyer-demo.js` | [README](x402/README.md) |
 | [**Micro ECF**](micro-ecf/) | Javascript | Beta | `micro-ecf/bin/micro-ecf.mjs` | [README](micro-ecf/README.md) |
 | [**Agoragentic Harness Core**](harness-core/) | Javascript | Beta | `harness-core/bin/agoragentic-harness.mjs` | [README](harness-core/README.md) |
+| [**Premortem Golden Loop Agent**](premortem-golden-loop/) | Javascript | Beta | `premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs` | [README](premortem-golden-loop/README.md) |
 | [**LangChain**](langchain/) | Python | ✅ Ready | `langchain/agoragentic_tools.py` | [README](langchain/README.md) |
 | [**CrewAI**](crewai/) | Python | ✅ Ready | `crewai/agoragentic_crewai.py` | [README](crewai/README.md) |
 | [**MCP (Claude, VS Code, Cursor)**](mcp/) | Javascript | ✅ Ready | `mcp/mcp-server.js` | [README](mcp/README.md) |
@@ -195,6 +199,19 @@ The hosted Triptych OS (Agent OS) control plane is not a downloadable npm packag
 | [**HumanLayer**](humanlayer/) | Python | Beta | `humanlayer/agoragentic_humanlayer.py` | [README](humanlayer/README.md) |
 
 > **Machine-readable index:** [`integrations.json`](./integrations.json)
+
+## Premortem Golden Loop Agent
+
+Use this before committing to a plan, publishing an installable agent repo, or enabling hosted deployment or paid execution. It can generate a six-month failure-frame premortem report, run a local repo release premortem, check no-spend Golden Loop readiness, propose additive self-heal scaffolds, and write JSON/Markdown receipts under `.agoragentic/premortem-golden-loop/`.
+
+```bash
+node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs session --plan "Launch an OSS AI agent" --audience "AI agent builders" --success "builders run it and revise a launch plan"
+node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs run --repo .
+node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs heal --repo .
+node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs heal --repo . --apply-safe-fixes
+```
+
+The default path is free and local: no API key, no wallet, no network calls, no repo contents sent anywhere, no paid execution, and no production mutation. `heal` is plan-only unless `--apply-safe-fixes` is passed, and even then it only creates missing additive docs/metadata/CI scaffolds without overwriting existing files. Pass `--allow-network-canaries` only when the owner explicitly wants public no-spend Agoragentic discovery and x402 canary probes.
 
 ## Recommended Tool Flow
 
@@ -354,6 +371,8 @@ Your Agent  →  Integration (tools/MCP)  →  Agent OS + Agoragentic API
 | Capability description | [`SKILL.md`](./SKILL.md) |
 | Agent OS public export | [`agent-os/README.md`](./agent-os/README.md) |
 | OpenFang bridge | [`openfang/README.md`](./openfang/README.md) |
+| Premortem Golden Loop Agent | [`premortem-golden-loop/README.md`](./premortem-golden-loop/README.md) |
+| Premortem prompt | [`premortem-golden-loop/PROMPT.md`](./premortem-golden-loop/PROMPT.md) |
 | Micro ECF | [`micro-ecf/README.md`](./micro-ecf/README.md) |
 | Micro ECF Syrin guide | [`micro-ecf/SYRIN_USER_GUIDE.md`](./micro-ecf/SYRIN_USER_GUIDE.md) |
 | Micro ECF post-install | [`micro-ecf/POST_INSTALL.md`](./micro-ecf/POST_INSTALL.md) |

--- a/SKILL.md
+++ b/SKILL.md
@@ -17,6 +17,7 @@ Use this skill when:
 * you want to move a local or self-hosted agent toward hosted Agent OS deployment
 * you need local policy, budget, approval, memory, or swarm controls through Micro ECF
 * you need no-spend local proof, local receipt, Agent OS export, or listing-readiness checks through Harness Core
+* you need a local release premortem, no-spend Golden Loop readiness receipt, or safe self-heal plan before publishing an OSS agent
 * you need agent infrastructure such as persistent memory, secret storage, or identity features
 
 Do **not** use this skill when:
@@ -159,7 +160,7 @@ For a working example, clone the summarizer agent:
 
 ### Public integration coverage
 
-The public integrations repo includes adapters and bridge patterns for LangChain, LangGraph, LangChain Deep Agents, CrewAI, AutoGen, OpenAI Agents SDK, Google ADK, Vercel AI SDK, Cloudflare Agents, Microsoft Semantic Kernel, n8n, Flowise, Zapier MCP, Composio, HumanLayer, Dify, MCP, ACP, A2A, OpenFang, Micro ECF, Harness Core, Agent OS control-plane examples, and an experimental Zoneless payout reference.
+The public integrations repo includes adapters and bridge patterns for LangChain, LangGraph, LangChain Deep Agents, CrewAI, AutoGen, OpenAI Agents SDK, Google ADK, Vercel AI SDK, Cloudflare Agents, Microsoft Semantic Kernel, n8n, Flowise, Zapier MCP, Composio, HumanLayer, Dify, MCP, ACP, A2A, OpenFang, Micro ECF, Harness Core, Premortem Golden Loop, Agent OS control-plane examples, and an experimental Zoneless payout reference.
 
 `harness-core/` is the local no-spend Harness Core package scaffold for `init`, `validate`, `proof`, `export --to agent-os`, `listing check`, and adapter inventory before any hosted preview or treasury funding.
 
@@ -219,6 +220,19 @@ node harness-core/bin/agoragentic-harness.mjs init
 node harness-core/bin/agoragentic-harness.mjs proof
 node harness-core/bin/agoragentic-harness.mjs export --to agent-os
 ```
+
+### Premortem Golden Loop Agent
+
+Use `premortem-golden-loop/` in this repo when a builder wants to release or install an OSS agent safely before enabling hosted deployment or paid execution.
+
+```bash
+node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs session --plan "Launch an OSS AI agent" --audience "AI agent builders" --success "builders run it and revise a launch plan"
+node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs run --repo .
+node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs heal --repo .
+node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs heal --repo . --apply-safe-fixes
+```
+
+The `session` command follows `premortem-golden-loop/PROMPT.md`: it gathers the minimum context, frames the plan as already failed six months from now, generates failure reasons, runs one investigator pass per failure reason, and writes an HTML report plus transcript. The default path is free and local: no API key, no wallet, no network calls, no repo contents sent anywhere, no paid execution, and no production mutation. The `heal` command is plan-only unless `--apply-safe-fixes` is passed; safe fixes only create missing additive docs, metadata, env examples, or CI scaffolds and never overwrite existing files, delete files, rotate secrets, deploy, publish, or call paid `execute()` routes. Pass `--allow-network-canaries` only when the owner wants public no-spend Agoragentic canaries.
 
 ---
 

--- a/integrations.json
+++ b/integrations.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.16.0",
-  "updated_at": "2026-05-20",
+  "version": "2.17.0",
+  "updated_at": "2026-05-23",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
   "packages": {
@@ -44,6 +44,12 @@
       "name": "agoragentic-micro-ecf",
       "install": "npx agoragentic-micro-ecf init",
       "registry": "https://www.npmjs.com/package/agoragentic-micro-ecf",
+      "min_node": "18"
+    },
+    "premortem_golden_loop": {
+      "name": "agoragentic-premortem-golden-loop",
+      "install": "node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs run --repo .",
+      "registry": "https://github.com/rhein1/agoragentic-integrations/tree/main/premortem-golden-loop",
       "min_node": "18"
     }
   },
@@ -349,6 +355,15 @@
       "path": "harness-core/bin/agoragentic-harness.mjs",
       "install": "node harness-core/bin/agoragentic-harness.mjs init",
       "docs": "harness-core/README.md"
+    },
+    {
+      "id": "premortem-golden-loop",
+      "name": "Premortem Golden Loop Agent",
+      "language": "javascript",
+      "status": "beta",
+      "path": "premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs",
+      "install": "node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs run --repo . && node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs heal --repo .",
+      "docs": "premortem-golden-loop/README.md"
     },
     {
       "id": "langchain",
@@ -751,6 +766,8 @@
     "acp_registry_positioning": "ACP_REGISTRY.md",
     "micro_ecf": "micro-ecf/README.md",
     "harness_core": "harness-core/README.md",
+    "premortem_golden_loop": "premortem-golden-loop/README.md",
+    "premortem_prompt": "premortem-golden-loop/PROMPT.md",
     "micro_ecf_llm_install": "micro-ecf/LLM_INSTALL.md",
     "micro_ecf_ecf_md": "Generated ECF.md in installed projects",
     "micro_ecf_frameworks": "micro-ecf/FRAMEWORKS.md",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6,12 +6,13 @@
 
 This repository contains drop-in integrations connecting agent frameworks, protocol adapters, Micro ECF harness packets, Harness Core no-spend proof/export tooling, and Agent OS deployment examples to Agoragentic. Agoragentic is Agent OS for deployed agents and swarms. Micro ECF is the local context wedge. Agent OS is the deployment product. Full ECF is the private enterprise runtime engine. The marketplace is the transaction rail where deployed agents buy, sell, invoke, and settle work in USDC on Base L2.
 
-The published packages are:
+The published packages and repo-local CLIs are:
 - **Python SDK**: `pip install agoragentic` (PyPI, Python ≥3.8)
 - **Node.js SDK**: `npm install agoragentic` (npm, Node ≥16)
 - **MCP Server**: `npx agoragentic-mcp` (npm, Node ≥18)
 - **Micro ECF**: `npx agoragentic-micro-ecf@latest init` (npm, Node ≥18)
 - **Harness Core source scaffold**: `node harness-core/bin/agoragentic-harness.mjs init` (Node ≥18; npm publication pending validation)
+- **Premortem Golden Loop Agent**: `node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs run --repo .` or `heal --repo .` (free local Node ≥18 CLI; no repo contents sent anywhere by default)
 
 ## Authentication
 
@@ -75,7 +76,7 @@ Framework adapters, Agent OS control-plane examples, and marketplace integration
 | CAMEL | camel/agoragentic_camel.py | pip install agoragentic camel-ai |
 | Syrin | syrin/agoragentic_syrin.py | pip install syrin requests |
 
-### JavaScript/TypeScript Integrations (12)
+### JavaScript/TypeScript Integrations (13)
 
 | Framework | File | Install |
 |-----------|------|---------|
@@ -90,6 +91,7 @@ Framework adapters, Agent OS control-plane examples, and marketplace integration
 | oh-my-claudecode | oh-my-claudecode/README.md | npx agoragentic-mcp |
 | DashClaw | dashclaw/agoragentic_dashclaw.mjs | npm install dashclaw agoragentic |
 | OpenFang | openfang/agoragentic_openfang.mjs | node 18+ with a local OpenFang Hand manifest |
+| Premortem Golden Loop Agent | premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs | node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs run --repo . |
 | Zoneless Payout Reference | zoneless/agoragentic_zoneless_payouts.ts | reference only; not live settlement |
 
 ### Config-Only Integrations (7)
@@ -104,19 +106,22 @@ Framework adapters, Agent OS control-plane examples, and marketplace integration
 | claude-view Local Provider | claude-view/claude_view.get_live_summary.manifest.json | Run claude-view locally; no hosted endpoint required |
 | Scrumboy | scrumboy/scrumboy.discover_tools.manifest.json | Enable Scrumboy Agoragentic-compatible HTTP routes |
 
-### Agent OS, Micro ECF, and Harness Core (3)
+### Agent OS, Micro ECF, Harness Core, and Release Agents (4)
 
 | Export | File | Install |
 |--------|------|---------|
 | Agent OS Control Plane | agent-os/agent_os_node.mjs | npm install agoragentic or pip install agoragentic |
 | Micro ECF Harness Export | micro-ecf/README.md | npx agoragentic-micro-ecf@latest doctor --dir . |
 | Harness Core No-Spend Scaffold | harness-core/bin/agoragentic-harness.mjs | node harness-core/bin/agoragentic-harness.mjs init |
+| Premortem Golden Loop Agent | premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs | node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs run --repo . |
 
 Agent OS is the hosted operating layer for deployed agents and swarms, not a local OS installation. External agents use the public SDK/API surface for launch previews, account checks, quote creation, procurement checks, supervisor approvals, quote-locked execution, receipts, and reconciliation. The examples in `agent-os/` are no-spend by default and only execute when `AGORAGENTIC_EXECUTE=true`.
 
 Micro ECF is the local context wedge for context, tools, budgets, approvals, memory, and swarm boundaries. It generates `ECF.md` as a persistent agent-readable policy contract, then `.micro-ecf/*` source maps, context packets, policy summaries, and Agent OS harness exports. Use `micro-ecf scan --dir .`, `micro-ecf doctor --dir .`, and `micro-ecf lint ECF.md` before relying on the artifacts. The harness export produces a stable `agent_os_preview_request` for hosted Agent OS preview. Use `npx agoragentic-os@latest deploy readiness --file .micro-ecf/harness-export.json`, then `deploy preview`, and only use `deploy create` when the owner is ready to record a hosted deployment request. Micro ECF does not execute hosted work, activate billing, provision runtime, publish marketplace listings, settle x402, or expose Full ECF internals.
 
 Harness Core is the local no-spend package scaffold for builders who need proof, local receipt, Agent OS export, and listing-readiness artifacts without installing the full Micro ECF workflow. It does not deploy infrastructure, spend funds, publish listings, activate x402, mutate trust, write hosted memory, or expose private runtime internals.
+
+The Premortem Golden Loop Agent is the local release safety agent for plans and installable repositories. It runs six-month failure-frame premortem sessions, repo release audits, no-spend Golden Loop readiness checks, and a conservative self-heal loop. `heal --repo .` writes only a plan; `heal --repo . --apply-safe-fixes` may create missing additive goals, workflows, safety-boundary docs, `agent.json`, `.env.example`, or a no-spend GitHub Actions workflow. It is free to use, requires no API key or wallet, makes no network calls by default, sends no repo contents anywhere, and does not overwrite files, delete files, rotate secrets, deploy, publish, or call paid `execute()`.
 
 ## MCP Client Install Configs
 
@@ -207,6 +212,8 @@ Full spec: specs/ACP-SPEC.md
 | Composio | composio/README.md |
 | HumanLayer | humanlayer/README.md |
 | Harness Core | harness-core/README.md |
+| Premortem Golden Loop Agent | premortem-golden-loop/README.md |
+| Premortem prompt | premortem-golden-loop/PROMPT.md |
 | Syrin Micro ECF guide | micro-ecf/SYRIN_USER_GUIDE.md |
 | Micro ECF framework guide | micro-ecf/FRAMEWORKS.md |
 | Agent OS evidence/eval backlog | micro-ecf/AGENT_OS_EVIDENCE_EVAL_BACKLOG.md |

--- a/llms.txt
+++ b/llms.txt
@@ -11,6 +11,7 @@
 - ACP: `npx agoragentic-mcp --acp` (Agent Client Protocol adapter, Node ≥18)
 - Micro ECF: `npx agoragentic-micro-ecf@latest init` (package-ready local context CLI, Node ≥18)
 - Harness Core source scaffold: `node harness-core/bin/agoragentic-harness.mjs init` (local no-spend proof/export/listing-readiness CLI, Node ≥18; npm publication pending validation)
+- Premortem Golden Loop Agent: `node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs run --repo .` or `heal --repo .` (free local Node ≥18 CLI; no repo contents sent anywhere by default)
 
 ## Auth
 - Env: AGORAGENTIC_API_KEY=amk_<key>
@@ -19,13 +20,14 @@
 
 ## Integrations
 - LangChain, LangGraph, LangChain Deep Agents, CrewAI, AutoGen, OpenAI Agents SDK, Google ADK, pydantic-ai, smolagents, Agno, MetaGPT, LlamaIndex, AutoGPT, Microsoft Semantic Kernel, Composio, HumanLayer, SuperAGI, CAMEL, Syrin (Python)
-- MCP, Vercel AI, Cloudflare Agents, Mastra, Bee Agent, ElizaOS, n8n, oh-my-claudecode, DashClaw, OpenFang, Harness Core, Zoneless payout reference (JS/TS)
+- MCP, Vercel AI, Cloudflare Agents, Mastra, Bee Agent, ElizaOS, n8n, oh-my-claudecode, DashClaw, OpenFang, Harness Core, Premortem Golden Loop, Zoneless payout reference (JS/TS)
 - Agent Client Protocol: acp/agent.json and `npx agoragentic-mcp --acp`
 - Dify, Flowise, Zapier MCP, A2A, RepoBrain Local Provider, claude-view Local Provider, Scrumboy (JSON)
 - LangSmith: langsmith/README.md (observability)
 - Agent OS Control Plane: agent-os/README.md (public quote, procurement, approval, execute, and reconciliation flow)
 - Micro ECF: micro-ecf/README.md (local context/policy packets and Agent OS Harness export)
 - Harness Core: harness-core/README.md (local no-spend proof, receipt, Agent OS export, and listing-readiness artifacts)
+- Premortem Golden Loop Agent: premortem-golden-loop/README.md and premortem-golden-loop/PROMPT.md (free local six-month failure-frame premortem reports plus OSS agent release premortem, no-spend Golden Loop readiness receipt, and safe self-heal scaffolds)
 
 ## Machine Index
 - integrations.json — structured index of all integrations, tools, packages
@@ -57,6 +59,7 @@
 - MICRO_ECF_LLM_BOOTSTRAP.md — generated per-project paste/attach handoff for new chats that do not auto-load repo instructions
 - micro-ecf/bin/micro-ecf.mjs — package-ready local CLI: init, scan, doctor, lint, diff, spec, index, build-packet, export, serve-mcp
 - harness-core/bin/agoragentic-harness.mjs — package-ready no-spend CLI: init, validate, proof, export --to agent-os, listing check, adapters
+- premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs — free local no-spend CLI: session, premortem, golden-loop, run, heal, HTML reports, transcripts, JSON/Markdown receipts, and additive self-heal plans
 
 ## Live API
 - Manifest: https://agoragentic.com/.well-known/agent-marketplace.json

--- a/premortem-golden-loop/LICENSE
+++ b/premortem-golden-loop/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Agoragentic
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/premortem-golden-loop/PROMPT.md
+++ b/premortem-golden-loop/PROMPT.md
@@ -1,0 +1,110 @@
+---
+name: premortem
+description: "Run a premortem on any plan, launch, product, hire, strategy, or decision. Assume it already failed 6 months from now and work backward to find every reason why. Produce a revised plan with blind spots exposed."
+mandatory_triggers:
+  - premortem this
+  - premortem my
+  - run a premortem
+  - what could kill this
+  - future-proof this
+  - stress test this plan
+  - what am i missing here
+  - find the blind spots
+strong_triggers:
+  - what could go wrong
+  - am i missing anything
+  - poke holes in this
+  - where will this break
+  - devil's advocate this
+---
+
+# Premortem Agent Prompt
+
+A premortem is the opposite of a postmortem. Instead of figuring out what went wrong after something fails, imagine it already failed and work backward to identify why before the user starts.
+
+Use this when the user has a concrete plan, launch, product, hire, strategy, or commitment where the cost of being wrong is high. Do not trigger on simple feedback requests, factual questions, vague ideas with no plan yet, or decisions that are already irreversible.
+
+## Minimum Context Threshold
+
+Before running the premortem, gather the minimum context:
+
+1. What is it? Describe the plan in one sentence.
+2. Who is it for or who does it affect?
+3. What does success look like?
+
+First scan available context:
+
+- current conversation
+- `CLAUDE.md`, `claude.md`, `AGENTS.md`, `README.md`
+- `memory/`, `docs/`, briefs, launch plans, product plans, or referenced files
+
+If any of the three required fields are missing, ask only the most important missing question and stop. Do not make the user fill out a form.
+
+## Frame
+
+Set the frame explicitly:
+
+```text
+It is 6 months from now. This plan has failed. It is done. We are looking back and trying to understand what went wrong.
+```
+
+## Raw Premortem
+
+Generate every genuine reason the plan could have died. Be comprehensive, specific, and grounded in the actual plan. Do not pad with weak reasons and do not stop early if there are more real failure modes.
+
+Each failure reason must be:
+
+- specific to this plan
+- grounded in provided context
+- a genuine threat, not a minor inconvenience
+
+## Deep-Dive Investigators
+
+Run one investigator per failure reason in parallel. Each investigator analyzes exactly one assigned failure reason.
+
+Investigator contract:
+
+```text
+You are an investigator in a premortem analysis. You have been assigned one specific failure reason to analyze in depth.
+
+The plan:
+[what it is, who it is for, what success looks like, and relevant workspace context]
+
+PREMORTEM FRAME: It is 6 months from now. This plan has failed.
+
+YOUR ASSIGNED FAILURE REASON: [failure reason]
+
+Write:
+1. THE FAILURE STORY: 2-3 paragraphs showing how this specific failure played out.
+2. THE UNDERLYING ASSUMPTION: one sentence naming what the user took for granted.
+3. EARLY WARNING SIGNS: 1-2 observable signals that this failure is starting.
+
+Keep the response under 300 words. Be direct. Do not hedge. Do not sugarcoat.
+```
+
+## Synthesis
+
+After all investigator outputs are complete, produce:
+
+1. The Most Likely Failure - the probable failure mode and why.
+2. The Most Dangerous Failure - the highest-damage failure mode and why.
+3. The Hidden Assumption - the biggest unexamined assumption across the analyses.
+4. The Revised Plan - concrete changes mapped to failure scenarios.
+5. The Pre-Launch Checklist - 3-5 specific things to verify, test, or put in place.
+
+The revised plan must be concrete. Do not say "consider testing pricing." Say "run a $47 pilot with 20 target users before committing to the $297 workshop."
+
+## Outputs
+
+Every complete session produces:
+
+```text
+premortem-report-[timestamp].html
+premortem-transcript-[timestamp].md
+```
+
+The HTML report should be self-contained with inline CSS, a dark background, prominent synthesis at the top, one visual card per failure reason, severity/likelihood indicators, and a grid showing all investigator findings.
+
+The transcript should include context gathered, raw failure reasons, all investigator deep dives, and the full synthesis.
+
+Chat response should be at most three sentences: most likely failure, hidden assumption, and the single most important revision.

--- a/premortem-golden-loop/README.md
+++ b/premortem-golden-loop/README.md
@@ -1,0 +1,169 @@
+# Agoragentic Premortem Golden Loop Agent
+
+OSS premortem agent for plans, launches, products, hires, strategies, and installable AI agent repositories. It can generate a full six-month failure-frame premortem report, run a repo release premortem, check the local no-spend Golden Loop, propose safe self-healing fixes, and write machine-readable receipts that an owner can inspect before publishing, deploying, or enabling paid execution.
+
+This package is local-first by default:
+
+- free to use
+- no Agoragentic API key required
+- no wallet required
+- no repo contents, prompts, business plans, reports, or receipts sent anywhere
+- no network calls unless explicitly requested
+- no paid execution
+- no production mutation
+- self-heal never overwrites existing files, deletes files, rotates secrets, deploys, or publishes
+
+## Install
+
+From this repository:
+
+```bash
+cd premortem-golden-loop
+npm test
+node bin/agoragentic-premortem-golden-loop.mjs run --repo ../my-agent --skip-network
+```
+
+When published as a package:
+
+```bash
+npx agoragentic-premortem-golden-loop run --repo .
+```
+
+## Commands
+
+```bash
+# Full Klein-style premortem session for a plan, launch, or decision.
+node bin/agoragentic-premortem-golden-loop.mjs session \
+  --plan "Launch an OSS AI agent that runs premortems and Golden Loop readiness checks" \
+  --audience "AI agent builders preparing public releases" \
+  --success "builders install it, run it, and make one concrete launch change"
+
+# Full local premortem plus no-spend Golden Loop receipt.
+node bin/agoragentic-premortem-golden-loop.mjs run --repo .
+
+# Self-heal plan only. No files are changed.
+node bin/agoragentic-premortem-golden-loop.mjs heal --repo .
+
+# Apply safe additive fixes: missing docs, agent.json, .env.example, or CI scaffold.
+node bin/agoragentic-premortem-golden-loop.mjs heal --repo . --apply-safe-fixes
+
+# Static repo release premortem only.
+node bin/agoragentic-premortem-golden-loop.mjs premortem --repo .
+
+# Golden Loop readiness only.
+node bin/agoragentic-premortem-golden-loop.mjs golden-loop --repo .
+
+# CI mode: fail when blockers or Golden Loop failures remain.
+node bin/agoragentic-premortem-golden-loop.mjs run --repo . --ci
+
+# Explicit offline mode. This is also the default.
+node bin/agoragentic-premortem-golden-loop.mjs run --repo . --skip-network
+
+# Optional public no-spend canaries. Sends no repo contents.
+node bin/agoragentic-premortem-golden-loop.mjs run --repo . --allow-network-canaries
+
+# Optional runtime probe for a locally running agent.
+node bin/agoragentic-premortem-golden-loop.mjs run --repo . --target-url http://localhost:3000
+```
+
+Artifacts are written to:
+
+```text
+.agoragentic/premortem-golden-loop/
+  premortem-report-[timestamp].html
+  premortem-transcript-[timestamp].md
+  premortem-session-[timestamp].json
+  premortem.json
+  premortem.md
+  golden-loop.json
+  golden-loop.md
+  local-receipt.json
+  summary.md
+  healing-plan.json
+  healing-plan.md
+  healing-recheck.json
+```
+
+## Workflow For Users
+
+1. Run `session` on the business plan, launch, product, hire, or strategy so the agent can expose how it could fail.
+2. Run `run --repo .` on the installable repo to audit the Golden Loop readiness path locally.
+3. Run `heal --repo .` to see the safe self-healing plan without changing files.
+4. Run `heal --repo . --apply-safe-fixes` only after reviewing the plan.
+5. Rerun `run --repo . --ci`; optionally add `--run-tests` if the repo's declared tests are safe in no-spend mode.
+6. Use Agent OS, Micro ECF, x402, hosted deployment, marketplace publication, or paid `execute()` only as separate owner-approved steps.
+
+## Premortem Session Workflow
+
+The `session` command implements the prompt in [`PROMPT.md`](./PROMPT.md):
+
+- checks whether it has the minimum context: what it is, who it is for, and what success looks like
+- frames the plan as already failed six months from now
+- generates the raw failure reasons
+- runs one independent investigator pass per failure reason
+- synthesizes the most likely failure, most dangerous failure, hidden assumption, revised plan, and pre-launch checklist
+- writes a self-contained dark HTML report and a full Markdown transcript
+
+If context is missing, it writes `premortem-context-needed.json` and asks the next single question instead of producing a generic report.
+
+## What The Premortem Checks
+
+The premortem looks for release blockers and operating risks:
+
+- README, OSS license, and reproducible install contract
+- declared test contract
+- agent discovery metadata such as `agent.json`, `agent-card.json`, `SKILL.md`, OpenAPI, MCP, or a manifest
+- committed secret-like values without printing the secret value
+- `.env.example` or equivalent configuration instructions
+- explicit no-spend, budget, owner approval, x402, USDC, or paid-execution boundaries
+- receipt, trace, invocation, reconciliation, or audit-proof contract
+- basic runtime operations notes such as health, readiness, rollback, or runbook
+- Agent OS / Micro ECF / `execute(task,input,constraints)` alignment when the repo is meant to launch through Agoragentic
+
+## What The No-Spend Golden Loop Tests
+
+The local Golden Loop is a readiness loop, not a settlement proof:
+
+1. install contract exists
+2. configuration and secret boundary is clear
+3. agent discovery contract exists
+4. premortem blockers are resolved
+5. receipt/proof contract exists
+6. owner approval and spend boundary is explicit
+7. public no-spend Agoragentic canaries respond, only when `--allow-network-canaries` is used
+8. optional target runtime responds, when `--target-url` is provided
+9. optional declared tests pass, when `--run-tests` is used
+
+The public canaries are off by default. If enabled, they use only unauthenticated no-spend surfaces and do not send repository contents:
+
+- `GET /api/discovery/check`
+- `GET /api/x402/info`
+- `GET /api/x402/test/echo`
+- `GET /api/catalog?spend_possible=false&auth=none`
+
+## Self-Healing Boundaries
+
+The `heal` command is deliberately conservative. In plan mode it writes only `healing-plan.json` and `healing-plan.md` under `.agoragentic/premortem-golden-loop/`.
+
+With `--apply-safe-fixes`, it may create only missing additive scaffolds:
+
+- `docs/AGORAGENTIC_GOALS.md`
+- `docs/AGORAGENTIC_WORKFLOWS.md`
+- `docs/AGORAGENTIC_SAFETY_BOUNDARIES.md`
+- `agent.json`
+- `.env.example`
+- `.github/workflows/agoragentic-premortem-golden-loop.yml`
+
+It does not overwrite existing files, edit application source code, delete files, remove secrets, rotate credentials, install dependencies, call paid `execute()`, transfer USDC, publish listings, deploy, or open a production runtime. Secret findings and license choices remain manual owner actions.
+
+## Paid Proof Boundary
+
+This package intentionally does not sign wallet payments or run paid `execute()` calls. Real Golden Loop proof on Agoragentic includes wallet ownership, funding, quote-backed execution, receipt, and reconciliation. That path must remain explicitly owner-approved and budget-gated.
+
+For integrations, keep external paid work routed through:
+
+```text
+execute(task, input, constraints)
+```
+
+Do not hardcode provider IDs unless the agent intentionally needs a specific provider.

--- a/premortem-golden-loop/agent.json
+++ b/premortem-golden-loop/agent.json
@@ -1,0 +1,58 @@
+{
+  "schema": "agoragentic.agent-descriptor.v1",
+  "name": "Agoragentic Premortem Golden Loop Agent",
+  "id": "premortem-golden-loop",
+  "description": "Free local OSS premortem agent for plans and launches plus no-spend Golden Loop readiness checks and safe self-healing scaffolds for installable AI agent repositories.",
+  "entrypoint": "bin/agoragentic-premortem-golden-loop.mjs",
+  "runtime": {
+    "language": "javascript",
+    "node": ">=18"
+  },
+  "commands": [
+    "session",
+    "run",
+    "heal",
+    "premortem",
+    "golden-loop"
+  ],
+  "default_boundary": {
+    "free_to_use": true,
+    "local_only": true,
+    "network_calls": false,
+    "repo_contents_uploaded": false,
+    "data_sent_anywhere": false,
+    "credentials_required": false,
+    "wallet_required": false,
+    "paid_execution": false,
+    "production_mutation": false,
+    "real_usdc_transfer": false
+  },
+  "artifacts": [
+    ".agoragentic/premortem-golden-loop/premortem-report-[timestamp].html",
+    ".agoragentic/premortem-golden-loop/premortem-transcript-[timestamp].md",
+    ".agoragentic/premortem-golden-loop/premortem.json",
+    ".agoragentic/premortem-golden-loop/golden-loop.json",
+    ".agoragentic/premortem-golden-loop/local-receipt.json",
+    ".agoragentic/premortem-golden-loop/healing-plan.json",
+    ".agoragentic/premortem-golden-loop/healing-plan.md"
+  ],
+  "agoragentic": {
+    "agent_os_alias": true,
+    "external_work_rule": "Prefer execute(task,input,constraints) when the inspected agent needs routed external work.",
+    "self_heal": {
+      "plan_command": "heal --repo .",
+      "apply_command": "heal --repo . --apply-safe-fixes",
+      "writes_only_new_files": true,
+      "overwrites_existing_files": false,
+      "deletes_files": false,
+      "edits_application_code": false,
+      "sends_repo_contents": false
+    },
+    "public_no_spend_canaries": [
+      "GET /api/discovery/check",
+      "GET /api/x402/info",
+      "GET /api/x402/test/echo",
+      "GET /api/catalog?spend_possible=false&auth=none"
+    ]
+  }
+}

--- a/premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs
+++ b/premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import {
+  DEFAULT_BASE_URL,
+  DEFAULT_OUTPUT_DIR,
+  premortemSessionFileNames,
+  renderGoldenLoopMarkdown,
+  renderHealingPlanMarkdown,
+  renderPremortemMarkdown,
+  renderPremortemSessionHtml,
+  renderPremortemSessionSummary,
+  renderPremortemSessionTranscript,
+  renderSummaryMarkdown,
+  runAll,
+  runGoldenLoop,
+  runHeal,
+  runPremortem,
+  runPremortemSession,
+  writeJson,
+  writeText
+} from '../src/core.mjs';
+
+const USAGE = `
+Agoragentic Premortem Golden Loop
+
+Usage:
+  agoragentic-premortem-golden-loop run [options]
+  agoragentic-premortem-golden-loop session --plan <text> --audience <who> --success <outcome>
+  agoragentic-premortem-golden-loop heal [options]
+  agoragentic-premortem-golden-loop premortem [options]
+  agoragentic-premortem-golden-loop golden-loop [options]
+
+Options:
+  --repo <path>         Agent repository to inspect. Defaults to current directory.
+  --out <path>          Output directory. Defaults to .agoragentic/premortem-golden-loop.
+  --plan <text>         Plan, launch, product, hire, strategy, or decision to premortem.
+  --plan-file <path>    File containing the plan context.
+  --audience <text>     Who the plan is for or affects.
+  --success <text>      What a win looks like.
+  --base-url <url>      Agoragentic base URL for no-spend public canaries.
+  --target-url <url>    Optional running agent URL to health/discovery probe.
+  --allow-network-canaries
+                       Opt in to public no-spend Agoragentic canaries. Sends no repo contents.
+  --skip-network        Force local-only mode.
+  --run-tests           Run package.json scripts.test with AGORAGENTIC_NO_SPEND=1.
+  --apply-safe-fixes    For heal: create only missing additive docs/metadata/CI files.
+  --open-report         Open the generated HTML report with the OS default app.
+  --json                Print JSON to stdout.
+  --ci                  Exit non-zero when blockers or Golden Loop failures remain.
+  --fail-on <level>     never, blocker, warning. Defaults to never.
+  --help                Show this help.
+`;
+
+async function main(argv) {
+  const parsed = parseArgs(argv);
+  if (parsed.help) {
+    process.stdout.write(USAGE.trimStart());
+    return;
+  }
+
+  const command = parsed.command || 'run';
+  const repo = path.resolve(parsed.repo || '.');
+  const outDir = path.resolve(parsed.out || path.join(repo, DEFAULT_OUTPUT_DIR));
+  const options = {
+    repo,
+    baseUrl: parsed.baseUrl || DEFAULT_BASE_URL,
+    targetUrl: parsed.targetUrl || null,
+    plan: parsed.plan || null,
+    planFile: parsed.planFile || null,
+    audience: parsed.audience || null,
+    success: parsed.success || null,
+    skipNetwork: parsed.skipNetwork,
+    allowNetworkCanaries: parsed.allowNetworkCanaries,
+    applySafeFixes: parsed.applySafeFixes,
+    runTests: parsed.runTests
+  };
+
+  if (command === 'session') {
+    const session = await runPremortemSession(options);
+    if (session.status === 'needs_context') {
+      await writeJson(path.join(outDir, 'premortem-context-needed.json'), session);
+      emit(parsed, session, `Premortem needs more context: ${session.question}`);
+      if (parsed.ci) process.exitCode = 1;
+      return;
+    }
+
+    const names = premortemSessionFileNames(session.timestamp);
+    const reportPath = path.join(outDir, names.report);
+    const transcriptPath = path.join(outDir, names.transcript);
+    await writeJson(path.join(outDir, names.json), session);
+    await writeText(reportPath, renderPremortemSessionHtml(session));
+    await writeText(transcriptPath, renderPremortemSessionTranscript(session));
+    if (parsed.openReport) openReport(reportPath);
+    emit(parsed, session, `Premortem report written to ${reportPath}\nTranscript written to ${transcriptPath}\n${renderPremortemSessionSummary(session)}`);
+    return;
+  }
+
+  if (command === 'premortem') {
+    const report = await runPremortem(options);
+    await writeJson(path.join(outDir, 'premortem.json'), report);
+    await writeText(path.join(outDir, 'premortem.md'), renderPremortemMarkdown(report));
+    emit(parsed, report, `Premortem written to ${outDir}`);
+    exitFor(parsed, report.summary.blockers, report.summary.warnings, 0);
+    return;
+  }
+
+  if (command === 'golden-loop') {
+    const report = await runGoldenLoop(options);
+    await writeJson(path.join(outDir, 'golden-loop.json'), report);
+    await writeText(path.join(outDir, 'golden-loop.md'), renderGoldenLoopMarkdown(report));
+    emit(parsed, report, `Golden Loop receipt written to ${outDir}`);
+    exitFor(parsed, report.summary.fail, report.summary.warn, report.summary.fail);
+    return;
+  }
+
+  if (command === 'heal') {
+    const report = await runHeal(options);
+    await writeJson(path.join(outDir, 'healing-plan.json'), report);
+    await writeText(path.join(outDir, 'healing-plan.md'), renderHealingPlanMarkdown(report));
+    if (report.after) {
+      await writeJson(path.join(outDir, 'healing-recheck.json'), report.after);
+    }
+    const created = report.applied.filter((item) => item.status === 'created').length;
+    const suffix = parsed.applySafeFixes
+      ? `Created ${created} safe file(s). Recheck written to ${outDir}.`
+      : 'Plan only. No files changed. Pass --apply-safe-fixes to create safe missing scaffolds.';
+    emit(parsed, report, `Self-heal artifacts written to ${outDir}\n${suffix}`);
+    const effective = report.after || report.before;
+    exitFor(parsed, effective.premortem.summary.blockers, effective.premortem.summary.warnings, effective.golden_loop.summary.fail);
+    return;
+  }
+
+  if (command !== 'run') {
+    throw new Error(`Unknown command: ${command}`);
+  }
+
+  const run = await runAll(options);
+  await writeJson(path.join(outDir, 'premortem.json'), run.premortem);
+  await writeText(path.join(outDir, 'premortem.md'), renderPremortemMarkdown(run.premortem));
+  await writeJson(path.join(outDir, 'golden-loop.json'), run.golden_loop);
+  await writeText(path.join(outDir, 'golden-loop.md'), renderGoldenLoopMarkdown(run.golden_loop));
+  await writeJson(path.join(outDir, 'local-receipt.json'), run.receipt);
+  await writeText(path.join(outDir, 'summary.md'), renderSummaryMarkdown(run));
+  emit(parsed, run, `Premortem Golden Loop artifacts written to ${outDir}`);
+  exitFor(parsed, run.premortem.summary.blockers, run.premortem.summary.warnings, run.golden_loop.summary.fail);
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    command: null,
+    repo: null,
+    out: null,
+    baseUrl: null,
+    targetUrl: null,
+    skipNetwork: false,
+    allowNetworkCanaries: false,
+    runTests: false,
+    applySafeFixes: false,
+    plan: null,
+    planFile: null,
+    audience: null,
+    success: null,
+    openReport: false,
+    json: false,
+    ci: false,
+    failOn: 'never',
+    help: false
+  };
+
+  const args = [...argv];
+  if (args[0] && !args[0].startsWith('-')) parsed.command = args.shift();
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--help' || arg === '-h') parsed.help = true;
+    else if (arg === '--repo') parsed.repo = takeValue(args, ++index, arg);
+    else if (arg === '--out') parsed.out = takeValue(args, ++index, arg);
+    else if (arg === '--plan') parsed.plan = takeValue(args, ++index, arg);
+    else if (arg === '--plan-file') parsed.planFile = takeValue(args, ++index, arg);
+    else if (arg === '--audience') parsed.audience = takeValue(args, ++index, arg);
+    else if (arg === '--success') parsed.success = takeValue(args, ++index, arg);
+    else if (arg === '--base-url') parsed.baseUrl = takeValue(args, ++index, arg);
+    else if (arg === '--target-url') parsed.targetUrl = takeValue(args, ++index, arg);
+    else if (arg === '--skip-network') parsed.skipNetwork = true;
+    else if (arg === '--allow-network-canaries') parsed.allowNetworkCanaries = true;
+    else if (arg === '--run-tests') parsed.runTests = true;
+    else if (arg === '--apply-safe-fixes') parsed.applySafeFixes = true;
+    else if (arg === '--open-report') parsed.openReport = true;
+    else if (arg === '--json') parsed.json = true;
+    else if (arg === '--ci') parsed.ci = true;
+    else if (arg === '--fail-on') parsed.failOn = takeValue(args, ++index, arg);
+    else throw new Error(`Unknown option: ${arg}`);
+  }
+
+  if (!['never', 'blocker', 'warning'].includes(parsed.failOn)) {
+    throw new Error('--fail-on must be never, blocker, or warning');
+  }
+  return parsed;
+}
+
+function takeValue(args, index, flag) {
+  const value = args[index];
+  if (!value || value.startsWith('-')) throw new Error(`${flag} requires a value`);
+  return value;
+}
+
+function emit(parsed, value, text) {
+  if (parsed.json) {
+    process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(`${text}\n`);
+}
+
+function exitFor(parsed, blockers, warnings, goldenLoopFailures) {
+  const shouldFail = parsed.ci
+    ? blockers > 0 || goldenLoopFailures > 0
+    : parsed.failOn === 'blocker'
+      ? blockers > 0 || goldenLoopFailures > 0
+      : parsed.failOn === 'warning'
+        ? blockers > 0 || warnings > 0 || goldenLoopFailures > 0
+        : false;
+
+  if (shouldFail) process.exitCode = 1;
+}
+
+function openReport(filePath) {
+  const child = process.platform === 'win32'
+    ? spawn(process.env.ComSpec || 'cmd.exe', ['/d', '/s', '/c', 'start', '', filePath], { detached: true, stdio: 'ignore' })
+    : process.platform === 'darwin'
+      ? spawn('open', [filePath], { detached: true, stdio: 'ignore' })
+      : spawn('xdg-open', [filePath], { detached: true, stdio: 'ignore' });
+  child.unref();
+}
+
+main(process.argv.slice(2)).catch((err) => {
+  process.stderr.write(`${err.message || err}\n`);
+  process.exitCode = 1;
+});

--- a/premortem-golden-loop/package.json
+++ b/premortem-golden-loop/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "agoragentic-premortem-golden-loop",
+  "version": "0.1.0",
+  "description": "Free local OSS premortem, self-heal, and no-spend Golden Loop readiness CLI for plans, launches, and installable AI agent repositories.",
+  "type": "module",
+  "license": "MIT",
+  "bin": {
+    "agoragentic-premortem-golden-loop": "./bin/agoragentic-premortem-golden-loop.mjs",
+    "agoragentic-premortem": "./bin/agoragentic-premortem-golden-loop.mjs",
+    "agoragentic-golden-loop": "./bin/agoragentic-premortem-golden-loop.mjs"
+  },
+  "files": [
+    "bin/",
+    "src/",
+    "agent.json",
+    "PROMPT.md",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "test": "node --test test/*.test.mjs",
+    "check": "node --check bin/agoragentic-premortem-golden-loop.mjs && node --check src/core.mjs"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "agoragentic",
+    "agent-os",
+    "ai-agents",
+    "premortem",
+    "golden-loop",
+    "self-heal",
+    "x402",
+    "receipts",
+    "oss"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rhein1/agoragentic-integrations.git",
+    "directory": "premortem-golden-loop"
+  },
+  "homepage": "https://agoragentic.com",
+  "bugs": {
+    "url": "https://github.com/rhein1/agoragentic-integrations/issues"
+  }
+}

--- a/premortem-golden-loop/src/core.mjs
+++ b/premortem-golden-loop/src/core.mjs
@@ -1,0 +1,1906 @@
+import crypto from 'node:crypto';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export const DEFAULT_BASE_URL = 'https://agoragentic.com';
+export const DEFAULT_OUTPUT_DIR = '.agoragentic/premortem-golden-loop';
+
+const TEXT_EXTENSIONS = new Set([
+  '',
+  '.cjs',
+  '.css',
+  '.env',
+  '.html',
+  '.ini',
+  '.js',
+  '.json',
+  '.jsx',
+  '.md',
+  '.mjs',
+  '.py',
+  '.sh',
+  '.toml',
+  '.ts',
+  '.tsx',
+  '.txt',
+  '.yaml',
+  '.yml'
+]);
+
+const IGNORED_DIRS = new Set([
+  '.agoragentic',
+  '.cache',
+  '.git',
+  '.micro-ecf',
+  '.next',
+  '.turbo',
+  '.venv',
+  '__pycache__',
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+  'target',
+  'venv'
+]);
+
+const SECRET_PATTERNS = [
+  {
+    id: 'private-key-block',
+    label: 'private key block',
+    regex: /-----BEGIN (?:[A-Z]+ )?PRIVATE KEY-----/i
+  },
+  {
+    id: 'aws-access-key',
+    label: 'AWS access key',
+    regex: /\bAKIA[0-9A-Z]{16}\b/
+  },
+  {
+    id: 'openai-style-key',
+    label: 'OpenAI-style secret key',
+    regex: /\bsk-[A-Za-z0-9_-]{20,}\b/
+  },
+  {
+    id: 'agoragentic-api-key',
+    label: 'Agoragentic API key',
+    regex: /\bamk_[A-Za-z0-9_-]{12,}\b/
+  },
+  {
+    id: 'github-token',
+    label: 'GitHub token',
+    regex: /\b(?:ghp|github_pat)_[A-Za-z0-9_]{20,}\b/
+  },
+  {
+    id: 'env-secret-value',
+    label: 'secret-like environment value',
+    regex: /\b(?:API[_-]?KEY|SECRET|TOKEN|PRIVATE[_-]?KEY|PASSWORD)\s*[:=]\s*["']?(?!your|example|sample|changeme|placeholder|<|$)[A-Za-z0-9_./+=:@-]{12,}/i
+  }
+];
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function slash(value) {
+  return value.replace(/\\/g, '/');
+}
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function normalizeRoot(root = '.') {
+  return path.resolve(root);
+}
+
+async function exists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readText(filePath) {
+  return fs.readFile(filePath, 'utf8');
+}
+
+async function readJson(filePath) {
+  try {
+    return JSON.parse(await readText(filePath));
+  } catch {
+    return null;
+  }
+}
+
+async function statSafe(filePath) {
+  try {
+    return await fs.stat(filePath);
+  } catch {
+    return null;
+  }
+}
+
+async function walkFiles(root, { maxFiles = 2500 } = {}) {
+  const files = [];
+  const queue = [root];
+
+  while (queue.length && files.length < maxFiles) {
+    const current = queue.shift();
+    let entries = [];
+    try {
+      entries = await fs.readdir(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const entry of entries) {
+      if (entry.isSymbolicLink()) continue;
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        if (!IGNORED_DIRS.has(entry.name)) queue.push(full);
+        continue;
+      }
+      if (entry.isFile()) files.push(full);
+      if (files.length >= maxFiles) break;
+    }
+  }
+
+  return files;
+}
+
+function relative(root, filePath) {
+  return slash(path.relative(root, filePath) || '.');
+}
+
+function fileBasenames(files) {
+  return new Set(files.map((file) => path.basename(file).toLowerCase()));
+}
+
+function hasFile(files, names) {
+  const basenames = fileBasenames(files);
+  return names.some((name) => basenames.has(name.toLowerCase()));
+}
+
+function hasPath(files, root, candidates) {
+  const rels = files.map((file) => relative(root, file).toLowerCase());
+  return candidates.some((candidate) => {
+    const normalized = slash(candidate).toLowerCase().replace(/\/$/, '');
+    return rels.some((rel) => rel === normalized || rel.startsWith(`${normalized}/`));
+  });
+}
+
+async function readSearchableText(root, files) {
+  const candidates = files.filter((file) => {
+    const rel = relative(root, file).toLowerCase();
+    const ext = path.extname(file).toLowerCase();
+    return TEXT_EXTENSIONS.has(ext)
+      && !rel.includes('package-lock.json')
+      && !rel.includes('pnpm-lock.yaml')
+      && !rel.includes('yarn.lock');
+  }).slice(0, 300);
+
+  const chunks = [];
+  for (const file of candidates) {
+    const stat = await statSafe(file);
+    if (!stat || stat.size > 250_000) continue;
+    try {
+      chunks.push(await readText(file));
+    } catch {
+      // Ignore unreadable files; the premortem will still report structural gaps.
+    }
+  }
+  return chunks.join('\n').toLowerCase();
+}
+
+async function scanSecrets(root, files) {
+  const findings = [];
+  for (const file of files) {
+    const rel = relative(root, file);
+    const ext = path.extname(file).toLowerCase();
+    if (!TEXT_EXTENSIONS.has(ext)) continue;
+    if (/package-lock\.json$|pnpm-lock\.yaml$|yarn\.lock$/i.test(rel)) continue;
+
+    const stat = await statSafe(file);
+    if (!stat || stat.size > 350_000) continue;
+
+    let text = '';
+    try {
+      text = await readText(file);
+    } catch {
+      continue;
+    }
+
+    const lines = text.split(/\r?\n/);
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index];
+      const lowered = line.toLowerCase();
+      if (lowered.includes('placeholder') || lowered.includes('your_') || lowered.includes('example')) {
+        continue;
+      }
+      for (const pattern of SECRET_PATTERNS) {
+        if (pattern.regex.test(line)) {
+          findings.push({
+            id: pattern.id,
+            label: pattern.label,
+            file: rel,
+            line: index + 1
+          });
+          break;
+        }
+      }
+      if (findings.length >= 25) return findings;
+    }
+  }
+  return findings;
+}
+
+function includesAny(text, terms) {
+  return terms.some((term) => text.includes(term.toLowerCase()));
+}
+
+function statusFromRisk(severity) {
+  if (severity === 'blocker') return 'fail';
+  if (severity === 'warning') return 'warn';
+  return 'pass';
+}
+
+function addRisk(risks, checks, risk) {
+  risks.push(risk);
+  checks.push({
+    id: risk.id,
+    title: risk.title,
+    status: statusFromRisk(risk.severity),
+    evidence: risk.evidence,
+    action: risk.action
+  });
+}
+
+function addPass(checks, id, title, evidence) {
+  checks.push({ id, title, status: 'pass', evidence });
+}
+
+function summarizeRisks(risks) {
+  const blockers = risks.filter((risk) => risk.severity === 'blocker').length;
+  const warnings = risks.filter((risk) => risk.severity === 'warning').length;
+  const info = risks.filter((risk) => risk.severity === 'info').length;
+  const score = Math.max(0, 100 - blockers * 22 - warnings * 8 - info * 2);
+  return { score, blockers, warnings, info, risk_count: risks.length };
+}
+
+function nextActionsFromRisks(risks) {
+  return risks
+    .sort((a, b) => severityRank(a.severity) - severityRank(b.severity))
+    .slice(0, 8)
+    .map((risk) => ({
+      risk_id: risk.id,
+      severity: risk.severity,
+      action: risk.action
+    }));
+}
+
+function severityRank(severity) {
+  return { blocker: 0, warning: 1, info: 2 }[severity] ?? 3;
+}
+
+function repoFingerprint(root, files) {
+  const hash = crypto.createHash('sha256');
+  hash.update(slash(root));
+  for (const file of files.map((item) => relative(root, item)).sort()) {
+    hash.update('\n');
+    hash.update(file);
+  }
+  return hash.digest('hex').slice(0, 16);
+}
+
+export async function runPremortem(options = {}) {
+  const root = normalizeRoot(options.repo || options.root || '.');
+  const rootExists = await exists(root);
+  const generatedAt = nowIso();
+
+  if (!rootExists) {
+    const risks = [{
+      id: 'repo-not-found',
+      severity: 'blocker',
+      title: 'Repository path does not exist',
+      evidence: [root],
+      action: 'Run the premortem from an existing agent repository or pass --repo <path>.'
+    }];
+    return {
+      schema: 'agoragentic.premortem.v1',
+      generated_at: generatedAt,
+      root,
+      summary: summarizeRisks(risks),
+      risks,
+      checks: risks.map((risk) => ({
+        id: risk.id,
+        title: risk.title,
+        status: 'fail',
+        evidence: risk.evidence,
+        action: risk.action
+      })),
+      next_actions: nextActionsFromRisks(risks),
+      no_spend: true
+    };
+  }
+
+  const files = await walkFiles(root);
+  const relFiles = files.map((file) => relative(root, file));
+  const basenames = fileBasenames(files);
+  const text = await readSearchableText(root, files);
+  const packageJsonPath = path.join(root, 'package.json');
+  const packageJson = await readJson(packageJsonPath);
+  const pyproject = await exists(path.join(root, 'pyproject.toml'));
+  const risks = [];
+  const checks = [];
+
+  if (hasFile(files, ['README.md', 'README.txt', 'readme.md'])) {
+    addPass(checks, 'readme-present', 'README exists', ['README is present.']);
+  } else {
+    addRisk(risks, checks, {
+      id: 'readme-missing',
+      severity: 'blocker',
+      title: 'No README found',
+      evidence: ['Expected README.md or equivalent.'],
+      action: 'Add a README with install, configuration, run, test, safety, and support instructions.'
+    });
+  }
+
+  if (hasFile(files, ['LICENSE', 'LICENSE.md', 'COPYING'])) {
+    addPass(checks, 'license-present', 'OSS license exists', ['License file is present.']);
+  } else {
+    addRisk(risks, checks, {
+      id: 'license-missing',
+      severity: 'blocker',
+      title: 'OSS license is missing',
+      evidence: ['Expected LICENSE, LICENSE.md, or COPYING.'],
+      action: 'Add a clear OSS license before releasing the repository.'
+    });
+  }
+
+  const installEvidence = [];
+  if (packageJson) installEvidence.push('package.json');
+  if (pyproject) installEvidence.push('pyproject.toml');
+  if (basenames.has('requirements.txt')) installEvidence.push('requirements.txt');
+  if (basenames.has('setup.py')) installEvidence.push('setup.py');
+  if (basenames.has('dockerfile')) installEvidence.push('Dockerfile');
+  if (installEvidence.length) {
+    addPass(checks, 'install-contract-present', 'Install contract exists', installEvidence);
+  } else {
+    addRisk(risks, checks, {
+      id: 'install-contract-missing',
+      severity: 'blocker',
+      title: 'Install contract is missing',
+      evidence: ['No package.json, pyproject.toml, requirements.txt, setup.py, or Dockerfile found.'],
+      action: 'Add one reproducible install path so a new owner or agent can set up the repo without guessing.'
+    });
+  }
+
+  const testEvidence = [];
+  if (packageJson?.scripts?.test) testEvidence.push('package.json scripts.test');
+  if (hasPath(files, root, ['tests', 'test'])) testEvidence.push('tests/ or test/');
+  if (hasPath(files, root, ['.github/workflows'])) testEvidence.push('.github/workflows');
+  if (testEvidence.length) {
+    addPass(checks, 'test-contract-present', 'Test contract exists', testEvidence);
+  } else {
+    addRisk(risks, checks, {
+      id: 'test-contract-missing',
+      severity: 'warning',
+      title: 'No test contract found',
+      evidence: ['No package test script, tests directory, or GitHub Actions workflow found.'],
+      action: 'Add a no-spend smoke test that proves install, configuration, and one deterministic agent action.'
+    });
+  }
+
+  const descriptorEvidence = relFiles.filter((file) => /(^|\/)(agent-card|agent|openapi|skill|mcp|manifest)\.(json|ya?ml|md)$/i.test(file));
+  if (descriptorEvidence.length) {
+    addPass(checks, 'agent-discovery-present', 'Agent discovery contract exists', descriptorEvidence.slice(0, 8));
+  } else {
+    addRisk(risks, checks, {
+      id: 'agent-discovery-missing',
+      severity: 'warning',
+      title: 'Agent discovery contract is missing',
+      evidence: ['Expected agent.json, agent-card.json, openapi.yaml/json, SKILL.md, MCP manifest, or equivalent.'],
+      action: 'Add a small machine-readable agent descriptor with name, purpose, inputs, outputs, auth, and no-spend/paid boundaries.'
+    });
+  }
+
+  const secretFindings = await scanSecrets(root, files);
+  if (secretFindings.length) {
+    addRisk(risks, checks, {
+      id: 'secret-hygiene-failed',
+      severity: 'blocker',
+      title: 'Potential secrets are present in repository text',
+      evidence: secretFindings.map((finding) => `${finding.file}:${finding.line} ${finding.label}`),
+      action: 'Remove committed secrets, rotate exposed values, and replace them with placeholders in .env.example.'
+    });
+  } else {
+    addPass(checks, 'secret-hygiene-clear', 'No obvious committed secrets found', ['Scanned text files without printing secret values.']);
+  }
+
+  const envEvidence = [];
+  if (hasFile(files, ['.env.example', 'env.example', 'sample.env'])) envEvidence.push('.env.example or equivalent');
+  if (includesAny(text, ['environment variable', 'env var', 'agoragentic_api_key', 'api key', 'configuration'])) {
+    envEvidence.push('configuration docs');
+  }
+  if (envEvidence.length) {
+    addPass(checks, 'configuration-contract-present', 'Configuration contract exists', unique(envEvidence));
+  } else {
+    addRisk(risks, checks, {
+      id: 'configuration-contract-missing',
+      severity: 'warning',
+      title: 'Configuration contract is unclear',
+      evidence: ['No .env.example or obvious configuration instructions found.'],
+      action: 'Add .env.example plus docs for required and optional environment variables, including which calls can spend money.'
+    });
+  }
+
+  if (includesAny(text, ['max_cost', 'budget', 'spend cap', 'approval', 'no-spend', 'no spend', 'paid execution', 'x402', 'usdc'])) {
+    addPass(checks, 'spend-boundary-present', 'Spend boundary is documented', ['Budget, approval, no-spend, paid execution, x402, or USDC language found.']);
+  } else {
+    addRisk(risks, checks, {
+      id: 'spend-boundary-missing',
+      severity: 'warning',
+      title: 'Spend boundary is not explicit',
+      evidence: ['No obvious budget, approval, no-spend, paid execution, x402, or USDC language found.'],
+      action: 'Document exactly which paths are free, which can spend, and which owner approval or environment gate is required before paid execution.'
+    });
+  }
+
+  if (includesAny(text, ['receipt', 'invocation_id', 'trace id', 'trace_id', 'reconciliation', 'audit trail', 'proof'])) {
+    addPass(checks, 'receipt-contract-present', 'Receipt or proof contract is documented', ['Receipt, invocation, trace, reconciliation, audit, or proof language found.']);
+  } else {
+    addRisk(risks, checks, {
+      id: 'receipt-contract-missing',
+      severity: 'warning',
+      title: 'Receipt/proof contract is missing',
+      evidence: ['No obvious receipt, invocation, trace, reconciliation, audit, or proof language found.'],
+      action: 'Define what artifact proves the agent ran correctly: local receipt JSON, invocation ID, audit trail, or reconciliation record.'
+    });
+  }
+
+  if (includesAny(text, ['health', '/health', 'ready', 'readiness', 'rollback', 'runbook', 'incident'])) {
+    addPass(checks, 'runtime-operations-present', 'Runtime operations notes exist', ['Health, readiness, rollback, runbook, or incident language found.']);
+  } else {
+    addRisk(risks, checks, {
+      id: 'runtime-operations-missing',
+      severity: 'info',
+      title: 'Runtime operations notes are thin',
+      evidence: ['No obvious health, readiness, rollback, runbook, or incident language found.'],
+      action: 'Add a short operations section covering health checks, rollback, support contact, and what to do after a failed run.'
+    });
+  }
+
+  if (includesAny(text, ['agent os', 'execute(', 'execute(task', 'micro ecf', 'agoragentic'])) {
+    addPass(checks, 'agoragentic-alignment-present', 'Agoragentic/Agent OS alignment is visible', ['Agent OS, execute(), Micro ECF, or Agoragentic language found.']);
+  } else {
+    addRisk(risks, checks, {
+      id: 'agoragentic-alignment-missing',
+      severity: 'info',
+      title: 'Agoragentic alignment is not visible',
+      evidence: ['No obvious Agent OS, execute(), Micro ECF, or Agoragentic language found.'],
+      action: 'If this repo is meant to launch from Agoragentic, document the Agent OS handoff and prefer execute(task,input,constraints) for external work.'
+    });
+  }
+
+  const summary = summarizeRisks(risks);
+  return {
+    schema: 'agoragentic.premortem.v1',
+    generated_at: generatedAt,
+    root,
+    repo_fingerprint: repoFingerprint(root, files),
+    summary,
+    risks: risks.sort((a, b) => severityRank(a.severity) - severityRank(b.severity)),
+    checks,
+    next_actions: nextActionsFromRisks(risks),
+    file_count_scanned: files.length,
+    no_spend: true,
+    boundary: {
+      credentials_required: false,
+      paid_execution: false,
+      production_mutation: false
+    }
+  };
+}
+
+async function fetchWithTimeout(url, options = {}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), options.timeoutMs || 10000);
+  const started = Date.now();
+  try {
+    const response = await fetch(url, {
+      method: options.method || 'GET',
+      headers: {
+        'content-type': 'application/json',
+        'user-agent': 'agoragentic-premortem-golden-loop/0.1'
+      },
+      body: options.body === undefined ? undefined : JSON.stringify(options.body),
+      signal: controller.signal
+    });
+    const contentType = response.headers.get('content-type') || '';
+    const raw = await response.text();
+    let body = raw;
+    if (contentType.includes('application/json')) {
+      try {
+        body = raw ? JSON.parse(raw) : {};
+      } catch {
+        body = raw;
+      }
+    }
+    return {
+      ok: response.ok,
+      status: response.status,
+      elapsed_ms: Date.now() - started,
+      content_type: contentType,
+      body_shape: bodyShape(body)
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      status: null,
+      elapsed_ms: Date.now() - started,
+      error: err.name === 'AbortError' ? 'timeout' : err.message
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function bodyShape(body) {
+  if (Array.isArray(body)) return { type: 'array', length: body.length };
+  if (body && typeof body === 'object') return { type: 'object', keys: Object.keys(body).slice(0, 12) };
+  if (typeof body === 'string') return { type: 'text', length: body.length };
+  return { type: typeof body };
+}
+
+function stage(id, title, status, evidence = [], action = null) {
+  return { id, title, status, evidence, action };
+}
+
+function stageSummary(stages) {
+  return {
+    pass: stages.filter((item) => item.status === 'pass').length,
+    warn: stages.filter((item) => item.status === 'warn').length,
+    fail: stages.filter((item) => item.status === 'fail').length,
+    skip: stages.filter((item) => item.status === 'skip').length
+  };
+}
+
+function findCheck(report, idPrefix) {
+  return report.checks.find((check) => check.id.startsWith(idPrefix));
+}
+
+async function runPublicCanaries(baseUrl) {
+  const cleanBase = String(baseUrl || DEFAULT_BASE_URL).replace(/\/$/, '');
+  const probes = [
+    {
+      id: 'discovery-check',
+      title: 'Agoragentic public discovery self-test',
+      url: `${cleanBase}/api/discovery/check`,
+      method: 'GET',
+      accept: [200]
+    },
+    {
+      id: 'x402-info',
+      title: 'x402 public info surface',
+      url: `${cleanBase}/api/x402/info`,
+      method: 'GET',
+      accept: [200]
+    },
+    {
+      id: 'x402-test-echo',
+      title: 'Free x402 test echo surface',
+      url: `${cleanBase}/api/x402/test/echo`,
+      method: 'GET',
+      accept: [200, 402]
+    },
+    {
+      id: 'catalog-no-spend',
+      title: 'No-spend catalog metadata surface',
+      url: `${cleanBase}/api/catalog?spend_possible=false&auth=none`,
+      method: 'GET',
+      accept: [200]
+    }
+  ];
+
+  const results = [];
+  for (const probe of probes) {
+    const response = await fetchWithTimeout(probe.url, { method: probe.method });
+    const passed = response.status && probe.accept.includes(response.status);
+    results.push({
+      id: probe.id,
+      title: probe.title,
+      url: probe.url,
+      method: probe.method,
+      status: passed ? 'pass' : 'warn',
+      http_status: response.status,
+      elapsed_ms: response.elapsed_ms,
+      evidence: response.error
+        ? [`${probe.method} ${probe.url} failed: ${response.error}`]
+        : [`${probe.method} ${probe.url} returned HTTP ${response.status}`],
+      body_shape: response.body_shape
+    });
+  }
+  return results;
+}
+
+async function runTargetChecks(targetUrl) {
+  if (!targetUrl) return [];
+  const clean = String(targetUrl).replace(/\/$/, '');
+  const candidates = [
+    clean,
+    `${clean}/health`,
+    `${clean}/.well-known/agent.json`,
+    `${clean}/agent.json`,
+    `${clean}/openapi.json`,
+    `${clean}/openapi.yaml`
+  ];
+  const checks = [];
+  for (const url of candidates) {
+    const response = await fetchWithTimeout(url, { method: 'GET', timeoutMs: 8000 });
+    checks.push({
+      url,
+      status: response.status && response.status < 500 ? 'pass' : 'warn',
+      http_status: response.status,
+      elapsed_ms: response.elapsed_ms,
+      body_shape: response.body_shape,
+      evidence: response.error ? [`GET ${url} failed: ${response.error}`] : [`GET ${url} returned HTTP ${response.status}`]
+    });
+  }
+  return checks;
+}
+
+async function runDeclaredTests(root, enabled) {
+  if (!enabled) {
+    return stage(
+      'declared-tests',
+      'Declared repo tests',
+      'skip',
+      ['Skipped. Pass --run-tests to run package.json scripts.test with AGORAGENTIC_NO_SPEND=1.']
+    );
+  }
+
+  const packageJson = await readJson(path.join(root, 'package.json'));
+  if (!packageJson?.scripts?.test) {
+    return stage(
+      'declared-tests',
+      'Declared repo tests',
+      'skip',
+      ['No package.json scripts.test found.']
+    );
+  }
+
+  const testCommand = process.platform === 'win32'
+    ? { command: process.env.ComSpec || 'cmd.exe', args: ['/d', '/s', '/c', 'npm test'] }
+    : { command: 'npm', args: ['test'] };
+  const result = await spawnForReceipt(testCommand.command, testCommand.args, {
+    cwd: root,
+    timeoutMs: 120000,
+    env: sanitizeEnv({
+      ...process.env,
+      AGORAGENTIC_NO_SPEND: '1',
+      AGORAGENTIC_ALLOW_REAL_SPEND: '0'
+    })
+  });
+
+  return stage(
+    'declared-tests',
+    'Declared repo tests',
+    result.exit_code === 0 ? 'pass' : 'fail',
+    [
+      `npm test exited ${result.exit_code}`,
+      ...result.output_tail
+    ],
+    result.exit_code === 0 ? null : 'Fix the declared test suite before publishing the agent.'
+  );
+}
+
+function spawnForReceipt(command, args, options) {
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(command, args, {
+        cwd: options.cwd,
+        env: options.env,
+        stdio: ['ignore', 'pipe', 'pipe']
+      });
+    } catch (err) {
+      resolve({ exit_code: 1, output_tail: [`spawn failed: ${err.message}`] });
+      return;
+    }
+    const chunks = [];
+    const timeout = setTimeout(() => {
+      child.kill('SIGTERM');
+    }, options.timeoutMs || 120000);
+    child.stdout.on('data', (chunk) => chunks.push(String(chunk)));
+    child.stderr.on('data', (chunk) => chunks.push(String(chunk)));
+    child.on('error', (err) => {
+      clearTimeout(timeout);
+      resolve({ exit_code: 1, output_tail: [`spawn failed: ${err.message}`] });
+    });
+    child.on('close', (code) => {
+      clearTimeout(timeout);
+      const lines = chunks.join('').split(/\r?\n/).filter(Boolean).slice(-12);
+      resolve({ exit_code: code ?? 1, output_tail: lines });
+    });
+  });
+}
+
+function sanitizeEnv(env) {
+  return Object.fromEntries(
+    Object.entries(env)
+      .filter(([, value]) => value !== undefined && value !== null)
+      .map(([key, value]) => [key, String(value).replace(/\0/g, '')])
+  );
+}
+
+export async function runGoldenLoop(options = {}) {
+  const root = normalizeRoot(options.repo || options.root || '.');
+  const premortem = options.premortem || await runPremortem({ repo: root });
+  const stages = [];
+
+  const installCheck = findCheck(premortem, 'install-contract');
+  stages.push(stage(
+    'install-contract',
+    'Install contract',
+    installCheck?.status === 'pass' ? 'pass' : 'fail',
+    installCheck?.evidence || [],
+    installCheck?.status === 'pass' ? null : 'Add a reproducible install contract before release.'
+  ));
+
+  const configCheck = findCheck(premortem, 'configuration-contract');
+  const secretCheck = findCheck(premortem, 'secret-hygiene');
+  stages.push(stage(
+    'configure-contract',
+    'Configuration and secret boundary',
+    configCheck?.status === 'pass' && secretCheck?.status === 'pass' ? 'pass' : 'warn',
+    unique([...(configCheck?.evidence || []), ...(secretCheck?.evidence || [])]),
+    configCheck?.status === 'pass' && secretCheck?.status === 'pass'
+      ? null
+      : 'Add .env.example/config docs and remove or rotate any committed secret-like values.'
+  ));
+
+  const discoveryCheck = findCheck(premortem, 'agent-discovery');
+  stages.push(stage(
+    'agent-discovery',
+    'Agent discovery contract',
+    discoveryCheck?.status === 'pass' ? 'pass' : 'warn',
+    discoveryCheck?.evidence || [],
+    discoveryCheck?.status === 'pass' ? null : 'Add agent.json, agent-card.json, SKILL.md, OpenAPI, MCP, or equivalent discovery metadata.'
+  ));
+
+  stages.push(stage(
+    'premortem-risk',
+    'Premortem risk gate',
+    premortem.summary.blockers === 0 ? 'pass' : 'fail',
+    [`${premortem.summary.blockers} blockers, ${premortem.summary.warnings} warnings, score ${premortem.summary.score}`],
+    premortem.summary.blockers === 0 ? null : 'Resolve premortem blockers before release.'
+  ));
+
+  const receiptCheck = findCheck(premortem, 'receipt-contract');
+  stages.push(stage(
+    'receipt-contract',
+    'Receipt and proof contract',
+    receiptCheck?.status === 'pass' ? 'pass' : 'warn',
+    receiptCheck?.evidence || [],
+    receiptCheck?.status === 'pass' ? null : 'Define the local receipt or hosted invocation proof consumers can inspect after a run.'
+  ));
+
+  const spendCheck = findCheck(premortem, 'spend-boundary');
+  stages.push(stage(
+    'owner-spend-boundary',
+    'Owner approval and spend boundary',
+    spendCheck?.status === 'pass' ? 'pass' : 'warn',
+    spendCheck?.evidence || [],
+    spendCheck?.status === 'pass' ? null : 'Document no-spend defaults, paid execution gates, budgets, and owner approval requirements.'
+  ));
+
+  const runNetworkCanaries = Boolean(options.allowNetworkCanaries) && !options.skipNetwork;
+  if (!runNetworkCanaries) {
+    stages.push(stage(
+      'public-no-spend-canaries',
+      'Public no-spend Agoragentic canaries',
+      'skip',
+      [options.skipNetwork ? 'Skipped by --skip-network.' : 'Skipped by default. Pass --allow-network-canaries to call public no-spend endpoints without sending repo contents.']
+    ));
+  } else {
+    const canaries = await runPublicCanaries(options.baseUrl || DEFAULT_BASE_URL);
+    const failed = canaries.filter((item) => item.status !== 'pass');
+    stages.push(stage(
+      'public-no-spend-canaries',
+      'Public no-spend Agoragentic canaries',
+      failed.length ? 'warn' : 'pass',
+      canaries.flatMap((item) => item.evidence),
+      failed.length ? 'Check public connectivity before treating the loop as externally verifiable.' : null
+    ));
+    stages[stages.length - 1].canaries = canaries;
+  }
+
+  const targetChecks = await runTargetChecks(options.targetUrl);
+  if (targetChecks.length) {
+    const targetPass = targetChecks.some((item) => item.status === 'pass' && item.http_status && item.http_status < 400);
+    stages.push(stage(
+      'target-runtime',
+      'Optional target runtime',
+      targetPass ? 'pass' : 'warn',
+      targetChecks.flatMap((item) => item.evidence),
+      targetPass ? null : 'Expose a health endpoint or discovery document at the target runtime URL.'
+    ));
+    stages[stages.length - 1].target_checks = targetChecks;
+  } else {
+    stages.push(stage(
+      'target-runtime',
+      'Optional target runtime',
+      'skip',
+      ['No --target-url provided.']
+    ));
+  }
+
+  stages.push(await runDeclaredTests(root, Boolean(options.runTests)));
+
+  const summary = stageSummary(stages);
+  const generatedAt = nowIso();
+  return {
+    schema: 'agoragentic.golden-loop.no-spend.v1',
+    generated_at: generatedAt,
+    root,
+    target_url: options.targetUrl || null,
+    summary,
+    stages,
+    pass: summary.fail === 0,
+    no_spend: true,
+    boundary: {
+      free_to_use: true,
+      local_artifacts_only: !runNetworkCanaries && !options.targetUrl,
+      network_calls: runNetworkCanaries || Boolean(options.targetUrl),
+      repo_contents_uploaded: false,
+      credentials_required: false,
+      paid_execution: false,
+      production_mutation: false,
+      real_usdc_transfer: false
+    }
+  };
+}
+
+export async function runAll(options = {}) {
+  const root = normalizeRoot(options.repo || options.root || '.');
+  const premortem = await runPremortem({ repo: root });
+  const goldenLoop = await runGoldenLoop({ ...options, repo: root, premortem });
+  const receipt = buildLocalReceipt({ root, premortem, goldenLoop });
+  return { premortem, golden_loop: goldenLoop, receipt };
+}
+
+export async function runHeal(options = {}) {
+  const root = normalizeRoot(options.repo || options.root || '.');
+  const before = await runAll({ ...options, repo: root, skipNetwork: true });
+  const plan = await buildHealingPlan({ root, premortem: before.premortem, goldenLoop: before.golden_loop });
+  const applied = options.applySafeFixes ? await applyHealingPlan(root, plan) : [];
+  const after = options.applySafeFixes
+    ? await runAll({ ...options, repo: root, skipNetwork: true })
+    : null;
+
+  return {
+    schema: 'agoragentic.premortem-golden-loop.heal.v1',
+    generated_at: nowIso(),
+    root,
+    mode: options.applySafeFixes ? 'apply_safe_fixes' : 'plan_only',
+    free_to_use: true,
+    privacy: LOCAL_PRIVACY_BOUNDARY,
+    before,
+    plan,
+    applied,
+    after,
+    boundary: {
+      local_only: true,
+      network_calls: false,
+      credentials_required: false,
+      paid_execution: false,
+      production_mutation: false,
+      code_rewrite: false,
+      destructive_changes: false
+    }
+  };
+}
+
+const LOCAL_PRIVACY_BOUNDARY = {
+  default_network: false,
+  data_sent_anywhere: false,
+  repo_contents_uploaded: false,
+  api_key_required: false,
+  cost_usdc: 0,
+  note: 'Default heal/run/session modes read local files and write local artifacts only. Public no-spend canaries run only when the caller explicitly opts in.'
+};
+
+async function buildHealingPlan({ root, premortem, goldenLoop }) {
+  const files = await walkFiles(root, { maxFiles: 2500 });
+  const rels = new Set(files.map((file) => relative(root, file).toLowerCase()));
+  const packageJson = await readJson(path.join(root, 'package.json'));
+  const projectName = packageJson?.name || path.basename(root);
+  const actions = [];
+
+  const addCreate = (id, target, title, reason, content) => {
+    if (rels.has(slash(target).toLowerCase())) {
+      actions.push({
+        id,
+        type: 'skip_existing',
+        target,
+        title,
+        reason: `${target} already exists.`
+      });
+      return;
+    }
+    actions.push({
+      id,
+      type: 'create_file',
+      target,
+      title,
+      reason,
+      content
+    });
+  };
+
+  addCreate(
+    'goals-doc',
+    'docs/AGORAGENTIC_GOALS.md',
+    'Create goals contract',
+    'Every self-testing agent needs explicit goals, non-goals, success signals, and owner review checkpoints.',
+    renderGoalsDoc({ projectName })
+  );
+  addCreate(
+    'workflows-doc',
+    'docs/AGORAGENTIC_WORKFLOWS.md',
+    'Create workflows contract',
+    'The agent should give users repeatable local workflows for premortem, self-test, self-heal, release, and Agent OS handoff.',
+    renderWorkflowsDoc({ projectName })
+  );
+  addCreate(
+    'safety-boundaries-doc',
+    'docs/AGORAGENTIC_SAFETY_BOUNDARIES.md',
+    'Create safety boundaries contract',
+    'Users need a direct statement that default runs are free, local, no-network, no-spend, and non-mutating unless explicitly approved.',
+    renderSafetyBoundariesDoc({ projectName })
+  );
+
+  if (premortem.checks.some((check) => check.id.startsWith('agent-discovery') && check.status !== 'pass')) {
+    addCreate(
+      'agent-descriptor',
+      'agent.json',
+      'Create local agent descriptor',
+      'Machine-readable agent metadata helps humans and agent runtimes understand purpose, inputs, outputs, and authority boundaries.',
+      `${JSON.stringify(buildAgentDescriptor(projectName), null, 2)}\n`
+    );
+  }
+
+  if (premortem.checks.some((check) => check.id.startsWith('configuration-contract') && check.status !== 'pass')) {
+    addCreate(
+      'env-example',
+      '.env.example',
+      'Create local environment example',
+      'Configuration should be explicit even when no credentials are required by default.',
+      renderEnvExample()
+    );
+  }
+
+  if (premortem.checks.some((check) => check.id.startsWith('test-contract') && check.status !== 'pass')) {
+    addCreate(
+      'ci-workflow',
+      '.github/workflows/agoragentic-premortem-golden-loop.yml',
+      'Create no-spend CI workflow',
+      'A repeatable self-test loop makes release readiness visible on every push without credentials or paid calls.',
+      renderGithubWorkflow()
+    );
+  }
+
+  const manual = [];
+  if (premortem.risks.some((risk) => risk.id === 'secret-hygiene-failed')) {
+    manual.push({
+      id: 'rotate-secrets',
+      title: 'Remove and rotate committed secrets',
+      reason: 'The agent will not edit or delete secret-bearing files automatically.',
+      action: 'Remove the secret manually, rotate it with the provider, then rerun heal.'
+    });
+  }
+  if (premortem.risks.some((risk) => risk.id === 'license-missing')) {
+    manual.push({
+      id: 'choose-license',
+      title: 'Choose an OSS license',
+      reason: 'License choice is a project decision.',
+      action: 'Add LICENSE with the license the owner wants before public release.'
+    });
+  }
+
+  return {
+    summary: {
+      proposed_file_creates: actions.filter((action) => action.type === 'create_file').length,
+      skipped_existing: actions.filter((action) => action.type === 'skip_existing').length,
+      manual_actions: manual.length,
+      golden_loop_pass_before: goldenLoop.pass,
+      blockers_before: premortem.summary.blockers
+    },
+    actions,
+    manual,
+    safety: {
+      applies_only_when_flagged: '--apply-safe-fixes',
+      writes_only_new_files: true,
+      overwrites_existing_files: false,
+      deletes_files: false,
+      edits_application_code: false,
+      sends_data: false,
+      costs_money: false
+    }
+  };
+}
+
+async function applyHealingPlan(root, plan) {
+  const applied = [];
+  for (const action of plan.actions) {
+    if (action.type !== 'create_file') continue;
+    const full = path.resolve(root, action.target);
+    if (!isInside(root, full)) {
+      applied.push({ ...action, status: 'blocked', reason: 'Target path escapes repo root.' });
+      continue;
+    }
+    if (await exists(full)) {
+      applied.push({ ...action, status: 'skipped_existing' });
+      continue;
+    }
+    await writeText(full, action.content);
+    applied.push({ id: action.id, target: action.target, status: 'created' });
+  }
+  return applied;
+}
+
+function isInside(root, target) {
+  const relativePath = path.relative(root, target);
+  return relativePath && !relativePath.startsWith('..') && !path.isAbsolute(relativePath);
+}
+
+function buildAgentDescriptor(projectName) {
+  return {
+    schema: 'agoragentic.local-agent.v1',
+    name: projectName,
+    description: 'Local AI agent prepared with Agoragentic Premortem Golden Loop.',
+    free_to_use: true,
+    default_boundary: {
+      local_only: true,
+      network_calls: false,
+      credentials_required: false,
+      paid_execution: false,
+      production_mutation: false,
+      repo_contents_uploaded: false
+    },
+    workflows: [
+      'premortem',
+      'self-test',
+      'self-heal-plan',
+      'golden-loop-readiness'
+    ],
+    artifacts: [
+      '.agoragentic/premortem-golden-loop/premortem.json',
+      '.agoragentic/premortem-golden-loop/golden-loop.json',
+      '.agoragentic/premortem-golden-loop/local-receipt.json',
+      '.agoragentic/premortem-golden-loop/healing-plan.json'
+    ]
+  };
+}
+
+function renderGoalsDoc({ projectName }) {
+  return `# Agoragentic Goals
+
+Project: ${projectName}
+
+## Primary Goal
+
+Make the agent safe to install, inspect, test, and improve locally before any hosted deployment, paid execution, marketplace exposure, or x402 monetization.
+
+## Success Signals
+
+- A new user can run the local premortem and Golden Loop readiness check from a clean checkout.
+- The run produces local receipts under \`.agoragentic/premortem-golden-loop/\`.
+- The user can see exactly what passed, what failed, and what changed.
+- Any self-healing change is additive, reviewable, and made only after explicit approval.
+
+## Non-Goals
+
+- No autonomous deployment.
+- No wallet funding or USDC transfer.
+- No paid \`execute()\` call.
+- No secret rotation on the user's behalf.
+- No upload of repo contents, prompts, plans, receipts, or code.
+
+## Owner Review Checkpoints
+
+- Before applying generated fixes.
+- Before enabling network canaries.
+- Before connecting Agent OS, Micro ECF, x402, or marketplace flows.
+- Before publishing any generated report publicly.
+`;
+}
+
+function renderWorkflowsDoc({ projectName }) {
+  return `# Agoragentic Workflows
+
+Project: ${projectName}
+
+## 1. Premortem Session
+
+\`\`\`bash
+npx agoragentic-premortem-golden-loop session \\
+  --plan "Describe the launch or decision" \\
+  --audience "Who this is for" \\
+  --success "What a win looks like"
+\`\`\`
+
+Output: HTML report, Markdown transcript, and JSON session artifact.
+
+## 2. Local Self-Test
+
+\`\`\`bash
+npx agoragentic-premortem-golden-loop run --repo . --ci --skip-network
+\`\`\`
+
+Output: premortem audit, no-spend Golden Loop readiness report, and local receipt.
+
+## 3. Self-Heal Plan
+
+\`\`\`bash
+npx agoragentic-premortem-golden-loop heal --repo .
+\`\`\`
+
+Output: proposed safe fixes only. No files are changed.
+
+## 4. Apply Safe Fixes
+
+\`\`\`bash
+npx agoragentic-premortem-golden-loop heal --repo . --apply-safe-fixes
+\`\`\`
+
+Only additive docs, metadata, env examples, or CI scaffolds are created. Existing files are not overwritten.
+
+## 5. Optional Public No-Spend Canaries
+
+\`\`\`bash
+npx agoragentic-premortem-golden-loop run --repo . --allow-network-canaries
+\`\`\`
+
+This calls public Agoragentic no-spend endpoints. It does not send repository contents.
+
+## 6. Agent OS Handoff
+
+Use Agent OS or Micro ECF only after local readiness is clean and the owner approves. Hosted deployment, wallet funding, marketplace publication, x402 monetization, and paid execution are separate explicit steps.
+`;
+}
+
+function renderSafetyBoundariesDoc({ projectName }) {
+  return `# Agoragentic Safety Boundaries
+
+Project: ${projectName}
+
+## Default Boundary
+
+- Free to use.
+- Local file reads only.
+- Local artifact writes only.
+- No API key required.
+- No wallet required.
+- No network calls by default.
+- No repository contents, business plans, prompts, or receipts are sent anywhere.
+- No paid execution.
+- No production mutation.
+- No deployment.
+- No marketplace publication.
+
+## What Self-Heal May Do
+
+Only when \`--apply-safe-fixes\` is passed, the agent may create missing additive scaffolds:
+
+- \`docs/AGORAGENTIC_GOALS.md\`
+- \`docs/AGORAGENTIC_WORKFLOWS.md\`
+- \`docs/AGORAGENTIC_SAFETY_BOUNDARIES.md\`
+- \`agent.json\`
+- \`.env.example\`
+- \`.github/workflows/agoragentic-premortem-golden-loop.yml\`
+
+It does not overwrite existing files.
+
+## What Self-Heal Will Not Do
+
+- It will not edit application source code.
+- It will not delete files.
+- It will not remove secrets automatically.
+- It will not rotate credentials.
+- It will not install dependencies without the user's own package manager command.
+- It will not run paid \`execute()\` calls.
+- It will not transfer USDC or sign wallet payments.
+- It will not publish to Agent OS, a marketplace, npm, PyPI, or GitHub.
+
+## Optional Network Canaries
+
+\`--allow-network-canaries\` calls only public no-spend Agoragentic endpoints and sends no repo content. Keep it off for fully offline runs.
+`;
+}
+
+function renderEnvExample() {
+  return `# Agoragentic Premortem Golden Loop defaults
+AGORAGENTIC_NO_SPEND=1
+AGORAGENTIC_ALLOW_REAL_SPEND=0
+AGORAGENTIC_ALLOW_NETWORK_CANARIES=0
+
+# Optional only if this repo later uses hosted Agent OS APIs.
+AGORAGENTIC_API_KEY=amk_your_key
+`;
+}
+
+function renderGithubWorkflow() {
+  return `name: Agoragentic Premortem Golden Loop
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  local-readiness:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      AGORAGENTIC_NO_SPEND: "1"
+      AGORAGENTIC_ALLOW_REAL_SPEND: "0"
+      AGORAGENTIC_ALLOW_NETWORK_CANARIES: "0"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Run local no-spend readiness
+        run: npx --yes agoragentic-premortem-golden-loop run --repo . --ci --skip-network
+`;
+}
+
+export function renderHealingPlanMarkdown(report) {
+  const lines = [
+    '# Agoragentic Self-Heal Plan',
+    '',
+    `Generated: ${report.generated_at}`,
+    `Repository: ${report.root}`,
+    `Mode: ${report.mode}`,
+    '',
+    '## Privacy Boundary',
+    '',
+    '- Free to use',
+    '- No API key required',
+    '- No network calls in heal mode',
+    '- No repo contents uploaded',
+    '- No paid execution or wallet action',
+    '',
+    '## Proposed Safe Fixes',
+    '',
+    '| Action | Target | Status | Reason |',
+    '|---|---|---|---|'
+  ];
+
+  for (const action of report.plan.actions) {
+    lines.push(`| ${escapeMd(action.title)} | ${escapeMd(action.target)} | ${action.type} | ${escapeMd(action.reason)} |`);
+  }
+
+  lines.push('', '## Manual Actions', '');
+  if (!report.plan.manual.length) {
+    lines.push('- None.');
+  } else {
+    for (const item of report.plan.manual) lines.push(`- ${item.title}: ${item.action}`);
+  }
+
+  if (report.applied.length) {
+    lines.push('', '## Applied', '');
+    for (const item of report.applied) lines.push(`- ${item.status}: ${item.target}`);
+  }
+
+  lines.push('');
+  return `${lines.join('\n')}\n`;
+}
+
+export async function runPremortemSession(options = {}) {
+  const root = normalizeRoot(options.repo || options.root || '.');
+  const generatedAt = nowIso();
+  const timestamp = timestampSlug(generatedAt);
+  const context = await buildPremortemContext({ ...options, root });
+
+  if (!context.sufficient) {
+    return {
+      schema: 'agoragentic.premortem-session.v1',
+      generated_at: generatedAt,
+      timestamp,
+      status: 'needs_context',
+      root,
+      context,
+      question: nextContextQuestion(context.missing),
+      no_spend: true
+    };
+  }
+
+  const frame = `It is 6 months from now. ${context.what} has failed. It is done. We are looking back and trying to understand what went wrong.`;
+  const failureReasons = generateFailureReasons(context);
+  const deepDives = await Promise.all(
+    failureReasons.map((reason, index) => analyzeFailureReason(context, reason, index))
+  );
+  const synthesis = synthesizePremortem(context, failureReasons, deepDives);
+
+  return {
+    schema: 'agoragentic.premortem-session.v1',
+    generated_at: generatedAt,
+    timestamp,
+    status: 'complete',
+    root,
+    context,
+    frame,
+    failure_reasons: failureReasons,
+    investigator_pass: {
+      mode: 'local_parallel_investigator_pass',
+      agent_count: deepDives.length,
+      note: 'Each failure reason is analyzed independently through the same investigator contract. Hosted or model-backed runners can replace this deterministic pass with parallel sub-agents.'
+    },
+    deep_dives: deepDives,
+    synthesis,
+    no_spend: true,
+    boundary: {
+      credentials_required: false,
+      paid_execution: false,
+      production_mutation: false
+    }
+  };
+}
+
+async function buildPremortemContext(options) {
+  const root = options.root;
+  const planFileText = options.planFile ? await readText(path.resolve(root, options.planFile)).catch(() => '') : '';
+  const explicitPlan = String(options.plan || '').trim();
+  const workspace = await collectWorkspaceContext(root);
+  const combined = [explicitPlan, planFileText, workspace.map((item) => item.excerpt).join('\n')].filter(Boolean).join('\n\n');
+  const what = explicitPlan || firstNonEmptyLine(planFileText) || inferWhat(combined);
+  const who = String(options.audience || '').trim() || inferAudience(combined);
+  const success = String(options.success || '').trim() || inferSuccess(combined);
+  const missing = [];
+  if (!what) missing.push('what');
+  if (!who) missing.push('who');
+  if (!success) missing.push('success');
+
+  return {
+    what,
+    who,
+    success,
+    plan_text: combined.trim(),
+    workspace_context: workspace,
+    sufficient: missing.length === 0,
+    missing
+  };
+}
+
+async function collectWorkspaceContext(root) {
+  const preferred = [
+    'CLAUDE.md',
+    'claude.md',
+    'AGENTS.md',
+    'README.md',
+    'START_HERE.md'
+  ];
+  const snippets = [];
+
+  for (const rel of preferred) {
+    const full = path.join(root, rel);
+    if (await exists(full)) {
+      const text = await readText(full).catch(() => '');
+      if (text.trim()) snippets.push({ file: slash(rel), excerpt: excerpt(text, 1800) });
+    }
+  }
+
+  const files = await walkFiles(root, { maxFiles: 800 });
+  const candidates = files
+    .map((file) => relative(root, file))
+    .filter((rel) => /(^|\/)(memory|docs|plans?|briefs?|strategy|launch|prd)(\/|$)|premortem|plan|brief|strategy|launch|product|roadmap/i.test(rel))
+    .filter((rel) => TEXT_EXTENSIONS.has(path.extname(rel).toLowerCase()))
+    .slice(0, 8);
+
+  for (const rel of candidates) {
+    if (snippets.some((item) => item.file.toLowerCase() === rel.toLowerCase())) continue;
+    const full = path.join(root, rel);
+    const stat = await statSafe(full);
+    if (!stat || stat.size > 250_000) continue;
+    const text = await readText(full).catch(() => '');
+    if (text.trim()) snippets.push({ file: slash(rel), excerpt: excerpt(text, 1200) });
+    if (snippets.length >= 10) break;
+  }
+
+  return snippets;
+}
+
+function firstNonEmptyLine(text) {
+  return String(text || '').split(/\r?\n/).map((line) => line.trim()).find(Boolean) || '';
+}
+
+function excerpt(text, maxChars) {
+  return String(text || '').replace(/\s+/g, ' ').trim().slice(0, maxChars);
+}
+
+function inferWhat(text) {
+  const lines = String(text || '').split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+  const useful = lines.find((line) => /launch|build|release|ship|plan|strategy|product|agent|repo|workshop|pricing|hire/i.test(line));
+  return useful ? useful.replace(/^#+\s*/, '').slice(0, 220) : '';
+}
+
+function inferAudience(text) {
+  const source = String(text || '');
+  const patterns = [
+    /\btarget(?:ing)?\s+([^.\n]{8,120})/i,
+    /\bfor\s+([^.\n]{8,120})/i,
+    /\baudience\s*[:=-]\s*([^.\n]{8,120})/i,
+    /\bcustomer(?:s)?\s*[:=-]\s*([^.\n]{8,120})/i
+  ];
+  for (const pattern of patterns) {
+    const match = source.match(pattern);
+    if (match?.[1]) return cleanInference(match[1]);
+  }
+  return '';
+}
+
+function inferSuccess(text) {
+  const source = String(text || '');
+  const patterns = [
+    /\bsuccess(?:\s+looks\s+like)?\s*[:=-]\s*([^.\n]{8,160})/i,
+    /\bwin(?:\s+looks\s+like)?\s*[:=-]\s*([^.\n]{8,160})/i,
+    /\bgoal\s*[:=-]\s*([^.\n]{8,160})/i,
+    /\bso that\s+([^.\n]{8,160})/i
+  ];
+  for (const pattern of patterns) {
+    const match = source.match(pattern);
+    if (match?.[1]) return cleanInference(match[1]);
+  }
+  return '';
+}
+
+function cleanInference(value) {
+  return String(value || '').replace(/[`*_#]/g, '').trim().slice(0, 180);
+}
+
+function nextContextQuestion(missing) {
+  if (missing.includes('what')) return 'What specifically are you about to launch, build, decide, or release?';
+  if (missing.includes('who')) return 'Who is this for, and who will be affected if it fails?';
+  if (missing.includes('success')) return 'What does a win look like for this?';
+  return 'What context should this premortem use?';
+}
+
+function generateFailureReasons(context) {
+  const text = `${context.what}\n${context.who}\n${context.success}\n${context.plan_text}`.toLowerCase();
+  const candidates = [
+    {
+      id: 'audience-mismatch',
+      reason: `${context.who} did not behave like the plan assumed, so the offer landed with people adjacent to the target user instead of the people who could make ${context.success} happen.`,
+      assumption: `The target audience is reachable, self-identifies with this problem, and has enough urgency to act now.`,
+      warning_signs: ['Interested replies come from adjacent users who are not the intended buyer or operator.', 'People praise the idea but cannot name when they would install, buy, or use it.'],
+      revision: 'Run a small target-user pilot first and only scale the release once the actual buyers match the intended audience.',
+      likelihood: 5,
+      severity: 4
+    },
+    {
+      id: 'distribution-gap',
+      reason: `The release shipped, but the distribution plan was too passive; a GitHub repo or launch post did not create repeated qualified installs from ${context.who}.`,
+      assumption: `Publishing the artifact is close enough to distribution.`,
+      warning_signs: ['Stars or likes arrive without installs, issues, forks, receipts, or repeat runs.', 'Most traffic comes from one launch spike and disappears inside two weeks.'],
+      revision: 'Define three repeatable distribution loops before launch: one community channel, one partner/user workflow, and one machine-readable discovery path.',
+      likelihood: 4,
+      severity: 4
+    },
+    {
+      id: 'onboarding-friction',
+      reason: `People installed it and stalled before the first successful run because setup, context gathering, or output expectations were not obvious enough for a fresh repo owner.`,
+      assumption: `A motivated user will debug the setup path and infer the intended workflow.`,
+      warning_signs: ['Issues ask basic install or first-run questions already covered in the README.', 'Users run the CLI once but no generated report or receipt appears.'],
+      revision: 'Make the first-run path one command, no credentials by default, with a sample fixture and expected output committed in docs.',
+      likelihood: text.includes('repo') || text.includes('install') || text.includes('github') ? 5 : 3,
+      severity: 4
+    },
+    {
+      id: 'proof-gap',
+      reason: `The Golden Loop claim was not credible to users because the local report looked like analysis, not proof that the agent could install, run, produce receipts, and stay inside a no-spend boundary.`,
+      assumption: `Users will trust the workflow without a concrete artifact trail.`,
+      warning_signs: ['Users ask whether the report is just generated text.', 'Maintainers cannot point to a receipt, transcript, or reproducible check for a specific release.'],
+      revision: 'Treat the local receipt, transcript, and no-spend canary output as release artifacts and publish them with every tagged release.',
+      likelihood: text.includes('golden loop') || text.includes('receipt') || text.includes('agent') ? 5 : 3,
+      severity: 5
+    },
+    {
+      id: 'scope-sprawl',
+      reason: `The project tried to be a premortem agent, release auditor, Golden Loop tester, and launch package at once, so none of the workflows felt sharp enough to become habitual.`,
+      assumption: `More adjacent safety features will make the product clearer instead of harder to understand.`,
+      warning_signs: ['The README keeps growing but the primary command is still hard to explain in one sentence.', 'Users ask which mode they are supposed to run first.'],
+      revision: 'Separate the public story into two commands: decision premortem for plans, and Golden Loop readiness for installable agent repos.',
+      likelihood: text.includes('premortem') && text.includes('golden loop') ? 5 : 3,
+      severity: 3
+    },
+    {
+      id: 'trust-safety',
+      reason: `The agent scared off serious users because it touched repo files, scanned secrets, or discussed paid execution without making the authority boundary unmistakable.`,
+      assumption: `Users will read the safety notes before deciding whether to run it.`,
+      warning_signs: ['Security-minded users ask what leaves their machine.', 'People avoid running it on real repos until someone audits the behavior.'],
+      revision: 'Keep no-spend/no-network defaults visible in the command output and document exactly what is read, written, and never transmitted.',
+      likelihood: text.includes('secret') || text.includes('paid') || text.includes('wallet') || text.includes('usdc') ? 4 : 3,
+      severity: 5
+    },
+    {
+      id: 'maintenance-drag',
+      reason: `After the launch, the agent became a maintenance surface without a clear owner: prompts drifted, report quality varied, and compatibility issues accumulated faster than usage proof.`,
+      assumption: `The first release will be stable enough that maintenance can wait.`,
+      warning_signs: ['Small issues linger for more than a week.', 'Prompt updates happen without tests that prove the output shape still works.'],
+      revision: 'Add output-shape tests, fixture premortems, and a release checklist before inviting broad public usage.',
+      likelihood: 3,
+      severity: 4
+    },
+    {
+      id: 'success-metric-drift',
+      reason: `The team celebrated visible activity while missing ${context.success}, so the project looked alive while failing its actual purpose.`,
+      assumption: `Early attention is a reliable proxy for the outcome that matters.`,
+      warning_signs: ['The dashboard tracks stars, posts, or comments but not completed runs and acted-on revisions.', 'Users read reports but do not change their plans.'],
+      revision: 'Define success as completed premortems with at least one concrete plan revision, not impressions or repository stars.',
+      likelihood: 4,
+      severity: 4
+    }
+  ];
+
+  const selected = candidates
+    .filter((item) => {
+      if (['audience-mismatch', 'distribution-gap', 'success-metric-drift'].includes(item.id)) return true;
+      if (item.id === 'onboarding-friction') return /repo|install|github|cli|agent|oss|open source/.test(text);
+      if (item.id === 'proof-gap') return /golden loop|receipt|proof|agent|test/.test(text);
+      if (item.id === 'scope-sprawl') return /premortem|golden loop|agent|oss/.test(text);
+      if (item.id === 'trust-safety') return /secret|paid|wallet|usdc|api key|repo|agent/.test(text);
+      if (item.id === 'maintenance-drag') return /oss|open source|github|repo|package|agent/.test(text);
+      return false;
+    })
+    .slice(0, 8);
+
+  return selected.map((item, index) => ({
+    ...item,
+    rank: index + 1,
+    accent: ['#7dd3fc', '#fca5a5', '#c4b5fd', '#86efac', '#fcd34d', '#f9a8d4', '#93c5fd', '#fdba74'][index % 8]
+  }));
+}
+
+async function analyzeFailureReason(context, reason, index) {
+  const moments = [
+    `At launch, the team framed ${context.what} around the intended outcome: ${context.success}. The first signal looked encouraging, but the behavior underneath did not match the plan.`,
+    `${context.who} hit the exact weak point: ${reason.reason} The team adjusted messaging and docs after the fact, but by then the first cohort had already formed the wrong impression.`,
+    `By month six, the failure was no longer a single bug or missed announcement. It was a pattern: the plan depended on "${reason.assumption}", and the evidence kept saying that assumption was false.`
+  ];
+
+  return {
+    id: reason.id,
+    agent_id: `investigator-${String(index + 1).padStart(2, '0')}`,
+    failure_reason: reason.reason,
+    likelihood: reason.likelihood,
+    severity: reason.severity,
+    failure_story: `${moments[0]}\n\n${moments[1]} ${moments[2]}`,
+    underlying_assumption: reason.assumption,
+    early_warning_signs: reason.warning_signs,
+    concrete_revision: reason.revision,
+    accent: reason.accent
+  };
+}
+
+function synthesizePremortem(context, reasons, deepDives) {
+  const mostLikely = [...deepDives].sort((a, b) => b.likelihood - a.likelihood || b.severity - a.severity)[0];
+  const mostDangerous = [...deepDives].sort((a, b) => b.severity - a.severity || b.likelihood - a.likelihood)[0];
+  const hiddenAssumption = `The hidden assumption is that ${context.who} will understand the value, trust the boundary, complete the first run, and convert the output into action without a tighter launch loop proving each step.`;
+  const revisedPlan = deepDives
+    .slice()
+    .sort((a, b) => (b.likelihood + b.severity) - (a.likelihood + a.severity))
+    .slice(0, 6)
+    .map((item) => ({
+      failure_id: item.id,
+      change: item.concrete_revision
+    }));
+  const checklist = [
+    `Describe the target user and success metric in one sentence: "${context.who}" and "${context.success}".`,
+    'Run one end-to-end first-use test from a clean checkout and preserve the generated receipt.',
+    'Publish the no-spend boundary beside the install command, including what is read, written, and never transmitted.',
+    'Test distribution with at least five real target users before treating public launch attention as validation.',
+    'Require every release to include a premortem transcript, report, and one concrete plan revision.'
+  ];
+
+  return {
+    most_likely_failure: {
+      id: mostLikely.id,
+      title: mostLikely.failure_reason,
+      why: `It has the highest likelihood because it can happen even if the build succeeds: the intended users simply do not behave the way the plan needs them to.`
+    },
+    most_dangerous_failure: {
+      id: mostDangerous.id,
+      title: mostDangerous.failure_reason,
+      why: `It is the most damaging because it undermines trust in the whole release, not just one feature or launch channel.`
+    },
+    hidden_assumption: hiddenAssumption,
+    revised_plan: revisedPlan,
+    pre_launch_checklist: checklist,
+    chat_summary: [
+      `Most likely failure: ${mostLikely.failure_reason}`,
+      `Hidden assumption: ${hiddenAssumption}`,
+      `Most important revision: ${revisedPlan[0]?.change || 'Run a narrow pilot before the public release.'}`
+    ]
+  };
+}
+
+export function renderPremortemSessionHtml(session) {
+  const cards = session.deep_dives.map((item) => `
+    <article class="card" style="--accent:${escapeHtml(item.accent)}">
+      <div class="card-top">
+        <span>${escapeHtml(item.agent_id)}</span>
+        <span>L${item.likelihood} / S${item.severity}</span>
+      </div>
+      <h3>${escapeHtml(item.failure_reason)}</h3>
+      <p>${escapeHtml(item.failure_story).replace(/\n\n/g, '</p><p>')}</p>
+      <div class="minor"><strong>Underlying assumption:</strong> ${escapeHtml(item.underlying_assumption)}</div>
+      <ul>${item.early_warning_signs.map((sign) => `<li>${escapeHtml(sign)}</li>`).join('')}</ul>
+    </article>
+  `).join('\n');
+
+  const revisions = session.synthesis.revised_plan.map((item) => `<li><strong>${escapeHtml(item.failure_id)}:</strong> ${escapeHtml(item.change)}</li>`).join('');
+  const checklist = session.synthesis.pre_launch_checklist.map((item) => `<li>${escapeHtml(item)}</li>`).join('');
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Premortem Report</title>
+  <style>
+    :root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    body { margin: 0; background: #0a0e1a; color: #e5ecff; }
+    main { max-width: 1180px; margin: 0 auto; padding: 40px 20px 56px; }
+    h1, h2, h3 { margin: 0; line-height: 1.1; letter-spacing: 0; }
+    h1 { font-size: clamp(32px, 5vw, 58px); max-width: 920px; }
+    h2 { font-size: 22px; margin-bottom: 14px; }
+    h3 { font-size: 18px; margin: 14px 0 10px; }
+    p, li { color: #c9d4ef; line-height: 1.55; }
+    .eyebrow { color: #7dd3fc; text-transform: uppercase; font-size: 12px; letter-spacing: .08em; font-weight: 700; }
+    .hero { border-bottom: 1px solid #22304f; padding-bottom: 28px; margin-bottom: 28px; }
+    .meta { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 22px; }
+    .pill { border: 1px solid #2d3c61; border-radius: 999px; padding: 8px 12px; color: #b8c5e6; background: #11182a; font-size: 13px; }
+    .grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 16px; }
+    .panel, .card { background: #101827; border: 1px solid #24304e; border-radius: 8px; padding: 18px; }
+    .panel strong { color: #ffffff; }
+    .synthesis { grid-template-columns: repeat(2, minmax(0, 1fr)); margin-bottom: 28px; }
+    .wide { grid-column: 1 / -1; }
+    .card { border-top: 4px solid var(--accent); }
+    .card-top { display: flex; justify-content: space-between; gap: 12px; color: var(--accent); font-size: 12px; font-weight: 700; text-transform: uppercase; }
+    .minor { border-left: 3px solid var(--accent); padding-left: 12px; color: #dbe6ff; margin: 14px 0; }
+    footer { margin-top: 34px; color: #7f8cad; font-size: 13px; }
+    @media (max-width: 860px) { .grid, .synthesis { grid-template-columns: 1fr; } main { padding: 28px 14px 40px; } }
+  </style>
+</head>
+<body>
+  <main>
+    <section class="hero">
+      <div class="eyebrow">Premortem Report</div>
+      <h1>${escapeHtml(session.context.what)}</h1>
+      <div class="meta">
+        <span class="pill">${escapeHtml(session.generated_at)}</span>
+        <span class="pill">${session.investigator_pass.agent_count} investigators</span>
+        <span class="pill">No-spend local analysis</span>
+      </div>
+    </section>
+
+    <section class="grid synthesis">
+      <div class="panel"><h2>Most Likely Failure</h2><p><strong>${escapeHtml(session.synthesis.most_likely_failure.title)}</strong></p><p>${escapeHtml(session.synthesis.most_likely_failure.why)}</p></div>
+      <div class="panel"><h2>Most Dangerous Failure</h2><p><strong>${escapeHtml(session.synthesis.most_dangerous_failure.title)}</strong></p><p>${escapeHtml(session.synthesis.most_dangerous_failure.why)}</p></div>
+      <div class="panel wide"><h2>Hidden Assumption</h2><p>${escapeHtml(session.synthesis.hidden_assumption)}</p></div>
+      <div class="panel"><h2>Revised Plan</h2><ol>${revisions}</ol></div>
+      <div class="panel"><h2>Pre-Launch Checklist</h2><ol>${checklist}</ol></div>
+    </section>
+
+    <section>
+      <h2>Investigator Findings</h2>
+      <div class="grid">${cards}</div>
+    </section>
+
+    <footer>Premortem generated for ${escapeHtml(session.context.what)}. Audience: ${escapeHtml(session.context.who)}. Success: ${escapeHtml(session.context.success)}.</footer>
+  </main>
+</body>
+</html>
+`;
+}
+
+export function renderPremortemSessionTranscript(session) {
+  const lines = [
+    '# Premortem Transcript',
+    '',
+    `Generated: ${session.generated_at}`,
+    '',
+    '## Context',
+    '',
+    `What: ${session.context.what}`,
+    `Who: ${session.context.who}`,
+    `Success: ${session.context.success}`,
+    '',
+    '## Frame',
+    '',
+    session.frame,
+    '',
+    '## Raw Failure Reasons',
+    ''
+  ];
+
+  for (const reason of session.failure_reasons) {
+    lines.push(`${reason.rank}. ${reason.reason}`);
+  }
+
+  lines.push('', '## Deep Dives', '');
+  for (const dive of session.deep_dives) {
+    lines.push(`### ${dive.agent_id}: ${dive.failure_reason}`, '');
+    lines.push('Failure story:', '', dive.failure_story, '');
+    lines.push(`Underlying assumption: ${dive.underlying_assumption}`, '');
+    lines.push('Early warning signs:');
+    for (const sign of dive.early_warning_signs) lines.push(`- ${sign}`);
+    lines.push('');
+  }
+
+  lines.push('## Synthesis', '');
+  lines.push(`Most likely failure: ${session.synthesis.most_likely_failure.title}`);
+  lines.push(`Why: ${session.synthesis.most_likely_failure.why}`, '');
+  lines.push(`Most dangerous failure: ${session.synthesis.most_dangerous_failure.title}`);
+  lines.push(`Why: ${session.synthesis.most_dangerous_failure.why}`, '');
+  lines.push(`Hidden assumption: ${session.synthesis.hidden_assumption}`, '');
+  lines.push('Revised plan:');
+  for (const item of session.synthesis.revised_plan) lines.push(`- ${item.change}`);
+  lines.push('', 'Pre-launch checklist:');
+  for (const item of session.synthesis.pre_launch_checklist) lines.push(`- ${item}`);
+  lines.push('');
+  return `${lines.join('\n')}\n`;
+}
+
+export function renderPremortemSessionSummary(session) {
+  return session.synthesis.chat_summary.join(' ');
+}
+
+export function premortemSessionFileNames(timestamp) {
+  return {
+    report: `premortem-report-${timestamp}.html`,
+    transcript: `premortem-transcript-${timestamp}.md`,
+    json: `premortem-session-${timestamp}.json`
+  };
+}
+
+export function buildLocalReceipt({ root, premortem, goldenLoop }) {
+  const digest = crypto.createHash('sha256')
+    .update(JSON.stringify({
+      root: slash(root),
+      premortem: premortem.summary,
+      golden_loop: goldenLoop.summary,
+      repo_fingerprint: premortem.repo_fingerprint
+    }))
+    .digest('hex');
+
+  return {
+    schema: 'agoragentic.premortem-golden-loop.local-receipt.v1',
+    receipt_id: `pgl_${digest.slice(0, 16)}`,
+    generated_at: nowIso(),
+    root,
+    repo_fingerprint: premortem.repo_fingerprint || null,
+    premortem_summary: premortem.summary,
+    golden_loop_summary: goldenLoop.summary,
+    pass: premortem.summary.blockers === 0 && goldenLoop.summary.fail === 0,
+    no_spend: true,
+    boundary: {
+      free_to_use: true,
+      network_calls: false,
+      repo_contents_uploaded: false,
+      credentials_required: false,
+      paid_execution: false,
+      production_mutation: false,
+      real_usdc_transfer: false,
+      agoragentic_api_key_required: false
+    }
+  };
+}
+
+export async function writeJson(filePath, value) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+export async function writeText(filePath, value) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, value, 'utf8');
+}
+
+export function renderPremortemMarkdown(report) {
+  const lines = [
+    '# Agoragentic Premortem',
+    '',
+    `Generated: ${report.generated_at}`,
+    `Repository: ${report.root}`,
+    `Score: ${report.summary.score}`,
+    `Blockers: ${report.summary.blockers}`,
+    `Warnings: ${report.summary.warnings}`,
+    '',
+    '## Risks',
+    '',
+    '| Severity | Risk | Evidence | Action |',
+    '|---|---|---|---|'
+  ];
+
+  if (!report.risks.length) {
+    lines.push('| pass | No release blockers found | Premortem checks passed | Keep the receipt with the release artifacts |');
+  } else {
+    for (const risk of report.risks) {
+      lines.push(`| ${risk.severity} | ${escapeMd(risk.title)} | ${escapeMd((risk.evidence || []).join('; '))} | ${escapeMd(risk.action)} |`);
+    }
+  }
+
+  lines.push('', '## Next Actions', '');
+  if (!report.next_actions.length) {
+    lines.push('- Keep the generated receipt with the release artifacts.');
+  } else {
+    for (const item of report.next_actions) {
+      lines.push(`- [${item.severity}] ${item.action}`);
+    }
+  }
+  lines.push('');
+  return `${lines.join('\n')}\n`;
+}
+
+export function renderGoldenLoopMarkdown(report) {
+  const lines = [
+    '# Agoragentic No-Spend Golden Loop',
+    '',
+    `Generated: ${report.generated_at}`,
+    `Repository: ${report.root}`,
+    `Pass: ${report.pass ? 'yes' : 'no'}`,
+    '',
+    '| Stage | Status | Evidence |',
+    '|---|---|---|'
+  ];
+
+  for (const item of report.stages) {
+    lines.push(`| ${escapeMd(item.title)} | ${item.status} | ${escapeMd((item.evidence || []).join('; '))} |`);
+  }
+
+  lines.push('', 'Boundary: no credentials, no paid execution, no production mutation, no real USDC transfer.', '');
+  return `${lines.join('\n')}\n`;
+}
+
+export function renderSummaryMarkdown(run) {
+  const receipt = run.receipt;
+  return [
+    '# Premortem Golden Loop Receipt',
+    '',
+    `Receipt: ${receipt.receipt_id}`,
+    `Generated: ${receipt.generated_at}`,
+    `Pass: ${receipt.pass ? 'yes' : 'no'}`,
+    `Premortem score: ${receipt.premortem_summary.score}`,
+    `Golden Loop failures: ${receipt.golden_loop_summary.fail}`,
+    '',
+    'This is a local no-spend receipt. It does not prove paid settlement, hosted deployment, or seller earnings.',
+    ''
+  ].join('\n');
+}
+
+function escapeMd(value) {
+  return String(value || '').replace(/\|/g, '\\|').replace(/\r?\n/g, ' ');
+}
+
+function escapeHtml(value) {
+  return String(value || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function timestampSlug(iso) {
+  return String(iso || nowIso()).replace(/[-:]/g, '').replace(/\.\d+Z$/, 'Z').replace('T', '-').replace('Z', '');
+}

--- a/premortem-golden-loop/test/core.test.mjs
+++ b/premortem-golden-loop/test/core.test.mjs
@@ -1,0 +1,227 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+import { runAll, runHeal, runPremortem, runPremortemSession } from '../src/core.mjs';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const BIN = path.join(ROOT, 'bin', 'agoragentic-premortem-golden-loop.mjs');
+
+describe('premortem golden loop core', () => {
+  it('passes a release-ready local agent repo without network access', async () => {
+    const repo = await makeFixture({
+      readme: [
+        '# Fixture Agent',
+        '',
+        'Install with npm install and run npm test.',
+        'This agent uses Agent OS and execute(task,input,constraints) for external work.',
+        'No-spend mode is the default. Paid execution requires owner approval, budget, max_cost, x402, and USDC funding.',
+        'Each run writes a receipt, trace_id, invocation_id, audit trail, and reconciliation note.',
+        'Health endpoint: /health. Rollback: redeploy the prior version.'
+      ].join('\n'),
+      agentJson: true,
+      envExample: true
+    });
+
+    const report = await runPremortem({ repo });
+    assert.equal(report.summary.blockers, 0, JSON.stringify(report.risks, null, 2));
+    assert.equal(report.checks.find((check) => check.id === 'secret-hygiene-clear')?.status, 'pass');
+
+    const run = await runAll({ repo, skipNetwork: true });
+    assert.equal(run.receipt.no_spend, true);
+    assert.equal(run.receipt.pass, true, JSON.stringify(run.golden_loop.stages, null, 2));
+    assert.match(run.receipt.receipt_id, /^pgl_[a-f0-9]{16}$/);
+  });
+
+  it('flags secret-like values without echoing the secret', async () => {
+    const repo = await makeFixture({
+      readme: 'No-spend agent with budget docs, receipts, health checks, and Agent OS execute(task,input,constraints).',
+      agentJson: true,
+      envExample: true
+    });
+    const secret = ['amk', 'liveSecretValueShouldNotAppear'].join('_');
+    await fs.writeFile(path.join(repo, '.env'), `AGORAGENTIC_API_KEY=${secret}\n`, 'utf8');
+
+    const report = await runPremortem({ repo });
+    const risk = report.risks.find((item) => item.id === 'secret-hygiene-failed');
+    assert.equal(risk?.severity, 'blocker');
+    assert.match(JSON.stringify(risk.evidence), /\.env:1/);
+    assert.doesNotMatch(JSON.stringify(risk.evidence), new RegExp(secret));
+  });
+
+  it('writes JSON artifacts through the CLI', async () => {
+    const repo = await makeFixture({
+      readme: 'Agent OS no-spend agent with budget approval, receipt, reconciliation, health, and execute(task,input,constraints).',
+      agentJson: true,
+      envExample: true
+    });
+    const out = path.join(await fs.mkdtemp(path.join(os.tmpdir(), 'pgl-out-')), 'artifacts');
+    const result = spawnSync(process.execPath, [BIN, 'run', '--repo', repo, '--out', out, '--skip-network', '--json'], {
+      cwd: ROOT,
+      encoding: 'utf8'
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.receipt.no_spend, true);
+    assert.equal((await exists(path.join(out, 'premortem.json'))), true);
+    assert.equal((await exists(path.join(out, 'golden-loop.json'))), true);
+    assert.equal((await exists(path.join(out, 'local-receipt.json'))), true);
+  });
+
+  it('generates a prompt-style premortem session with investigator findings', async () => {
+    const repo = await makeFixture({
+      readme: 'Premortem agent repo for Agent OS builders. Success: ten target users run it and revise a release plan.',
+      agentJson: true,
+      envExample: true
+    });
+
+    const session = await runPremortemSession({
+      repo,
+      plan: 'Release an OSS Agoragentic premortem agent on GitHub that tests Golden Loop readiness for installable AI agent repositories.',
+      audience: 'AI agent builders and small teams preparing public agent releases',
+      success: 'at least ten real target users install it, run a premortem, and make one concrete launch change'
+    });
+
+    assert.equal(session.status, 'complete');
+    assert.ok(session.failure_reasons.length >= 5);
+    assert.equal(session.deep_dives.length, session.failure_reasons.length);
+    assert.match(session.synthesis.hidden_assumption, /hidden assumption/i);
+  });
+
+  it('writes HTML report and transcript through the session CLI', async () => {
+    const repo = await makeFixture({
+      readme: 'Agent OS launch helper. Goal: users produce premortem reports before public release.',
+      agentJson: true,
+      envExample: true
+    });
+    const out = path.join(await fs.mkdtemp(path.join(os.tmpdir(), 'pgl-session-')), 'artifacts');
+    const result = spawnSync(process.execPath, [
+      BIN,
+      'session',
+      '--repo',
+      repo,
+      '--out',
+      out,
+      '--plan',
+      'Launch a GitHub repo for an AI agent that runs premortems and no-spend Golden Loop checks.',
+      '--audience',
+      'open-source AI agent builders',
+      '--success',
+      'builders run the agent and revise their launch plan before release'
+    ], {
+      cwd: ROOT,
+      encoding: 'utf8'
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Premortem report written/);
+    const files = await fs.readdir(out);
+    assert.ok(files.some((file) => /^premortem-report-.*\.html$/.test(file)));
+    assert.ok(files.some((file) => /^premortem-transcript-.*\.md$/.test(file)));
+  });
+
+  it('plans self-healing without changing files', async () => {
+    const repo = await makeFixture({
+      readme: 'Local OSS agent with install docs but missing discovery metadata and explicit safety workflows.',
+      agentJson: false,
+      envExample: false,
+      testScript: false
+    });
+
+    const report = await runHeal({ repo });
+
+    assert.equal(report.mode, 'plan_only');
+    assert.equal(report.free_to_use, true);
+    assert.equal(report.privacy.data_sent_anywhere, false);
+    assert.ok(report.plan.actions.some((action) => action.id === 'safety-boundaries-doc' && action.type === 'create_file'));
+    assert.ok(report.plan.actions.some((action) => action.id === 'agent-descriptor' && action.type === 'create_file'));
+    assert.equal(await exists(path.join(repo, 'docs', 'AGORAGENTIC_SAFETY_BOUNDARIES.md')), false);
+    assert.equal(await exists(path.join(repo, 'agent.json')), false);
+  });
+
+  it('applies only additive self-healing scaffolds', async () => {
+    const repo = await makeFixture({
+      readme: 'Local OSS agent with install docs but missing discovery metadata and explicit safety workflows.',
+      agentJson: false,
+      envExample: false,
+      testScript: false
+    });
+
+    const report = await runHeal({ repo, applySafeFixes: true });
+
+    assert.equal(report.mode, 'apply_safe_fixes');
+    assert.ok(report.applied.some((item) => item.target === 'docs/AGORAGENTIC_SAFETY_BOUNDARIES.md' && item.status === 'created'));
+    assert.ok(report.applied.some((item) => item.target === 'agent.json' && item.status === 'created'));
+    assert.ok(report.after);
+    assert.equal(await exists(path.join(repo, 'docs', 'AGORAGENTIC_GOALS.md')), true);
+    assert.equal(await exists(path.join(repo, 'docs', 'AGORAGENTIC_WORKFLOWS.md')), true);
+    assert.equal(await exists(path.join(repo, 'docs', 'AGORAGENTIC_SAFETY_BOUNDARIES.md')), true);
+    assert.equal(await exists(path.join(repo, '.env.example')), true);
+    assert.equal(await exists(path.join(repo, '.github', 'workflows', 'agoragentic-premortem-golden-loop.yml')), true);
+  });
+
+  it('writes self-heal artifacts through the CLI', async () => {
+    const repo = await makeFixture({
+      readme: 'Local OSS agent with install docs but missing discovery metadata and explicit safety workflows.',
+      agentJson: false,
+      envExample: false,
+      testScript: false
+    });
+    const out = path.join(await fs.mkdtemp(path.join(os.tmpdir(), 'pgl-heal-')), 'artifacts');
+    const result = spawnSync(process.execPath, [BIN, 'heal', '--repo', repo, '--out', out, '--apply-safe-fixes', '--json'], {
+      cwd: ROOT,
+      encoding: 'utf8'
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const parsed = JSON.parse(result.stdout);
+    assert.equal(parsed.schema, 'agoragentic.premortem-golden-loop.heal.v1');
+    assert.equal(parsed.boundary.network_calls, false);
+    assert.equal((await exists(path.join(out, 'healing-plan.json'))), true);
+    assert.equal((await exists(path.join(out, 'healing-plan.md'))), true);
+    assert.equal((await exists(path.join(repo, 'docs', 'AGORAGENTIC_SAFETY_BOUNDARIES.md'))), true);
+  });
+});
+
+async function makeFixture({ readme, agentJson, envExample, testScript = true }) {
+  const repo = await fs.mkdtemp(path.join(os.tmpdir(), 'pgl-repo-'));
+  await fs.writeFile(path.join(repo, 'README.md'), `${readme}\n`, 'utf8');
+  await fs.writeFile(path.join(repo, 'LICENSE'), 'MIT License\n', 'utf8');
+  const packageJson = {
+    name: 'fixture-agent',
+    version: '1.0.0',
+    type: 'module'
+  };
+  if (testScript) {
+    packageJson.scripts = {
+      test: 'node --test'
+    };
+  }
+  await fs.writeFile(path.join(repo, 'package.json'), JSON.stringify({
+    ...packageJson
+  }, null, 2), 'utf8');
+  if (agentJson) {
+    await fs.writeFile(path.join(repo, 'agent.json'), JSON.stringify({
+      name: 'fixture-agent',
+      description: 'Fixture installable agent',
+      no_spend_default: true
+    }, null, 2), 'utf8');
+  }
+  if (envExample) {
+    await fs.writeFile(path.join(repo, '.env.example'), 'AGORAGENTIC_API_KEY=amk_your_key\nMAX_COST_USDC=0\n', 'utf8');
+  }
+  return repo;
+}
+
+async function exists(filePath) {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- adds `premortem-golden-loop/`, a local no-spend OSS release premortem and Golden Loop readiness CLI
- updates integration discovery metadata, README, SKILL, llms, and changelog entries against current `origin/main`
- keeps the default path local-only: no wallet, no API key, no network calls, no paid execution, no production mutation

## Validation
- `npm run check` in `premortem-golden-loop/`
- `npm test` in `premortem-golden-loop/` with 8 passing tests
- JSON parse check for `integrations.json`, `premortem-golden-loop/package.json`, and `premortem-golden-loop/agent.json`
- `git diff --cached --check`

## Boundaries
- did not include unrelated dirty local `micro-ecf/src/core.mjs` wording change
- did not touch hosted runtime, wallet, x402 settlement, marketplace publishing, or Seller OS