### PR TITLE
[codex] Clarify Micro ECF builder value

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ Agoragentic integrations should give an agent four things before it goes live:
 - The `execute(task, input, constraints)` rail for routed marketplace work, receipts, and settlement.
 - Optional context graph providers that let Agent OS inspect structural impact before the agent acts.
 
+## What This Means For Builders
+
+Installing Micro ECF on a codebase gives the builder a local governance contract for AI work in that repo. It creates durable files an IDE agent can read across sessions: what sources are allowed, what files are blocked, what tools or context providers are in scope, what must stay local, and what can be exported into an Agent OS preview.
+
+For builders, this means an AI coding agent does not have to start each conversation from memory or guesswork. The agent can load `AGENTS.md`, `ECF.md`, and `.micro-ecf/*` artifacts to understand the project boundary, cite local sources, preserve handoff history, and keep docs-sync or next-session work explicit. Micro ECF is still local-only: it does not deploy, spend, publish, settle x402, or expose private Full ECF internals.
+
 For code/workspace agents, GitNexus can be attached as an optional local `code_graph` provider through Micro ECF. Existing local RAG, database tools, or MCP context systems can be attached as `retrieval_context` providers. Treat these as provider patterns: the provider brings retrieval or graph evidence; Micro ECF wraps it with source boundaries, policy, provenance, and action-risk controls. Agoragentic Agent OS gives deployed agents structural action awareness.
 
 ## Smart Routing For Agents

--- a/micro-ecf/README.md
+++ b/micro-ecf/README.md
@@ -18,6 +18,21 @@ In the public package family, use `agoragentic-micro-ecf` before hosted deployme
   <img src="assets/micro-ecf-architecture.png" alt="Micro ECF architecture diagram showing local inputs, bounded context artifacts, blocked secret paths, and Agent OS preview outputs" width="100%" />
 </p>
 
+## What This Means For Builders
+
+When a builder installs Micro ECF on a codebase, the repo gains a persistent AI work boundary. Future agents can read the generated `AGENTS.md`, `ECF.md`, `.micro-ecf/context-packet.json`, `.micro-ecf/policy-summary.json`, and `.micro-ecf/source-map.json` before making changes.
+
+That gives the builder:
+
+- continuity across Codex, Cursor, Claude, Gemini, and other IDE-agent sessions
+- an explicit list of allowed and blocked local sources
+- citation-ready context packets for reviewing why an agent used a source
+- local tool, budget, approval, memory, and swarm boundaries
+- resident worklog, docs-sync plan, and handoff artifacts for long goals
+- an Agent OS Harness export when the builder wants a no-spend hosted preview
+
+Micro ECF does not replace source-code inspection. It gives agents a durable starting contract and local governance packet so they know what to inspect, what not to expose, and what should require owner review.
+
 ## Syrin User Roadmap
 
 Use the Syrin guide when you want the shortest path from local Micro ECF artifacts to hosted Agent OS readiness:


### PR DESCRIPTION
## Summary
- explains what installing Micro ECF on a codebase does for builders
- clarifies the durable repo artifacts agents can read across sessions
- reinforces local-only boundaries: no deploy, spend, publish, settlement, or Full ECF exposure

## Validation
- `git diff --check`
- `npm run check` in `micro-ecf/`
- `npm test` in `micro-ecf/` with 6 passing tests