### PR TITLE
[codex] Document Micro ECF resident memory continuity

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The first call to this paid route returns an x402 payment challenge. A signed pa
 - Get receipts and reconciliation metadata
 - Plug into MCP, OpenAI Agents, AutoGen, smolagents, LangChain, CrewAI, and more
 - Prepare governed deployments with Micro ECF and Agent OS Harness packets
+- Keep local resident work memory, docs-sync plans, and next-session handoffs under `.micro-ecf/`
 - Run local no-spend Harness Core proof, receipt, export, and listing-readiness checks before hosted launch
 - Run local release premortems, no-spend Golden Loop readiness checks, and additive self-heal plans before publishing an OSS agent
 
@@ -96,6 +97,7 @@ Do **not** start with `GET /api/capabilities` or `POST /api/invoke/{listing_id}`
 Agoragentic integrations should give an agent four things before it goes live:
 
 - A local Micro ECF context wedge for context packets, source boundaries, tool policy, budgets, approvals, memory, swarms, and external context providers.
+- A resident continuity layer that records worklogs, checkpoints, docs-sync plans, and handoffs as local `.micro-ecf/` artifacts.
 - An Agent OS Harness packet that can preview the hosted deployment before spend or public exposure.
 - The `execute(task, input, constraints)` rail for routed marketplace work, receipts, and settlement.
 - Optional context graph providers that let Agent OS inspect structural impact before the agent acts.
@@ -104,7 +106,11 @@ Agoragentic integrations should give an agent four things before it goes live:
 
 Installing Micro ECF on a codebase gives the builder a local governance contract for AI work in that repo. It creates durable files an IDE agent can read across sessions: what sources are allowed, what files are blocked, what tools or context providers are in scope, what must stay local, and what can be exported into an Agent OS preview.
 
-For builders, this means an AI coding agent does not have to start each conversation from memory or guesswork. The agent can load `AGENTS.md`, `ECF.md`, and `.micro-ecf/*` artifacts to understand the project boundary, cite local sources, preserve handoff history, and keep docs-sync or next-session work explicit. Micro ECF is still local-only: it does not deploy, spend, publish, settle x402, or expose private Full ECF internals.
+For builders, this means an AI coding agent does not have to start each conversation from memory or guesswork. The agent can load `AGENTS.md`, `ECF.md`, and `.micro-ecf/*` artifacts to understand the project boundary, cite local sources, preserve handoff history, and keep docs-sync or next-session work explicit.
+
+The resident layer is deliberately boring and inspectable. It writes files such as `.micro-ecf/worklog/current.json`, `.micro-ecf/worklog/checkpoints.jsonl`, `.micro-ecf/docs-sync-plan.json`, `.micro-ecf/handoff.md`, and `.micro-ecf/next-session.md`. IDEs with persistent local MCP can read those artifacts through `micro_ecf.worklog_status`, `micro_ecf.handoff`, and `micro_ecf.work_memory`. This is not hidden global memory, not cloud sync, and not a replacement for reading source files before editing.
+
+Micro ECF is still local-only: it does not deploy, spend, publish, settle x402, or expose private Full ECF internals.
 
 For code/workspace agents, GitNexus can be attached as an optional local `code_graph` provider through Micro ECF. Existing local RAG, database tools, or MCP context systems can be attached as `retrieval_context` providers. Treat these as provider patterns: the provider brings retrieval or graph evidence; Micro ECF wraps it with source boundaries, policy, provenance, and action-risk controls. Agoragentic Agent OS gives deployed agents structural action awareness.
 
@@ -334,6 +340,16 @@ The safe flow is consent-gated: `micro-ecf plan --dir .` first, then `micro-ecf 
 After install, Micro ECF is persistent as repo artifacts, not hidden global chat memory. Compatible IDE agents should read the generated `AGENTS.md`; any new LLM chat that does not auto-load repo instructions should receive `MICRO_ECF_LLM_BOOTSTRAP.md`; IDEs with persistent local tools can run `micro-ecf serve-mcp --root .micro-ecf`.
 
 `ECF.md` is the persistent agent-readable Micro ECF contract. It gives new chats a durable policy file before they inspect generated `.micro-ecf/*` artifacts.
+
+For goal/session continuity, use the resident work memory commands:
+
+```bash
+npx agoragentic-micro-ecf@latest worklog begin --goal "current goal"
+npx agoragentic-micro-ecf@latest worklog checkpoint --summary "what changed"
+npx agoragentic-micro-ecf@latest docs-sync plan --dir .
+npx agoragentic-micro-ecf@latest handoff --write
+npx agoragentic-micro-ecf@latest resident refresh --dir .
+```
 
 Use [`micro-ecf/POST_INSTALL.md`](./micro-ecf/POST_INSTALL.md) for the after-install workflow.
 

--- a/micro-ecf/CODEX_MCP.md
+++ b/micro-ecf/CODEX_MCP.md
@@ -41,6 +41,14 @@ The generated server exposes:
 - `micro_ecf.handoff`
 - `micro_ecf.work_memory`
 
+Before restarting Codex or ending a long session, refresh local continuity artifacts:
+
+```bash
+micro-ecf resident refresh --dir .
+```
+
+This writes `resident-status.json`, `context-pack.json`, `docs-sync-plan.json`, `handoff.md`, `handoff.json`, and `next-session.md` under `.micro-ecf/`.
+
 ## Boundary
 
-The resident MCP server is local-only. It reads Micro ECF artifacts and does not deploy, spend, mutate wallets, settle x402, publish marketplace listings, rank providers, or expose Full ECF private internals.
+The resident MCP server and resident refresh command are local-only. They read or write Micro ECF artifacts and do not deploy, spend, mutate wallets, settle x402, publish marketplace listings, rank providers, provision hosted runtime, auto-edit docs, or expose Full ECF private internals.

--- a/micro-ecf/POST_INSTALL.md
+++ b/micro-ecf/POST_INSTALL.md
@@ -140,6 +140,14 @@ This writes local artifacts under `.micro-ecf/worklog/`, plus `.micro-ecf/docs-s
 
 The docs-sync command only creates a plan. It does not edit `WRAPUP.md`, `DOCUMENTATION_INDEX.md`, API docs, or README files.
 
+When you want the full local resident snapshot in one command, run:
+
+```bash
+micro-ecf resident refresh --dir .
+```
+
+This is equivalent to writing resident status, context pack, docs-sync plan, and handoff artifacts. It writes only local `.micro-ecf/` JSON/JSONL/Markdown files. It does not deploy, spend, mutate wallets, settle x402, publish marketplace listings, provision hosted runtime, or expose Full ECF private internals.
+
 ## 6. Preview In Agent OS Only When Ready
 
 The harness export is no-spend and non-provisioning:

--- a/micro-ecf/README.md
+++ b/micro-ecf/README.md
@@ -33,6 +33,8 @@ That gives the builder:
 
 Micro ECF does not replace source-code inspection. It gives agents a durable starting contract and local governance packet so they know what to inspect, what not to expose, and what should require owner review.
 
+The resident memory layer adds continuity for work that spans multiple chats or IDE restarts. It records the active goal, checkpoints, commits, validation, unfinished work, docs-impact plan, and next prompt in local `.micro-ecf/` files that a future agent can inspect. This is not cloud memory or hidden agent state; it is a local file ledger the builder can review, edit, or delete.
+
 ## Syrin User Roadmap
 
 Use the Syrin guide when you want the shortest path from local Micro ECF artifacts to hosted Agent OS readiness:
@@ -116,7 +118,11 @@ ECF.md
 .micro-ecf/resident-status.json
 .micro-ecf/context-pack.json
 .micro-ecf/worklog/current.json
+.micro-ecf/worklog/history.jsonl
+.micro-ecf/worklog/checkpoints.jsonl
+.micro-ecf/worklog/latest-summary.md
 .micro-ecf/docs-sync-plan.json
+.micro-ecf/handoff.json
 .micro-ecf/handoff.md
 .micro-ecf/next-session.md
 AGENTS.md
@@ -274,6 +280,14 @@ micro-ecf handoff --write
 
 The worklog and handoff artifacts are local-only. `docs-sync plan` proposes documentation updates but does not edit docs. Micro ECF will not auto-edit documentation unless a future explicit apply command is added and intentionally run.
 
+For builders, the resident files answer five practical questions at the start of the next session:
+
+- What goal was active?
+- What changed and which files were involved?
+- Which validation ran?
+- Which docs probably need updates?
+- What exact next prompt should the next agent continue from?
+
 For a single local refresh before closing an IDE or Codex session, use:
 
 ```bash
@@ -281,6 +295,12 @@ micro-ecf resident refresh --dir .
 ```
 
 `resident refresh` writes only `.micro-ecf/` resident artifacts: `resident-status.json`, `context-pack.json`, `docs-sync-plan.json`, `handoff.md`, `handoff.json`, and `next-session.md`. It does not deploy, spend, mutate wallets, settle x402, publish marketplace listings, provision hosted runtime, or expose Full ECF private internals.
+
+If Codex or another IDE supports local MCP tools, `micro-ecf serve-mcp --root .micro-ecf` exposes read-only resident tools for future sessions:
+
+- `micro_ecf.worklog_status`
+- `micro_ecf.handoff`
+- `micro_ecf.work_memory`
 
 ## Local Workflow
 

--- a/micro-ecf/README.md
+++ b/micro-ecf/README.md
@@ -117,6 +117,7 @@ ECF.md
 .micro-ecf/context-pack.json
 .micro-ecf/worklog/current.json
 .micro-ecf/docs-sync-plan.json
+.micro-ecf/handoff.md
 .micro-ecf/next-session.md
 AGENTS.md
 MICRO_ECF_LLM_BOOTSTRAP.md
@@ -249,6 +250,8 @@ micro-ecf export --agent-os
 micro-ecf serve-mcp
 micro-ecf status --write
 micro-ecf context-pack --write
+micro-ecf resident status
+micro-ecf resident refresh
 micro-ecf mcp-config --target codex --write
 micro-ecf worklog begin --goal "..."
 micro-ecf worklog checkpoint --summary "..."
@@ -269,7 +272,15 @@ micro-ecf docs-sync plan --dir .
 micro-ecf handoff --write
 ```
 
-The worklog and handoff artifacts are local-only. `docs-sync plan` proposes documentation updates but does not edit docs.
+The worklog and handoff artifacts are local-only. `docs-sync plan` proposes documentation updates but does not edit docs. Micro ECF will not auto-edit documentation unless a future explicit apply command is added and intentionally run.
+
+For a single local refresh before closing an IDE or Codex session, use:
+
+```bash
+micro-ecf resident refresh --dir .
+```
+
+`resident refresh` writes only `.micro-ecf/` resident artifacts: `resident-status.json`, `context-pack.json`, `docs-sync-plan.json`, `handoff.md`, `handoff.json`, and `next-session.md`. It does not deploy, spend, mutate wallets, settle x402, publish marketplace listings, provision hosted runtime, or expose Full ECF private internals.
 
 ## Local Workflow
 

--- a/micro-ecf/bin/micro-ecf.mjs
+++ b/micro-ecf/bin/micro-ecf.mjs
@@ -71,6 +71,8 @@ Usage:
   micro-ecf doctor [--dir .] [--output-dir .micro-ecf]
   micro-ecf status [--dir .] [--output-dir .micro-ecf] [--write]
   micro-ecf context-pack [task] [--dir .] [--output-dir .micro-ecf] [--write]
+  micro-ecf resident status [--dir .] [--output-dir .micro-ecf] [--write]
+  micro-ecf resident refresh [--dir .] [--output-dir .micro-ecf] [--task "..."]
   micro-ecf mcp-config --target codex [--dir .] [--output-dir .micro-ecf] [--write] [--install-codex]
   micro-ecf worklog begin --goal "..." [--dir .] [--output-dir .micro-ecf]
   micro-ecf worklog checkpoint --summary "..." [--dir .] [--output-dir .micro-ecf]
@@ -272,6 +274,48 @@ function commandHandoff(flags) {
   return flags.write ? writeHandoff(workMemoryOptions(flags)) : buildHandoff(workMemoryOptions(flags));
 }
 
+function commandResident(flags) {
+  const [subcommand = 'status'] = flags._;
+  if (subcommand === 'status') return commandStatus(flags);
+  if (subcommand !== 'refresh') throw new Error(`Unknown resident subcommand: ${subcommand}`);
+  const writeFlags = {
+    ...flags,
+    write: true,
+    _: flags._.slice(1),
+  };
+  const status = writeMicroEcfResidentStatus({
+    targetDir: writeFlags.dir || process.cwd(),
+    outputDir: writeFlags['output-dir'] || null,
+  });
+  const contextPack = writeMicroEcfContextPack({
+    targetDir: writeFlags.dir || process.cwd(),
+    outputDir: writeFlags['output-dir'] || null,
+    task: writeFlags.task || writeFlags._.join(' ') || 'resident_refresh',
+  });
+  const docsSyncPlan = planDocsSync(workMemoryOptions(writeFlags));
+  const handoff = writeHandoff(workMemoryOptions(writeFlags));
+  return {
+    schema: 'agoragentic.micro-ecf.resident-refresh.v1',
+    ok: status.ok && contextPack.ok && docsSyncPlan.ok && handoff.ok,
+    generated_at: new Date().toISOString(),
+    status,
+    context_pack: contextPack,
+    docs_sync_plan: docsSyncPlan,
+    handoff,
+    authority_boundary: {
+      local_only: true,
+      docs_auto_edit_enabled: false,
+      deploy_enabled: false,
+      spend_enabled: false,
+      wallet_mutation_enabled: false,
+      x402_settlement_enabled: false,
+      marketplace_publication_enabled: false,
+      hosted_runtime_enabled: false,
+      full_ecf_private_internals_included: false,
+    },
+  };
+}
+
 async function main() {
   const [command, ...rest] = process.argv.slice(2);
   if (!command || command === '--help' || command === '-h') {
@@ -289,6 +333,7 @@ async function main() {
   else if (command === 'doctor') output(commandDoctor(flags));
   else if (command === 'status') output(commandStatus(flags));
   else if (command === 'context-pack') output(commandContextPack(flags));
+  else if (command === 'resident') output(commandResident(flags));
   else if (command === 'mcp-config') output(commandMcpConfig(flags));
   else if (command === 'worklog') output(commandWorklog(flags));
   else if (command === 'docs-sync') output(commandDocsSync(flags));

--- a/micro-ecf/test/cli.test.mjs
+++ b/micro-ecf/test/cli.test.mjs
@@ -203,6 +203,37 @@ test('resident status and context pack expose local always-on handoff artifacts'
     assert.equal(pack.summary.source_counts.included_sources > 0, true);
     assert.ok(fs.existsSync(path.join(tmp, '.micro-ecf', 'context-pack.json')));
 
+    const residentStatus = run(['resident', 'status', '--dir', tmp, '--write'], microEcfRoot);
+    assert.equal(residentStatus.schema, 'agoragentic.micro-ecf.resident-status.v1');
+    assert.equal(residentStatus.ok, true);
+    assert.equal(residentStatus.authority_boundary.local_only, true);
+    assert.equal(residentStatus.authority_boundary.no_deploy, true);
+    assert.equal(residentStatus.authority_boundary.no_spend, true);
+    assert.equal(residentStatus.authority_boundary.full_ecf_private_internals_included, false);
+
+    const refresh = run(['resident', 'refresh', '--dir', tmp, '--task', 'refresh resident continuity'], microEcfRoot);
+    assert.equal(refresh.schema, 'agoragentic.micro-ecf.resident-refresh.v1');
+    assert.equal(refresh.ok, true);
+    assert.equal(refresh.context_pack.task, 'refresh resident continuity');
+    assert.equal(refresh.authority_boundary.local_only, true);
+    assert.equal(refresh.authority_boundary.deploy_enabled, false);
+    assert.equal(refresh.authority_boundary.spend_enabled, false);
+    assert.equal(refresh.authority_boundary.wallet_mutation_enabled, false);
+    assert.equal(refresh.authority_boundary.x402_settlement_enabled, false);
+    assert.equal(refresh.authority_boundary.marketplace_publication_enabled, false);
+    assert.equal(refresh.authority_boundary.hosted_runtime_enabled, false);
+    assert.equal(refresh.authority_boundary.full_ecf_private_internals_included, false);
+    assert.ok(refresh.status.status_path.endsWith('.micro-ecf/resident-status.json'));
+    assert.ok(refresh.context_pack.context_pack_path.endsWith('.micro-ecf/context-pack.json'));
+    assert.ok(refresh.docs_sync_plan.plan_path.endsWith('.micro-ecf/docs-sync-plan.json'));
+    assert.ok(refresh.handoff.handoff_path.endsWith('.micro-ecf/handoff.md'));
+    assert.ok(fs.existsSync(path.join(tmp, '.micro-ecf', 'resident-status.json')));
+    assert.ok(fs.existsSync(path.join(tmp, '.micro-ecf', 'context-pack.json')));
+    assert.ok(fs.existsSync(path.join(tmp, '.micro-ecf', 'docs-sync-plan.json')));
+    assert.ok(fs.existsSync(path.join(tmp, '.micro-ecf', 'handoff.md')));
+    assert.ok(fs.existsSync(path.join(tmp, '.micro-ecf', 'handoff.json')));
+    assert.ok(fs.existsSync(path.join(tmp, '.micro-ecf', 'next-session.md')));
+
     const codexHome = path.join(tmp, 'codex-home');
     const mcpConfig = run([
       'mcp-config',
@@ -441,6 +472,7 @@ test('context provider docs and examples keep Micro ECF as a governance wrapper'
   const guide = fs.readFileSync(path.join(microEcfRoot, 'PROVIDER_WRAPPING.md'), 'utf8');
   const postInstall = fs.readFileSync(path.join(microEcfRoot, 'POST_INSTALL.md'), 'utf8');
   const codexMcp = fs.readFileSync(path.join(microEcfRoot, 'CODEX_MCP.md'), 'utf8');
+  const readme = fs.readFileSync(path.join(microEcfRoot, 'README.md'), 'utf8');
   assert.match(guide, /does not replace your RAG/i);
   assert.match(guide, /raw_secret_content_allowed/);
   assert.match(guide, /fail closed/i);
@@ -453,9 +485,14 @@ test('context provider docs and examples keep Micro ECF as a governance wrapper'
   assert.match(postInstall, /micro-ecf worklog begin/);
   assert.match(postInstall, /micro-ecf docs-sync plan/);
   assert.match(postInstall, /micro-ecf handoff --write/);
+  assert.match(postInstall, /micro-ecf resident refresh --dir \./);
+  assert.match(readme, /micro-ecf resident refresh/);
+  assert.match(readme, /does not deploy, spend, mutate wallets/);
   assert.match(codexMcp, /Resident MCP for Codex/);
   assert.match(codexMcp, /micro_ecf\.context_pack/);
   assert.match(codexMcp, /micro_ecf\.work_memory/);
+  assert.match(codexMcp, /resident refresh/);
+  assert.match(codexMcp, /auto-edit docs/);
 
   const examples = [
     ['context-provider-rag.policy.json', 'retrieval_context', 'local_rag'],


### PR DESCRIPTION
## Summary

- Documents Micro ECF resident work memory as a local `.micro-ecf/` continuity layer for IDE/Codex sessions.
- Explains worklog, docs-sync, handoff, next-session artifacts, and MCP read tools for builders.
- Keeps the public boundary explicit: local-only, no hosted runtime, no wallet/x402, no marketplace publishing, and no Full ECF internals.

## Validation

- `git diff --check`
- `npm run check` in `micro-ecf/`
- `npm test` in `micro-ecf/`

## Notes

Direct push to `main` is blocked by branch protection, so this PR is the required path to land the already-validated local commits.