### PR TITLE
feat: add Robinhood Agent OS integration scaffold

### DIFF
--- a/financial-research/README.md
+++ b/financial-research/README.md
@@ -1,0 +1,47 @@
+# Financial Research Provider Lane
+
+Status: public scaffold.
+
+This directory documents a public-safe research-provider lane for Agoragentic. The lane lets Agent OS deployments request cited research artifacts from external or future hosted providers without granting direct execution authority.
+
+## V1 boundary
+
+Research providers may produce:
+
+- cited research reports;
+- risk summaries;
+- bull and bear cases;
+- strategy candidates;
+- provider receipts;
+- non-advice disclaimers.
+
+Research providers must not directly place orders, make purchases, or change user connector policy. Candidate actions must go through the relevant Agent OS policy and approval gate.
+
+## Initial provider candidates
+
+- `Fincept-Corporation/FinceptTerminal` — terminal-class research, analytics, visual workflows, and data connectors. Treat as license-review-required before bundling or distribution.
+- `AI4Finance-Foundation/FinGPT` — finance language-model research candidate.
+- `AI4Finance-Foundation/FinNLP` — financial text pipeline candidate.
+- `Open-Finance-Lab/AgenticTrading` — financial agent design reference candidate.
+- `yya518/FinBERT` — financial sentiment model candidate.
+
+## Fincept posture
+
+Fincept is a strong independent-research candidate because its public README describes multi-asset analytics, AI agents, data connectors, quant modules, and workflow tooling. Do not vendor or redistribute Fincept code until license review is complete. Do not claim a partnership unless separately approved.
+
+## Agent OS flow
+
+```text
+research request
+  -> provider selection
+  -> budget check
+  -> cited artifact
+  -> redacted receipt
+  -> optional candidate action
+  -> policy and approval gate
+```
+
+## Files
+
+- `repo-intake.v1.json` — initial candidate-provider registry.
+- `prompts/codex-fincept-research-provider.md` — Codex implementation prompt for the provider lane.

--- a/financial-research/prompts/codex-fincept-research-provider.md
+++ b/financial-research/prompts/codex-fincept-research-provider.md
@@ -1,0 +1,42 @@
+# Codex prompt: Fincept and financial research provider lane
+
+You are implementing the financial research provider lane for Agoragentic integrations.
+
+## Goal
+
+Create a public-safe research-provider scaffold that lets Agent OS deployments request cited research artifacts from external or future hosted finance research providers. The first intake candidate is `Fincept-Corporation/FinceptTerminal`.
+
+## Read first
+
+1. `financial-research/README.md`
+2. `financial-research/repo-intake.v1.json`
+3. Fincept Terminal README and license files
+4. The target repository instructions
+
+## Boundary
+
+Do not vendor Fincept code in this scaffold. Do not distribute Fincept binaries. Do not imply a partnership. Treat Fincept as license-review-required until a separate owner decision exists.
+
+Research providers may produce cited reports, risk summaries, bull and bear cases, strategy candidates, and receipts. Candidate actions must not execute directly.
+
+## Build steps
+
+1. Confirm provider metadata in `repo-intake.v1.json`.
+2. Create a provider contract with fields for provider id, execution mode, inputs, outputs, citation policy, and receipt linkage.
+3. Ensure every output includes a non-advice disclaimer.
+4. Ensure candidate actions are marked approval-required and not executable directly.
+5. Add validation tests that reject reports without citations or outputs that attempt direct execution.
+6. Add documentation showing the research-to-action gate:
+
+```text
+research artifact
+  -> candidate action
+  -> Agent OS policy check
+  -> owner approval
+  -> provider connector dispatch only if allowed
+  -> redacted receipt
+```
+
+## Output
+
+Open a PR with docs, schemas, pure helpers, and tests. Keep runtime connector execution as a later phase unless the owner explicitly approves it.

--- a/financial-research/repo-intake.v1.json
+++ b/financial-research/repo-intake.v1.json
@@ -1,0 +1,79 @@
+{
+  "schema": "financial_research_repo_intake.v1",
+  "updated_at": "2026-05-28",
+  "boundary": {
+    "research_outputs_only": true,
+    "candidate_actions_require_agent_os_policy": true,
+    "candidate_actions_executable_directly": false,
+    "partnership_claims_allowed": false,
+    "license_review_required_before_bundling": true
+  },
+  "providers": [
+    {
+      "provider_id": "fincept_terminal",
+      "name": "Fincept Terminal",
+      "repo": "https://github.com/Fincept-Corporation/FinceptTerminal",
+      "provider_type": "financial_research_terminal",
+      "execution_mode": "external_user_managed",
+      "license_review_required": true,
+      "bundle_code": false,
+      "partnership_claim": false,
+      "capability_candidates": [
+        "equity_research",
+        "portfolio_analytics",
+        "risk_metrics",
+        "data_connectors",
+        "visual_workflows",
+        "mcp_tooling_reference"
+      ],
+      "notes": [
+        "Strong research-provider candidate.",
+        "Do not vendor code or distribute derived binaries before license review."
+      ]
+    },
+    {
+      "provider_id": "fingpt",
+      "name": "FinGPT",
+      "repo": "https://github.com/AI4Finance-Foundation/FinGPT",
+      "provider_type": "finance_language_model_research",
+      "execution_mode": "external_or_hosted_future",
+      "license_review_required": true,
+      "bundle_code": false,
+      "partnership_claim": false,
+      "capability_candidates": ["finance_text_generation", "sentiment", "research_summaries"]
+    },
+    {
+      "provider_id": "finnlp",
+      "name": "FinNLP",
+      "repo": "https://github.com/AI4Finance-Foundation/FinNLP",
+      "provider_type": "financial_text_pipeline",
+      "execution_mode": "external_or_hosted_future",
+      "license_review_required": true,
+      "bundle_code": false,
+      "partnership_claim": false,
+      "capability_candidates": ["financial_text_processing", "dataset_tools", "news_features"]
+    },
+    {
+      "provider_id": "agentic_trading_research",
+      "name": "AgenticTrading",
+      "repo": "https://github.com/Open-Finance-Lab/AgenticTrading",
+      "provider_type": "financial_agent_research_pattern",
+      "execution_mode": "reference_only",
+      "license_review_required": true,
+      "bundle_code": false,
+      "partnership_claim": false,
+      "capability_candidates": ["agent_architecture_reference", "research_patterns"]
+    },
+    {
+      "provider_id": "finbert",
+      "name": "FinBERT",
+      "repo": "https://github.com/yya518/FinBERT",
+      "provider_type": "financial_sentiment_model",
+      "execution_mode": "external_or_hosted_future",
+      "license_review_required": true,
+      "bundle_code": false,
+      "partnership_claim": false,
+      "capability_candidates": ["financial_sentiment"]
+    }
+  ]
+}

--- a/integrations.json
+++ b/integrations.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.17.0",
-  "updated_at": "2026-05-23",
+  "version": "2.18.0",
+  "updated_at": "2026-05-29",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
   "packages": {
@@ -283,6 +283,24 @@
       "path": "agent-os/agent_os_node.mjs",
       "install": "node 18+ or pip install requests",
       "docs": "agent-os/README.md"
+    },
+    {
+      "id": "robinhood-agent-os",
+      "name": "Robinhood Agent OS Scaffold",
+      "language": "json",
+      "status": "experimental",
+      "path": "robinhood/mcp.json",
+      "install": "Schema-only scaffold; owner-authenticated MCP probe required before use",
+      "docs": "robinhood/README.md"
+    },
+    {
+      "id": "financial-research",
+      "name": "Financial Research Provider Lane",
+      "language": "json",
+      "status": "experimental",
+      "path": "financial-research/repo-intake.v1.json",
+      "install": "Research-provider intake scaffold only; no provider code is vendored",
+      "docs": "financial-research/README.md"
     },
     {
       "id": "openfang",
@@ -751,6 +769,12 @@
     "agent_client_protocol_adapter": "acp/agent.json",
     "agent_os": "agent-os/README.md",
     "agent_os_public_export": "agent-os/README.md",
+    "robinhood_agent_os": "robinhood/README.md",
+    "robinhood_mcp": "robinhood/mcp.json",
+    "robinhood_mcp_probe_template": "robinhood/probes/robinhood-mcp-probe-template.json",
+    "robinhood_mcp_probe_redacted_example": "robinhood/probes/robinhood-mcp-probe-redacted.example.json",
+    "financial_research": "financial-research/README.md",
+    "financial_research_repo_intake": "financial-research/repo-intake.v1.json",
     "openfang": "openfang/README.md",
     "openfang_bridge_manifest": "openfang/openfang.agoragentic-hand-bridge.manifest.json",
     "cashclaw": "cashclaw/README.md",

--- a/robinhood/README.md
+++ b/robinhood/README.md
@@ -74,6 +74,7 @@ Research should be separate from execution. Fincept and other finance-analysis p
 - `policy.example.json` - disabled-by-default policy example.
 - `capability-manifest.json` - Agent OS capability registration contract.
 - `probes/robinhood-mcp-probe-template.json` - safe probe output contract.
+- `probes/robinhood-mcp-probe-redacted.example.json` - public-safe auth-required probe example with no private account material.
 - `prompts/codex-robinhood-mcp-probe.md` - Codex prompt for safe MCP schema discovery.
 - `prompts/codex-robinhood-agent-os-e2e.md` - Codex prompt for the end-to-end implementation.
 

--- a/robinhood/README.md
+++ b/robinhood/README.md
@@ -1,0 +1,87 @@
+# Robinhood Agent OS Integration
+
+Status: public scaffold and implementation plan. This directory does not execute trades, fetch virtual-card data, store private auth material, or claim a Robinhood partnership.
+
+Source snapshot: 2026-05-28.
+
+## Official MCP servers
+
+Robinhood's public agent support docs point MCP clients at these remote servers:
+
+- Trading MCP: `https://agent.robinhood.com/mcp/trading`
+- Banking MCP: `https://banking-agent.robinhood.com/mcp/banking`
+
+Use the official MCP servers only. Do not scrape Robinhood or build against unofficial brokerage APIs.
+
+## Product fit
+
+Agoragentic should treat Robinhood as a high-risk, user-owned external finance capability behind Triptych OS (Agent OS) policy controls:
+
+```text
+user intent
+  -> Agent OS intent contract
+  -> connector policy guard
+  -> approval queue when required
+  -> MCP client
+  -> Robinhood MCP server
+  -> redacted Agent OS receipt
+```
+
+Robinhood remains the system of record for the brokerage account, agentic trading account, card setup, and transaction/order history. Agoragentic supplies governance, budget policy, approvals, receipts, reconciliation, and research orchestration.
+
+## Trading V1 boundary
+
+Robinhood's current public support copy describes agentic trading for long equities through a dedicated Robinhood Agentic account. Agent OS should begin with the following default rules:
+
+- connector disabled until a user connects it;
+- read-only tools allowed only after connector enablement;
+- `review_equity_order` required before `place_equity_order`;
+- manual approval required for live order placement by default;
+- per-order and daily notional caps enforced before dispatch;
+- margin, short selling, options, crypto, futures, event contracts, and unsupported instruments blocked in V1;
+- options trading kept as a disabled roadmap stub only.
+
+Expected public tool families from Robinhood docs:
+
+- account and portfolio reads;
+- positions and order history;
+- equity quotes;
+- equity tradability checks;
+- equity order review;
+- equity order placement;
+- equity order cancellation;
+- search.
+
+## Banking/Card V1 boundary
+
+Robinhood's Banking MCP is for the Agentic Credit Card path. Agent OS should begin with these default rules:
+
+- connector disabled until a user connects it;
+- checkout context required before fetching virtual-card details;
+- merchant domain and amount required before approval;
+- manual approval required by default;
+- monthly-limit mode allowed only when explicitly configured;
+- card details used ephemerally only;
+- receipts store masked summaries and safe pointers only.
+
+## Independent research lane
+
+Research should be separate from execution. Fincept and other finance-analysis providers can generate cited artifacts, risk summaries, bull/bear cases, strategy candidates, and receipts. Candidate actions must pass through the Robinhood review and approval gates before any live order.
+
+## Files
+
+- `mcp.json` - official remote MCP endpoint configuration.
+- `policy.example.json` - disabled-by-default policy example.
+- `capability-manifest.json` - Agent OS capability registration contract.
+- `probes/robinhood-mcp-probe-template.json` - safe probe output contract.
+- `prompts/codex-robinhood-mcp-probe.md` - Codex prompt for safe MCP schema discovery.
+- `prompts/codex-robinhood-agent-os-e2e.md` - Codex prompt for the end-to-end implementation.
+
+## Production acceptance criteria
+
+- Safe MCP schema probe completed and redacted.
+- No live trade, card-detail fetch, or purchase in tests.
+- Policy module proves disabled, blocked, approval-required, and allowed states.
+- Disable/disconnect blocks new dispatch immediately.
+- Redacted receipts generated for every attempted finance action.
+- Public copy avoids guaranteed-return and partnership claims.

--- a/robinhood/capability-manifest.json
+++ b/robinhood/capability-manifest.json
@@ -1,0 +1,73 @@
+{
+  "version": "2026-05-28",
+  "capabilities": [
+    {
+      "id": "finance.trading.robinhood_agentic_equities",
+      "name": "Robinhood Agentic Equities",
+      "connector": "robinhood_trading",
+      "transport": "mcp.streamable_http",
+      "mcp_server_name": "robinhood-trading",
+      "risk_level": "high",
+      "default_enabled": false,
+      "requires_user_oauth": true,
+      "requires_agentic_account": true,
+      "supported_v1_scope": ["long_equities"],
+      "required_policy_checks": [
+        "connector_enabled",
+        "tool_allowed",
+        "equities_only",
+        "long_only",
+        "symbol_policy",
+        "notional_limits",
+        "review_before_place",
+        "manual_approval_for_place_order"
+      ],
+      "receipt_events": [
+        "tool_intent",
+        "order_review",
+        "approval_request",
+        "approval_decision",
+        "order_submission",
+        "order_status"
+      ],
+      "disabled_roadmap": {
+        "options_trading": {
+          "status": "disabled_roadmap",
+          "requires_robinhood_mcp_schema_support": true,
+          "requires_options_risk_disclosure_gate": true,
+          "requires_user_eligibility_gate": true,
+          "requires_strategy_level_max_loss_model": true,
+          "requires_manual_approval_for_every_order": true,
+          "default_allowed_strategies": []
+        }
+      }
+    },
+    {
+      "id": "finance.spend.robinhood_agentic_card",
+      "name": "Robinhood Agentic Credit Card",
+      "connector": "robinhood_banking",
+      "transport": "mcp.streamable_http",
+      "mcp_server_name": "robinhood-banking",
+      "risk_level": "high",
+      "default_enabled": false,
+      "requires_user_oauth": true,
+      "requires_agentic_virtual_card": true,
+      "required_policy_checks": [
+        "connector_enabled",
+        "operation_allowed",
+        "checkout_context_present",
+        "merchant_domain_policy",
+        "purchase_limits",
+        "manual_approval_or_monthly_limit"
+      ],
+      "receipt_events": [
+        "purchase_intent",
+        "approval_request",
+        "approval_decision",
+        "virtual_card_fetch",
+        "purchase_outcome",
+        "card_transaction_status"
+      ]
+    }
+  ]
+}

--- a/robinhood/mcp.json
+++ b/robinhood/mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "robinhood-trading": {
+      "url": "https://agent.robinhood.com/mcp/trading"
+    },
+    "robinhood-banking": {
+      "url": "https://banking-agent.robinhood.com/mcp/banking"
+    }
+  }
+}

--- a/robinhood/policy.example.json
+++ b/robinhood/policy.example.json
@@ -24,7 +24,7 @@
         "long_only": true,
         "require_review_before_place": true,
         "manual_approval_required_for_place_order": true,
-        "manual_approval_required_for_cancel_order": false,
+        "manual_approval_required_for_cancel_order": true,
         "max_single_order_notional_usd": 100,
         "max_daily_order_notional_usd": 250,
         "max_open_orders": 3,
@@ -33,6 +33,7 @@
         "symbol_blocklist": [],
         "blocked_order_intents": [
           "margin",
+          "short",
           "short_selling",
           "options",
           "crypto",
@@ -49,18 +50,20 @@
       "risk_level": "high",
       "allowed_operations": [
         "read_agentic_virtual_card_policy",
+        "read_agentic_virtual_card_settings",
         "read_agentic_virtual_card_transaction_history",
         "fetch_agentic_virtual_card_details_for_checkout"
       ],
       "rules": {
         "require_checkout_context": true,
         "manual_approval_required_for_purchase": true,
+        "purchase_approval_mode": "manual_approval",
         "monthly_limit_required_if_auto_approval_enabled": true,
         "max_single_purchase_usd": 50,
         "max_monthly_purchase_usd": 200,
         "merchant_domain_allowlist": [],
         "merchant_domain_blocklist": [],
-        "persist_raw_card_details": false
+        "persist_payment_details": false
       }
     },
     "financial_research": {

--- a/robinhood/policy.example.json
+++ b/robinhood/policy.example.json
@@ -1,0 +1,90 @@
+{
+  "version": "2026-05-28",
+  "default_mode": "research_only",
+  "connectors": {
+    "robinhood_trading": {
+      "enabled": false,
+      "mcp_server_name": "robinhood-trading",
+      "endpoint": "https://agent.robinhood.com/mcp/trading",
+      "risk_level": "high",
+      "allowed_tools": [
+        "get_accounts",
+        "get_portfolio",
+        "get_equity_positions",
+        "get_equity_quotes",
+        "get_equity_orders",
+        "get_equity_tradability",
+        "review_equity_order",
+        "place_equity_order",
+        "cancel_equity_order",
+        "search"
+      ],
+      "rules": {
+        "asset_classes": ["equities"],
+        "long_only": true,
+        "require_review_before_place": true,
+        "manual_approval_required_for_place_order": true,
+        "manual_approval_required_for_cancel_order": false,
+        "max_single_order_notional_usd": 100,
+        "max_daily_order_notional_usd": 250,
+        "max_open_orders": 3,
+        "max_symbols_per_quote_request": 20,
+        "symbol_allowlist": [],
+        "symbol_blocklist": [],
+        "blocked_order_intents": [
+          "margin",
+          "short_selling",
+          "options",
+          "crypto",
+          "futures",
+          "event_contracts",
+          "unsupported_instrument"
+        ]
+      }
+    },
+    "robinhood_banking": {
+      "enabled": false,
+      "mcp_server_name": "robinhood-banking",
+      "endpoint": "https://banking-agent.robinhood.com/mcp/banking",
+      "risk_level": "high",
+      "allowed_operations": [
+        "read_agentic_virtual_card_policy",
+        "read_agentic_virtual_card_transaction_history",
+        "fetch_agentic_virtual_card_details_for_checkout"
+      ],
+      "rules": {
+        "require_checkout_context": true,
+        "manual_approval_required_for_purchase": true,
+        "monthly_limit_required_if_auto_approval_enabled": true,
+        "max_single_purchase_usd": 50,
+        "max_monthly_purchase_usd": 200,
+        "merchant_domain_allowlist": [],
+        "merchant_domain_blocklist": [],
+        "persist_raw_card_details": false
+      }
+    },
+    "financial_research": {
+      "enabled": true,
+      "risk_level": "medium",
+      "rules": {
+        "require_citations": true,
+        "require_non_advice_disclaimer": true,
+        "candidate_actions_cannot_execute_directly": true,
+        "max_job_budget_usdc": 5,
+        "provider_allowlist": [],
+        "provider_blocklist": []
+      }
+    }
+  },
+  "roadmap": {
+    "options_trading": {
+      "status": "disabled_roadmap",
+      "requires_robinhood_mcp_schema_support": true,
+      "requires_options_risk_disclosure_gate": true,
+      "requires_user_eligibility_gate": true,
+      "requires_strategy_level_max_loss_model": true,
+      "requires_manual_approval_for_every_order": true,
+      "default_allowed_strategies": []
+    }
+  }
+}

--- a/robinhood/probes/robinhood-mcp-probe-redacted.example.json
+++ b/robinhood/probes/robinhood-mcp-probe-redacted.example.json
@@ -1,6 +1,6 @@
 {
   "schema": "robinhood_mcp_probe.v1",
-  "created_at": "2026-05-29T16:45:00Z",
+  "created_at": "2026-05-30T03:02:04Z",
   "probe_mode": "schema_only_no_action",
   "probe_status": "unauthenticated_probe_auth_required",
   "servers": [
@@ -16,18 +16,15 @@
         "safe_error_class": "authentication_required"
       },
       "tools_list": {
-        "status": "not_available_without_owner_auth",
-        "http_status": 401,
+        "status": "not_run_after_initialize_auth_required",
         "tools": []
       },
       "resources_list": {
-        "status": "not_available_without_owner_auth",
-        "http_status": 401,
+        "status": "not_run_after_initialize_auth_required",
         "resources": []
       },
       "prompts_list": {
-        "status": "not_available_without_owner_auth",
-        "http_status": 401,
+        "status": "not_run_after_initialize_auth_required",
         "prompts": []
       },
       "assumed_tool_family_mapping": {
@@ -41,8 +38,10 @@
       },
       "notes": [
         "No owner authorization was completed for this public example.",
+        "A schema-only initialize probe was rerun on 2026-05-30 and returned authentication required.",
+        "List-tools, list-resources, and list-prompts were not attempted after initialize returned HTTP 401.",
         "No tools were invoked.",
-        "Tool names must be confirmed from an owner-authorized schema-only probe before platform mapping."
+        "Tool names must be confirmed from an owner-authenticated schema-only probe before platform mapping."
       ]
     },
     {
@@ -57,18 +56,15 @@
         "safe_error_class": "authentication_required"
       },
       "tools_list": {
-        "status": "not_available_without_owner_auth",
-        "http_status": 401,
+        "status": "not_run_after_initialize_auth_required",
         "tools": []
       },
       "resources_list": {
-        "status": "not_available_without_owner_auth",
-        "http_status": 401,
+        "status": "not_run_after_initialize_auth_required",
         "resources": []
       },
       "prompts_list": {
-        "status": "not_available_without_owner_auth",
-        "http_status": 401,
+        "status": "not_run_after_initialize_auth_required",
         "prompts": []
       },
       "assumed_tool_family_mapping": {
@@ -78,6 +74,8 @@
       },
       "notes": [
         "No owner authorization was completed for this public example.",
+        "A schema-only initialize probe was rerun on 2026-05-30 and returned authentication required.",
+        "List-tools, list-resources, and list-prompts were not attempted after initialize returned HTTP 401.",
         "No tools were invoked.",
         "Virtual-card detail fetch remains forbidden in probes."
       ]

--- a/robinhood/probes/robinhood-mcp-probe-redacted.example.json
+++ b/robinhood/probes/robinhood-mcp-probe-redacted.example.json
@@ -1,0 +1,103 @@
+{
+  "schema": "robinhood_mcp_probe.v1",
+  "created_at": "2026-05-29T00:00:00Z",
+  "probe_mode": "schema_only_no_action",
+  "probe_status": "auth_required_no_private_session",
+  "servers": [
+    {
+      "server_name": "robinhood-trading",
+      "url": "https://agent.robinhood.com/mcp/trading",
+      "transport": "streamable_http",
+      "auth_required": true,
+      "initialize": {
+        "status": "blocked_auth_required",
+        "server_info_redacted": null,
+        "safe_error_class": "authentication_required"
+      },
+      "tools_list": {
+        "status": "not_available_without_owner_auth",
+        "tools": []
+      },
+      "resources_list": {
+        "status": "not_available_without_owner_auth",
+        "resources": []
+      },
+      "prompts_list": {
+        "status": "not_available_without_owner_auth",
+        "prompts": []
+      },
+      "assumed_tool_family_mapping": {
+        "account_and_portfolio_reads": "schema_pending_owner_auth",
+        "equity_positions": "schema_pending_owner_auth",
+        "equity_quotes": "schema_pending_owner_auth",
+        "equity_tradability": "schema_pending_owner_auth",
+        "equity_order_review": "schema_pending_owner_auth",
+        "equity_order_placement": "schema_pending_owner_auth",
+        "equity_order_cancellation": "schema_pending_owner_auth"
+      },
+      "notes": [
+        "No owner authorization was completed for this public example.",
+        "No tools were invoked.",
+        "Tool names must be confirmed from an owner-authorized schema-only probe before platform mapping."
+      ]
+    },
+    {
+      "server_name": "robinhood-banking",
+      "url": "https://banking-agent.robinhood.com/mcp/banking",
+      "transport": "streamable_http",
+      "auth_required": true,
+      "initialize": {
+        "status": "blocked_auth_required",
+        "server_info_redacted": null,
+        "safe_error_class": "authentication_required"
+      },
+      "tools_list": {
+        "status": "not_available_without_owner_auth",
+        "tools": []
+      },
+      "resources_list": {
+        "status": "not_available_without_owner_auth",
+        "resources": []
+      },
+      "prompts_list": {
+        "status": "not_available_without_owner_auth",
+        "prompts": []
+      },
+      "assumed_tool_family_mapping": {
+        "agentic_virtual_card_policy_or_settings": "schema_pending_owner_auth",
+        "virtual_card_transaction_history": "schema_pending_owner_auth",
+        "virtual_card_detail_fetch_for_checkout": "schema_pending_owner_auth"
+      },
+      "notes": [
+        "No owner authorization was completed for this public example.",
+        "No tools were invoked.",
+        "Virtual-card detail fetch remains forbidden in probes."
+      ]
+    }
+  ],
+  "forbidden_probe_actions": [
+    "do_not_place_trades",
+    "do_not_cancel_orders",
+    "do_not_fetch_virtual_card_details",
+    "do_not_make_purchases",
+    "do_not_persist_private_auth_material",
+    "do_not_persist_private_account_values",
+    "do_not_persist_private_balances_positions_or_order_ids"
+  ],
+  "redaction_assertion": {
+    "no_private_auth_material": true,
+    "no_raw_card_data": true,
+    "no_private_account_numbers": true,
+    "no_private_balances_or_positions": true,
+    "no_private_order_identifiers": true,
+    "no_live_action_results": true,
+    "no_credentials_collected": true
+  },
+  "live_action_assertion": {
+    "trades_placed": false,
+    "orders_cancelled": false,
+    "virtual_card_details_fetched": false,
+    "purchases_made": false
+  },
+  "next_safe_action": "Owner may run a local authenticated schema-only probe and replace tool mappings with redacted names and JSON schema shapes only."
+}

--- a/robinhood/probes/robinhood-mcp-probe-redacted.example.json
+++ b/robinhood/probes/robinhood-mcp-probe-redacted.example.json
@@ -1,8 +1,8 @@
 {
   "schema": "robinhood_mcp_probe.v1",
-  "created_at": "2026-05-29T00:00:00Z",
+  "created_at": "2026-05-29T16:45:00Z",
   "probe_mode": "schema_only_no_action",
-  "probe_status": "auth_required_no_private_session",
+  "probe_status": "unauthenticated_probe_auth_required",
   "servers": [
     {
       "server_name": "robinhood-trading",
@@ -11,19 +11,23 @@
       "auth_required": true,
       "initialize": {
         "status": "blocked_auth_required",
+        "http_status": 401,
         "server_info_redacted": null,
         "safe_error_class": "authentication_required"
       },
       "tools_list": {
         "status": "not_available_without_owner_auth",
+        "http_status": 401,
         "tools": []
       },
       "resources_list": {
         "status": "not_available_without_owner_auth",
+        "http_status": 401,
         "resources": []
       },
       "prompts_list": {
         "status": "not_available_without_owner_auth",
+        "http_status": 401,
         "prompts": []
       },
       "assumed_tool_family_mapping": {
@@ -48,19 +52,23 @@
       "auth_required": true,
       "initialize": {
         "status": "blocked_auth_required",
+        "http_status": 401,
         "server_info_redacted": null,
         "safe_error_class": "authentication_required"
       },
       "tools_list": {
         "status": "not_available_without_owner_auth",
+        "http_status": 401,
         "tools": []
       },
       "resources_list": {
         "status": "not_available_without_owner_auth",
+        "http_status": 401,
         "resources": []
       },
       "prompts_list": {
         "status": "not_available_without_owner_auth",
+        "http_status": 401,
         "prompts": []
       },
       "assumed_tool_family_mapping": {

--- a/robinhood/probes/robinhood-mcp-probe-redacted.example.json
+++ b/robinhood/probes/robinhood-mcp-probe-redacted.example.json
@@ -1,6 +1,6 @@
 {
   "schema": "robinhood_mcp_probe.v1",
-  "created_at": "2026-05-30T03:02:04Z",
+  "created_at": "2026-05-30T04:07:14Z",
   "probe_mode": "schema_only_no_action",
   "probe_status": "unauthenticated_probe_auth_required",
   "servers": [
@@ -12,6 +12,9 @@
       "initialize": {
         "status": "blocked_auth_required",
         "http_status": 401,
+        "content_type": "text/plain; charset=utf-8",
+        "oauth_protected_resource_metadata_ref": "https://agent.robinhood.com/.well-known/oauth-protected-resource/mcp/trading",
+        "oauth_redirect_persisted": false,
         "server_info_redacted": null,
         "safe_error_class": "authentication_required"
       },
@@ -38,7 +41,8 @@
       },
       "notes": [
         "No owner authorization was completed for this public example.",
-        "A schema-only initialize probe was rerun on 2026-05-30 and returned authentication required.",
+        "A schema-only initialize probe was rerun on 2026-05-30T04:07:14Z and returned authentication required.",
+        "The response included a public OAuth protected-resource metadata reference and no Location redirect.",
         "List-tools, list-resources, and list-prompts were not attempted after initialize returned HTTP 401.",
         "No tools were invoked.",
         "Tool names must be confirmed from an owner-authenticated schema-only probe before platform mapping."
@@ -52,6 +56,9 @@
       "initialize": {
         "status": "blocked_auth_required",
         "http_status": 401,
+        "content_type": "text/plain; charset=utf-8",
+        "oauth_protected_resource_metadata_ref": "https://banking-agent.robinhood.com/.well-known/oauth-protected-resource/mcp/banking",
+        "oauth_redirect_persisted": false,
         "server_info_redacted": null,
         "safe_error_class": "authentication_required"
       },
@@ -74,7 +81,8 @@
       },
       "notes": [
         "No owner authorization was completed for this public example.",
-        "A schema-only initialize probe was rerun on 2026-05-30 and returned authentication required.",
+        "A schema-only initialize probe was rerun on 2026-05-30T04:07:14Z and returned authentication required.",
+        "The response included a public OAuth protected-resource metadata reference and no Location redirect.",
         "List-tools, list-resources, and list-prompts were not attempted after initialize returned HTTP 401.",
         "No tools were invoked.",
         "Virtual-card detail fetch remains forbidden in probes."
@@ -97,7 +105,8 @@
     "no_private_balances_or_positions": true,
     "no_private_order_identifiers": true,
     "no_live_action_results": true,
-    "no_credentials_collected": true
+    "no_credentials_collected": true,
+    "no_oauth_redirect_persisted": true
   },
   "live_action_assertion": {
     "trades_placed": false,

--- a/robinhood/probes/robinhood-mcp-probe-template.json
+++ b/robinhood/probes/robinhood-mcp-probe-template.json
@@ -1,0 +1,68 @@
+{
+  "schema": "robinhood_mcp_probe.v1",
+  "created_at": "YYYY-MM-DDTHH:mm:ssZ",
+  "probe_mode": "schema_only_no_action",
+  "servers": [
+    {
+      "server_name": "robinhood-trading",
+      "url": "https://agent.robinhood.com/mcp/trading",
+      "transport": "streamable_http",
+      "auth_required": null,
+      "initialize": {
+        "status": "not_run",
+        "server_info_redacted": null
+      },
+      "tools_list": {
+        "status": "not_run",
+        "tools": []
+      },
+      "resources_list": {
+        "status": "not_run",
+        "resources": []
+      },
+      "prompts_list": {
+        "status": "not_run",
+        "prompts": []
+      },
+      "notes": []
+    },
+    {
+      "server_name": "robinhood-banking",
+      "url": "https://banking-agent.robinhood.com/mcp/banking",
+      "transport": "streamable_http",
+      "auth_required": null,
+      "initialize": {
+        "status": "not_run",
+        "server_info_redacted": null
+      },
+      "tools_list": {
+        "status": "not_run",
+        "tools": []
+      },
+      "resources_list": {
+        "status": "not_run",
+        "resources": []
+      },
+      "prompts_list": {
+        "status": "not_run",
+        "prompts": []
+      },
+      "notes": []
+    }
+  ],
+  "forbidden_probe_actions": [
+    "do_not_place_trades",
+    "do_not_cancel_orders",
+    "do_not_fetch_virtual_card_details",
+    "do_not_make_purchases",
+    "do_not_persist_private_auth_material",
+    "do_not_persist_private_account_values"
+  ],
+  "redaction_assertion": {
+    "no_private_auth_material": true,
+    "no_raw_card_data": true,
+    "no_private_account_numbers": true,
+    "no_private_balances_or_positions": true,
+    "no_live_action_results": true
+  }
+}

--- a/robinhood/prompts/codex-robinhood-agent-os-e2e.md
+++ b/robinhood/prompts/codex-robinhood-agent-os-e2e.md
@@ -1,0 +1,106 @@
+# Codex prompt: Robinhood Agent OS end-to-end implementation
+
+You are implementing the Robinhood Agent OS integration for Agoragentic.
+
+## Mandatory safety boundary
+
+Do not place live trades, cancel live orders, fetch live virtual-card details, make purchases, scrape Robinhood, use unofficial Robinhood APIs, or persist private account data. Do not make guaranteed-return claims, broker-dealer claims, bank/card-issuer claims, or Robinhood partnership claims.
+
+V1 is governed long-equity and agentic-card support behind explicit user enablement, policy checks, approvals, receipts, and stop controls. Options trading remains disabled roadmap-only.
+
+## Read first
+
+1. The repository `AGENTS.md`.
+2. `integrations.json` and `integrations.schema.json`.
+3. `agent-os/README.md`.
+4. `robinhood/README.md` in this branch.
+5. Robinhood's Agentic Trading and Agentic Credit Card support pages.
+6. The safe MCP probe output, if available.
+
+## Build sequence
+
+### Phase 0: public scaffold
+
+Confirm these files exist and are valid JSON/Markdown:
+
+```text
+robinhood/README.md
+robinhood/mcp.json
+robinhood/policy.example.json
+robinhood/capability-manifest.json
+robinhood/probes/robinhood-mcp-probe-template.json
+robinhood/prompts/codex-robinhood-mcp-probe.md
+```
+
+Add any missing redacted probe example and validation scripts.
+
+### Phase 1: platform handoff contract
+
+Document exactly how the platform should consume:
+
+- MCP server names;
+- endpoint URLs;
+- capability IDs;
+- policy keys;
+- approval-required states;
+- redacted receipt fields;
+- disabled options roadmap flag.
+
+### Phase 2: Agent OS platform implementation
+
+In `rhein1/agent-marketplace`, implement pure modules before routes:
+
+```text
+server/modules/finance-agent-policy.js
+server/modules/robinhood-agent-os-connector.js
+server/modules/financial-research-provider-registry.js
+tests/finance-agent-policy.test.js
+tests/robinhood-agent-os-connector.test.js
+tests/financial-research-provider-registry.test.js
+```
+
+Rules:
+
+- disabled connector blocks all dispatch;
+- read-only trading calls require enabled connector;
+- `place_equity_order` is blocked without review;
+- `place_equity_order` is approval-required after review;
+- approved order still must pass symbol and notional limits;
+- card-detail fetch requires checkout context and approval or explicit monthly-limit policy;
+- research output cannot directly execute trades or purchases;
+- receipts redact private finance fields.
+
+### Phase 3: owner/admin routes and UI
+
+Only after pure modules and tests pass, add owner/admin routes for:
+
+- connector status;
+- policy read/update;
+- no-spend/no-trade readiness proof;
+- research job creation and artifact readback;
+- redacted receipt readback.
+
+Do not add live execution routes before a separate owner-approved beta plan.
+
+### Phase 4: live-read beta
+
+After owner-authorized MCP connection, allow read-only status and schema checks. Do not enable live order placement or card-detail fetch until a separate approved beta change.
+
+## Acceptance tests
+
+- No private data fixtures.
+- No live action in tests.
+- Options remains disabled.
+- Fincept is external/license-review-required.
+- Public copy says research and governed execution, not guaranteed profit.
+
+## Pull request body
+
+Include:
+
+- docs reviewed;
+- files changed;
+- tests run;
+- production authority boundary;
+- statement that no live trades, purchases, card-detail fetches, or credential collection occurred;
+- remaining work for authenticated MCP probe, route/UI beta, and legal/compliance review.

--- a/robinhood/prompts/codex-robinhood-mcp-probe.md
+++ b/robinhood/prompts/codex-robinhood-mcp-probe.md
@@ -1,0 +1,86 @@
+# Codex prompt: Robinhood MCP schema probe
+
+Goal: inspect Robinhood's official MCP servers safely and produce a redacted schema report for Agent OS integration.
+
+## Official endpoints
+
+```text
+Trading MCP: https://agent.robinhood.com/mcp/trading
+Banking MCP: https://banking-agent.robinhood.com/mcp/banking
+```
+
+## Non-negotiable boundary
+
+This is a schema probe only.
+
+Do not place orders. Do not cancel orders. Do not fetch live virtual-card details. Do not make purchases. Do not collect or commit credentials. Do not save private account values, raw balances, account numbers, positions, order identifiers, card details, browser authorization redirects, or private user data.
+
+If authorization is required, record only the safe status: authorization required, server method attempted, and non-secret error class.
+
+## Setup
+
+For Codex CLI, add the trading MCP server with:
+
+```bash
+codex mcp add robinhood-trading --url https://agent.robinhood.com/mcp/trading
+```
+
+Then add the banking server using the same remote MCP pattern:
+
+```bash
+codex mcp add robinhood-banking --url https://banking-agent.robinhood.com/mcp/banking
+```
+
+## Probe steps
+
+1. Read Robinhood's current Agentic Trading and Agentic Credit Card support docs.
+2. Attempt MCP initialize for both servers.
+3. Attempt list-tools, list-resources, and list-prompts where the server permits it.
+4. If unauthenticated access is blocked, stop before any user-private authorization step unless the owner completes authorization locally.
+5. If authorized by the owner, list schemas only. Do not call action tools.
+6. Save only public-safe schema metadata using `probes/robinhood-mcp-probe-template.json`.
+
+## Expected report fields
+
+- server name
+- endpoint URL
+- transport behavior
+- whether authorization is required
+- initialize status
+- tool names and redacted JSON schema shapes
+- resource list status
+- prompt list status
+- unsupported or blocked methods
+- no-private-material assertion
+
+## Expected trading tool families
+
+The docs currently point to long-equity agentic trading. Verify whether schemas expose the following families:
+
+- account and portfolio reads
+- equity positions
+- equity quote lookup
+- equity tradability checks
+- order history
+- order review
+- order placement
+- order cancellation
+- search
+
+## Expected banking tool families
+
+Verify whether schemas expose the following families:
+
+- agentic virtual-card policy or settings read
+- virtual-card transaction history read
+- virtual-card detail fetch for checkout
+
+## Output
+
+Commit a redacted report to:
+
+```text
+robinhood/probes/robinhood-mcp-probe-redacted.example.json
+```
+
+The report must say whether any live action occurred. For this probe, the correct answer should be no.


### PR DESCRIPTION
## Summary

Adds a public-safe Robinhood Agent OS integration scaffold plus financial research provider intake lane. This PR is docs/config/probe scaffold only. It does not execute trades, cancel orders, fetch virtual-card details, make purchases, collect credentials, call private provider APIs, or vendor Fincept code.

Current PR head: `e0aad1d`.

## Docs Reviewed

- `AGENTS.md`
- `integrations.json`
- `integrations.schema.json`
- `README.md`
- `agent-os/README.md`
- issue `rhein1/agent-marketplace#192`
- platform PR `rhein1/agent-marketplace#226`

## Files Changed

- `integrations.json`
- `robinhood/README.md`
- `robinhood/mcp.json`
- `robinhood/policy.example.json`
- `robinhood/capability-manifest.json`
- `robinhood/probes/robinhood-mcp-probe-template.json`
- `robinhood/probes/robinhood-mcp-probe-redacted.example.json`
- `robinhood/prompts/codex-robinhood-mcp-probe.md`
- `robinhood/prompts/codex-robinhood-agent-os-e2e.md`
- `financial-research/README.md`
- `financial-research/repo-intake.v1.json`
- `financial-research/prompts/codex-fincept-research-provider.md`

## Production Authority Boundary

- No live trades were placed.
- No live orders were cancelled.
- No virtual-card details were fetched.
- No purchases were made.
- No Robinhood credentials, OAuth tokens, MFA codes, private account data, private balances, private positions, private order IDs, or private transaction IDs were collected.
- No unofficial Robinhood APIs or scraping are introduced.
- No broker-dealer, RIA, bank, card-issuer, official-partner, or guaranteed-return claims are made.
- Options remain disabled roadmap-only.
- Fincept remains external and license-review-required; no Fincept code or binaries are vendored.

## MCP Probe Status

The latest no-credential raw MCP HTTP probe attempted `initialize` only against both official endpoints:
- Trading: `https://agent.robinhood.com/mcp/trading`
- Banking: `https://banking-agent.robinhood.com/mcp/banking`

Observed result:
- Both endpoints returned HTTP `401 authentication required` with protected-resource metadata references.
- After the `401`, no `tools/list`, `resources/list`, `prompts/list`, or tool calls were attempted.
- No live action occurred.
- No private account, card, order, balance, position, transaction, auth redirect, credential, token, or MFA material was observed or stored.
- Available tool names and schemas remain unconfirmed until an owner-authenticated schema-only probe is run.

## Validation

Passed on the PR head:
- JSON parse validation for `integrations.json`, Robinhood config/policy/manifest/probe files, and financial research intake.
- `node scripts/verify-integrations-json.js`
- `git diff --check`
- Safety grep over changed files for credentials/secrets/private-key/seed material, live-action wording, partnership/guaranteed-return claims, process spawn, network code, and truthy live/public/wallet/x402 flags.
- Clean staged-patch validation in a temporary clean worktree.

GitHub checks:
- `validate` passed.

## Remaining Work

- Owner-authenticated MCP schema-only probe to confirm actual tool names and schemas.
- Feed confirmed schema differences into `rhein1/agent-marketplace#226` before any live-route work.
- Legal/compliance review before live trading/card enablement.
- License review before any deeper Fincept integration.

This PR is review-ready as a public-safe scaffold, but should remain draft until the owner decides whether authenticated schema confirmation is required before merge.