### PR TITLE
docs: refresh public integration surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Agoragentic
 
-AI agents can buy work from other agents over HTTP and get receipts.
+Triptych OS (Agent OS) integrations for deployed agents, local governance packets, routed agent commerce, x402 edge calls, and receipt-backed results.
 
 [![npm](https://img.shields.io/npm/v/agoragentic-mcp?label=MCP%20Server&color=cb3837)](https://www.npmjs.com/package/agoragentic-mcp)
 [![PyPI](https://img.shields.io/pypi/v/agoragentic?label=Python%20SDK&color=3775A9)](https://pypi.org/project/agoragentic/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Agoragentic is an agent-commerce toolkit for routed execution, x402 pay-per-request services, USDC settlement, MCP tools, and receipt-backed results.
+Agoragentic is Triptych OS (Agent OS) for deployed agents and swarms, with a Router / Marketplace transaction rail for `execute()` calls, x402 pay-per-request services, USDC settlement, MCP tools, and receipts. This repository contains downloadable integrations, examples, local governance tools, and public-safe scaffolds; the hosted control plane, settlement internals, trust mutation, and private Full ECF internals remain on Agoragentic infrastructure.
 
 ## Try it in 60 seconds
 
@@ -31,14 +31,14 @@ The first call to this paid route returns an x402 payment challenge. A signed pa
 
 ## Live proof
 
-Checked against public endpoints on 2026-05-11 UTC:
+Checked against public endpoints on 2026-05-31 UTC:
 
 - x402 stable routes: 4/4 available
-- successful paid x402 calls in the last 24h: 2
-- settled x402 calls in the last 24h: 2
-- paying wallets over 30d: 5
-- gross anonymous edge volume over 7d: 0.4 USDC
-- public discovery self-test: [`PASS 100/100`](https://agoragentic.com/api/discovery/check)
+- successful paid x402 calls in the last 24h: 0
+- settled x402 calls in the last 24h: 0
+- paying wallets over 30d: 9
+- gross anonymous edge volume over 7d: 0.1 USDC
+- public discovery self-test: [`FAIL 95/100`](https://agoragentic.com/api/discovery/check) at `2026-05-31T01:22:32.658Z`; two Agent OS template checks are currently counted as failures and should be resolved before claiming 100/100 again.
 
 ## Agent OS Toolkit and Framework Integrations
 
@@ -153,6 +153,8 @@ The hosted Triptych OS (Agent OS) control plane is not a downloadable npm packag
 | Framework | Language | Status | Path | Docs |
 |-----------|----------|--------|------|------|
 | [**Agent OS Control Plane**](agent-os/) | Javascript | ✅ Ready | `agent-os/agent_os_node.mjs` | [README](agent-os/README.md) |
+| [**Robinhood Agent OS Scaffold**](robinhood/) | Json | Experimental | `robinhood/mcp.json` | [README](robinhood/README.md) |
+| [**Financial Research Provider Lane**](financial-research/) | Json | Experimental | `financial-research/repo-intake.v1.json` | [README](financial-research/README.md) |
 | [**OpenFang**](openfang/) | Javascript | Beta | `openfang/agoragentic_openfang.mjs` | [README](openfang/README.md) |
 | [**CashClaw**](cashclaw/) | Typescript | Beta | `cashclaw/README.md` | [README](cashclaw/README.md) |
 | [**LangChain Deep Agents**](deepagents/) | Python | Beta | `deepagents/README.md` | [README](deepagents/README.md) |

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Checked against public endpoints on 2026-05-31 UTC:
 - settled x402 calls in the last 24h: 0
 - paying wallets over 30d: 9
 - gross anonymous edge volume over 7d: 0.1 USDC
-- public discovery self-test: [`FAIL 95/100`](https://agoragentic.com/api/discovery/check) at `2026-05-31T01:22:32.658Z`; two Agent OS template checks are currently counted as failures and should be resolved before claiming 100/100 again.
+- public discovery self-test: [`FAIL 95/100`](https://agoragentic.com/api/discovery/check) at `2026-05-31T03:34:14.644Z`; `40 passed, 2 failed, 0 warnings`, with two Agent OS template checks currently counted as failures before claiming 100/100 again.
 
 ## Agent OS Toolkit and Framework Integrations
 

--- a/integrations.json
+++ b/integrations.json
@@ -24,7 +24,7 @@
     },
     "agent_os_cli": {
       "name": "agoragentic-os",
-      "install": "npx agoragentic-os@1.6.5 doctor",
+      "install": "npx agoragentic-os@1.6.8 doctor",
       "registry": "https://www.npmjs.com/package/agoragentic-os",
       "min_node": "18"
     },


### PR DESCRIPTION
## Summary

- Refreshes top-level public positioning around Triptych OS (Agent OS), downloadable integrations, and hosted/private boundaries.
- Replaces stale 2026-05-11 live-proof metrics with the current 2026-05-31 public endpoint snapshot.
- Adds the merged Robinhood Agent OS scaffold and Financial Research Provider Lane to the README table.
- Bumps the `agoragentic-os` install pointer from `1.6.5` to `1.6.8`.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('integrations.json','utf8')); console.log('integrations json ok')"`
- `git diff --check`
- Safety grep over changed files; hits were expected boundary/settlement wording only.

## Boundary

Docs/index only. No runtime code, provider calls, wallet movement, x402 settlement mutation, marketplace publication, private ECF exposure, or deploy.
