### PR TITLE
[codex] feat: add Rust framework HTTP examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - 2026-05-19
 
 ### Added
+- Added `rust-framework/`, a public Agoragentic Rust Framework HTTP runtime integration folder with TypeScript/Node and Python examples, a self-hosted Agent OS Harness packet example, and no-spend verification.
+- Added Rust Framework discovery pointers in `integrations.json`, `README.md`, `llms.txt`, `llms-full.txt`, and `SKILL.md` while keeping hosted Router / Marketplace SDK semantics unchanged.
 - Added `harness-core/`, the package-ready local no-spend Harness Core scaffold for `init`, `validate`, `proof`, `export --to agent-os`, `listing check`, and adapter discovery.
 - Added Harness Core schemas, tests, and a Trusted Publishing release workflow gated by `harness-core-v*` release tags.
 - Added `premortem-golden-loop/`, a free local OSS agent release premortem, no-spend Golden Loop readiness, and safe self-heal scaffold CLI.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The first call to this paid route returns an x402 payment challenge. A signed pa
 - Get receipts and reconciliation metadata
 - Plug into MCP, OpenAI Agents, AutoGen, smolagents, LangChain, CrewAI, and more
 - Prepare governed deployments with Micro ECF and Agent OS Harness packets
+- Call a local or self-hosted Agoragentic Rust Framework runtime over HTTP/JSON from TypeScript/Node or Python
 - Keep local resident work memory, docs-sync plans, and next-session handoffs under `.micro-ecf/`
 - Run local no-spend Harness Core proof, receipt, export, and listing-readiness checks before hosted launch
 - Run local release premortems, no-spend Golden Loop readiness checks, and additive self-heal plans before publishing an OSS agent
@@ -136,6 +137,7 @@ Use this chooser before picking a framework wrapper:
 |---------|---------|-------------|
 | Call Router / Marketplace from a JavaScript agent or app | `npm install agoragentic` | SDK and `execute()` client |
 | Run no-spend Agent OS readiness, preview, and deploy-request checks | `npx agoragentic-os@latest` | Triptych OS (Agent OS) CLI |
+| Call a self-hosted Rust framework runtime from TypeScript or Python | `AGORAGENTIC_RUST_AGENT_URL=http://127.0.0.1:8080` plus `rust-framework/` examples | HTTP/JSON runtime contract |
 | Expose Agoragentic tools inside MCP-native hosts | `npx agoragentic-mcp@latest` | MCP stdio relay |
 | Prepare local context, policy, source maps, and Harness exports before hosted deployment | `npx agoragentic-micro-ecf@latest` | Micro ECF local wedge |
 | Build no-spend local proof, receipt, Agent OS export, and listing-readiness artifacts | `node harness-core/bin/agoragentic-harness.mjs` | Harness Core source scaffold |
@@ -159,6 +161,7 @@ The hosted Triptych OS (Agent OS) control plane is not a downloadable npm packag
 | Framework | Language | Status | Path | Docs |
 |-----------|----------|--------|------|------|
 | [**Agent OS Control Plane**](agent-os/) | Javascript | ✅ Ready | `agent-os/agent_os_node.mjs` | [README](agent-os/README.md) |
+| [**Agoragentic Rust Framework HTTP Runtime**](rust-framework/) | Rust | Beta | `rust-framework/README.md` | [README](rust-framework/README.md) |
 | [**Robinhood Agent OS Scaffold**](robinhood/) | Json | Experimental | `robinhood/mcp.json` | [README](robinhood/README.md) |
 | [**Financial Research Provider Lane**](financial-research/) | Json | Experimental | `financial-research/repo-intake.v1.json` | [README](financial-research/README.md) |
 | [**OpenFang**](openfang/) | Javascript | Beta | `openfang/agoragentic_openfang.mjs` | [README](openfang/README.md) |
@@ -394,6 +397,7 @@ Your Agent  →  Integration (tools/MCP)  →  Agent OS + Agoragentic API
 | LLM full context | [`llms-full.txt`](./llms-full.txt) |
 | Capability description | [`SKILL.md`](./SKILL.md) |
 | Agent OS public export | [`agent-os/README.md`](./agent-os/README.md) |
+| Agoragentic Rust Framework HTTP runtime examples | [`rust-framework/README.md`](./rust-framework/README.md) |
 | OpenFang bridge | [`openfang/README.md`](./openfang/README.md) |
 | Premortem Golden Loop Agent | [`premortem-golden-loop/README.md`](./premortem-golden-loop/README.md) |
 | Premortem prompt | [`premortem-golden-loop/PROMPT.md`](./premortem-golden-loop/PROMPT.md) |

--- a/SKILL.md
+++ b/SKILL.md
@@ -17,6 +17,7 @@ Use this skill when:
 * you want to move a local or self-hosted agent toward hosted Agent OS deployment
 * you need local policy, budget, approval, memory, or swarm controls through Micro ECF
 * you need no-spend local proof, local receipt, Agent OS export, or listing-readiness checks through Harness Core
+* you need public TypeScript/Node or Python examples that call a self-hosted Agoragentic Rust Framework runtime over HTTP/JSON
 * you need a local release premortem, no-spend Golden Loop readiness receipt, or safe self-heal plan before publishing an OSS agent
 * you need agent infrastructure such as persistent memory, secret storage, or identity features
 
@@ -160,7 +161,9 @@ For a working example, clone the summarizer agent:
 
 ### Public integration coverage
 
-The public integrations repo includes adapters and bridge patterns for LangChain, LangGraph, LangChain Deep Agents, CrewAI, AutoGen, OpenAI Agents SDK, Google ADK, Vercel AI SDK, Cloudflare Agents, Microsoft Semantic Kernel, n8n, Flowise, Zapier MCP, Composio, HumanLayer, Dify, MCP, ACP, A2A, OpenFang, Micro ECF, Harness Core, Premortem Golden Loop, Agent OS control-plane examples, and an experimental Zoneless payout reference.
+The public integrations repo includes adapters and bridge patterns for LangChain, LangGraph, LangChain Deep Agents, CrewAI, AutoGen, OpenAI Agents SDK, Google ADK, Vercel AI SDK, Cloudflare Agents, Microsoft Semantic Kernel, n8n, Flowise, Zapier MCP, Composio, HumanLayer, Dify, MCP, ACP, A2A, OpenFang, Micro ECF, Harness Core, Premortem Golden Loop, Agent OS control-plane examples, Agoragentic Rust Framework HTTP examples, and an experimental Zoneless payout reference.
+
+`rust-framework/` contains public TypeScript/Node and Python examples for calling a local or self-hosted Agoragentic Rust Framework runtime over `/health`, `/tools`, `/openapi.json`, and `/invoke`, plus a public-safe Agent OS Harness packet. It is an HTTP/JSON client/example layer only: no crate publish, hosted provisioning, wallet spend, x402 settlement, marketplace publication, trust mutation, private Full ECF export, or native binding requirement.
 
 `harness-core/` is the local no-spend Harness Core package scaffold for `init`, `validate`, `proof`, `export --to agent-os`, `listing check`, and adapter inventory before any hosted preview or treasury funding.
 

--- a/integrations.json
+++ b/integrations.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.18.0",
-  "updated_at": "2026-05-29",
+  "version": "2.19.0",
+  "updated_at": "2026-06-01",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
   "packages": {
@@ -283,6 +283,15 @@
       "path": "agent-os/agent_os_node.mjs",
       "install": "node 18+ or pip install requests",
       "docs": "agent-os/README.md"
+    },
+    {
+      "id": "agoragentic-rust-framework",
+      "name": "Agoragentic Rust Framework HTTP Runtime",
+      "language": "rust",
+      "status": "beta",
+      "path": "rust-framework/README.md",
+      "install": "Run a local agoragentic-rust HTTP runtime, then set AGORAGENTIC_RUST_AGENT_URL=http://127.0.0.1:8080",
+      "docs": "rust-framework/README.md"
     },
     {
       "id": "robinhood-agent-os",
@@ -769,6 +778,13 @@
     "agent_client_protocol_adapter": "acp/agent.json",
     "agent_os": "agent-os/README.md",
     "agent_os_public_export": "agent-os/README.md",
+    "rust_framework": "rust-framework/README.md",
+    "rust_framework_typescript_example": "rust-framework/typescript-call-rust-agent.ts",
+    "rust_framework_node_example": "rust-framework/typescript-call-rust-agent.mjs",
+    "rust_framework_python_example": "rust-framework/python_call_rust_agent.py",
+    "rust_framework_harness_example": "rust-framework/agent-os-harness.example.json",
+    "rust_framework_schema": "https://agoragentic.com/schema/agoragentic-rust-framework.v1.json",
+    "rust_framework_openapi": "https://agoragentic.com/openapi-agoragentic-rust-framework.yaml",
     "robinhood_agent_os": "robinhood/README.md",
     "robinhood_mcp": "robinhood/mcp.json",
     "robinhood_mcp_probe_template": "robinhood/probes/robinhood-mcp-probe-template.json",

--- a/integrations.schema.json
+++ b/integrations.schema.json
@@ -202,7 +202,8 @@
             "python",
             "javascript",
             "typescript",
-            "json"
+            "json",
+            "rust"
           ],
           "description": "Primary language."
         },

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -13,6 +13,7 @@ The published packages and repo-local CLIs are:
 - **Micro ECF**: `npx agoragentic-micro-ecf@latest init` (npm, Node ≥18)
 - **Harness Core source scaffold**: `node harness-core/bin/agoragentic-harness.mjs init` (Node ≥18; npm publication pending validation)
 - **Premortem Golden Loop Agent**: `node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs run --repo .` or `heal --repo .` (free local Node ≥18 CLI; no repo contents sent anywhere by default)
+- **Agoragentic Rust Framework HTTP Runtime examples**: `rust-framework/` contains TypeScript/Node and Python clients for a local or self-hosted Rust runtime plus a public-safe Agent OS Harness packet example. It does not publish crates, provision hosted runtimes, spend, settle x402, publish listings, mutate trust, or require native bindings.
 
 ## Authentication
 
@@ -93,6 +94,7 @@ Framework adapters, Agent OS control-plane examples, and marketplace integration
 | OpenFang | openfang/agoragentic_openfang.mjs | node 18+ with a local OpenFang Hand manifest |
 | Premortem Golden Loop Agent | premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs | node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs run --repo . |
 | Zoneless Payout Reference | zoneless/agoragentic_zoneless_payouts.ts | reference only; not live settlement |
+| Agoragentic Rust Framework HTTP Runtime | rust-framework/README.md | run a local Rust framework HTTP runtime and set AGORAGENTIC_RUST_AGENT_URL |
 
 ### Config-Only Integrations (7)
 
@@ -111,6 +113,7 @@ Framework adapters, Agent OS control-plane examples, and marketplace integration
 | Export | File | Install |
 |--------|------|---------|
 | Agent OS Control Plane | agent-os/agent_os_node.mjs | npm install agoragentic or pip install agoragentic |
+| Agoragentic Rust Framework HTTP Runtime | rust-framework/README.md | set AGORAGENTIC_RUST_AGENT_URL for self-hosted runtime calls |
 | Micro ECF Harness Export | micro-ecf/README.md | npx agoragentic-micro-ecf@latest doctor --dir . |
 | Harness Core No-Spend Scaffold | harness-core/bin/agoragentic-harness.mjs | node harness-core/bin/agoragentic-harness.mjs init |
 | Premortem Golden Loop Agent | premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs | node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs run --repo . |

--- a/llms.txt
+++ b/llms.txt
@@ -12,6 +12,7 @@
 - Micro ECF: `npx agoragentic-micro-ecf@latest init` (package-ready local context CLI, Node ≥18)
 - Harness Core source scaffold: `node harness-core/bin/agoragentic-harness.mjs init` (local no-spend proof/export/listing-readiness CLI, Node ≥18; npm publication pending validation)
 - Premortem Golden Loop Agent: `node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs run --repo .` or `heal --repo .` (free local Node ≥18 CLI; no repo contents sent anywhere by default)
+- Rust Framework HTTP runtime examples: `AGORAGENTIC_RUST_AGENT_URL=http://127.0.0.1:8080 node rust-framework/typescript-call-rust-agent.mjs` or `python rust-framework/python_call_rust_agent.py` (client examples only; no hosted provisioning or spend)
 
 ## Auth
 - Env: AGORAGENTIC_API_KEY=amk_<key>
@@ -25,6 +26,7 @@
 - Dify, Flowise, Zapier MCP, A2A, RepoBrain Local Provider, claude-view Local Provider, Scrumboy (JSON)
 - LangSmith: langsmith/README.md (observability)
 - Agent OS Control Plane: agent-os/README.md (public quote, procurement, approval, execute, and reconciliation flow)
+- Agoragentic Rust Framework HTTP Runtime: rust-framework/README.md (self-hosted Rust runtime contract, TypeScript/Node client, Python client, and Agent OS Harness packet example)
 - Micro ECF: micro-ecf/README.md (local context/policy packets and Agent OS Harness export)
 - Harness Core: harness-core/README.md (local no-spend proof, receipt, Agent OS export, and listing-readiness artifacts)
 - Premortem Golden Loop Agent: premortem-golden-loop/README.md and premortem-golden-loop/PROMPT.md (free local six-month failure-frame premortem reports plus OSS agent release premortem, no-spend Golden Loop readiness receipt, and safe self-heal scaffolds)
@@ -38,6 +40,7 @@
 - acp/agent.json — Agent Client Protocol adapter manifest
 - glama.json — Glama registry
 - agent-os/README.md — Agent OS public control-plane export
+- rust-framework/README.md — Rust Framework HTTP/JSON examples and self-hosted runtime boundary
 - openfang/README.md — OpenFang Hand bridge for routed buying, receipts, and seller listing drafts
 - zoneless/README.md — experimental Solana seller-payout reference only; not live Agoragentic settlement
 - n8n/README.md — n8n community node for x402 edge calls and authenticated router flows

--- a/rust-framework/README.md
+++ b/rust-framework/README.md
@@ -1,0 +1,84 @@
+# Agoragentic Rust Framework HTTP Runtime
+
+Use this folder when a local or self-hosted Agoragentic Rust Framework agent needs public, language-neutral examples for TypeScript/Node, Python, and Agent OS Harness preview.
+
+The Rust framework runtime is Rust-native internally and language-neutral externally. Consumers should talk to it over HTTP/JSON first:
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/health` | Runtime and framework readiness. |
+| `GET` | `/tools` | Public-safe tool specs. |
+| `GET` | `/openapi.json` | Local runtime OpenAPI profile. |
+| `GET` | `/schema/agoragentic-rust-framework.json` | JSON Schema contract. |
+| `POST` | `/invoke` | Typed or raw JSON invocation. |
+| `POST` | `/a2a/invoke` | Local A2A-compatible invocation. |
+
+## Boundary
+
+This public integration is a client/example layer only.
+
+It does not publish Rust crates, start Rust processes, provision hosted runtimes, spend wallet funds, settle x402, publish marketplace listings, mutate Router trust/ranking, expose private Full ECF internals, or bypass owner approval.
+
+Hosted Router / Marketplace work still uses `POST /api/execute`. Direct listing invocation still uses `POST /api/invoke/:id` only when a known provider is required. The Node SDK remains a hosted-router client, and Python/TypeScript callers use the Rust runtime over HTTP/JSON rather than PyO3, N-API, WASM, local model downloads, GPU dependencies, external vector DBs, or paid provider calls.
+
+## Prerequisite
+
+Start a local or self-hosted Rust framework runtime that serves the endpoints above. During local development, the private framework stack exposes the runtime from examples such as `examples/rust-basic-agent/`.
+
+Set:
+
+```bash
+export AGORAGENTIC_RUST_AGENT_URL="http://127.0.0.1:8080"
+```
+
+Use the root URL without a trailing route. The examples append `/health`, `/tools`, `/openapi.json`, and `/invoke`.
+
+## TypeScript / Node
+
+`typescript-call-rust-agent.ts` is the typed source example. `typescript-call-rust-agent.mjs` is the dependency-free Node 18+ runnable version used by the local verification script.
+
+```bash
+AGORAGENTIC_RUST_AGENT_URL=http://127.0.0.1:8080 \
+node rust-framework/typescript-call-rust-agent.mjs
+```
+
+The script calls:
+
+1. `GET /health`
+2. `GET /tools`
+3. `GET /openapi.json`
+4. `POST /invoke` with a typed envelope
+5. `POST /invoke` with a raw marketplace-compatible payload
+
+It prints a compact JSON summary and never reads an API key.
+
+## Python
+
+```bash
+AGORAGENTIC_RUST_AGENT_URL=http://127.0.0.1:8080 \
+python rust-framework/python_call_rust_agent.py
+```
+
+The Python example uses only the standard library. It follows the same HTTP contract as the TypeScript/Node example and prints JSON.
+
+## Agent OS Harness Preview
+
+`agent-os-harness.example.json` shows how a self-hosted Rust runtime can be represented as a public-safe Agent OS Harness packet for preview.
+
+The packet is private-only by default. It includes endpoint references and no runtime secrets, raw prompts, raw tool output, local SQLite memory contents, wallet-private data, payment payloads, or Full ECF internals.
+
+Preview remains no-spend:
+
+```bash
+AGORAGENTIC_API_KEY=amk_your_key \
+npx agoragentic-os@latest deploy readiness --file rust-framework/agent-os-harness.example.json
+```
+
+Only use `deploy create` when the owner explicitly wants to record a hosted Agent OS deployment request. Runtime provisioning, public exposure, marketplace selling, x402 activation, wallet funding, and trust changes remain separate gated steps.
+
+## Public Contract Links
+
+- Rust framework JSON Schema: https://agoragentic.com/schema/agoragentic-rust-framework.v1.json
+- Rust framework OpenAPI profile: https://agoragentic.com/openapi-agoragentic-rust-framework.yaml
+- Agent OS Harness schema: https://agoragentic.com/schema/agent-os-harness.v1.json
+- Hosted Router execute: https://agoragentic.com/api/execute

--- a/rust-framework/README.md
+++ b/rust-framework/README.md
@@ -7,6 +7,7 @@ The Rust framework runtime is Rust-native internally and language-neutral extern
 | Method | Path | Purpose |
 | --- | --- | --- |
 | `GET` | `/health` | Runtime and framework readiness. |
+| `GET` | `/.well-known/agent-card.json` | A2A-style local Agent Card discovery. |
 | `GET` | `/tools` | Public-safe tool specs. |
 | `GET` | `/openapi.json` | Local runtime OpenAPI profile. |
 | `GET` | `/schema/agoragentic-rust-framework.json` | JSON Schema contract. |
@@ -31,7 +32,7 @@ Set:
 export AGORAGENTIC_RUST_AGENT_URL="http://127.0.0.1:8080"
 ```
 
-Use the root URL without a trailing route. The examples append `/health`, `/tools`, `/openapi.json`, and `/invoke`.
+Use the root URL without a trailing route. The examples append `/health`, `/.well-known/agent-card.json`, `/tools`, `/openapi.json`, and `/invoke`.
 
 ## TypeScript / Node
 
@@ -45,10 +46,11 @@ node rust-framework/typescript-call-rust-agent.mjs
 The script calls:
 
 1. `GET /health`
-2. `GET /tools`
-3. `GET /openapi.json`
-4. `POST /invoke` with a typed envelope
-5. `POST /invoke` with a raw marketplace-compatible payload
+2. `GET /.well-known/agent-card.json`
+3. `GET /tools`
+4. `GET /openapi.json`
+5. `POST /invoke` with a typed envelope
+6. `POST /invoke` with a raw marketplace-compatible payload
 
 It prints a compact JSON summary and never reads an API key.
 

--- a/rust-framework/agent-os-harness.example.json
+++ b/rust-framework/agent-os-harness.example.json
@@ -1,0 +1,143 @@
+{
+  "schema": "agoragentic.agent-os.harness.v1",
+  "agent_manifest": {
+    "name": "rust-self-hosted-summarizer",
+    "primary_goal": "Serve a local Rust agent over the Agoragentic Rust Framework HTTP/JSON contract.",
+    "framework": "agoragentic-rust",
+    "runtime_language": "rust",
+    "runtime_shape": "self_hosted_http",
+    "public_contracts": [
+      "GET /health",
+      "GET /tools",
+      "GET /openapi.json",
+      "GET /schema/agoragentic-rust-framework.json",
+      "POST /invoke",
+      "POST /a2a/invoke"
+    ]
+  },
+  "context_policy": {
+    "allowed_sources": [
+      "owner_docs",
+      "public_docs",
+      "runtime_tool_specs"
+    ],
+    "denied_sources": [
+      "private_ecf",
+      "wallet_private_data",
+      "raw_payment_payloads",
+      "raw_local_sqlite_memory"
+    ],
+    "redaction": "public_safe_summaries_only"
+  },
+  "tool_policy": {
+    "allowed_tools": [
+      "summarize",
+      "classify"
+    ],
+    "denied_tools": [
+      "wallet_spend",
+      "x402_settle",
+      "publish_marketplace_listing",
+      "mutate_router_trust",
+      "start_or_stop_local_process"
+    ],
+    "side_effects": "owner_review_required"
+  },
+  "budget_policy": {
+    "treasury_required": false,
+    "max_daily_spend_usdc": 0,
+    "approval_required_above_usdc": 0,
+    "notes": "Local Rust runtime preview is no-spend. Hosted Router calls still require normal Agoragentic account policy."
+  },
+  "approval_policy": {
+    "autonomous": [
+      "read_runtime_health",
+      "read_runtime_tools",
+      "draft_local_preview"
+    ],
+    "human_gated": [
+      "deploy_create",
+      "public_exposure",
+      "marketplace_publication",
+      "x402_activation",
+      "wallet_funding"
+    ]
+  },
+  "memory_policy": {
+    "write_gate": "local_only_owner_reviewed",
+    "secret_storage": "reference_only",
+    "agent_os_governed_memory_write_enabled": false,
+    "local_store": "sqlite"
+  },
+  "swarm_policy": {
+    "max_agents": 3,
+    "delegation": "local_graph_only",
+    "gateway_roundtrip_required_for_local_handoffs": false
+  },
+  "deployment_policy": {
+    "hosting_target": "self_hosted_http",
+    "template_id": "self_hosted_rust_framework",
+    "runtime_lane": "customer_managed_http_runtime",
+    "exposure_mode": "private_only",
+    "first_proof_required": true,
+    "paid_canary_required": false
+  },
+  "public_boundary": {
+    "full_ecf_internals_excluded": true,
+    "raw_prompts_excluded": true,
+    "raw_tool_outputs_excluded": true,
+    "raw_receipts_excluded": true,
+    "wallet_private_data_excluded": true,
+    "local_sqlite_memory_contents_excluded": true
+  },
+  "rust_framework_runtime": {
+    "name": "agoragentic-rust",
+    "version": "0.1.0",
+    "language": "rust",
+    "transport": "http-json",
+    "harness_compatible": true,
+    "base_url": "http://127.0.0.1:8080",
+    "health_url": "http://127.0.0.1:8080/health",
+    "tools_url": "http://127.0.0.1:8080/tools",
+    "invoke_url": "http://127.0.0.1:8080/invoke",
+    "a2a_invoke_url": "http://127.0.0.1:8080/a2a/invoke",
+    "schema_url": "http://127.0.0.1:8080/schema/agoragentic-rust-framework.json",
+    "openapi_url": "http://127.0.0.1:8080/openapi.json"
+  },
+  "agent_os_export": {
+    "catalog_endpoint": "GET /api/hosting/agent-os/catalog",
+    "preview_endpoint": "POST /api/hosting/agent-os/preview",
+    "deployment_endpoint": "POST /api/hosting/agent-os/deployments",
+    "treasury_endpoint": "GET /api/commerce/account",
+    "workspace_surface": "Agent OS owner workspace"
+  },
+  "agent_os_preview_request": {
+    "name": "rust-self-hosted-summarizer",
+    "hosting_target": "self_hosted_http",
+    "template_id": "self_hosted_rust_framework",
+    "runtime_lane": "customer_managed_http_runtime",
+    "exposure_mode": "private_only",
+    "goals": [
+      "Expose a local Rust agent through Harness-compatible HTTP/JSON.",
+      "Keep all spend, publication, x402, and public exposure gates disabled until owner review."
+    ],
+    "safety_policy": {
+      "owner_approval_required_for_spend": true,
+      "owner_approval_required_for_public_exposure": true,
+      "marketplace_publication_enabled": false,
+      "wallet_spend_enabled": false,
+      "x402_settlement_enabled": false,
+      "trust_mutation_enabled": false
+    },
+    "deployment_packet": {
+      "runtime_framework": "agoragentic-rust",
+      "runtime_language": "rust",
+      "transport": "http-json",
+      "endpoint_url": "http://127.0.0.1:8080/invoke",
+      "health_url": "http://127.0.0.1:8080/health",
+      "tools_url": "http://127.0.0.1:8080/tools",
+      "schema_url": "http://127.0.0.1:8080/schema/agoragentic-rust-framework.json",
+      "openapi_url": "http://127.0.0.1:8080/openapi.json"
+    }
+  }
+}

--- a/rust-framework/agent-os-harness.example.json
+++ b/rust-framework/agent-os-harness.example.json
@@ -8,6 +8,7 @@
     "runtime_shape": "self_hosted_http",
     "public_contracts": [
       "GET /health",
+      "GET /.well-known/agent-card.json",
       "GET /tools",
       "GET /openapi.json",
       "GET /schema/agoragentic-rust-framework.json",
@@ -98,6 +99,7 @@
     "harness_compatible": true,
     "base_url": "http://127.0.0.1:8080",
     "health_url": "http://127.0.0.1:8080/health",
+    "agent_card_url": "http://127.0.0.1:8080/.well-known/agent-card.json",
     "tools_url": "http://127.0.0.1:8080/tools",
     "invoke_url": "http://127.0.0.1:8080/invoke",
     "a2a_invoke_url": "http://127.0.0.1:8080/a2a/invoke",
@@ -135,6 +137,7 @@
       "transport": "http-json",
       "endpoint_url": "http://127.0.0.1:8080/invoke",
       "health_url": "http://127.0.0.1:8080/health",
+      "agent_card_url": "http://127.0.0.1:8080/.well-known/agent-card.json",
       "tools_url": "http://127.0.0.1:8080/tools",
       "schema_url": "http://127.0.0.1:8080/schema/agoragentic-rust-framework.json",
       "openapi_url": "http://127.0.0.1:8080/openapi.json"

--- a/rust-framework/python_call_rust_agent.py
+++ b/rust-framework/python_call_rust_agent.py
@@ -36,6 +36,7 @@ def request_json(path: str, method: str = "GET", body: Optional[Dict[str, Any]] 
 
 def main() -> int:
     health = request_json("/health")
+    agent_card = request_json("/.well-known/agent-card.json")
     tools = request_json("/tools")
     openapi = request_json("/openapi.json")
 
@@ -67,6 +68,20 @@ def main() -> int:
             "harness_compatible": health.get("runtime", {}).get("harness_compatible") is True,
         },
         "tools_count": len(tools.get("tools", [])) if isinstance(tools.get("tools"), list) else 0,
+        "agent_card": {
+            "name": agent_card.get("name"),
+            "version": agent_card.get("version"),
+            "supported_interface_count": len(agent_card.get("supportedInterfaces", []))
+            if isinstance(agent_card.get("supportedInterfaces"), list)
+            else 0,
+            "skill_count": len(agent_card.get("skills", []))
+            if isinstance(agent_card.get("skills"), list)
+            else 0,
+            "local_only": (agent_card.get("extensions") or {})
+            .get("agoragentic:rust_framework", {})
+            .get("local_only")
+            is True,
+        },
         "openapi_paths": sorted((openapi.get("paths") or {}).keys()),
         "typed_invoke": {
             "status": typed_invoke.get("status"),

--- a/rust-framework/python_call_rust_agent.py
+++ b/rust-framework/python_call_rust_agent.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Call a local Agoragentic Rust Framework runtime over HTTP/JSON."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any, Dict, Optional
+
+
+BASE_URL = os.environ.get("AGORAGENTIC_RUST_AGENT_URL", "http://127.0.0.1:8080").rstrip("/")
+
+
+def request_json(path: str, method: str = "GET", body: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    if not BASE_URL.startswith(("http://", "https://")):
+        raise ValueError("AGORAGENTIC_RUST_AGENT_URL must be an http(s) URL")
+
+    payload = None if body is None else json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        f"{BASE_URL}{path}",
+        data=payload,
+        method=method,
+        headers={"Content-Type": "application/json"},
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=10) as res:
+            return json.loads(res.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"{path} failed with HTTP {exc.code}: {detail}") from exc
+
+
+def main() -> int:
+    health = request_json("/health")
+    tools = request_json("/tools")
+    openapi = request_json("/openapi.json")
+
+    typed_request = {
+        "request_id": "req_public_python_example",
+        "agent_id": health.get("agent_id", "rust-agent"),
+        "task": "summarize",
+        "input": {
+            "text": "Rust agents expose HTTP/JSON contracts for Python callers."
+        },
+        "trace": {"trace_id": "trace_public_python_example"},
+        "limits": {"timeout_ms": 30000, "max_cost_usdc": 0},
+    }
+
+    typed_invoke = request_json("/invoke", method="POST", body=typed_request)
+    raw_invoke = request_json(
+        "/invoke",
+        method="POST",
+        body={
+            "text": "Raw JSON payloads remain compatible with simple marketplace-style callers."
+        },
+    )
+
+    summary = {
+        "runtime": {
+            "framework": health.get("framework"),
+            "framework_version": health.get("framework_version"),
+            "transport": health.get("runtime", {}).get("transport"),
+            "harness_compatible": health.get("runtime", {}).get("harness_compatible") is True,
+        },
+        "tools_count": len(tools.get("tools", [])) if isinstance(tools.get("tools"), list) else 0,
+        "openapi_paths": sorted((openapi.get("paths") or {}).keys()),
+        "typed_invoke": {
+            "status": typed_invoke.get("status"),
+            "request_id": typed_invoke.get("request_id"),
+            "trace_id": (typed_invoke.get("trace") or {}).get("trace_id"),
+        },
+        "raw_invoke": {
+            "status": raw_invoke.get("status"),
+            "request_id": raw_invoke.get("request_id"),
+        },
+        "authority_boundary": {
+            "hosted_router_execute_changed": False,
+            "direct_invoke_changed": False,
+            "wallet_spend_enabled": False,
+            "x402_settlement_enabled": False,
+            "marketplace_publication_enabled": False,
+            "trust_mutation_enabled": False,
+            "native_bindings_required": False,
+        },
+    }
+
+    print(json.dumps(summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:  # pragma: no cover - command-line error path
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(1)

--- a/rust-framework/typescript-call-rust-agent.mjs
+++ b/rust-framework/typescript-call-rust-agent.mjs
@@ -79,6 +79,7 @@ async function postJson(path, body) {
 
 async function main() {
   const health = await requestJson('/health');
+  const agentCard = await requestJson('/.well-known/agent-card.json');
   const tools = await requestJson('/tools');
   const openapi = await requestJson('/openapi.json');
 
@@ -111,6 +112,15 @@ async function main() {
       harness_compatible: health.runtime?.harness_compatible === true,
     },
     tools_count: Array.isArray(tools.tools) ? tools.tools.length : 0,
+    agent_card: {
+      name: agentCard.name,
+      version: agentCard.version,
+      supported_interface_count: Array.isArray(agentCard.supportedInterfaces)
+        ? agentCard.supportedInterfaces.length
+        : 0,
+      skill_count: Array.isArray(agentCard.skills) ? agentCard.skills.length : 0,
+      local_only: agentCard.extensions?.['agoragentic:rust_framework']?.local_only === true,
+    },
     openapi_paths: Object.keys(openapi.paths || {}).sort(),
     typed_invoke: {
       status: typedInvoke.status,

--- a/rust-framework/typescript-call-rust-agent.mjs
+++ b/rust-framework/typescript-call-rust-agent.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+import http from 'node:http';
+import https from 'node:https';
+
+const baseUrl = normalizeBaseUrl(
+  process.env.AGORAGENTIC_RUST_AGENT_URL || 'http://127.0.0.1:8080'
+);
+
+function normalizeBaseUrl(value) {
+  const trimmed = String(value || '').trim().replace(/\/+$/, '');
+  if (!/^https?:\/\//.test(trimmed)) {
+    throw new Error('AGORAGENTIC_RUST_AGENT_URL must be an http(s) URL');
+  }
+  return trimmed;
+}
+
+function requestJson(path, options = {}) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(path, baseUrl);
+    const payload = options.body || null;
+    const headers = {
+      'content-type': 'application/json',
+      connection: 'close',
+      ...(options.headers || {}),
+    };
+    if (payload) {
+      headers['content-length'] = Buffer.byteLength(payload);
+    }
+
+    const transport = url.protocol === 'https:' ? https : http;
+    const req = transport.request(
+      url,
+      {
+        method: options.method || 'GET',
+        headers,
+        timeout: 10000,
+      },
+      (res) => {
+        let text = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => {
+          text += chunk;
+        });
+        res.on('end', () => {
+          let json;
+          try {
+            json = text ? JSON.parse(text) : null;
+          } catch (error) {
+            reject(new Error(`${path} returned non-JSON response: ${text.slice(0, 120)}`));
+            return;
+          }
+          if ((res.statusCode || 500) < 200 || (res.statusCode || 500) >= 300) {
+            reject(new Error(`${path} failed with HTTP ${res.statusCode}: ${JSON.stringify(json)}`));
+            return;
+          }
+          resolve(json);
+        });
+      }
+    );
+
+    req.on('timeout', () => {
+      req.destroy(new Error(`${path} timed out`));
+    });
+    req.on('error', reject);
+    if (payload) {
+      req.write(payload);
+    }
+    req.end();
+  });
+}
+
+async function postJson(path, body) {
+  return requestJson(path, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+async function main() {
+  const health = await requestJson('/health');
+  const tools = await requestJson('/tools');
+  const openapi = await requestJson('/openapi.json');
+
+  const typedRequest = {
+    request_id: 'req_public_ts_example',
+    agent_id: health.agent_id || 'rust-agent',
+    task: 'summarize',
+    input: {
+      text: 'Rust agents expose HTTP/JSON contracts for TypeScript and Python callers.',
+    },
+    trace: {
+      trace_id: 'trace_public_ts_example',
+    },
+    limits: {
+      timeout_ms: 30000,
+      max_cost_usdc: 0,
+    },
+  };
+
+  const typedInvoke = await postJson('/invoke', typedRequest);
+  const rawInvoke = await postJson('/invoke', {
+    text: 'Raw JSON payloads remain compatible with simple marketplace-style callers.',
+  });
+
+  const summary = {
+    runtime: {
+      framework: health.framework,
+      framework_version: health.framework_version,
+      transport: health.runtime?.transport,
+      harness_compatible: health.runtime?.harness_compatible === true,
+    },
+    tools_count: Array.isArray(tools.tools) ? tools.tools.length : 0,
+    openapi_paths: Object.keys(openapi.paths || {}).sort(),
+    typed_invoke: {
+      status: typedInvoke.status,
+      request_id: typedInvoke.request_id,
+      trace_id: typedInvoke.trace?.trace_id,
+    },
+    raw_invoke: {
+      status: rawInvoke.status,
+      request_id: rawInvoke.request_id,
+    },
+    authority_boundary: {
+      hosted_router_execute_changed: false,
+      direct_invoke_changed: false,
+      wallet_spend_enabled: false,
+      x402_settlement_enabled: false,
+      marketplace_publication_enabled: false,
+      trust_mutation_enabled: false,
+      native_bindings_required: false,
+    },
+  };
+
+  process.stdout.write(`${JSON.stringify(summary, null, 2)}\n`);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/rust-framework/typescript-call-rust-agent.ts
+++ b/rust-framework/typescript-call-rust-agent.ts
@@ -1,0 +1,145 @@
+type JsonObject = Record<string, unknown>;
+
+declare const process: {
+  env: Record<string, string | undefined>;
+  exitCode?: number;
+};
+
+interface RustHealthResponse {
+  framework?: string;
+  framework_version?: string;
+  agent_id?: string;
+  runtime?: {
+    transport?: string;
+    harness_compatible?: boolean;
+  };
+}
+
+interface RustToolsResponse {
+  tools?: unknown[];
+}
+
+interface RustOpenApiResponse {
+  paths?: Record<string, unknown>;
+}
+
+interface RustInvocationRequest {
+  request_id?: string;
+  agent_id?: string;
+  task?: string;
+  input?: JsonObject;
+  trace?: JsonObject;
+  limits?: JsonObject;
+  [key: string]: unknown;
+}
+
+interface RustInvocationResponse {
+  request_id?: string;
+  status?: string;
+  trace?: {
+    trace_id?: string;
+  };
+}
+
+const baseUrl = normalizeBaseUrl(
+  process.env.AGORAGENTIC_RUST_AGENT_URL || 'http://127.0.0.1:8080'
+);
+
+function normalizeBaseUrl(value: string): string {
+  const trimmed = value.trim().replace(/\/+$/, '');
+  if (!/^https?:\/\//.test(trimmed)) {
+    throw new Error('AGORAGENTIC_RUST_AGENT_URL must be an http(s) URL');
+  }
+  return trimmed;
+}
+
+async function requestJson<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const res = await fetch(`${baseUrl}${path}`, {
+    ...init,
+    headers: {
+      'content-type': 'application/json',
+      connection: 'close',
+      ...(init.headers || {}),
+    },
+  });
+  const text = await res.text();
+  const json = text ? JSON.parse(text) : null;
+  if (!res.ok) {
+    throw new Error(`${path} failed with HTTP ${res.status}: ${JSON.stringify(json)}`);
+  }
+  return json as T;
+}
+
+async function postJson<T>(path: string, body: JsonObject): Promise<T> {
+  return requestJson<T>(path, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+async function main(): Promise<void> {
+  const health = await requestJson<RustHealthResponse>('/health');
+  const tools = await requestJson<RustToolsResponse>('/tools');
+  const openapi = await requestJson<RustOpenApiResponse>('/openapi.json');
+
+  const typedRequest: RustInvocationRequest = {
+    request_id: 'req_public_ts_example',
+    agent_id: health.agent_id || 'rust-agent',
+    task: 'summarize',
+    input: {
+      text: 'Rust agents expose HTTP/JSON contracts for TypeScript and Python callers.',
+    },
+    trace: {
+      trace_id: 'trace_public_ts_example',
+    },
+    limits: {
+      timeout_ms: 30000,
+      max_cost_usdc: 0,
+    },
+  };
+
+  const typedInvoke = await postJson<RustInvocationResponse>('/invoke', typedRequest);
+  const rawInvoke = await postJson<RustInvocationResponse>('/invoke', {
+    text: 'Raw JSON payloads remain compatible with simple marketplace-style callers.',
+  });
+
+  console.log(
+    JSON.stringify(
+      {
+        runtime: {
+          framework: health.framework,
+          framework_version: health.framework_version,
+          transport: health.runtime?.transport,
+          harness_compatible: health.runtime?.harness_compatible === true,
+        },
+        tools_count: Array.isArray(tools.tools) ? tools.tools.length : 0,
+        openapi_paths: Object.keys(openapi.paths || {}).sort(),
+        typed_invoke: {
+          status: typedInvoke.status,
+          request_id: typedInvoke.request_id,
+          trace_id: typedInvoke.trace?.trace_id,
+        },
+        raw_invoke: {
+          status: rawInvoke.status,
+          request_id: rawInvoke.request_id,
+        },
+        authority_boundary: {
+          hosted_router_execute_changed: false,
+          direct_invoke_changed: false,
+          wallet_spend_enabled: false,
+          x402_settlement_enabled: false,
+          marketplace_publication_enabled: false,
+          trust_mutation_enabled: false,
+          native_bindings_required: false,
+        },
+      },
+      null,
+      2
+    )
+  );
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/rust-framework/typescript-call-rust-agent.ts
+++ b/rust-framework/typescript-call-rust-agent.ts
@@ -19,6 +19,18 @@ interface RustToolsResponse {
   tools?: unknown[];
 }
 
+interface RustAgentCardResponse {
+  name?: string;
+  version?: string;
+  supportedInterfaces?: unknown[];
+  skills?: unknown[];
+  extensions?: {
+    'agoragentic:rust_framework'?: {
+      local_only?: boolean;
+    };
+  };
+}
+
 interface RustOpenApiResponse {
   paths?: Record<string, unknown>;
 }
@@ -79,6 +91,7 @@ async function postJson<T>(path: string, body: JsonObject): Promise<T> {
 
 async function main(): Promise<void> {
   const health = await requestJson<RustHealthResponse>('/health');
+  const agentCard = await requestJson<RustAgentCardResponse>('/.well-known/agent-card.json');
   const tools = await requestJson<RustToolsResponse>('/tools');
   const openapi = await requestJson<RustOpenApiResponse>('/openapi.json');
 
@@ -113,6 +126,15 @@ async function main(): Promise<void> {
           harness_compatible: health.runtime?.harness_compatible === true,
         },
         tools_count: Array.isArray(tools.tools) ? tools.tools.length : 0,
+        agent_card: {
+          name: agentCard.name,
+          version: agentCard.version,
+          supported_interface_count: Array.isArray(agentCard.supportedInterfaces)
+            ? agentCard.supportedInterfaces.length
+            : 0,
+          skill_count: Array.isArray(agentCard.skills) ? agentCard.skills.length : 0,
+          local_only: agentCard.extensions?.['agoragentic:rust_framework']?.local_only === true,
+        },
         openapi_paths: Object.keys(openapi.paths || {}).sort(),
         typed_invoke: {
           status: typedInvoke.status,

--- a/scripts/verify-rust-framework-public-sync.js
+++ b/scripts/verify-rust-framework-public-sync.js
@@ -60,12 +60,46 @@ function startMockRustRuntime() {
       });
     }
 
+    if (req.method === 'GET' && req.url === '/.well-known/agent-card.json') {
+      return jsonResponse(res, 200, {
+        name: 'public-sync-rust-agent',
+        version: '0.1.0',
+        documentationUrl: 'https://agoragentic.com/openapi-agoragentic-rust-framework.yaml',
+        supportedInterfaces: [
+          { type: 'http-json', url: '/invoke' },
+          { type: 'a2a-json-rpc', url: '/a2a/invoke' },
+        ],
+        skills: [
+          {
+            id: 'summarize',
+            name: 'summarize',
+            description: 'Summarize public-safe text',
+            inputModes: ['application/json'],
+            outputModes: ['application/json'],
+          },
+        ],
+        extensions: {
+          'agoragentic:rust_framework': {
+            framework: 'agoragentic-rust',
+            local_only: true,
+            authority_boundary: {
+              wallet_spend_enabled: false,
+              x402_settlement_enabled: false,
+              marketplace_publication_enabled: false,
+              trust_state_mutation_enabled: false,
+            },
+          },
+        },
+      });
+    }
+
     if (req.method === 'GET' && req.url === '/openapi.json') {
       return jsonResponse(res, 200, {
         openapi: '3.1.0',
         info: { title: 'Agoragentic Rust Framework Runtime', version: '0.1.0' },
         paths: {
           '/health': {},
+          '/.well-known/agent-card.json': {},
           '/tools': {},
           '/openapi.json': {},
           '/invoke': {},
@@ -171,7 +205,14 @@ function assertExampleOutput(output, label) {
   assert.equal(output.runtime.framework, 'agoragentic-rust', `${label} framework`);
   assert.equal(output.runtime.transport, 'http-json', `${label} transport`);
   assert.equal(output.runtime.harness_compatible, true, `${label} harness flag`);
+  assert.equal(output.agent_card.name, 'public-sync-rust-agent', `${label} agent card name`);
+  assert.equal(output.agent_card.local_only, true, `${label} agent card local-only flag`);
+  assert.equal(output.agent_card.skill_count, 1, `${label} agent card skills`);
   assert.ok(output.openapi_paths.includes('/invoke'), `${label} openapi includes /invoke`);
+  assert.ok(
+    output.openapi_paths.includes('/.well-known/agent-card.json'),
+    `${label} openapi includes agent card`
+  );
   assert.ok(output.openapi_paths.includes('/openapi.json'), `${label} openapi includes /openapi.json`);
   assert.equal(output.typed_invoke.status, 'completed', `${label} typed invoke`);
   assert.equal(output.raw_invoke.status, 'completed', `${label} raw invoke`);
@@ -189,11 +230,13 @@ function assertExampleOutput(output, label) {
 async function main() {
   const readme = read('rust-framework/README.md');
   assertIncludes(readme, 'AGORAGENTIC_RUST_AGENT_URL', 'rust README');
+  assertIncludes(readme, '/.well-known/agent-card.json', 'rust README');
   assertIncludes(readme, 'POST /api/execute', 'rust README');
   assertIncludes(readme, 'PyO3, N-API, WASM', 'rust README');
   assertIncludes(readme, 'does not publish Rust crates', 'rust README');
 
   const typescriptExample = read('rust-framework/typescript-call-rust-agent.ts');
+  assertIncludes(typescriptExample, 'interface RustAgentCardResponse', 'TypeScript example');
   assertIncludes(typescriptExample, 'interface RustInvocationRequest', 'TypeScript example');
   assertIncludes(typescriptExample, "postJson<RustInvocationResponse>('/invoke'", 'TypeScript example');
   assertIncludes(typescriptExample, 'wallet_spend_enabled: false', 'TypeScript example');

--- a/scripts/verify-rust-framework-public-sync.js
+++ b/scripts/verify-rust-framework-public-sync.js
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const http = require('http');
+const path = require('path');
+const { execFile, execFileSync } = require('child_process');
+
+const root = path.resolve(__dirname, '..');
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8');
+}
+
+function parseJson(relativePath) {
+  return JSON.parse(read(relativePath));
+}
+
+function assertIncludes(haystack, needle, label) {
+  assert.ok(haystack.includes(needle), `${label || 'file'} missing ${needle}`);
+}
+
+function jsonResponse(res, status, body) {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    'content-type': 'application/json',
+    'content-length': Buffer.byteLength(payload),
+    connection: 'close',
+  });
+  res.end(payload);
+}
+
+function startMockRustRuntime() {
+  const server = http.createServer((req, res) => {
+    if (req.method === 'GET' && req.url === '/health') {
+      return jsonResponse(res, 200, {
+        status: 'ok',
+        framework: 'agoragentic-rust',
+        framework_version: '0.1.0',
+        agent_id: 'public-sync-rust-agent',
+        runtime: {
+          language: 'rust',
+          transport: 'http-json',
+          harness_compatible: true,
+        },
+      });
+    }
+
+    if (req.method === 'GET' && req.url === '/tools') {
+      return jsonResponse(res, 200, {
+        tools: [
+          {
+            name: 'summarize',
+            description: 'Summarize public-safe text',
+            input_schema: { type: 'object' },
+            output_schema: { type: 'object' },
+          },
+        ],
+      });
+    }
+
+    if (req.method === 'GET' && req.url === '/openapi.json') {
+      return jsonResponse(res, 200, {
+        openapi: '3.1.0',
+        info: { title: 'Agoragentic Rust Framework Runtime', version: '0.1.0' },
+        paths: {
+          '/health': {},
+          '/tools': {},
+          '/openapi.json': {},
+          '/invoke': {},
+          '/a2a/invoke': {},
+          '/schema/agoragentic-rust-framework.json': {},
+        },
+        'x-agoragentic': {
+          framework: 'agoragentic-rust',
+          transport: 'http-json',
+          hosted_provisioning: false,
+          wallet_spend: false,
+          x402_settlement: false,
+          marketplace_publication: false,
+          trust_mutation: false,
+        },
+      });
+    }
+
+    if (req.method === 'POST' && req.url === '/invoke') {
+      let raw = '';
+      req.on('data', (chunk) => {
+        raw += chunk;
+      });
+      req.on('end', () => {
+        const body = raw ? JSON.parse(raw) : {};
+        const requestId = body.request_id || 'req_mock_raw';
+        return jsonResponse(res, 200, {
+          request_id: requestId,
+          agent_id: body.agent_id || 'public-sync-rust-agent',
+          status: 'completed',
+          output: {
+            summary: String(body.input?.text || body.text || '').slice(0, 80),
+          },
+          trace: body.trace || { trace_id: 'trace_mock_raw' },
+        });
+      });
+      return undefined;
+    }
+
+    return jsonResponse(res, 404, { error: 'not_found' });
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({ server, baseUrl: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+function execJson(command, args, options) {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, options, (error, stdout, stderr) => {
+      if (error) {
+        error.message = `${error.message}\n${stderr || stdout || ''}`.trim();
+        reject(error);
+        return;
+      }
+      try {
+        resolve(JSON.parse(stdout));
+      } catch (parseError) {
+        reject(new Error(`Expected JSON output from ${command}: ${stdout || stderr}`));
+      }
+    });
+  });
+}
+
+function runNodeExample(baseUrl) {
+  return execJson(process.execPath, ['rust-framework/typescript-call-rust-agent.mjs'], {
+    cwd: root,
+    env: { ...process.env, AGORAGENTIC_RUST_AGENT_URL: baseUrl },
+    encoding: 'utf8',
+    timeout: 15000,
+  });
+}
+
+function runPythonCompile() {
+  execFileSync(
+    'python',
+    [
+      '-c',
+      "import ast, pathlib; ast.parse(pathlib.Path('rust-framework/python_call_rust_agent.py').read_text(encoding='utf-8')); print('python syntax ok')",
+    ],
+    {
+      cwd: root,
+      stdio: 'pipe',
+      timeout: 15000,
+    }
+  );
+}
+
+function runPythonExample(baseUrl) {
+  return execJson('python', ['rust-framework/python_call_rust_agent.py'], {
+    cwd: root,
+    env: { ...process.env, AGORAGENTIC_RUST_AGENT_URL: baseUrl },
+    encoding: 'utf8',
+    timeout: 15000,
+  });
+}
+
+function assertExampleOutput(output, label) {
+  assert.equal(output.runtime.framework, 'agoragentic-rust', `${label} framework`);
+  assert.equal(output.runtime.transport, 'http-json', `${label} transport`);
+  assert.equal(output.runtime.harness_compatible, true, `${label} harness flag`);
+  assert.ok(output.openapi_paths.includes('/invoke'), `${label} openapi includes /invoke`);
+  assert.ok(output.openapi_paths.includes('/openapi.json'), `${label} openapi includes /openapi.json`);
+  assert.equal(output.typed_invoke.status, 'completed', `${label} typed invoke`);
+  assert.equal(output.raw_invoke.status, 'completed', `${label} raw invoke`);
+  assert.deepEqual(output.authority_boundary, {
+    hosted_router_execute_changed: false,
+    direct_invoke_changed: false,
+    wallet_spend_enabled: false,
+    x402_settlement_enabled: false,
+    marketplace_publication_enabled: false,
+    trust_mutation_enabled: false,
+    native_bindings_required: false,
+  });
+}
+
+async function main() {
+  const readme = read('rust-framework/README.md');
+  assertIncludes(readme, 'AGORAGENTIC_RUST_AGENT_URL', 'rust README');
+  assertIncludes(readme, 'POST /api/execute', 'rust README');
+  assertIncludes(readme, 'PyO3, N-API, WASM', 'rust README');
+  assertIncludes(readme, 'does not publish Rust crates', 'rust README');
+
+  const typescriptExample = read('rust-framework/typescript-call-rust-agent.ts');
+  assertIncludes(typescriptExample, 'interface RustInvocationRequest', 'TypeScript example');
+  assertIncludes(typescriptExample, "postJson<RustInvocationResponse>('/invoke'", 'TypeScript example');
+  assertIncludes(typescriptExample, 'wallet_spend_enabled: false', 'TypeScript example');
+
+  const rootReadme = read('README.md');
+  assertIncludes(rootReadme, 'Agoragentic Rust Framework HTTP Runtime', 'root README');
+
+  const llms = read('llms.txt');
+  assertIncludes(llms, 'Rust Framework HTTP runtime examples', 'llms.txt');
+
+  const skill = read('SKILL.md');
+  assertIncludes(skill, 'Agoragentic Rust Framework HTTP examples', 'SKILL.md');
+
+  const manifest = parseJson('integrations.json');
+  assert.equal(manifest.updated_at, '2026-06-01');
+  assert.ok(
+    manifest.integrations.some(
+      (item) =>
+        item.id === 'agoragentic-rust-framework' &&
+        item.language === 'rust' &&
+        item.path === 'rust-framework/README.md'
+    ),
+    'integrations.json missing rust framework integration'
+  );
+  assert.equal(manifest.discovery.rust_framework, 'rust-framework/README.md');
+  assert.equal(manifest.discovery.rust_framework_typescript_example, 'rust-framework/typescript-call-rust-agent.ts');
+  assert.equal(manifest.discovery.rust_framework_node_example, 'rust-framework/typescript-call-rust-agent.mjs');
+
+  const schema = parseJson('integrations.schema.json');
+  assert.ok(
+    schema.$defs.integration.properties.language.enum.includes('rust'),
+    'integrations schema must allow rust integrations'
+  );
+
+  const harness = parseJson('rust-framework/agent-os-harness.example.json');
+  assert.equal(harness.schema, 'agoragentic.agent-os.harness.v1');
+  assert.equal(harness.rust_framework_runtime.name, 'agoragentic-rust');
+  assert.equal(harness.rust_framework_runtime.harness_compatible, true);
+  assert.equal(harness.agent_os_preview_request.safety_policy.wallet_spend_enabled, false);
+  assert.equal(harness.agent_os_preview_request.safety_policy.x402_settlement_enabled, false);
+  assert.equal(harness.agent_os_preview_request.safety_policy.marketplace_publication_enabled, false);
+  assert.equal(harness.agent_os_preview_request.safety_policy.trust_mutation_enabled, false);
+
+  runPythonCompile();
+
+  const { server, baseUrl } = await startMockRustRuntime();
+  try {
+    assertExampleOutput(await runNodeExample(baseUrl), 'node');
+    assertExampleOutput(await runPythonExample(baseUrl), 'python');
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+
+  console.log('✅ Rust framework public sync verification passed');
+}
+
+main().catch((error) => {
+  console.error(error.stack || error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `rust-framework/` public HTTP/JSON examples for a self-hosted Agoragentic Rust Framework runtime
- include typed TypeScript source, dependency-free Node runner, Python stdlib runner, and public-safe Agent OS Harness packet
- index the Rust framework surface in `integrations.json`, schema, README, llms files, SKILL, and changelog without changing hosted Router / Marketplace SDK semantics
- add a no-spend verifier that runs the examples against a local mock Rust-compatible runtime

## Validation
- `node scripts/verify-integrations-json.js`
- `node scripts/verify-rust-framework-public-sync.js`
- `node --check rust-framework/typescript-call-rust-agent.mjs; node --check scripts/verify-rust-framework-public-sync.js`
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('integrations.json','utf8')); JSON.parse(fs.readFileSync('rust-framework/agent-os-harness.example.json','utf8')); console.log('json ok')"`
- `git diff --check`