### PR TITLE
feat: port 20 framework integrations + honesty fixes

### DIFF
--- a/ACP_REGISTRY.md
+++ b/ACP_REGISTRY.md
@@ -7,7 +7,7 @@ Agoragentic already has an ACP Registry entry. Keep that entry focused on Agent 
 The public registry copy can drift toward old marketplace-only language:
 
 ```text
-Agent marketplace with 174+ AI capabilities. Browse, invoke, and pay for agent services settled in USDC on Base L2.
+Agent marketplace with 40+ verified AI capabilities. Browse, invoke, and pay for agent services settled in USDC on Base L2.
 ```
 
 That is no longer the clearest product spine. The registry should describe Agoragentic as Agent OS plus router/marketplace execution rails.

--- a/agenttax/README.md
+++ b/agenttax/README.md
@@ -1,0 +1,59 @@
+# Agoragentic x AgentTax
+
+Use AgentTax with Agoragentic when a buyer or operator wants tax-review or compliance review before a marketplace purchase executes.
+
+This wrapper is intentionally narrow:
+
+- AgentTax is treated as the review layer.
+- Agoragentic is still the routing, execution, and settlement layer.
+- This does not claim native tax filing, withholding, or remittance inside Agoragentic.
+
+## Install
+
+```bash
+npm install
+```
+
+Official surfaces:
+
+- Site: <https://www.agenttax.io/>
+- API docs: <https://www.agenttax.io/api-docs>
+
+## Example
+
+```ts
+import { AgoragenticAgentTaxClient } from "./agoragentic_agenttax";
+
+const client = new AgoragenticAgentTaxClient({
+  apiKey: process.env.AGORAGENTIC_API_KEY
+});
+
+const result = await client.executeWithTaxReview(
+  "summarize",
+  { text: "Summarize the quarterly report." },
+  0.50,
+  async (reviewPayload) => {
+    console.log("Send this review payload through AgentTax:", reviewPayload);
+    return {
+      approved: true,
+      review_id: "tax_review_123",
+      classification: "software_service"
+    };
+  },
+  { jurisdiction: "US", buyerEntity: "Treasury Agent LLC" }
+);
+
+console.log(result);
+```
+
+## What this wrapper does
+
+- previews the routed provider set and expected price
+- packages the preview into a tax-review payload
+- executes only after your external review callback returns `approved: true`
+
+## What it does not claim
+
+- native AgentTax tax filing inside Agoragentic
+- automatic remittance or withholding
+- tax advice or jurisdiction-specific correctness by itself

--- a/agenttax/agoragentic_agenttax.ts
+++ b/agenttax/agoragentic_agenttax.ts
@@ -1,0 +1,123 @@
+/**
+ * Agoragentic x AgentTax
+ *
+ * Honest boundary:
+ * - AgentTax is treated as the tax and compliance review layer around a planned spend.
+ * - Agoragentic still handles routing, execution, and settlement.
+ * - This wrapper does not claim native tax filing or remittance inside Agoragentic.
+ */
+
+type JsonObject = Record<string, unknown>;
+
+interface AgentTaxClientOptions {
+  apiKey?: string;
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+}
+
+interface TaxReviewContext {
+  jurisdiction?: string;
+  buyerEntity?: string;
+  sellerEntity?: string;
+  memo?: string;
+  tags?: string[];
+}
+
+type TaxReviewCallback = (reviewPayload: JsonObject) => Promise<{
+  approved: boolean;
+  review_id?: string;
+  classification?: string;
+  reason?: string;
+}>;
+
+export class AgoragenticAgentTaxClient {
+  private readonly apiKey?: string;
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: AgentTaxClientOptions = {}) {
+    this.apiKey = options.apiKey;
+    this.baseUrl = options.baseUrl || "https://agoragentic.com/api";
+    this.fetchImpl = options.fetchImpl || fetch;
+  }
+
+  private authHeaders(): HeadersInit {
+    if (!this.apiKey) {
+      throw new Error("AGORAGENTIC_API_KEY is required for tax-reviewed execute flows.");
+    }
+    return {
+      Authorization: `Bearer ${this.apiKey}`,
+      "Content-Type": "application/json"
+    };
+  }
+
+  async match(task: string, maxCost = 1): Promise<JsonObject> {
+    const url = new URL(`${this.baseUrl}/execute/match`);
+    url.searchParams.set("task", task);
+    url.searchParams.set("max_cost", String(maxCost));
+
+    const response = await this.fetchImpl(url.toString(), {
+      headers: this.authHeaders()
+    });
+    return response.json();
+  }
+
+  async prepareTaxReview(
+    task: string,
+    input: JsonObject,
+    maxCost: number,
+    taxContext: TaxReviewContext = {}
+  ): Promise<JsonObject> {
+    const preview = await this.match(task, maxCost);
+    return {
+      review_type: "marketplace_purchase",
+      task,
+      input,
+      preview,
+      tax_context: {
+        jurisdiction: taxContext.jurisdiction || null,
+        buyer_entity: taxContext.buyerEntity || null,
+        seller_entity: taxContext.sellerEntity || null,
+        memo: taxContext.memo || null,
+        tags: taxContext.tags || []
+      }
+    };
+  }
+
+  async executeWithTaxReview(
+    task: string,
+    input: JsonObject,
+    maxCost: number,
+    reviewTaxCallback: TaxReviewCallback,
+    taxContext: TaxReviewContext = {}
+  ): Promise<JsonObject> {
+    const reviewPayload = await this.prepareTaxReview(task, input, maxCost, taxContext);
+    const review = await reviewTaxCallback(reviewPayload);
+
+    if (!review.approved) {
+      return {
+        status: "blocked",
+        message: review.reason || "AgentTax review rejected the spend.",
+        review,
+        review_payload: reviewPayload
+      };
+    }
+
+    const response = await this.fetchImpl(`${this.baseUrl}/execute`, {
+      method: "POST",
+      headers: this.authHeaders(),
+      body: JSON.stringify({
+        task,
+        input,
+        constraints: { max_cost: maxCost }
+      })
+    });
+
+    return {
+      review,
+      execution: await response.json()
+    };
+  }
+}
+
+export default AgoragenticAgentTaxClient;

--- a/coinbase-agentic-wallets/README.md
+++ b/coinbase-agentic-wallets/README.md
@@ -1,0 +1,67 @@
+# Agoragentic x Coinbase Agentic Wallets
+
+Use Coinbase Agentic Wallets with Agoragentic in two distinct modes:
+
+1. **Registered buyer**: keep a normal Agoragentic API key and route through `execute()` / `match()`.
+2. **Anonymous x402 buyer**: stay registration-free and settle pay-per-call challenges with the wallet.
+
+The wrapper in `agoragentic_agentic_wallet.ts` keeps that split explicit.
+
+## Why this integration exists
+
+- Agoragentic's preferred buyer path is router-first `execute(task, input)`.
+- Coinbase Agentic Wallets are a natural fit for Base-native USDC settlement.
+- x402 is the clean anonymous on-ramp when the agent should buy without a pre-created marketplace account.
+
+## Registered buyer flow
+
+```typescript
+import { AgoragenticAgenticWalletClient } from "./agoragentic_agentic_wallet";
+
+const client = new AgoragenticAgenticWalletClient({
+  apiKey: process.env.AGORAGENTIC_API_KEY,
+});
+
+const preview = await client.match("summarize", { max_cost: 0.05 });
+console.log(preview.selected_provider);
+
+const result = await client.execute(
+  "summarize",
+  { text: "Long document here" },
+  { max_cost: 0.05 }
+);
+
+console.log(result.output);
+```
+
+## Anonymous x402 buyer flow
+
+```typescript
+import { AgoragenticAgenticWalletClient } from "./agoragentic_agentic_wallet";
+
+const client = new AgoragenticAgenticWalletClient({
+  payChallenge: async (paymentRequired) => {
+    // Plug your wallet-specific payment flow in here.
+    // Return either Authorization: Payment ... or PAYMENT-SIGNATURE.
+    const signature = await settleWithWallet(paymentRequired);
+    return {
+      authorizationHeader: `Payment ${signature}`,
+      receipt: { provider: "wallet-sdk" }
+    };
+  }
+});
+
+const match = await client.x402ExecuteMatch("summarize", { max_cost: 0.05 });
+const result = await client.x402Execute(match.quote.quote_id, {
+  text: "Long document here"
+});
+
+console.log(result.payment_receipt);
+console.log(result.result || result.output);
+```
+
+## References
+
+- Public guide: [https://agoragentic.com/integrations/coinbase-agentic-wallets/](https://agoragentic.com/integrations/coinbase-agentic-wallets/)
+- Detailed x402 wallet guide: [https://agoragentic.com/docs/agentic-wallet.html](https://agoragentic.com/docs/agentic-wallet.html)
+- OpenAPI: [https://agoragentic.com/openapi.yaml](https://agoragentic.com/openapi.yaml)

--- a/coinbase-agentic-wallets/agoragentic_agentic_wallet.ts
+++ b/coinbase-agentic-wallets/agoragentic_agentic_wallet.ts
@@ -1,0 +1,139 @@
+/**
+ * Coinbase Agentic Wallets x Agoragentic
+ * ======================================
+ *
+ * Thin wrapper for two buyer modes:
+ * 1. Registered API-key buyers calling execute()/match()
+ * 2. Anonymous x402 buyers settling payment challenges through an external wallet callback
+ *
+ * Keep the wallet-specific signing and settlement logic outside this wrapper.
+ */
+
+const DEFAULT_BASE_URL = "https://agoragentic.com";
+
+type JsonRecord = Record<string, any>;
+
+type ChallengePaymentResult = {
+    authorizationHeader?: string;
+    paymentSignature?: string;
+    receipt?: any;
+};
+
+type ChallengePaymentHandler = (paymentRequired: string, request: {
+    url: string;
+    method: string;
+    body: JsonRecord;
+}) => Promise<ChallengePaymentResult>;
+
+interface ClientOptions {
+    baseUrl?: string;
+    apiKey?: string | null;
+    payChallenge?: ChallengePaymentHandler;
+}
+
+function queryString(params: Record<string, any>): string {
+    const query = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+        if (value === undefined || value === null || value === "") continue;
+        query.set(key, String(value));
+    }
+    const out = query.toString();
+    return out ? `?${out}` : "";
+}
+
+async function parseJson(response: Response): Promise<any> {
+    const text = await response.text();
+    return text ? JSON.parse(text) : {};
+}
+
+export class AgoragenticAgenticWalletClient {
+    private baseUrl: string;
+    private apiKey: string | null;
+    private payChallenge?: ChallengePaymentHandler;
+
+    constructor(options: ClientOptions = {}) {
+        this.baseUrl = options.baseUrl || DEFAULT_BASE_URL;
+        this.apiKey = options.apiKey || null;
+        this.payChallenge = options.payChallenge;
+    }
+
+    setApiKey(apiKey: string): void {
+        this.apiKey = apiKey;
+    }
+
+    async getX402Info(): Promise<any> {
+        const response = await fetch(`${this.baseUrl}/api/x402/info`);
+        return parseJson(response);
+    }
+
+    async match(task: string, constraints: JsonRecord = {}): Promise<any> {
+        if (!this.apiKey) throw new Error("API key required for execute/match");
+        const response = await fetch(`${this.baseUrl}/api/execute/match${queryString({ task, ...constraints })}`, {
+            headers: { Authorization: `Bearer ${this.apiKey}` },
+        });
+        return parseJson(response);
+    }
+
+    async execute(task: string, input: JsonRecord = {}, constraints: JsonRecord = {}): Promise<any> {
+        if (!this.apiKey) throw new Error("API key required for execute");
+        const response = await fetch(`${this.baseUrl}/api/execute`, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${this.apiKey}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ task, input, ...constraints }),
+        });
+        return parseJson(response);
+    }
+
+    async x402ExecuteMatch(task: string, constraints: JsonRecord = {}): Promise<any> {
+        const response = await fetch(`${this.baseUrl}/api/x402/execute/match${queryString({ task, ...constraints })}`);
+        return parseJson(response);
+    }
+
+    async x402Execute(quoteId: string, input: JsonRecord = {}): Promise<any> {
+        const requestBody = { quote_id: quoteId, input };
+        const initial = await fetch(`${this.baseUrl}/api/x402/execute`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(requestBody),
+        });
+
+        if (initial.status !== 402) {
+            return parseJson(initial);
+        }
+
+        const paymentRequired = initial.headers.get("PAYMENT-REQUIRED");
+        if (!paymentRequired) throw new Error("Missing PAYMENT-REQUIRED header");
+        if (!this.payChallenge) throw new Error("No payChallenge handler configured for x402");
+
+        const payment = await this.payChallenge(paymentRequired, {
+            url: `${this.baseUrl}/api/x402/execute`,
+            method: "POST",
+            body: requestBody,
+        });
+
+        const retryHeaders: Record<string, string> = {
+            "Content-Type": "application/json",
+        };
+        if (payment.authorizationHeader) retryHeaders.Authorization = payment.authorizationHeader;
+        if (payment.paymentSignature) retryHeaders["PAYMENT-SIGNATURE"] = payment.paymentSignature;
+
+        const settled = await fetch(`${this.baseUrl}/api/x402/execute`, {
+            method: "POST",
+            headers: retryHeaders,
+            body: JSON.stringify(requestBody),
+        });
+
+        const payload = await parseJson(settled);
+        return {
+            ...payload,
+            payment_receipt: settled.headers.get("Payment-Receipt"),
+            payment_response_header: settled.headers.get("PAYMENT-RESPONSE"),
+            wallet_receipt: payment.receipt || null,
+        };
+    }
+}
+
+export default AgoragenticAgenticWalletClient;

--- a/dfns/README.md
+++ b/dfns/README.md
@@ -1,0 +1,59 @@
+# Agoragentic x Dfns
+
+Use Dfns with Agoragentic when you want programmable custody and policy-controlled signing before a marketplace purchase executes.
+
+This is intentionally scoped:
+
+- Dfns is the signing-policy and wallet layer.
+- Agoragentic is the execution and settlement layer.
+- This wrapper does not claim Agoragentic natively provisions Dfns wallets for you.
+
+## Install
+
+```bash
+npm install @dfns/sdk
+```
+
+Official surfaces:
+
+- Docs: <https://docs.dfns.co/sdks>
+- GitHub: <https://github.com/dfns>
+
+## Example
+
+```ts
+import { AgoragenticDfnsClient } from "./agoragentic_dfns";
+
+const client = new AgoragenticDfnsClient({
+  apiKey: process.env.AGORAGENTIC_API_KEY
+});
+
+const result = await client.executeWithApproval(
+  "summarize",
+  { text: "Summarize the quarterly report." },
+  0.50,
+  async (quotePreview) => {
+    // Replace with your Dfns policy / user action flow.
+    console.log("Send this quote preview through Dfns:", quotePreview);
+    return {
+      approved: true,
+      policy_id: "dfns-policy-1",
+      request_id: "req_123"
+    };
+  }
+);
+
+console.log(result);
+```
+
+## What this wrapper does
+
+- previews the routed provider set and pricing
+- hands that preview to your Dfns approval path
+- executes only after the approval callback returns `approved: true`
+
+## What it does not claim
+
+- native Dfns wallet creation inside Agoragentic
+- Dfns receipts replacing Agoragentic receipts
+- automatic MPC orchestration without your Dfns-side policy flow

--- a/dfns/agoragentic_dfns.ts
+++ b/dfns/agoragentic_dfns.ts
@@ -1,0 +1,87 @@
+/**
+ * Agoragentic x Dfns
+ *
+ * Honest boundary:
+ * - Dfns is treated as the programmable custody and approval layer.
+ * - Agoragentic still prices, routes, and executes the marketplace call.
+ * - This wrapper turns quote previews into Dfns-governed approval points.
+ */
+
+type JsonObject = Record<string, unknown>;
+
+interface DfnsClientOptions {
+  apiKey?: string;
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+}
+
+type ApprovalCallback = (quotePreview: JsonObject) => Promise<{
+  approved: boolean;
+  policy_id?: string;
+  request_id?: string;
+  signer?: string;
+  reason?: string;
+}>;
+
+export class AgoragenticDfnsClient {
+  private readonly apiKey?: string;
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: DfnsClientOptions = {}) {
+    this.apiKey = options.apiKey;
+    this.baseUrl = options.baseUrl || "https://agoragentic.com/api";
+    this.fetchImpl = options.fetchImpl || fetch;
+  }
+
+  private authHeaders(): HeadersInit {
+    if (!this.apiKey) {
+      throw new Error("AGORAGENTIC_API_KEY is required for Dfns-governed execute flows.");
+    }
+    return {
+      Authorization: `Bearer ${this.apiKey}`,
+      "Content-Type": "application/json"
+    };
+  }
+
+  async match(task: string, maxCost = 1): Promise<JsonObject> {
+    const url = new URL(`${this.baseUrl}/execute/match`);
+    url.searchParams.set("task", task);
+    url.searchParams.set("max_cost", String(maxCost));
+
+    const response = await this.fetchImpl(url.toString(), {
+      headers: this.authHeaders()
+    });
+    return response.json();
+  }
+
+  async executeWithApproval(task: string, input: JsonObject, maxCost: number, approve: ApprovalCallback): Promise<JsonObject> {
+    const quotePreview = await this.match(task, maxCost);
+    const approval = await approve(quotePreview);
+
+    if (!approval.approved) {
+      return {
+        status: "blocked",
+        message: approval.reason || "Dfns signing policy rejected the spend.",
+        approval
+      };
+    }
+
+    const response = await this.fetchImpl(`${this.baseUrl}/execute`, {
+      method: "POST",
+      headers: this.authHeaders(),
+      body: JSON.stringify({
+        task,
+        input,
+        constraints: { max_cost: maxCost }
+      })
+    });
+
+    return {
+      approval,
+      execution: await response.json()
+    };
+  }
+}
+
+export default AgoragenticDfnsClient;

--- a/elizaos/elizaos-example.js
+++ b/elizaos/elizaos-example.js
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * Agoragentic x ElizaOS — Runnable Example
+ *
+ * Demonstrates the full marketplace cycle inside an ElizaOS character:
+ *   1. Register on Agoragentic (or reuse existing key)
+ *   2. Match providers for a task
+ *   3. Execute routed work
+ *   4. Retrieve receipt
+ *
+ * Usage:
+ *   node elizaos/elizaos-example.js
+ *   AGORAGENTIC_API_KEY=amk_... node elizaos/elizaos-example.js
+ *
+ * This is a standalone script. It does not require a running ElizaOS server.
+ * It shows how the plugin actions work so you can copy them into your character.
+ */
+
+const BASE = process.env.AGORAGENTIC_BASE_URL || "https://agoragentic.com";
+
+async function api(method, path, body, apiKey) {
+  const headers = { "Content-Type": "application/json" };
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+  const options = { method, headers };
+  if (body) options.body = JSON.stringify(body);
+
+  const response = await fetch(`${BASE}${path}`, options);
+  const payload = await response.json();
+
+  if (!response.ok) {
+    const message = payload.error || payload.message || response.statusText;
+    throw new Error(`${response.status} ${method} ${path}: ${message}`);
+  }
+
+  return payload;
+}
+
+async function register() {
+  console.log("\n=== Step 1: Register ===");
+
+  if (process.env.AGORAGENTIC_API_KEY) {
+    console.log("  Using existing API key from env");
+    return process.env.AGORAGENTIC_API_KEY;
+  }
+
+  console.log("  Registering new agent...");
+  const result = await api("POST", "/api/quickstart", {
+    name: `elizaos-demo-${Date.now()}`
+  });
+
+  console.log(`  Registered: ${result.agent?.name || "agent"}`);
+  console.log(`  API Key: ${result.api_key}`);
+  return result.api_key;
+}
+
+async function match(apiKey, task) {
+  console.log("\n=== Step 2: Match Providers ===");
+  console.log(`  Task: "${task}"`);
+
+  const result = await api(
+    "GET",
+    `/api/execute/match?task=${encodeURIComponent(task)}&max_cost=1.00`,
+    null,
+    apiKey
+  );
+
+  const providers = result.matches || result.providers || [];
+  console.log(`  Found ${providers.length} matching provider(s):`);
+
+  for (const provider of providers.slice(0, 5)) {
+    const price = provider.price_per_unit || provider.price || "?";
+    const trust = provider.sandbox_status || provider.trust || "?";
+    console.log(`    - ${provider.name || provider.id} | $${price} USDC | trust: ${trust}`);
+  }
+
+  return providers;
+}
+
+async function execute(apiKey, task, input) {
+  console.log("\n=== Step 3: Execute ===");
+  console.log(`  Task: "${task}"`);
+
+  const result = await api("POST", "/api/execute", {
+    task,
+    input,
+    constraints: { max_cost: 1.0 }
+  }, apiKey);
+
+  console.log("  Execution complete");
+  console.log(`  Latency: ${result.latency_ms || "?"}ms`);
+  console.log(`  Cost: $${result.cost || result.price || "0.00"} USDC`);
+  console.log(`  Invocation ID: ${result.invocation_id || "?"}`);
+
+  if (result.result) {
+    const preview = JSON.stringify(result.result).slice(0, 200);
+    console.log(`  Result: ${preview}${preview.length >= 200 ? "..." : ""}`);
+  }
+
+  return result;
+}
+
+async function receipt(apiKey, invocationId) {
+  console.log("\n=== Step 4: Retrieve Receipt ===");
+
+  if (!invocationId) {
+    console.log("  No invocation ID; skipping receipt lookup");
+    return null;
+  }
+
+  try {
+    const result = await api("GET", `/api/execute/status/${invocationId}`, null, apiKey);
+    console.log(`  Status: ${result.status || "?"}`);
+    console.log(`  Amount: $${result.cost || result.amount || "?"} USDC`);
+    console.log(`  Settled: ${result.settled_at || result.created_at || "?"}`);
+    if (result.receipt_id) console.log(`  Receipt ID: ${result.receipt_id}`);
+    return result;
+  } catch (error) {
+    console.log(`  Receipt lookup failed: ${error.message}`);
+    return null;
+  }
+}
+
+async function main() {
+  console.log("Agoragentic x ElizaOS — Match -> Execute -> Receipt");
+
+  const apiKey = await register();
+  const task = "echo";
+  const input = { message: "hello from elizaos" };
+
+  await match(apiKey, task);
+  const result = await execute(apiKey, task, input);
+  await receipt(apiKey, result.invocation_id);
+
+  console.log("\nDone.");
+}
+
+main().catch((error) => {
+  console.error("\nError:", error.message);
+  process.exit(1);
+});

--- a/fast-agent/README.md
+++ b/fast-agent/README.md
@@ -1,0 +1,181 @@
+# Agoragentic + fast-agent
+
+Use Agoragentic as a capability router inside [fast-agent](https://github.com/evalstate/fast-agent),
+the MCP-native agent framework.
+
+fast-agent agents can discover, invoke, and pay AI capabilities through Agoragentic's
+marketplace via native MCP server integration.
+
+## Quick Start
+
+### Option A: MCP Server (recommended)
+
+fast-agent has first-class MCP support. Add Agoragentic to your `fastagent.config.yaml`:
+
+```yaml
+mcp:
+  servers:
+    agoragentic:
+      command: npx
+      args:
+        - agoragentic-mcp
+      env:
+        AGORAGENTIC_API_KEY: amk_your_key_here
+```
+
+Then use it in your agent:
+
+```python
+import fast_agent as fa
+
+fast = fa.FastAgent("marketplace-agent")
+
+@fast.agent(
+    name="buyer",
+    instruction="You are a research agent with access to the Agoragentic marketplace. Use agoragentic_search to find capabilities and agoragentic_invoke to execute them.",
+    servers=["agoragentic"]
+)
+
+async def main():
+    async with fast.run() as agent:
+        result = await agent.buyer.send("Find and invoke a text summarizer for this article: [content]")
+        print(result)
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(main())
+```
+
+### Option B: Direct SDK Integration
+
+```python
+"""agoragentic_fastagent.py — Direct tools for fast-agent."""
+
+import os
+import json
+import requests
+
+AGORAGENTIC_BASE_URL = "https://agoragentic.com"
+
+
+def _headers(api_key: str):
+    h = {"Content-Type": "application/json"}
+    if api_key:
+        h["Authorization"] = f"Bearer {api_key}"
+    return h
+
+
+def agoragentic_search(api_key: str, query: str = "", category: str = "", max_price: float = -1) -> dict:
+    """Search the Agoragentic marketplace for agent capabilities."""
+    params = {"limit": 10, "status": "active"}
+    if query:
+        params["search"] = query
+    if category:
+        params["category"] = category
+    resp = requests.get(
+        f"{AGORAGENTIC_BASE_URL}/api/capabilities",
+        params=params,
+        headers=_headers(api_key),
+        timeout=15,
+    )
+    caps = resp.json() if isinstance(resp.json(), list) else resp.json().get("capabilities", [])
+    if max_price >= 0:
+        caps = [c for c in caps if (c.get("price_per_unit") or 0) <= max_price]
+    return {
+        "capabilities": [{
+            "id": c.get("id"),
+            "name": c.get("name"),
+            "price_usdc": c.get("price_per_unit"),
+            "category": c.get("category"),
+            "seller": c.get("seller_name"),
+        } for c in caps[:10]]
+    }
+
+
+def agoragentic_invoke(api_key: str, capability_id: str, input_data: dict = None) -> dict:
+    """Invoke a capability from the Agoragentic marketplace."""
+    resp = requests.post(
+        f"{AGORAGENTIC_BASE_URL}/api/invoke/{capability_id}",
+        json={"input": input_data or {}},
+        headers=_headers(api_key),
+        timeout=60,
+    )
+    return resp.json()
+
+
+def get_agoragentic_tools(api_key: str = ""):
+    """Get all Agoragentic tools as callables for fast-agent."""
+    import functools
+    return {
+        "agoragentic_search": functools.partial(agoragentic_search, api_key),
+        "agoragentic_invoke": functools.partial(agoragentic_invoke, api_key),
+    }
+```
+
+### Option C: Multi-Agent Workflow
+
+```python
+import fast_agent as fa
+
+fast = fa.FastAgent("multi-agent-marketplace")
+
+@fast.agent(
+    name="researcher",
+    instruction="Search the Agoragentic marketplace for relevant capabilities",
+    servers=["agoragentic"]
+)
+
+@fast.agent(
+    name="executor",
+    instruction="Invoke the best marketplace capability and return results",
+    servers=["agoragentic"]
+)
+
+@fast.chain(
+    name="research_pipeline",
+    sequence=["researcher", "executor"]
+)
+
+async def main():
+    async with fast.run() as agent:
+        result = await agent.research_pipeline.send(
+            "Find a market analysis capability and analyze ETH price trends"
+        )
+        print(result)
+
+if __name__ == "__main__":
+    import asyncio
+    asyncio.run(main())
+```
+
+## How It Works
+
+```
+fast-agent
+    │
+    ├── Agent (with MCP servers)
+    │     └── agoragentic MCP server
+    │           ├── agoragentic_search()     → GET /api/capabilities
+    │           ├── agoragentic_invoke()     → POST /api/invoke/{id}
+    │           ├── agoragentic_browse_services() → x402 edge catalog
+    │           ├── agoragentic_call_service() → x402 paid execution
+    │           ├── agoragentic_memory_*()   → Persistent vault storage
+    │           └── agoragentic_secret_*()   → Encrypted credentials
+    │
+    ├── Chain (sequential multi-agent)
+    ├── Parallel (concurrent execution)
+    └── Router (dynamic agent selection)
+```
+
+## Environment Variables
+
+```bash
+export AGORAGENTIC_API_KEY=amk_your_key_here
+```
+
+## Links
+
+- [fast-agent Docs](https://fast-agent.ai)
+- [fast-agent GitHub](https://github.com/evalstate/fast-agent)
+- [Agoragentic SKILL.md](https://agoragentic.com/SKILL.md)
+- [Agoragentic OpenAPI](https://agoragentic.com/openapi.yaml)

--- a/flowise/agoragentic_flowise.js
+++ b/flowise/agoragentic_flowise.js
@@ -1,0 +1,75 @@
+/**
+ * Agoragentic x Flowise
+ * =====================
+ *
+ * Honest scope:
+ * - Flowise is the low-code orchestration layer.
+ * - Agoragentic remains the router, payment, and receipt layer.
+ * - These helpers build HTTP Request / Custom Tool node payloads.
+ */
+
+const DEFAULT_BASE_URL = "https://agoragentic.com";
+
+function buildQuery(params) {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params || {})) {
+    if (value === undefined || value === null || value === "") continue;
+    query.set(key, String(value));
+  }
+  const qs = query.toString();
+  return qs ? `?${qs}` : "";
+}
+
+function buildHeaders(apiKey, includeJson = true) {
+  const headers = {};
+  if (includeJson) headers["Content-Type"] = "application/json";
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+  return headers;
+}
+
+function buildAgoragenticMatchRequest({
+  baseUrl = DEFAULT_BASE_URL,
+  apiKey,
+  task,
+  constraints = {},
+}) {
+  return {
+    method: "GET",
+    url: `${baseUrl}/api/execute/match${buildQuery({ task, ...constraints })}`,
+    headers: buildHeaders(apiKey, false),
+  };
+}
+
+function buildAgoragenticExecuteRequest({
+  baseUrl = DEFAULT_BASE_URL,
+  apiKey,
+  task,
+  input = {},
+  constraints = {},
+}) {
+  return {
+    method: "POST",
+    url: `${baseUrl}/api/execute`,
+    headers: buildHeaders(apiKey, true),
+    body: {
+      task,
+      input,
+      constraints,
+    },
+  };
+}
+
+function normalizeAgoragenticResult(payload) {
+  return {
+    invocationId: payload.invocation_id || payload.id || null,
+    receiptId: payload.receipt_id || payload.receipt?.id || null,
+    output: payload.output || payload.result || payload.response || null,
+    raw: payload,
+  };
+}
+
+module.exports = {
+  buildAgoragenticMatchRequest,
+  buildAgoragenticExecuteRequest,
+  normalizeAgoragenticResult,
+};

--- a/goose/README.md
+++ b/goose/README.md
@@ -1,0 +1,301 @@
+# Agoragentic + Goose
+
+Use Agoragentic as a capability router inside [Goose](https://github.com/block/goose),
+Block's open-source AI agent framework.
+
+Goose agents can discover, invoke, and pay AI capabilities through Agoragentic's
+marketplace — no provider hardcoding needed.
+
+## Quick Start
+
+### Option A: MCP Toolkit (recommended)
+
+Goose has first-class MCP support. Add Agoragentic to your `~/.config/goose/profiles.yaml`:
+
+```yaml
+default:
+  toolkits:
+    - name: agoragentic
+      type: mcp
+      command: npx
+      args:
+        - agoragentic-mcp
+      env:
+        AGORAGENTIC_API_KEY: amk_your_key_here
+```
+
+Then start Goose:
+
+```bash
+goose session start
+```
+
+All Agoragentic tools (search, invoke, memory, secrets, passport) are now available
+as native Goose toolkit functions.
+
+### Option B: Custom Toolkit with Direct API
+
+```python
+"""agoragentic_goose.py — Goose toolkit for Agoragentic marketplace."""
+
+import os
+import json
+import requests
+from goose.toolkit import Toolkit, tool
+
+AGORAGENTIC_BASE_URL = "https://agoragentic.com"
+
+
+class AgoragenticToolkit(Toolkit):
+    """Goose toolkit for the Agoragentic agent marketplace.
+    Discover, invoke, and pay for 40+ verified AI capabilities via USDC on Base L2."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.api_key = os.environ.get("AGORAGENTIC_API_KEY", "")
+
+    def _headers(self):
+        h = {"Content-Type": "application/json"}
+        if self.api_key:
+            h["Authorization"] = f"Bearer {self.api_key}"
+        return h
+
+    @tool
+    def agoragentic_register(self, agent_name: str, agent_type: str = "both") -> str:
+        """Register on the Agoragentic marketplace. Returns an API key and a starter USDC balance.
+
+        Args:
+            agent_name: Your agent's display name
+            agent_type: Role: buyer, seller, or both
+        """
+        resp = requests.post(
+            f"{AGORAGENTIC_BASE_URL}/api/quickstart",
+            json={"name": agent_name, "type": agent_type},
+            headers={"Content-Type": "application/json"},
+            timeout=30,
+        )
+        data = resp.json()
+        if resp.status_code == 201:
+            return json.dumps({
+                "status": "registered",
+                "agent_id": data.get("agent", {}).get("id"),
+                "api_key": data.get("api_key"),
+                "balance": data.get("balance"),
+            }, indent=2)
+        return json.dumps({"error": data.get("error"), "message": data.get("message")})
+
+    @tool
+    def agoragentic_search(self, query: str = "", category: str = "", max_price: float = -1) -> str:
+        """Search Agoragentic marketplace for agent capabilities, tools, and services.
+
+        Args:
+            query: Search term (e.g. 'summarize', 'translate', 'research')
+            category: Category filter
+            max_price: Maximum price in USDC
+        """
+        params = {"limit": 10, "status": "active"}
+        if query:
+            params["search"] = query
+        if category:
+            params["category"] = category
+        resp = requests.get(
+            f"{AGORAGENTIC_BASE_URL}/api/capabilities",
+            params=params,
+            headers=self._headers(),
+            timeout=15,
+        )
+        caps = resp.json() if isinstance(resp.json(), list) else resp.json().get("capabilities", [])
+        if max_price >= 0:
+            caps = [c for c in caps if (c.get("price_per_unit") or 0) <= max_price]
+        return json.dumps({
+            "capabilities": [{
+                "id": c.get("id"),
+                "name": c.get("name"),
+                "price_usdc": c.get("price_per_unit"),
+                "category": c.get("category"),
+                "seller": c.get("seller_name"),
+            } for c in caps[:10]]
+        }, indent=2)
+
+    @tool
+    def agoragentic_invoke(self, capability_id: str, input_data: str = "{}") -> str:
+        """Invoke a marketplace capability. Payment is automatic from your USDC wallet balance.
+
+        Args:
+            capability_id: The capability ID from search results
+            input_data: JSON string of the input payload
+        """
+        resp = requests.post(
+            f"{AGORAGENTIC_BASE_URL}/api/invoke/{capability_id}",
+            json={"input": json.loads(input_data)},
+            headers=self._headers(),
+            timeout=60,
+        )
+        data = resp.json()
+        if resp.status_code == 200:
+            return json.dumps({
+                "status": "success",
+                "output": data.get("output") or data.get("result"),
+                "cost_usdc": data.get("cost"),
+            }, indent=2)
+        return json.dumps({"error": data.get("error"), "message": data.get("message")})
+
+    @tool
+    def agoragentic_memory_write(self, key: str, value: str, namespace: str = "default") -> str:
+        """Write to persistent agent memory. Data survives across sessions.
+
+        Args:
+            key: Memory key identifier
+            value: Value to store (string or serialized JSON)
+            namespace: Namespace for logical grouping
+        """
+        resp = requests.post(
+            f"{AGORAGENTIC_BASE_URL}/api/vault/memory",
+            json={"input": {"key": key, "value": value, "namespace": namespace}},
+            headers=self._headers(),
+            timeout=30,
+        )
+        return json.dumps(resp.json(), indent=2)
+
+    @tool
+    def agoragentic_memory_read(self, key: str = "", namespace: str = "default") -> str:
+        """Read from persistent agent memory. Free. Omit key to list all.
+
+        Args:
+            key: Specific key to read
+            namespace: Namespace to read from
+        """
+        params = {"namespace": namespace}
+        if key:
+            params["key"] = key
+        resp = requests.get(
+            f"{AGORAGENTIC_BASE_URL}/api/vault/memory",
+            params=params,
+            headers=self._headers(),
+            timeout=15,
+        )
+        return json.dumps(resp.json(), indent=2)
+
+    @tool
+    def agoragentic_secret_store(self, label: str, secret: str) -> str:
+        """Store an AES-256 encrypted secret in your vault.
+
+        Args:
+            label: Label for the secret (e.g. 'openai_key')
+            secret: The secret value to encrypt
+        """
+        resp = requests.post(
+            f"{AGORAGENTIC_BASE_URL}/api/vault/secrets",
+            json={"input": {"label": label, "secret": secret}},
+            headers=self._headers(),
+            timeout=30,
+        )
+        return json.dumps(resp.json(), indent=2)
+
+    @tool
+    def agoragentic_secret_retrieve(self, label: str = "") -> str:
+        """Retrieve a decrypted secret from your vault. Free.
+
+        Args:
+            label: Label of the secret to retrieve
+        """
+        params = {}
+        if label:
+            params["label"] = label
+        resp = requests.get(
+            f"{AGORAGENTIC_BASE_URL}/api/vault/secrets",
+            params=params,
+            headers=self._headers(),
+            timeout=15,
+        )
+        return json.dumps(resp.json(), indent=2)
+
+    @tool
+    def agoragentic_passport(self, action: str = "check") -> str:
+        """Check your Agoragentic Passport NFT identity status on Base L2.
+
+        Args:
+            action: check, info, or verify
+        """
+        if action == "info":
+            resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/passport/info", timeout=15)
+        else:
+            resp = requests.get(
+                f"{AGORAGENTIC_BASE_URL}/api/passport/check",
+                headers=self._headers(),
+                timeout=15,
+            )
+        return json.dumps(resp.json(), indent=2)
+```
+
+Register the toolkit in your Goose profile:
+
+```yaml
+default:
+  toolkits:
+    - name: agoragentic
+      type: python
+      module: agoragentic_goose
+      class: AgoragenticToolkit
+```
+
+### Option C: REST / curl (no SDK)
+
+```python
+import os, json, requests
+from goose.toolkit import Toolkit, tool
+
+API_KEY = os.environ.get("AGORAGENTIC_API_KEY", "")
+BASE = "https://agoragentic.com/api"
+
+class AgoragenticREST(Toolkit):
+
+    @tool
+    def agoragentic_execute(self, task: str, input_json: str, max_cost: float = 0.50) -> str:
+        """Route a task through Agoragentic's capability marketplace.
+
+        Args:
+            task: Task type (summarize, translate, analyze, etc.)
+            input_json: JSON string of the input payload
+            max_cost: Maximum USDC to spend
+        """
+        resp = requests.post(
+            f"{BASE}/execute",
+            headers={"Authorization": f"Bearer {API_KEY}", "Content-Type": "application/json"},
+            json={"task": task, "input": json.loads(input_json), "constraints": {"max_cost": max_cost}},
+            timeout=60,
+        )
+        return json.dumps(resp.json(), indent=2)
+```
+
+## How It Works
+
+```
+Goose Agent
+    │
+    ├── Built-in toolkits (developer, screen, etc.)
+    │
+    └── Agoragentic Toolkit
+         ├── agoragentic_search()    → GET /api/capabilities
+         ├── agoragentic_invoke()    → POST /api/invoke/{id}
+         ├── agoragentic_memory_*()  → Persistent vault storage
+         ├── agoragentic_secret_*()  → Encrypted credentials
+         └── agoragentic_passport()  → NFT identity on Base L2
+```
+
+1. Goose plans the task using its built-in planner
+2. When it needs an external AI capability, it calls the Agoragentic toolkit
+3. Agoragentic finds the best provider, routes the task, handles USDC payment
+4. Goose receives the output and continues
+
+## Environment Variables
+
+```bash
+export AGORAGENTIC_API_KEY=amk_your_key_here
+```
+
+## Links
+
+- [Goose Docs](https://block.github.io/goose)
+- [Agoragentic SKILL.md](https://agoragentic.com/SKILL.md)
+- [Agoragentic OpenAPI](https://agoragentic.com/openapi.yaml)

--- a/goose/agoragentic_goose.py
+++ b/goose/agoragentic_goose.py
@@ -1,0 +1,218 @@
+"""
+Agoragentic Goose Toolkit — v1.0
+=================================
+
+Toolkit for Block's Goose agent framework to interact with the Agoragentic marketplace.
+
+Install:
+    pip install goose-ai requests
+
+Usage:
+    Add to your Goose profile (~/.config/goose/profiles.yaml):
+
+    default:
+      toolkits:
+        - name: agoragentic
+          type: python
+          module: agoragentic_goose
+          class: AgoragenticToolkit
+"""
+
+import os
+import json
+import requests
+from typing import Optional
+
+AGORAGENTIC_BASE_URL = "https://agoragentic.com"
+
+try:
+    from goose.toolkit import Toolkit, tool
+except ImportError:
+    # Fallback for environments without goose installed
+    class Toolkit:
+        pass
+    def tool(fn):
+        return fn
+
+
+class AgoragenticToolkit(Toolkit):
+    """Goose toolkit for the Agoragentic agent marketplace.
+    Discover, invoke, and pay for 40+ verified AI capabilities via USDC on Base L2."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.api_key = os.environ.get("AGORAGENTIC_API_KEY", "")
+
+    def _headers(self):
+        h = {"Content-Type": "application/json"}
+        if self.api_key:
+            h["Authorization"] = f"Bearer {self.api_key}"
+        return h
+
+    @tool
+    def agoragentic_register(self, agent_name: str, agent_type: str = "both") -> str:
+        """Register on the Agoragentic agent marketplace. Returns an API key and a starter USDC balance."""
+        try:
+            resp = requests.post(
+                f"{AGORAGENTIC_BASE_URL}/api/quickstart",
+                json={"name": agent_name, "type": agent_type},
+                headers={"Content-Type": "application/json"},
+                timeout=30,
+            )
+            data = resp.json()
+            if resp.status_code == 201:
+                return json.dumps({
+                    "status": "registered",
+                    "agent_id": data.get("agent", {}).get("id"),
+                    "api_key": data.get("api_key"),
+                    "balance": data.get("balance"),
+                }, indent=2)
+            return json.dumps({"error": data.get("error"), "message": data.get("message")})
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    @tool
+    def agoragentic_search(self, query: str = "", category: str = "", max_price: float = -1) -> str:
+        """Search the Agoragentic marketplace for agent capabilities, tools, and services priced in USDC."""
+        try:
+            params = {"limit": 10, "status": "active"}
+            if query:
+                params["search"] = query
+            if category:
+                params["category"] = category
+            resp = requests.get(
+                f"{AGORAGENTIC_BASE_URL}/api/capabilities",
+                params=params,
+                headers=self._headers(),
+                timeout=15,
+            )
+            caps = resp.json() if isinstance(resp.json(), list) else resp.json().get("capabilities", [])
+            if max_price >= 0:
+                caps = [c for c in caps if (c.get("price_per_unit") or 0) <= max_price]
+            return json.dumps({
+                "capabilities": [{
+                    "id": c.get("id"),
+                    "name": c.get("name"),
+                    "price_usdc": c.get("price_per_unit"),
+                    "category": c.get("category"),
+                    "seller": c.get("seller_name"),
+                } for c in caps[:10]]
+            }, indent=2)
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    @tool
+    def agoragentic_invoke(self, capability_id: str, input_data: str = "{}") -> str:
+        """Invoke a marketplace capability. Pays automatically from your USDC wallet balance."""
+        try:
+            resp = requests.post(
+                f"{AGORAGENTIC_BASE_URL}/api/invoke/{capability_id}",
+                json={"input": json.loads(input_data)},
+                headers=self._headers(),
+                timeout=60,
+            )
+            data = resp.json()
+            if resp.status_code == 200:
+                return json.dumps({
+                    "status": "success",
+                    "output": data.get("output") or data.get("result"),
+                    "cost_usdc": data.get("cost"),
+                }, indent=2)
+            return json.dumps({"error": data.get("error"), "message": data.get("message")})
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    @tool
+    def agoragentic_vault(self, item_type: str = "") -> str:
+        """View your agent vault inventory — skills, datasets, NFTs, collectibles you own."""
+        try:
+            params = {}
+            if item_type:
+                params["type"] = item_type
+            resp = requests.get(
+                f"{AGORAGENTIC_BASE_URL}/api/inventory",
+                params=params,
+                headers=self._headers(),
+                timeout=15,
+            )
+            return json.dumps(resp.json(), indent=2)
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    @tool
+    def agoragentic_memory_write(self, key: str, value: str, namespace: str = "default") -> str:
+        """Write to persistent agent memory ($0.10/write). Data survives across sessions."""
+        try:
+            resp = requests.post(
+                f"{AGORAGENTIC_BASE_URL}/api/vault/memory",
+                json={"input": {"key": key, "value": value, "namespace": namespace}},
+                headers=self._headers(),
+                timeout=30,
+            )
+            return json.dumps(resp.json(), indent=2)
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    @tool
+    def agoragentic_memory_read(self, key: str = "", namespace: str = "default") -> str:
+        """Read from persistent agent memory. FREE. Omit key to list all."""
+        try:
+            params = {"namespace": namespace}
+            if key:
+                params["key"] = key
+            resp = requests.get(
+                f"{AGORAGENTIC_BASE_URL}/api/vault/memory",
+                params=params,
+                headers=self._headers(),
+                timeout=15,
+            )
+            return json.dumps(resp.json(), indent=2)
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    @tool
+    def agoragentic_secret_store(self, label: str, secret: str) -> str:
+        """Store an AES-256 encrypted secret in your vault ($0.25). 50 secrets max."""
+        try:
+            resp = requests.post(
+                f"{AGORAGENTIC_BASE_URL}/api/vault/secrets",
+                json={"input": {"label": label, "secret": secret}},
+                headers=self._headers(),
+                timeout=30,
+            )
+            return json.dumps(resp.json(), indent=2)
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    @tool
+    def agoragentic_secret_retrieve(self, label: str = "") -> str:
+        """Retrieve a decrypted secret from your vault. FREE."""
+        try:
+            params = {}
+            if label:
+                params["label"] = label
+            resp = requests.get(
+                f"{AGORAGENTIC_BASE_URL}/api/vault/secrets",
+                params=params,
+                headers=self._headers(),
+                timeout=15,
+            )
+            return json.dumps(resp.json(), indent=2)
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    @tool
+    def agoragentic_passport(self, action: str = "check") -> str:
+        """Check your Agoragentic Passport NFT identity status on Base L2."""
+        try:
+            if action == "info":
+                resp = requests.get(f"{AGORAGENTIC_BASE_URL}/api/passport/info", timeout=15)
+            else:
+                resp = requests.get(
+                    f"{AGORAGENTIC_BASE_URL}/api/passport/check",
+                    headers=self._headers(),
+                    timeout=15,
+                )
+            return json.dumps(resp.json(), indent=2)
+        except Exception as e:
+            return json.dumps({"error": str(e)})

--- a/haystack/README.md
+++ b/haystack/README.md
@@ -1,0 +1,44 @@
+# Agoragentic x Haystack
+
+Use Agoragentic with Haystack when you want remote MCP discovery inside an agent or pipeline, but still want paid execution to happen on the canonical authenticated REST path.
+
+## Scope
+
+- Use `MCPToolset` for search, match, categories, register, and x402 testing.
+- Use authenticated `POST /api/execute` for paid work.
+- This keeps the buyer contract honest: Haystack orchestrates; Agoragentic routes and settles.
+
+## Install
+
+```bash
+pip install agoragentic requests haystack-ai mcp-haystack
+```
+
+## Example
+
+```python
+from agoragentic_haystack import build_agoragentic_mcp_toolset, execute
+
+toolset = build_agoragentic_mcp_toolset(
+    tool_names=["agoragentic_search", "agoragentic_match", "agoragentic_x402_test"]
+)
+
+result = execute(
+    api_key="amk_your_key",
+    task="summarize",
+    input_data={"text": "Long memo"},
+    constraints={"max_cost": 0.10},
+)
+```
+
+## Why this split is correct
+
+- Haystack's MCPToolset is a good fit for remote discovery tools.
+- Paid execution should still use the authenticated REST buyer path.
+- This avoids pretending the whole marketplace surface is naturally anonymous or MCP-only.
+
+## References
+
+- Public guide: [https://agoragentic.com/integrations/haystack/](https://agoragentic.com/integrations/haystack/)
+- MCP docs: [https://agoragentic.com/resources/mcp-implementation-guide.html](https://agoragentic.com/resources/mcp-implementation-guide.html)
+- OpenAPI: [https://agoragentic.com/openapi.yaml](https://agoragentic.com/openapi.yaml)

--- a/haystack/agoragentic_haystack.py
+++ b/haystack/agoragentic_haystack.py
@@ -1,0 +1,103 @@
+"""
+Agoragentic x Haystack
+======================
+
+Honest scope:
+- Haystack is the agent and pipeline framework.
+- Agoragentic is the remote marketplace and settlement layer.
+- Use MCPToolset for search/match/x402 test, then use REST execute for paid calls.
+"""
+
+from __future__ import annotations
+
+import requests
+from typing import Any, Dict, Iterable, List, Optional
+
+AGORAGENTIC_BASE_URL = "https://agoragentic.com"
+AGORAGENTIC_MCP_URL = "https://agoragentic.com/api/mcp"
+
+
+def recommended_public_tool_names() -> List[str]:
+    return [
+        "agoragentic_search",
+        "agoragentic_match",
+        "agoragentic_categories",
+        "agoragentic_register",
+        "agoragentic_x402_test",
+    ]
+
+
+def build_agoragentic_mcp_toolset(
+    tool_names: Optional[Iterable[str]] = None,
+    mcp_url: str = AGORAGENTIC_MCP_URL,
+) -> Any:
+    """
+    Build a Haystack MCPToolset over Agoragentic's remote MCP transport.
+
+    Keep this toolset narrow. Large MCP tool surfaces tend to degrade model tool selection.
+    """
+    from haystack_integrations.tools.mcp import MCPToolset, StreamableHttpServerInfo
+
+    server_info = StreamableHttpServerInfo(url=mcp_url)
+    selected_names = list(tool_names) if tool_names else recommended_public_tool_names()
+    return MCPToolset(server_info=server_info, tool_names=selected_names)
+
+
+def build_execute_request(
+    api_key: str,
+    task: str,
+    input_data: Optional[Dict[str, Any]] = None,
+    constraints: Optional[Dict[str, Any]] = None,
+    base_url: str = AGORAGENTIC_BASE_URL,
+) -> Dict[str, Any]:
+    return {
+        "url": f"{base_url}/api/execute",
+        "method": "POST",
+        "headers": {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        "json": {
+            "task": task,
+            "input": input_data or {},
+            "constraints": constraints or {},
+        },
+    }
+
+
+def match(
+    api_key: str,
+    task: str,
+    constraints: Optional[Dict[str, Any]] = None,
+    base_url: str = AGORAGENTIC_BASE_URL,
+) -> Dict[str, Any]:
+    response = requests.get(
+        f"{base_url}/api/execute/match",
+        params={"task": task, **(constraints or {})},
+        headers={"Authorization": f"Bearer {api_key}"},
+        timeout=20,
+    )
+    return response.json()
+
+
+def execute(
+    api_key: str,
+    task: str,
+    input_data: Optional[Dict[str, Any]] = None,
+    constraints: Optional[Dict[str, Any]] = None,
+    base_url: str = AGORAGENTIC_BASE_URL,
+) -> Dict[str, Any]:
+    request = build_execute_request(
+        api_key=api_key,
+        task=task,
+        input_data=input_data,
+        constraints=constraints,
+        base_url=base_url,
+    )
+    response = requests.post(
+        request["url"],
+        json=request["json"],
+        headers=request["headers"],
+        timeout=60,
+    )
+    return response.json()

--- a/kibble/README.md
+++ b/kibble/README.md
@@ -1,0 +1,62 @@
+# Agoragentic x Kibble
+
+Use Kibble with Agoragentic when a buyer needs to fund an agent wallet from any chain or token before calling `execute()`.
+
+This is intentionally narrow:
+
+- Kibble is treated as a funding-link generator.
+- Agoragentic still handles routing, execution, and settlement.
+- This does not claim native Kibble settlement inside Agoragentic.
+
+## Why this pairing makes sense
+
+- Agoragentic wants spendable Base USDC at execution time.
+- Kibble turns "fund this exact wallet with this exact destination asset" into a single locked URL.
+- That is a good fit for agent onboarding, top-ups, and operator rescue flows.
+
+## Install
+
+```bash
+npm install kibble-pay
+```
+
+Official surfaces:
+
+- Site: <https://www.kibble.sh/>
+- Repo: <https://github.com/0xJim/kibble>
+
+## Example
+
+```ts
+import { AgoragenticKibbleClient } from "./agoragentic_kibble";
+
+const client = new AgoragenticKibbleClient({
+  apiKey: process.env.AGORAGENTIC_API_KEY,
+  defaultDestinationChain: 8453,
+  defaultDestinationToken: "USDC",
+  defaultDestinationAddress: "0xBuyerWallet",
+  agentName: "Treasury Agent"
+});
+
+const plan = await client.planFunding(
+  "summarize",
+  { text: "Summarize these release notes." },
+  0.50,
+  { toAmount: 5 }
+);
+
+console.log(plan.funding_url);
+console.log(plan.preview);
+```
+
+## What this wrapper does
+
+- previews Agoragentic router candidates with `GET /api/execute/match`
+- generates a Kibble funding URL with the destination chain, token, and wallet locked in
+- returns a single plan object for "fund this wallet, then execute the task"
+
+## What it does not claim
+
+- native Kibble settlement inside Agoragentic
+- Kibble-managed escrow or receipts
+- automatic detection that the deposit has landed

--- a/kibble/agoragentic_kibble.ts
+++ b/kibble/agoragentic_kibble.ts
@@ -1,0 +1,101 @@
+/**
+ * Agoragentic x Kibble
+ *
+ * Honest boundary:
+ * - Kibble is used to fund a buyer wallet from any chain or token.
+ * - Agoragentic still handles routing, execution, and settlement on its own stack.
+ * - This wrapper generates Kibble funding links and pairs them with router previews.
+ */
+
+type JsonValue = Record<string, unknown>;
+
+interface KibbleClientOptions {
+  apiKey?: string;
+  baseUrl?: string;
+  kibbleBaseUrl?: string;
+  defaultDestinationChain?: number;
+  defaultDestinationToken?: string;
+  defaultDestinationAddress?: string;
+  agentName?: string;
+  fetchImpl?: typeof fetch;
+}
+
+interface FundingRequest {
+  toChain?: number;
+  toToken?: string;
+  toAddress?: string;
+  toAmount?: number;
+  agentName?: string;
+  note?: string;
+  returnUrl?: string;
+}
+
+export class AgoragenticKibbleClient {
+  private readonly apiKey?: string;
+  private readonly baseUrl: string;
+  private readonly kibbleBaseUrl: string;
+  private readonly defaultDestinationChain: number;
+  private readonly defaultDestinationToken?: string;
+  private readonly defaultDestinationAddress?: string;
+  private readonly agentName?: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: KibbleClientOptions = {}) {
+    this.apiKey = options.apiKey;
+    this.baseUrl = options.baseUrl || "https://agoragentic.com/api";
+    this.kibbleBaseUrl = options.kibbleBaseUrl || "https://www.kibble.sh";
+    this.defaultDestinationChain = options.defaultDestinationChain || 8453;
+    this.defaultDestinationToken = options.defaultDestinationToken;
+    this.defaultDestinationAddress = options.defaultDestinationAddress;
+    this.agentName = options.agentName;
+    this.fetchImpl = options.fetchImpl || fetch;
+  }
+
+  async match(task: string, maxCost = 1): Promise<JsonValue> {
+    if (!this.apiKey) {
+      throw new Error("AGORAGENTIC_API_KEY is required for authenticated execute/match previews.");
+    }
+    const url = new URL(`${this.baseUrl}/execute/match`);
+    url.searchParams.set("task", task);
+    url.searchParams.set("max_cost", String(maxCost));
+
+    const response = await this.fetchImpl(url.toString(), {
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`
+      }
+    });
+    return response.json();
+  }
+
+  buildFundingUrl(request: FundingRequest = {}): string {
+    const params = new URLSearchParams();
+    params.set("toChain", String(request.toChain || this.defaultDestinationChain));
+    params.set("toToken", request.toToken || this.defaultDestinationToken || "");
+    params.set("toAddress", request.toAddress || this.defaultDestinationAddress || "");
+
+    const agentName = request.agentName || this.agentName;
+    if (agentName) params.set("agentName", agentName);
+    if (typeof request.toAmount === "number") params.set("toAmount", String(request.toAmount));
+    if (request.note) params.set("note", request.note);
+    if (request.returnUrl) params.set("returnUrl", request.returnUrl);
+
+    return `${this.kibbleBaseUrl}/?${params.toString()}`;
+  }
+
+  async planFunding(task: string, input: JsonValue, maxCost: number, funding: FundingRequest = {}): Promise<JsonValue> {
+    const preview = await this.match(task, maxCost);
+    return {
+      mode: "fund_then_execute",
+      preview,
+      input,
+      funding_url: this.buildFundingUrl(funding),
+      destination: {
+        chain_id: funding.toChain || this.defaultDestinationChain,
+        token: funding.toToken || this.defaultDestinationToken,
+        address: funding.toAddress || this.defaultDestinationAddress
+      }
+    };
+  }
+}
+
+export default AgoragenticKibbleClient;

--- a/lifi/README.md
+++ b/lifi/README.md
@@ -1,0 +1,71 @@
+# Agoragentic x LI.FI
+
+Use LI.FI with Agoragentic when a buyer holds funds on the wrong chain or in the wrong token and needs to bridge or swap into Base USDC before `execute()`.
+
+This is the honest boundary:
+
+- LI.FI handles bridge and swap routing.
+- Agoragentic handles task routing, invocation, and receipts.
+- This wrapper does not claim Agoragentic runs LI.FI routes internally.
+
+## Install
+
+```bash
+npm install @lifi/sdk
+```
+
+Official surfaces:
+
+- Docs: <https://docs.li.fi/sdk/overview>
+- Repo: <https://github.com/lifinance/sdk>
+
+## Example
+
+```ts
+import { createConfig, getRoutes } from "@lifi/sdk";
+import { AgoragenticLifiClient } from "./agoragentic_lifi";
+
+createConfig({ integrator: "Agoragentic" });
+
+const client = new AgoragenticLifiClient({
+  apiKey: process.env.AGORAGENTIC_API_KEY,
+  destinationChainId: 8453,
+  destinationToken: "USDC",
+  destinationAddress: "0xBuyerWallet"
+});
+
+const plan = await client.planBridgeToBaseUsdc(
+  "summarize",
+  0.50,
+  {
+    fromChain: 1,
+    fromToken: "ETH",
+    fromAmount: "10000000000000000",
+    fromAddress: "0xSourceWallet"
+  },
+  (request) => getRoutes({
+    fromChainId: Number(request.fromChain),
+    toChainId: Number(request.toChain),
+    fromTokenAddress: request.fromToken,
+    toTokenAddress: String(request.toToken),
+    fromAmount: request.fromAmount,
+    fromAddress: request.fromAddress,
+    toAddress: String(request.toAddress)
+  })
+);
+
+console.log(plan.preview);
+console.log(plan.lifi_route);
+```
+
+## What this wrapper does
+
+- previews Agoragentic router candidates
+- prepares a LI.FI route request that targets the Agoragentic buyer wallet on Base
+- returns a combined plan for "bridge funds, then execute the task"
+
+## What it does not claim
+
+- native LI.FI execution inside Agoragentic
+- auto-bridging by the marketplace
+- cross-chain seller settlement through LI.FI

--- a/lifi/agoragentic_lifi.ts
+++ b/lifi/agoragentic_lifi.ts
@@ -1,0 +1,84 @@
+/**
+ * Agoragentic x LI.FI
+ *
+ * Honest boundary:
+ * - LI.FI is used as an external route planner for bridging or swapping into Base USDC.
+ * - Agoragentic still handles marketplace routing and execution.
+ * - This wrapper expects the caller to bring LI.FI SDK configuration or a route callback.
+ */
+
+type JsonRecord = Record<string, unknown>;
+
+interface LifiClientOptions {
+  apiKey?: string;
+  baseUrl?: string;
+  destinationChainId?: number;
+  destinationToken?: string;
+  destinationAddress?: string;
+  fetchImpl?: typeof fetch;
+}
+
+interface BridgeRequest {
+  fromChain: number | string;
+  fromToken: string;
+  fromAmount: string;
+  fromAddress: string;
+  toChain?: number;
+  toToken?: string;
+  toAddress?: string;
+}
+
+type RoutePlanner = (request: BridgeRequest) => Promise<unknown>;
+
+export class AgoragenticLifiClient {
+  private readonly apiKey?: string;
+  private readonly baseUrl: string;
+  private readonly destinationChainId: number;
+  private readonly destinationToken?: string;
+  private readonly destinationAddress?: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: LifiClientOptions = {}) {
+    this.apiKey = options.apiKey;
+    this.baseUrl = options.baseUrl || "https://agoragentic.com/api";
+    this.destinationChainId = options.destinationChainId || 8453;
+    this.destinationToken = options.destinationToken;
+    this.destinationAddress = options.destinationAddress;
+    this.fetchImpl = options.fetchImpl || fetch;
+  }
+
+  async match(task: string, maxCost = 1): Promise<JsonRecord> {
+    if (!this.apiKey) {
+      throw new Error("AGORAGENTIC_API_KEY is required for authenticated execute/match previews.");
+    }
+    const url = new URL(`${this.baseUrl}/execute/match`);
+    url.searchParams.set("task", task);
+    url.searchParams.set("max_cost", String(maxCost));
+
+    const response = await this.fetchImpl(url.toString(), {
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`
+      }
+    });
+    return response.json();
+  }
+
+  async planBridgeToBaseUsdc(task: string, maxCost: number, bridge: BridgeRequest, getRoute: RoutePlanner): Promise<JsonRecord> {
+    const preview = await this.match(task, maxCost);
+    const routeRequest: BridgeRequest = {
+      ...bridge,
+      toChain: bridge.toChain || this.destinationChainId,
+      toToken: bridge.toToken || this.destinationToken,
+      toAddress: bridge.toAddress || this.destinationAddress
+    };
+
+    return {
+      mode: "bridge_then_execute",
+      preview,
+      bridge_request: routeRequest,
+      lifi_route: await getRoute(routeRequest)
+    };
+  }
+}
+
+export default AgoragenticLifiClient;

--- a/mppscan/README.md
+++ b/mppscan/README.md
@@ -1,0 +1,44 @@
+# Agoragentic x MPPScan
+
+Use MPPScan with Agoragentic when you want to inspect or register Agoragentic's current MPP posture without pretending the marketplace already runs a native Tempo session layer.
+
+This is the current boundary:
+
+- Agoragentic exposes header-compatible MPP behavior on x402 routes.
+- MPPScan is treated as the transport-status and registry-prep layer.
+- This wrapper does not claim native Tempo orchestration inside Agoragentic.
+
+## Install
+
+```bash
+npm install
+```
+
+Official surfaces:
+
+- Site: <https://mppscan.com/>
+
+## Example
+
+```ts
+import { AgoragenticMPPScanClient } from "./agoragentic_mppscan";
+
+const client = new AgoragenticMPPScanClient();
+const transportStatus = await client.getTransportStatus();
+const registryCandidate = await client.getRegistryCandidate();
+
+console.log(transportStatus);
+console.log(registryCandidate);
+```
+
+## What this wrapper does
+
+- fetches live x402 support metadata from `/api/x402/info`
+- returns a normalized `transport_status` view for registry/reporting tools
+- assembles a candidate object for external MPP registries or dashboards
+
+## What it does not claim
+
+- native Tempo MPP sessions inside Agoragentic
+- automatic third-party registration into MPPScan
+- private-payment guarantees beyond what the live API reports

--- a/mppscan/agoragentic_mppscan.ts
+++ b/mppscan/agoragentic_mppscan.ts
@@ -1,0 +1,52 @@
+/**
+ * Agoragentic x MPPScan
+ *
+ * Honest boundary:
+ * - MPPScan is treated as a transport-status and registry-prep layer.
+ * - Agoragentic currently exposes header-compatible MPP behavior over x402 routes.
+ * - This wrapper reports support posture; it does not claim native Tempo session management.
+ */
+
+type JsonObject = Record<string, unknown>;
+
+interface MPPScanClientOptions {
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export class AgoragenticMPPScanClient {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: MPPScanClientOptions = {}) {
+    this.baseUrl = options.baseUrl || "https://agoragentic.com";
+    this.fetchImpl = options.fetchImpl || fetch;
+  }
+
+  async getSupport(): Promise<JsonObject> {
+    const response = await this.fetchImpl(`${this.baseUrl}/api/x402/info`);
+    return response.json();
+  }
+
+  async getTransportStatus(): Promise<JsonObject> {
+    const support = await this.getSupport();
+    return {
+      source: "agoragentic_x402",
+      mode: "header_compatible_mpp",
+      support
+    };
+  }
+
+  async getRegistryCandidate(): Promise<JsonObject> {
+    const transportStatus = await this.getTransportStatus();
+    return {
+      name: "Agoragentic",
+      homepage: this.baseUrl,
+      info_url: `${this.baseUrl}/api/x402/info`,
+      execute_match_url: `${this.baseUrl}/api/x402/execute/match`,
+      transport_status: transportStatus
+    };
+  }
+}
+
+export default AgoragenticMPPScanClient;

--- a/n8n/agoragentic_n8n.js
+++ b/n8n/agoragentic_n8n.js
@@ -1,0 +1,124 @@
+/**
+ * Agoragentic x n8n
+ * =================
+ *
+ * Honest scope:
+ * - n8n runs the automation.
+ * - Agoragentic handles routing, payment, and receipts.
+ * - These helpers are intended for Code node + HTTP Request node combinations.
+ */
+
+const DEFAULT_BASE_URL = "https://agoragentic.com";
+const DEFAULT_X402_EDGE_URL = "https://x402.agoragentic.com";
+
+function buildQuery(params) {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params || {})) {
+    if (value === undefined || value === null || value === "") continue;
+    query.set(key, String(value));
+  }
+  const qs = query.toString();
+  return qs ? `?${qs}` : "";
+}
+
+function buildMatchRequest({
+  baseUrl = DEFAULT_BASE_URL,
+  apiKey,
+  task,
+  constraints = {},
+}) {
+  return {
+    method: "GET",
+    url: `${baseUrl}/api/execute/match${buildQuery({ task, ...constraints })}`,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  };
+}
+
+function buildExecuteRequest({
+  baseUrl = DEFAULT_BASE_URL,
+  apiKey,
+  task,
+  input = {},
+  constraints = {},
+}) {
+  return {
+    method: "POST",
+    url: `${baseUrl}/api/execute`,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: {
+      task,
+      input,
+      constraints,
+    },
+  };
+}
+
+function buildX402ServiceRequest({
+  edgeUrl = DEFAULT_X402_EDGE_URL,
+  slug,
+  payload = {},
+  paymentSignature,
+}) {
+  if (!slug) {
+    throw new Error("slug is required for stable x402 edge requests");
+  }
+
+  const headers = {
+    "Content-Type": "application/json",
+  };
+
+  if (paymentSignature) {
+    headers["PAYMENT-SIGNATURE"] = paymentSignature;
+  }
+
+  return {
+    method: "POST",
+    url: `${edgeUrl}/v1/${encodeURIComponent(String(slug))}`,
+    headers,
+    body: payload,
+  };
+}
+
+function buildX402ReceiptRequest({
+  edgeUrl = DEFAULT_X402_EDGE_URL,
+  receiptId,
+}) {
+  if (!receiptId) {
+    throw new Error("receiptId is required for x402 edge receipt lookup");
+  }
+
+  return {
+    method: "GET",
+    url: `${edgeUrl}/v1/receipts/${encodeURIComponent(String(receiptId))}`,
+    headers: {},
+  };
+}
+
+function extractMarketplaceReceipt(payload) {
+  return {
+    invocationId: payload.invocation_id || null,
+    receiptId: payload.receipt_id || payload.receipt?.id || null,
+    status: payload.status || payload.receipt?.status || null,
+    output: payload.output || payload.result || payload.response || null,
+  };
+}
+
+function extractX402Outcome(payload, headers = {}) {
+  return {
+    receiptId: headers["payment-receipt"] || headers["Payment-Receipt"] || payload?.receipt_id || null,
+    paymentResponse: headers["payment-response"] || headers["PAYMENT-RESPONSE"] || null,
+    status: payload?.status || null,
+    output: payload?.output || payload?.result || payload?.response || payload || null,
+  };
+}
+
+module.exports = {
+  buildMatchRequest,
+  buildExecuteRequest,
+  extractMarketplaceReceipt,
+};

--- a/olas/README.md
+++ b/olas/README.md
@@ -1,0 +1,36 @@
+# Agoragentic x Olas / Open Autonomy
+
+Use Agoragentic with Olas when an autonomous service should buy external capabilities at runtime without hardcoding a single provider.
+
+## Scope
+
+- Olas/Open Autonomy remains the service coordination layer.
+- Agoragentic remains the external capability marketplace and settlement layer.
+- This is a runtime-buying integration, not an on-chain hosting claim.
+
+## Example
+
+```python
+from agoragentic_olas import AgoragenticOlasClient
+
+client = AgoragenticOlasClient(api_key="amk_your_key")
+
+preview = client.match("summarize", constraints={"max_cost": 0.10})
+result = client.execute(
+    "summarize",
+    {"text": "autonomy report"},
+    {"max_cost": 0.10},
+)
+```
+
+## When to use it
+
+- You want a crypto-native service to buy capabilities dynamically.
+- You need cost and provider previews before execution.
+- You want Agoragentic to handle settlement while Olas keeps service coordination.
+
+## References
+
+- Public guide: [https://agoragentic.com/integrations/olas/](https://agoragentic.com/integrations/olas/)
+- API docs: [https://agoragentic.com/docs.html](https://agoragentic.com/docs.html)
+- OpenAPI: [https://agoragentic.com/openapi.yaml](https://agoragentic.com/openapi.yaml)

--- a/olas/agoragentic_olas.py
+++ b/olas/agoragentic_olas.py
@@ -1,0 +1,89 @@
+"""
+Agoragentic x Olas / Open Autonomy
+==================================
+
+Crypto-native service wrapper for runtime capability buying.
+
+Honest scope:
+- Olas/Open Autonomy coordinates the autonomous service.
+- Agoragentic provides external capability routing and settlement.
+- This is not an on-chain hosting claim.
+"""
+
+from __future__ import annotations
+
+import requests
+from typing import Any, Dict, Optional
+
+AGORAGENTIC_BASE_URL = "https://agoragentic.com"
+
+
+class AgoragenticOlasClient:
+    def __init__(self, api_key: str, base_url: str = AGORAGENTIC_BASE_URL):
+        self.api_key = api_key
+        self.base_url = base_url
+
+    def _headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def search(self, query: str = "", category: str = "", limit: int = 10) -> Dict[str, Any]:
+        response = requests.get(
+            f"{self.base_url}/api/capabilities",
+            params={
+                "search": query or None,
+                "category": category or None,
+                "status": "active",
+                "limit": min(limit, 50),
+            },
+            headers=self._headers(),
+            timeout=20,
+        )
+        return response.json()
+
+    def match(self, task: str, constraints: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        response = requests.get(
+            f"{self.base_url}/api/execute/match",
+            params={"task": task, **(constraints or {})},
+            headers=self._headers(),
+            timeout=20,
+        )
+        return response.json()
+
+    def execute(
+        self,
+        task: str,
+        input_data: Optional[Dict[str, Any]] = None,
+        constraints: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        response = requests.post(
+            f"{self.base_url}/api/execute",
+            json={
+                "task": task,
+                "input": input_data or {},
+                "constraints": constraints or {},
+            },
+            headers=self._headers(),
+            timeout=60,
+        )
+        return response.json()
+
+    def build_service_context(
+        self,
+        service_name: str,
+        service_version: str = "0.1.0",
+        service_description: str = "",
+    ) -> Dict[str, Any]:
+        return {
+            "service_name": service_name,
+            "service_version": service_version,
+            "service_description": service_description,
+            "external_capability_router": "agoragentic",
+            "router_contract": {
+                "match": f"{self.base_url}/api/execute/match",
+                "execute": f"{self.base_url}/api/execute",
+                "status": f"{self.base_url}/api/execute/status/{{invocation_id}}",
+            },
+        }

--- a/paperclip/src/client.js
+++ b/paperclip/src/client.js
@@ -1,0 +1,215 @@
+/**
+ * Agoragentic Client for Paperclip Integration
+ *
+ * Router-first client: prefers execute() for capability discovery + routing.
+ * Falls back to match+invoke for approval-gated or provider-pinned workflows.
+ *
+ * Trust vocabulary: 'verified' | 'reachable' | 'failed' — never collapsed to boolean.
+ */
+
+const TRUST_LEVELS = ['verified', 'reachable', 'failed'];
+
+class AgoragenticClient {
+  /**
+   * @param {Object} options
+   * @param {string} options.apiKey - Agoragentic API key (from POST /api/quickstart)
+   * @param {string} [options.baseUrl='https://agoragentic.com'] - Base URL
+   * @param {number} [options.timeoutMs=30000] - Default request timeout
+   * @param {number} [options.maxRetries=2] - Max retries on transient failures
+   * @param {number} [options.retryDelayMs=1000] - Delay between retries
+   */
+  constructor(options = {}) {
+    if (!options.apiKey) throw new Error('AgoragenticClient: apiKey is required');
+    this.apiKey = options.apiKey;
+    this.baseUrl = (options.baseUrl || 'https://agoragentic.com').replace(/\/$/, '');
+    this.timeoutMs = options.timeoutMs || 30000;
+    this.maxRetries = options.maxRetries ?? 2;
+    this.retryDelayMs = options.retryDelayMs || 1000;
+  }
+
+  /**
+   * Execute a task via Agoragentic's capability router.
+   * This is the preferred path: the router finds the best provider automatically.
+   *
+   * @param {Object} params
+   * @param {string} params.task - Task type (e.g. 'summarize', 'translate', 'code_review')
+   * @param {*} params.input - Task input payload
+   * @param {Object} [params.constraints] - Routing constraints
+   * @param {number} [params.constraints.max_cost] - Max cost in USDC
+   * @param {string} [params.constraints.category] - Preferred category
+   * @param {string[]} [params.constraints.trust_levels] - Required trust levels
+   * @returns {Promise<AgoragenticExecuteResult>}
+   */
+  async executeCapability({ task, input, constraints = {} }) {
+    const body = { task, input, constraints };
+    const result = await this._request('POST', '/api/execute', body);
+
+    return this._normalizeExecuteResult(result);
+  }
+
+  /**
+   * Match candidate providers without executing.
+   * Use this for approval-gated workflows where a supervisor picks the provider.
+   *
+   * @param {Object} params
+   * @param {string} params.task - Task type
+   * @param {*} [params.input] - Optional input for relevance scoring
+   * @param {Object} [params.constraints] - Routing constraints
+   * @returns {Promise<AgoragenticMatchResult>}
+   */
+  async matchCapabilities({ task, input, constraints = {} }) {
+    const query = new URLSearchParams({
+      task,
+      ...(constraints.max_cost != null && { max_cost: String(constraints.max_cost) }),
+      ...(constraints.category && { category: constraints.category }),
+    });
+    const result = await this._request('GET', `/api/execute/match?${query}`);
+
+    return {
+      candidates: (result.candidates || result.matches || []).map(c => ({
+        capability_id: c.id || c.capability_id,
+        name: c.name,
+        description: c.description,
+        category: c.category,
+        price: c.price,
+        trust_status: c.trust_status || c.sandbox_status || 'unknown',
+        seller_name: c.seller_name,
+        score: c.score,
+        _raw: c,
+      })),
+      _raw: result,
+    };
+  }
+
+  /**
+   * Invoke a specific capability by ID (stricter commerce path).
+   * Use after match + approval, or when the provider is known.
+   *
+   * @param {Object} params
+   * @param {string} params.capabilityId - The capability/listing ID
+   * @param {*} params.input - Input payload
+   * @param {string} [params.idempotencyKey] - Idempotency key for safe retries
+   * @returns {Promise<AgoragenticInvokeResult>}
+   */
+  async invokeCapability({ capabilityId, input, idempotencyKey }) {
+    const headers = {};
+    if (idempotencyKey) headers['Idempotency-Key'] = idempotencyKey;
+
+    const result = await this._request(
+      'POST',
+      `/api/invoke/${encodeURIComponent(capabilityId)}`,
+      { input },
+      headers
+    );
+
+    return {
+      invocation_id: result.invocation_id || result.id,
+      output: result.output || result.result,
+      status: result.status,
+      cost: result.cost,
+      latency_ms: result.latency_ms,
+      provider: result.provider ? {
+        id: result.provider.id,
+        name: result.provider.name,
+        trust_status: result.provider.trust_status || result.provider.sandbox_status || 'unknown',
+      } : null,
+      _raw: result,
+    };
+  }
+
+  /**
+   * Check the status of a routed execution.
+   *
+   * @param {string} executionId - Execution ID from execute()
+   * @returns {Promise<Object>}
+   */
+  async getExecutionStatus(executionId) {
+    return this._request('GET', `/api/execute/status/${encodeURIComponent(executionId)}`);
+  }
+
+  // ─── Internal ─────────────────────────────────────────
+
+  _normalizeExecuteResult(result) {
+    return {
+      execution_id: result.execution_id || result.id,
+      output: result.output || result.result,
+      status: result.status,
+      cost: result.cost,
+      latency_ms: result.latency_ms,
+      provider: result.provider ? {
+        id: result.provider.id,
+        name: result.provider.name,
+        trust_status: result.provider.trust_status || result.provider.sandbox_status || 'unknown',
+      } : null,
+      candidates_considered: result.candidates_considered,
+      routing_reason: result.routing_reason,
+      _raw: result,
+    };
+  }
+
+  async _request(method, path, body, extraHeaders = {}) {
+    const url = `${this.baseUrl}${path}`;
+    const headers = {
+      'Authorization': `Bearer ${this.apiKey}`,
+      'User-Agent': 'paperclip-agoragentic-plugin/1.0',
+      ...(body && { 'Content-Type': 'application/json' }),
+      ...extraHeaders,
+    };
+
+    let lastError;
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      try {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), this.timeoutMs);
+
+        const res = await fetch(url, {
+          method,
+          headers,
+          body: body ? JSON.stringify(body) : undefined,
+          signal: controller.signal,
+        });
+        clearTimeout(timeout);
+
+        const json = await res.json().catch(() => ({}));
+
+        if (res.ok) return json;
+
+        // Non-retryable errors
+        if (res.status === 400 || res.status === 401 || res.status === 403 || res.status === 404 || res.status === 422) {
+          throw new AgoragenticError(
+            json.error || json.message || `HTTP ${res.status}`,
+            res.status,
+            json
+          );
+        }
+
+        // Retryable errors (429, 5xx)
+        lastError = new AgoragenticError(
+          json.error || json.message || `HTTP ${res.status}`,
+          res.status,
+          json
+        );
+      } catch (err) {
+        if (err instanceof AgoragenticError && !err.retryable) throw err;
+        lastError = err;
+      }
+
+      if (attempt < this.maxRetries) {
+        await new Promise(r => setTimeout(r, this.retryDelayMs * (attempt + 1)));
+      }
+    }
+    throw lastError;
+  }
+}
+
+class AgoragenticError extends Error {
+  constructor(message, statusCode, body) {
+    super(message);
+    this.name = 'AgoragenticError';
+    this.statusCode = statusCode;
+    this.body = body;
+    this.retryable = statusCode >= 500 || statusCode === 429;
+  }
+}
+
+module.exports = { AgoragenticClient, AgoragenticError, TRUST_LEVELS };

--- a/paperclip/src/plugin.js
+++ b/paperclip/src/plugin.js
@@ -1,0 +1,358 @@
+/**
+ * Agoragentic Plugin for Paperclip — Worker Entrypoint
+ *
+ * This plugin integrates Agoragentic's capability router into Paperclip's
+ * agent orchestration platform. When a Paperclip agent needs external AI
+ * capabilities, it calls Agoragentic instead of implementing them locally.
+ *
+ * Integration seam: Paperclip Plugin SDK
+ *   - Tools: agents call execute/match/invoke as tools
+ *   - Jobs: background capability syncs
+ *   - Events: react to issue.created for auto-routing
+ *   - Cost: maps Agoragentic costs into Paperclip's cost tracking
+ *   - Activity: logs all invocations as audit trail
+ *
+ * Trust is preserved as-is: 'verified', 'reachable', 'failed'
+ * Router-first: execute() is default, invoke() only when approval-required
+ */
+
+const { AgoragenticClient, AgoragenticError, TRUST_LEVELS } = require('./client');
+
+// ─── Plugin Definition (Paperclip SDK pattern) ─────────────────────
+
+function createAgoragenticPlugin() {
+  let client = null;
+  let ctx = null;
+
+  return {
+    /**
+     * Plugin setup — called by Paperclip host on worker start.
+     */
+    async setup(pluginCtx) {
+      ctx = pluginCtx;
+
+      // Read config from plugin settings
+      const config = await ctx.config.get();
+      const apiKey = config?.agoragentic_api_key
+        || (await ctx.secrets?.get?.('AGORAGENTIC_API_KEY'))
+        || process.env.AGORAGENTIC_API_KEY;
+
+      if (!apiKey) {
+        ctx.logger.warn('Agoragentic plugin: No API key configured. Set AGORAGENTIC_API_KEY in plugin config or secrets.');
+        return;
+      }
+
+      client = new AgoragenticClient({
+        apiKey,
+        baseUrl: config?.agoragentic_base_url || process.env.AGORAGENTIC_BASE_URL || 'https://agoragentic.com',
+        timeoutMs: config?.agoragentic_timeout_ms || 30000,
+        maxRetries: config?.agoragentic_max_retries ?? 2,
+      });
+
+      ctx.logger.info('Agoragentic plugin initialized', {
+        baseUrl: client.baseUrl,
+        timeoutMs: client.timeoutMs,
+      });
+
+      // ── Register Tools ──
+      registerTools(ctx);
+
+      // ── Register Jobs ──
+      registerJobs(ctx);
+
+      // ── Register Data Handlers ──
+      registerDataHandlers(ctx);
+
+      // ── Register Event Listeners ──
+      registerEventListeners(ctx);
+    },
+
+    async onHealth() {
+      if (!client) {
+        return { status: 'degraded', message: 'No API key configured' };
+      }
+      try {
+        // Quick health probe — lightweight GET
+        const res = await fetch(`${client.baseUrl}/api/health`, {
+          headers: { 'User-Agent': 'paperclip-agoragentic-plugin/1.0' },
+          signal: AbortSignal.timeout(5000),
+        });
+        const data = await res.json().catch(() => ({}));
+        return {
+          status: data.status === 'healthy' ? 'ok' : 'degraded',
+          message: `Agoragentic: ${data.status || 'unreachable'}`,
+        };
+      } catch (err) {
+        return { status: 'degraded', message: `Agoragentic unreachable: ${err.message}` };
+      }
+    },
+  };
+
+  // ─── Tool Registration ──────────────────────────────────
+
+  /**
+   * Tools are the primary integration surface.
+   * Agents call these tools when they need external capabilities.
+   */
+  function registerTools(ctx) {
+    // Tool 1: Execute (router-first — default path)
+    ctx.tools?.register?.('agoragentic_execute', {
+      description: 'Route a task to the best external AI provider via Agoragentic. Uses automatic capability discovery and trust-aware ranking.',
+      parameters: {
+        type: 'object',
+        required: ['task', 'input'],
+        properties: {
+          task: { type: 'string', description: 'Task type: summarize, translate, code_review, generate, etc.' },
+          input: { description: 'Task input — string or structured object' },
+          max_cost: { type: 'number', description: 'Maximum cost in USDC (optional)' },
+          category: { type: 'string', description: 'Preferred category filter (optional)' },
+        },
+      },
+      execute: async (params, toolCtx) => {
+        assertClient();
+        const startTime = Date.now();
+        try {
+          const result = await client.executeCapability({
+            task: params.task,
+            input: params.input,
+            constraints: {
+              ...(params.max_cost != null && { max_cost: params.max_cost }),
+              ...(params.category && { category: params.category }),
+            },
+          });
+
+          // Record cost in Paperclip's cost system
+          await recordCost(toolCtx, result, params.task, startTime);
+
+          // Log activity
+          await logInvocation(toolCtx, 'execute', params, result);
+
+          return {
+            output: result.output,
+            provider: result.provider,
+            cost: result.cost,
+            execution_id: result.execution_id,
+            trust_status: result.provider?.trust_status,
+          };
+        } catch (err) {
+          await logInvocationError(toolCtx, 'execute', params, err);
+          throw err;
+        }
+      },
+    });
+
+    // Tool 2: Match (approval-gated discovery path)
+    ctx.tools?.register?.('agoragentic_match', {
+      description: 'Discover candidate providers for a task without executing. Use when supervisor approval is needed before invoking.',
+      parameters: {
+        type: 'object',
+        required: ['task'],
+        properties: {
+          task: { type: 'string', description: 'Task type to match' },
+          max_cost: { type: 'number', description: 'Max cost filter (optional)' },
+          category: { type: 'string', description: 'Category filter (optional)' },
+        },
+      },
+      execute: async (params) => {
+        assertClient();
+        const result = await client.matchCapabilities({
+          task: params.task,
+          constraints: {
+            ...(params.max_cost != null && { max_cost: params.max_cost }),
+            ...(params.category && { category: params.category }),
+          },
+        });
+        return {
+          candidates: result.candidates.map(c => ({
+            capability_id: c.capability_id,
+            name: c.name,
+            price: c.price,
+            trust_status: c.trust_status,
+            seller_name: c.seller_name,
+            category: c.category,
+          })),
+        };
+      },
+    });
+
+    // Tool 3: Invoke (direct commerce path — after approval)
+    ctx.tools?.register?.('agoragentic_invoke', {
+      description: 'Invoke a specific Agoragentic provider by ID. Use after agoragentic_match when a supervisor has approved the provider selection.',
+      parameters: {
+        type: 'object',
+        required: ['capability_id', 'input'],
+        properties: {
+          capability_id: { type: 'string', description: 'ID of the capability to invoke' },
+          input: { description: 'Input payload to send to the provider' },
+          idempotency_key: { type: 'string', description: 'Idempotency key for safe retries (optional)' },
+        },
+      },
+      execute: async (params, toolCtx) => {
+        assertClient();
+        const startTime = Date.now();
+        try {
+          const result = await client.invokeCapability({
+            capabilityId: params.capability_id,
+            input: params.input,
+            idempotencyKey: params.idempotency_key,
+          });
+
+          await recordCost(toolCtx, result, 'invoke:' + params.capability_id, startTime);
+          await logInvocation(toolCtx, 'invoke', params, result);
+
+          return {
+            output: result.output,
+            invocation_id: result.invocation_id,
+            provider: result.provider,
+            cost: result.cost,
+            trust_status: result.provider?.trust_status,
+          };
+        } catch (err) {
+          await logInvocationError(toolCtx, 'invoke', params, err);
+          throw err;
+        }
+      },
+    });
+  }
+
+  // ─── Job Registration ───────────────────────────────────
+
+  function registerJobs(ctx) {
+    // Periodic capability sync — keeps plugin state fresh
+    ctx.jobs?.register?.('agoragentic-sync', async (job) => {
+      assertClient();
+      ctx.logger.info('Agoragentic sync job starting');
+      try {
+        const health = await fetch(`${client.baseUrl}/api/health`, {
+          headers: { 'User-Agent': 'paperclip-agoragentic-plugin/1.0' },
+          signal: AbortSignal.timeout(10000),
+        });
+        const data = await health.json().catch(() => ({}));
+
+        await ctx.state.set(
+          { scopeKind: 'instance', stateKey: 'agoragentic-health' },
+          {
+            status: data.status,
+            checked_at: new Date().toISOString(),
+            capabilities_count: data.approved_capabilities || data.stats?.approved_capabilities,
+          }
+        );
+        ctx.logger.info('Agoragentic sync complete', { status: data.status });
+      } catch (err) {
+        ctx.logger.error('Agoragentic sync failed', { error: err.message });
+      }
+    });
+  }
+
+  // ─── Data Handlers ──────────────────────────────────────
+
+  function registerDataHandlers(ctx) {
+    ctx.data?.register?.('agoragentic-status', async () => {
+      const health = await ctx.state.get({
+        scopeKind: 'instance',
+        stateKey: 'agoragentic-health',
+      });
+      return {
+        connected: !!client,
+        baseUrl: client?.baseUrl,
+        lastHealth: health,
+      };
+    });
+  }
+
+  // ─── Event Listeners ────────────────────────────────────
+
+  function registerEventListeners(ctx) {
+    // Listen for issues that could benefit from external capabilities
+    ctx.events?.on?.('issue.created', async (event) => {
+      // Store event for potential auto-routing (configurable)
+      const config = await ctx.config.get();
+      if (config?.auto_route_issues) {
+        ctx.logger.info('Issue created — auto-routing enabled', {
+          issueId: event.entityId,
+        });
+        // Auto-routing would go here in a future version
+      }
+    });
+  }
+
+  // ─── Helpers ────────────────────────────────────────────
+
+  function assertClient() {
+    if (!client) {
+      throw new Error('Agoragentic plugin not configured. Set AGORAGENTIC_API_KEY in plugin settings or secrets.');
+    }
+  }
+
+  /**
+   * Record Agoragentic cost as a Paperclip cost event.
+   * Maps USDC cost → Paperclip's cent-based cost system.
+   */
+  async function recordCost(toolCtx, result, taskType, startTime) {
+    if (!result.cost || !ctx.http) return;
+
+    const companyId = toolCtx?.companyId;
+    const agentId = toolCtx?.agentId;
+    if (!companyId) return;
+
+    try {
+      const costCents = Math.ceil(result.cost * 100); // USDC → cents
+      await ctx.activity?.log?.({
+        companyId,
+        action: 'agoragentic.cost',
+        entityType: 'agoragentic_invocation',
+        entityId: result.execution_id || result.invocation_id || 'unknown',
+        details: {
+          costCents,
+          costUsdc: result.cost,
+          model: taskType,
+          provider: result.provider?.name,
+          trust_status: result.provider?.trust_status,
+          latency_ms: Date.now() - startTime,
+        },
+      });
+    } catch (err) {
+      ctx.logger.warn('Failed to record Agoragentic cost', { error: err.message });
+    }
+  }
+
+  async function logInvocation(toolCtx, method, params, result) {
+    try {
+      await ctx.activity?.log?.({
+        companyId: toolCtx?.companyId,
+        action: `agoragentic.${method}`,
+        entityType: 'agoragentic_invocation',
+        entityId: result.execution_id || result.invocation_id || 'unknown',
+        details: {
+          task: params.task || params.capability_id,
+          provider_id: result.provider?.id,
+          provider_name: result.provider?.name,
+          trust_status: result.provider?.trust_status,
+          cost: result.cost,
+          status: result.status,
+        },
+      });
+    } catch (err) {
+      ctx.logger.warn('Failed to log Agoragentic invocation', { error: err.message });
+    }
+  }
+
+  async function logInvocationError(toolCtx, method, params, error) {
+    try {
+      await ctx.activity?.log?.({
+        companyId: toolCtx?.companyId,
+        action: `agoragentic.${method}.error`,
+        entityType: 'agoragentic_invocation',
+        entityId: 'error',
+        details: {
+          task: params.task || params.capability_id,
+          error: error.message,
+          statusCode: error.statusCode,
+          retryable: error.retryable,
+        },
+      });
+    } catch { }
+  }
+}
+
+module.exports = { createAgoragenticPlugin };

--- a/paperclip/test/integration.test.js
+++ b/paperclip/test/integration.test.js
@@ -1,0 +1,298 @@
+/**
+ * Tests for Agoragentic Paperclip Integration
+ *
+ * Covers:
+ *  1. Client: execute, match, invoke, retry, error handling
+ *  2. Plugin: tool registration, cost recording, trust propagation
+ *  3. Budget constraint propagation
+ *  4. Failed provider / retry-safe behavior
+ */
+
+const assert = require('assert');
+const { AgoragenticClient, AgoragenticError, TRUST_LEVELS } = require('../src/client');
+const { createAgoragenticPlugin } = require('../src/plugin');
+
+let testsPassed = 0;
+let testsFailed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    testsPassed++;
+    console.log(`  ✓ ${name}`);
+  } catch (err) {
+    testsFailed++;
+    console.error(`  ✗ ${name}: ${err.message}`);
+  }
+}
+
+async function asyncTest(name, fn) {
+  try {
+    await fn();
+    testsPassed++;
+    console.log(`  ✓ ${name}`);
+  } catch (err) {
+    testsFailed++;
+    console.error(`  ✗ ${name}: ${err.message}`);
+  }
+}
+
+// ─── Mock Fetch ─────────────────────────────────────────
+
+let mockResponses = [];
+
+function mockFetch(url, opts) {
+  const handler = mockResponses.shift();
+  if (!handler) return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({}) });
+  const response = handler(url, opts);
+  return Promise.resolve({
+    ok: response.status >= 200 && response.status < 300,
+    status: response.status || 200,
+    json: () => Promise.resolve(response.body || {}),
+  });
+}
+
+// Inject mock
+global.fetch = mockFetch;
+
+// ─── Client Tests ───────────────────────────────────────
+
+async function main() {
+
+console.log('\n1. CLIENT CONSTRUCTION\n');
+
+test('requires apiKey', () => {
+  assert.throws(() => new AgoragenticClient(), /apiKey is required/);
+});
+
+test('accepts minimal config', () => {
+  const c = new AgoragenticClient({ apiKey: 'test-key' });
+  assert.strictEqual(c.baseUrl, 'https://agoragentic.com');
+  assert.strictEqual(c.timeoutMs, 30000);
+  assert.strictEqual(c.maxRetries, 2);
+});
+
+test('custom baseUrl strips trailing slash', () => {
+  const c = new AgoragenticClient({ apiKey: 'k', baseUrl: 'https://custom.example/' });
+  assert.strictEqual(c.baseUrl, 'https://custom.example');
+});
+
+console.log('\n2. EXECUTE PATH (router-first)\n');
+
+await asyncTest('executeCapability sends correct request', async () => {
+  mockResponses = [(url, opts) => {
+    assert(url.includes('/api/execute'));
+    const body = JSON.parse(opts.body);
+    assert.strictEqual(body.task, 'summarize');
+    assert.strictEqual(body.input, 'test input');
+    assert.strictEqual(body.constraints.max_cost, 0.50);
+    return {
+      status: 200,
+      body: {
+        execution_id: 'exec-1',
+        output: 'summary result',
+        status: 'success',
+        cost: 0.25,
+        provider: { id: 'p1', name: 'TestProvider', trust_status: 'verified' },
+        candidates_considered: 3,
+      },
+    };
+  }];
+
+  const c = new AgoragenticClient({ apiKey: 'test-key', maxRetries: 0 });
+  const result = await c.executeCapability({
+    task: 'summarize',
+    input: 'test input',
+    constraints: { max_cost: 0.50 },
+  });
+
+  assert.strictEqual(result.execution_id, 'exec-1');
+  assert.strictEqual(result.output, 'summary result');
+  assert.strictEqual(result.cost, 0.25);
+  assert.strictEqual(result.provider.trust_status, 'verified');
+  assert.strictEqual(result.candidates_considered, 3);
+});
+
+await asyncTest('budget constraint is propagated', async () => {
+  mockResponses = [(url, opts) => {
+    const body = JSON.parse(opts.body);
+    assert.strictEqual(body.constraints.max_cost, 1.00);
+    return { status: 200, body: { execution_id: 'e2', output: 'ok', cost: 0.10 } };
+  }];
+
+  const c = new AgoragenticClient({ apiKey: 'k', maxRetries: 0 });
+  const r = await c.executeCapability({ task: 't', input: 'i', constraints: { max_cost: 1.00 } });
+  assert.strictEqual(r.cost, 0.10);
+});
+
+console.log('\n3. MATCH PATH (approval-gated)\n');
+
+await asyncTest('matchCapabilities returns normalized candidates', async () => {
+  mockResponses = [(url) => {
+    assert(url.includes('/api/execute/match'));
+    assert(url.includes('task=translate'));
+    return {
+      status: 200,
+      body: {
+        candidates: [
+          { id: 'c1', name: 'TranslatorA', price: 0.10, trust_status: 'verified', seller_name: 'Seller1', score: 0.95 },
+          { id: 'c2', name: 'TranslatorB', price: 0.20, trust_status: 'reachable', seller_name: 'Seller2', score: 0.80 },
+          { id: 'c3', name: 'TranslatorC', price: 0.05, trust_status: 'failed', seller_name: 'Seller3', score: 0.60 },
+        ],
+      },
+    };
+  }];
+
+  const c = new AgoragenticClient({ apiKey: 'k', maxRetries: 0 });
+  const result = await c.matchCapabilities({ task: 'translate' });
+
+  assert.strictEqual(result.candidates.length, 3);
+  assert.strictEqual(result.candidates[0].trust_status, 'verified');
+  assert.strictEqual(result.candidates[1].trust_status, 'reachable');
+  assert.strictEqual(result.candidates[2].trust_status, 'failed');
+});
+
+console.log('\n4. INVOKE PATH (direct commerce)\n');
+
+await asyncTest('invokeCapability sends idempotency key', async () => {
+  mockResponses = [(url, opts) => {
+    assert(url.includes('/api/invoke/cap-123'));
+    assert.strictEqual(opts.headers['Idempotency-Key'], 'idem-abc');
+    return {
+      status: 200,
+      body: {
+        invocation_id: 'inv-1',
+        output: 'translated text',
+        cost: 0.15,
+        provider: { id: 'p2', name: 'TranslatorA', trust_status: 'verified' },
+      },
+    };
+  }];
+
+  const c = new AgoragenticClient({ apiKey: 'k', maxRetries: 0 });
+  const result = await c.invokeCapability({
+    capabilityId: 'cap-123',
+    input: 'hello world',
+    idempotencyKey: 'idem-abc',
+  });
+
+  assert.strictEqual(result.invocation_id, 'inv-1');
+  assert.strictEqual(result.provider.trust_status, 'verified');
+});
+
+console.log('\n5. TRUST METADATA PROPAGATION\n');
+
+test('TRUST_LEVELS has exact vocabulary', () => {
+  assert.deepStrictEqual(TRUST_LEVELS, ['verified', 'reachable', 'failed']);
+});
+
+await asyncTest('trust status is preserved through execute', async () => {
+  for (const trustLevel of TRUST_LEVELS) {
+    mockResponses = [() => ({
+      status: 200,
+      body: { output: 'ok', provider: { id: 'p', name: 'P', trust_status: trustLevel } },
+    })];
+    const c = new AgoragenticClient({ apiKey: 'k', maxRetries: 0 });
+    const r = await c.executeCapability({ task: 't', input: 'i' });
+    assert.strictEqual(r.provider.trust_status, trustLevel,
+      `Expected trust_status '${trustLevel}' but got '${r.provider.trust_status}'`);
+  }
+});
+
+console.log('\n6. ERROR HANDLING & RETRY\n');
+
+await asyncTest('4xx errors are not retried', async () => {
+  let callCount = 0;
+  mockResponses = [() => { callCount++; return { status: 422, body: { error: 'validation_failed' } }; }];
+
+  const c = new AgoragenticClient({ apiKey: 'k', maxRetries: 2 });
+  try {
+    await c.executeCapability({ task: 't', input: 'i' });
+    assert.fail('Should have thrown');
+  } catch (err) {
+    assert(err instanceof AgoragenticError);
+    assert.strictEqual(err.statusCode, 422);
+    assert.strictEqual(err.retryable, false);
+    assert.strictEqual(callCount, 1); // No retries
+  }
+});
+
+await asyncTest('5xx errors are retried', async () => {
+  let callCount = 0;
+  mockResponses = [
+    () => { callCount++; return { status: 500, body: { error: 'server_error' } }; },
+    () => { callCount++; return { status: 500, body: { error: 'server_error' } }; },
+    () => { callCount++; return { status: 200, body: { output: 'recovered' } }; },
+  ];
+
+  const c = new AgoragenticClient({ apiKey: 'k', maxRetries: 2, retryDelayMs: 10 });
+  const r = await c.executeCapability({ task: 't', input: 'i' });
+  assert.strictEqual(r.output, 'recovered');
+  assert.strictEqual(callCount, 3);
+});
+
+await asyncTest('401 throws immediately with correct error', async () => {
+  mockResponses = [() => ({ status: 401, body: { error: 'unauthorized' } })];
+
+  const c = new AgoragenticClient({ apiKey: 'bad-key', maxRetries: 2 });
+  try {
+    await c.executeCapability({ task: 't', input: 'i' });
+    assert.fail('Should have thrown');
+  } catch (err) {
+    assert(err instanceof AgoragenticError);
+    assert.strictEqual(err.statusCode, 401);
+    assert.strictEqual(err.retryable, false);
+  }
+});
+
+console.log('\n7. PLUGIN CONSTRUCTION\n');
+
+test('createAgoragenticPlugin returns plugin shape', () => {
+  const plugin = createAgoragenticPlugin();
+  assert.strictEqual(typeof plugin.setup, 'function');
+  assert.strictEqual(typeof plugin.onHealth, 'function');
+});
+
+await asyncTest('plugin health returns degraded without API key', async () => {
+  const plugin = createAgoragenticPlugin();
+  // No setup = no client
+  const health = await plugin.onHealth();
+  assert.strictEqual(health.status, 'degraded');
+});
+
+await asyncTest('plugin setup registers with API key', async () => {
+  const registered = { tools: {}, jobs: {}, data: {}, events: {} };
+  const mockCtx = {
+    config: { get: () => ({ agoragentic_api_key: 'test-key' }) },
+    secrets: null,
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+    tools: { register: (name, def) => { registered.tools[name] = def; } },
+    jobs: { register: (name, fn) => { registered.jobs[name] = fn; } },
+    data: { register: (name, fn) => { registered.data[name] = fn; } },
+    events: { on: (name, fn) => { registered.events[name] = fn; } },
+    activity: null,
+    state: { get: () => null, set: () => {} },
+  };
+
+  const plugin = createAgoragenticPlugin();
+  await plugin.setup(mockCtx);
+
+  assert(registered.tools['agoragentic_execute'], 'execute tool registered');
+  assert(registered.tools['agoragentic_match'], 'match tool registered');
+  assert(registered.tools['agoragentic_invoke'], 'invoke tool registered');
+  assert(registered.jobs['agoragentic-sync'], 'sync job registered');
+  assert(registered.data['agoragentic-status'], 'status data handler registered');
+  assert(registered.events['issue.created'], 'issue.created listener registered');
+});
+
+// ─── Summary ────────────────────────────────────────────
+
+console.log('\n============================================================');
+console.log(`PAPERCLIP INTEGRATION: ${testsPassed} PASS, ${testsFailed} FAIL`);
+console.log('============================================================');
+process.exit(testsFailed > 0 ? 1 : 0);
+
+} // end main
+
+main().catch(err => { console.error('Fatal:', err); process.exit(1); });
+

--- a/reown/README.md
+++ b/reown/README.md
@@ -1,0 +1,56 @@
+# Agoragentic x Reown / WalletConnect
+
+Use Reown with Agoragentic when you want wallet-connected agent UX in a browser or mobile app and still want task-first routing or x402 retries.
+
+This is the honest boundary:
+
+- Reown handles wallet connectivity, session UX, and signing surfaces.
+- Agoragentic handles routing, payment challenges, and receipts.
+- This wrapper does not claim Agoragentic is a native Reown wallet provider.
+
+## Install
+
+```bash
+npm install @reown/appkit
+```
+
+Official surfaces:
+
+- Docs: <https://docs.reown.com/>
+- GitHub: <https://github.com/reown-com/appkit>
+
+## Example
+
+```ts
+import { payRequest } from "@open-wallet-standard/core";
+import { AgoragenticReownClient } from "./agoragentic_reown";
+
+const client = new AgoragenticReownClient({
+  apiKey: process.env.AGORAGENTIC_API_KEY
+});
+
+// Registered buyer flow:
+const preview = await client.match("summarize", 0.50);
+const result = await client.execute("summarize", { text: "Summarize this memo." }, 0.50);
+
+// Anonymous x402 flow:
+const x402Result = await client.x402Execute(
+  "qt_123",
+  { text: "Summarize this memo." },
+  payRequest
+);
+
+console.log(preview, result, x402Result);
+```
+
+## What this wrapper does
+
+- authenticated `match()` and `execute()` for connected buyers
+- x402 `quote_id` execution through an external wallet-signing helper
+- keeps the marketplace API surface centered on `execute()`
+
+## What it does not claim
+
+- native Reown receipt handling inside Agoragentic
+- Reown-based seller hosting
+- automatic conversion from arbitrary assets into Base USDC

--- a/reown/agoragentic_reown.ts
+++ b/reown/agoragentic_reown.ts
@@ -1,0 +1,78 @@
+/**
+ * Agoragentic x Reown / WalletConnect
+ *
+ * Honest boundary:
+ * - Reown is used for wallet connectivity and signing UX.
+ * - Agoragentic still handles routing, x402 payment challenges, and marketplace execution.
+ * - This wrapper works for either wallet-backed execute flows or anonymous x402 retries.
+ */
+
+type JsonMap = Record<string, unknown>;
+
+interface ReownClientOptions {
+  apiKey?: string;
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+}
+
+type PayRequestFn = (url: string, init: RequestInit) => Promise<Response>;
+
+export class AgoragenticReownClient {
+  private readonly apiKey?: string;
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: ReownClientOptions = {}) {
+    this.apiKey = options.apiKey;
+    this.baseUrl = options.baseUrl || "https://agoragentic.com/api";
+    this.fetchImpl = options.fetchImpl || fetch;
+  }
+
+  async match(task: string, maxCost = 1): Promise<JsonMap> {
+    if (!this.apiKey) {
+      throw new Error("AGORAGENTIC_API_KEY is required for authenticated execute/match previews.");
+    }
+    const url = new URL(`${this.baseUrl}/execute/match`);
+    url.searchParams.set("task", task);
+    url.searchParams.set("max_cost", String(maxCost));
+    const response = await this.fetchImpl(url.toString(), {
+      headers: { Authorization: `Bearer ${this.apiKey}` }
+    });
+    return response.json();
+  }
+
+  async execute(task: string, input: JsonMap, maxCost: number): Promise<JsonMap> {
+    if (!this.apiKey) {
+      throw new Error("AGORAGENTIC_API_KEY is required for wallet-backed execute flows.");
+    }
+    const response = await this.fetchImpl(`${this.baseUrl}/execute`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        task,
+        input,
+        constraints: { max_cost: maxCost }
+      })
+    });
+    return response.json();
+  }
+
+  async x402Execute(quoteId: string, input: JsonMap, payRequest: PayRequestFn): Promise<JsonMap> {
+    const response = await payRequest(`${this.baseUrl}/x402/execute`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        quote_id: quoteId,
+        input
+      })
+    });
+    return response.json();
+  }
+}
+
+export default AgoragenticReownClient;

--- a/safe/README.md
+++ b/safe/README.md
@@ -1,0 +1,38 @@
+# Agoragentic x Safe
+
+Use Safe with Agoragentic when a treasury or multi-sig should approve the spend **before** the marketplace executes the task.
+
+## Scope
+
+- Agoragentic remains the router and execution layer.
+- Safe is modeled here as a quote approval gate.
+- The wrapper runs `execute/match`, passes the preview into your approval callback, and only then calls `execute`.
+
+This is an honest treasury integration, not a claim that Agoragentic natively deploys Safe modules or batches Safe transactions for you.
+
+## Example
+
+```typescript
+import { AgoragenticSafeClient } from "./agoragentic_safe";
+
+const client = new AgoragenticSafeClient({
+  apiKey: process.env.AGORAGENTIC_API_KEY!,
+  approveQuote: async (preview) => {
+    return preview.quote?.amount <= 0.10;
+  },
+});
+
+const result = await client.executeApproved(
+  "summarize",
+  { text: "Long document here" },
+  { max_cost: 0.10 }
+);
+
+console.log(result.output || result.result);
+```
+
+## References
+
+- Public guide: [https://agoragentic.com/integrations/safe/](https://agoragentic.com/integrations/safe/)
+- Buyer path docs: [https://agoragentic.com/docs.html](https://agoragentic.com/docs.html)
+- OpenAPI: [https://agoragentic.com/openapi.yaml](https://agoragentic.com/openapi.yaml)

--- a/safe/agoragentic_safe.ts
+++ b/safe/agoragentic_safe.ts
@@ -1,0 +1,90 @@
+/**
+ * Agoragentic x Safe
+ * ==================
+ *
+ * Honest scope:
+ * - Safe is used here as a treasury/policy approval layer.
+ * - Agoragentic still performs routing and execution.
+ * - This wrapper does not claim native Safe transaction packing or module deployment.
+ */
+
+const DEFAULT_BASE_URL = "https://agoragentic.com";
+
+type JsonRecord = Record<string, any>;
+
+type QuoteApprovalHandler = (preview: any) => Promise<boolean>;
+
+interface SafeClientOptions {
+    baseUrl?: string;
+    apiKey: string;
+    approveQuote: QuoteApprovalHandler;
+}
+
+function buildQuery(params: Record<string, any>): string {
+    const query = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+        if (value === undefined || value === null || value === "") continue;
+        query.set(key, String(value));
+    }
+    const qs = query.toString();
+    return qs ? `?${qs}` : "";
+}
+
+async function parseJson(response: Response): Promise<any> {
+    const text = await response.text();
+    return text ? JSON.parse(text) : {};
+}
+
+export class AgoragenticSafeClient {
+    private readonly baseUrl: string;
+    private readonly apiKey: string;
+    private readonly approveQuote: QuoteApprovalHandler;
+
+    constructor(options: SafeClientOptions) {
+        if (!options?.apiKey) throw new Error("apiKey is required");
+        if (!options?.approveQuote) throw new Error("approveQuote callback is required");
+        this.baseUrl = options.baseUrl || DEFAULT_BASE_URL;
+        this.apiKey = options.apiKey;
+        this.approveQuote = options.approveQuote;
+    }
+
+    async preview(task: string, input: JsonRecord = {}, constraints: JsonRecord = {}): Promise<any> {
+        const response = await fetch(
+            `${this.baseUrl}/api/execute/match${buildQuery({ task, ...constraints })}`,
+            {
+                headers: { Authorization: `Bearer ${this.apiKey}` },
+            }
+        );
+        const payload = await parseJson(response);
+        return {
+            ...payload,
+            proposed_input: input,
+        };
+    }
+
+    async executeApproved(task: string, input: JsonRecord = {}, constraints: JsonRecord = {}): Promise<any> {
+        const preview = await this.preview(task, input, constraints);
+        const approved = await this.approveQuote(preview);
+        if (!approved) {
+            return {
+                ok: false,
+                error: "quote_rejected",
+                message: "Safe approval callback rejected the quote preview.",
+                preview,
+            };
+        }
+
+        const response = await fetch(`${this.baseUrl}/api/execute`, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${this.apiKey}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ task, input, ...constraints }),
+        });
+
+        return parseJson(response);
+    }
+}
+
+export default AgoragenticSafeClient;

--- a/smolagents/agoragentic_smolagents.py
+++ b/smolagents/agoragentic_smolagents.py
@@ -51,7 +51,7 @@ class AgoragenticExecuteTool(Tool):
         "Describe what you need in plain English. The router finds, scores, "
         "and invokes the highest-ranked provider. Payment is automatic in "
         "USDC on Base L2 from your agent wallet. "
-        "200+ capabilities available across 20+ categories."
+        "40+ verified capabilities available across 20+ categories."
     )
     inputs = {
         "task": {"type": "string", "description": "What you need done (e.g., 'summarize this text', 'translate to Spanish')"},
@@ -145,11 +145,11 @@ class AgoragenticMatchTool(Tool):
 # ─── Marketplace Tools ────────────────────────────────────
 
 class AgoragenticRegisterTool(Tool):
-    """Register on the marketplace and get an API key + free USDC credits."""
+    """Register on the marketplace and get an API key + a starter USDC balance."""
     name = "agoragentic_register"
     description = (
         "Register on the Agoragentic agent marketplace. Returns an API key "
-        "and free test credits in USDC. Use this FIRST if you don't have an API key."
+        "and a starter balance in USDC. Use this FIRST if you don't have an API key."
     )
     inputs = {
         "agent_name": {"type": "string", "description": "Your agent's display name"},
@@ -183,7 +183,7 @@ class AgoragenticSearchTool(Tool):
     name = "agoragentic_search"
     description = (
         "Search the Agoragentic marketplace for agent capabilities, tools, "
-        "and services priced in USDC. 200+ capabilities across 20+ categories."
+        "and services priced in USDC. 40+ verified capabilities across 20+ categories."
     )
     inputs = {
         "query": {"type": "string", "description": "Search term", "nullable": True},

--- a/superfluid/README.md
+++ b/superfluid/README.md
@@ -1,0 +1,39 @@
+# Agoragentic x Superfluid
+
+Use Superfluid with Agoragentic when an external stream or allowance should gate recurring agent purchases.
+
+## Scope
+
+- Superfluid is used here as a recurring budget signal.
+- Agoragentic still routes, executes, meters, and settles each invocation.
+- The wrapper reads stream budget state and forwards `max_cost` into the normal buyer path.
+
+This is intentionally narrower than “native Superfluid settlement.” It is a practical integration for recurring budget control around Agoragentic's existing commerce stack.
+
+## Example
+
+```typescript
+import { AgoragenticSuperfluidClient } from "./agoragentic_superfluid";
+
+const client = new AgoragenticSuperfluidClient({
+  apiKey: process.env.AGORAGENTIC_API_KEY!,
+  readBudget: async () => ({
+    active: true,
+    maxCost: 0.05,
+    metadata: { streamId: "sf-stream-123" },
+  }),
+});
+
+const result = await client.executeIfBudgeted("summarize", {
+  text: "Recurring report payload",
+});
+
+console.log(result.stream_budget);
+console.log(result.output || result.result);
+```
+
+## References
+
+- Public guide: [https://agoragentic.com/integrations/superfluid/](https://agoragentic.com/integrations/superfluid/)
+- Buyer path docs: [https://agoragentic.com/docs.html](https://agoragentic.com/docs.html)
+- OpenAPI: [https://agoragentic.com/openapi.yaml](https://agoragentic.com/openapi.yaml)

--- a/superfluid/agoragentic_superfluid.ts
+++ b/superfluid/agoragentic_superfluid.ts
@@ -1,0 +1,78 @@
+/**
+ * Agoragentic x Superfluid
+ * ========================
+ *
+ * Honest scope:
+ * - Superfluid is treated as an external recurring budget signal.
+ * - Agoragentic still settles each invocation through its existing commerce rails.
+ * - This wrapper does not claim native stream settlement inside the marketplace.
+ */
+
+const DEFAULT_BASE_URL = "https://agoragentic.com";
+
+type JsonRecord = Record<string, any>;
+
+type BudgetReader = () => Promise<{
+    active: boolean;
+    maxCost?: number;
+    metadata?: any;
+}>;
+
+interface SuperfluidClientOptions {
+    baseUrl?: string;
+    apiKey: string;
+    readBudget: BudgetReader;
+}
+
+async function parseJson(response: Response): Promise<any> {
+    const text = await response.text();
+    return text ? JSON.parse(text) : {};
+}
+
+export class AgoragenticSuperfluidClient {
+    private readonly baseUrl: string;
+    private readonly apiKey: string;
+    private readonly readBudget: BudgetReader;
+
+    constructor(options: SuperfluidClientOptions) {
+        if (!options?.apiKey) throw new Error("apiKey is required");
+        if (!options?.readBudget) throw new Error("readBudget callback is required");
+        this.baseUrl = options.baseUrl || DEFAULT_BASE_URL;
+        this.apiKey = options.apiKey;
+        this.readBudget = options.readBudget;
+    }
+
+    async executeIfBudgeted(task: string, input: JsonRecord = {}, constraints: JsonRecord = {}): Promise<any> {
+        const budget = await this.readBudget();
+        if (!budget.active) {
+            return {
+                ok: false,
+                error: "inactive_stream_budget",
+                message: "No active Superfluid budget is available for this task.",
+                budget,
+            };
+        }
+
+        const response = await fetch(`${this.baseUrl}/api/execute`, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${this.apiKey}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                task,
+                input,
+                max_cost: budget.maxCost,
+                ...constraints,
+            }),
+        });
+
+        const payload = await parseJson(response);
+        return {
+            ...payload,
+            stream_budget: budget,
+        };
+    }
+}
+
+export default AgoragenticSuperfluidClient;

--- a/syrin/EVAL_SANDBOX_RFC.md
+++ b/syrin/EVAL_SANDBOX_RFC.md
@@ -1,0 +1,196 @@
+# Syrin Eval / Sandbox RFC Draft
+
+This is a narrow proposal for the first framework-level step after the Agoragentic example PRs.
+
+The point is not to redesign Syrin. The point is to give Syrin a first-class way to define, run, and inspect process-aware evaluations in self-hosted environments.
+
+## Problem
+
+Current agent examples can show:
+
+- tool usage
+- checkpoints
+- traces
+- serving
+
+What they do not yet give a user is a standard contract for saying:
+
+- what workflow is expected
+- which tools must or must not run
+- what checkpoints should exist
+- what artifacts should be captured
+- what environment policy should constrain the run
+
+That gap is where ad hoc harnesses start proliferating.
+
+## Design Goal
+
+Add a narrow, inspectable eval surface that:
+
+- is process-aware, not only final-answer-aware
+- is self-hostable
+- composes with existing Syrin tools, hooks, checkpoints, and serving
+- can be adopted incrementally
+
+## Proposed Surfaces
+
+### `EvalSpec`
+
+The top-level contract for a scenario:
+
+```python
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class EvalSpec:
+    name: str
+    prompt: str
+    input_data: dict[str, Any] = field(default_factory=dict)
+    expected_tools: list[str] = field(default_factory=list)
+    forbidden_tools: list[str] = field(default_factory=list)
+    trace_expectations: list["TraceExpectation"] = field(default_factory=list)
+    checkpoint_assertions: list["CheckpointAssertion"] = field(default_factory=list)
+    sandbox_policy: "SandboxPolicy | None" = None
+```
+
+### `TraceExpectation`
+
+Assertions about process, not just content:
+
+```python
+@dataclass
+class TraceExpectation:
+    step_type: str | None = None
+    tool_name: str | None = None
+    min_count: int = 0
+    max_count: int | None = None
+```
+
+Examples:
+
+- `tool_name="agoragentic_match", min_count=1`
+- `tool_name="agoragentic_execute", max_count=0`
+- `step_type="tool", min_count=2`
+
+### `CheckpointAssertion`
+
+Assertions over checkpoint behavior:
+
+```python
+@dataclass
+class CheckpointAssertion:
+    label_contains: str | None = None
+    min_count: int = 0
+```
+
+Examples:
+
+- at least one baseline checkpoint
+- at least one post-run checkpoint
+- at least one checkpoint after a tool event
+
+### `SandboxPolicy`
+
+The minimal self-hosted environment contract:
+
+```python
+@dataclass
+class SandboxPolicy:
+    network_mode: str = "default"
+    allow_hosts: list[str] = field(default_factory=list)
+    deny_hosts: list[str] = field(default_factory=list)
+    filesystem_mode: str = "workspace"
+    allow_env: list[str] = field(default_factory=list)
+    timeout_seconds: int = 120
+```
+
+This can stay intentionally small at first. The initial win is having a standard shape, not an exhaustive policy engine.
+
+## Minimal Runner Shape
+
+The first implementation does not need a large new runtime. It can be a thin orchestration helper over existing Syrin primitives.
+
+```python
+result = agent.run_eval(
+    EvalSpec(
+        name="paper-summary-preview-only",
+        prompt=(
+            "Use agoragentic_match to preview a provider for summarizing a paper under "
+            "$0.25, then search marketplace memory. Do not execute paid actions."
+        ),
+        expected_tools=["agoragentic_match", "agoragentic_memory_search"],
+        forbidden_tools=["agoragentic_execute", "agoragentic_save_learning_note"],
+        trace_expectations=[
+            TraceExpectation(tool_name="agoragentic_match", min_count=1),
+            TraceExpectation(tool_name="agoragentic_memory_search", min_count=1),
+        ],
+        checkpoint_assertions=[
+            CheckpointAssertion(label_contains="before", min_count=1),
+            CheckpointAssertion(label_contains="after", min_count=1),
+        ],
+        sandbox_policy=SandboxPolicy(
+            network_mode="restricted",
+            allow_hosts=["agoragentic.com"],
+            allow_env=["OPENAI_API_KEY", "AGORAGENTIC_API_KEY"],
+            timeout_seconds=90,
+        ),
+    )
+)
+```
+
+## Proposed Result Shape
+
+```python
+@dataclass
+class EvalResult:
+    success: bool
+    output_text: str
+    observed_tools: list[str]
+    missing_tools: list[str]
+    forbidden_tools_used: list[str]
+    trace_summary: list[dict[str, Any]]
+    checkpoints: list[dict[str, Any]]
+    artifacts_dir: str | None = None
+```
+
+The goal is not a clever score. The goal is inspectable evidence.
+
+## Artifact Bundle
+
+If an eval runs with artifact capture enabled, the runner should write:
+
+- `trace.json`
+- `checkpoints.json`
+- `result.json`
+- optional raw output files
+
+This is the bridge to self-hosted harnessing. Teams can archive, diff, and replay evals without depending on a hosted external platform.
+
+## CLI Direction
+
+Not required immediately, but this is the natural path once the Python surface exists:
+
+```bash
+syrin eval examples/thirdparty/agroagentic/agoragentic_marketplace_process_verification.py
+syrin sandbox run config/evals/paper-summary.yaml
+```
+
+The CLI should remain a thin wrapper around the Python contracts, not a separate hidden system.
+
+## Why This Is A Good First RFC
+
+- it builds directly on existing Syrin features
+- it stays small enough to discuss concretely
+- it gives maintainers a path toward process verification without demanding a big architecture rewrite
+- it creates a clean bridge from examples to self-hosted eval harnesses
+
+## Non-Goals
+
+- full deployment platform
+- full container orchestration system
+- large hosted eval service
+- replacing external benchmarking suites
+
+The first win is a standard process-aware contract and a local runner story.

--- a/syrin/SYRIN_ROADMAP.md
+++ b/syrin/SYRIN_ROADMAP.md
@@ -1,0 +1,165 @@
+# Syrin × Agoragentic Roadmap
+
+This file is the working roadmap behind the upstream `syrin-python` contribution sequence.
+
+It is not a maintainer pitch. It is the concrete internal plan for what we are trying to build, why the work is ordered this way, and what should happen after the current example PRs.
+
+## Current Upstream Stack
+
+Open PRs in `syrin-labs/syrin-python`:
+
+- `#3` — Agoragentic third-party marketplace example
+- `#4` — Agoragentic third-party serving example
+- `#5` — Agoragentic process-verification example
+
+Why this order:
+
+1. establish a real third-party tool surface
+2. prove that the same tool surface serves cleanly
+3. prove that the workflow can be process-verified
+
+That sequence creates a concrete foundation before proposing any larger framework changes.
+
+## Design Direction
+
+The long-term direction is:
+
+- schema-native agent development
+- multimodal workflows
+- aggressive schematic integration
+- internally hosted sandbox testing
+- process-aware evaluation
+- self-deployment
+
+Translated into maintainer-friendly terms, the actual Syrin roadmap is:
+
+- schema-native agent engineering
+- self-hosted evals and sandboxing
+- deployable agent runtimes
+
+## What We Think Syrin Already Has
+
+Syrin already covers much of the runtime layer:
+
+- model abstraction
+- budgets
+- memory
+- tools
+- hooks
+- checkpoints
+- serving
+- multimodal support
+- multi-agent patterns
+
+Because of that, the highest-leverage contribution is not another generic example or another standalone runtime primitive. It is closing the loop between authoring, verification, sandboxing, and deployment.
+
+## Phase Plan
+
+### Phase 0 — Examples First
+
+Goal:
+- land small, mergeable PRs that show real workflows
+
+Deliverables:
+- marketplace example
+- serving example
+- process-verification example
+
+Success criteria:
+- examples are accepted into `examples/thirdparty/agroagentic/`
+- maintainers are comfortable with third-party example structure
+- process verification is accepted as an example-worthy concept, not just external theory
+
+### Phase 1 — Eval And Process Verification RFC
+
+Goal:
+- introduce a narrow RFC for process-aware evaluation
+
+Target scope:
+- expected-vs-observed tool usage
+- trace artifact capture
+- checkpoint assertions
+- replayable eval inputs
+
+Potential API shape:
+- `EvalSpec`
+- `TraceExpectation`
+- `CheckpointAssertion`
+
+Success criteria:
+- maintainers agree that process-level verification belongs in the framework surface
+- at least one lightweight implementation path is accepted
+
+### Phase 2 — Sandbox Contract
+
+Goal:
+- make self-hosted sandboxing a first-class concept
+
+Target scope:
+- `SandboxPolicy`
+- local or Docker-backed runner contract
+- artifact bundle for traces, outputs, and failures
+- environment-level safety boundaries
+
+Success criteria:
+- clear distinction between agent runtime and sandbox runtime
+- self-hosted eval workflows become possible without ad hoc scripts
+
+### Phase 3 — Schema-Native Agent Specs
+
+Goal:
+- make contracts explicit and machine-readable
+
+Candidate types:
+- `TaskSpec`
+- `ToolSpec`
+- `EvalSpec`
+- `SandboxPolicy`
+- `DeploySpec`
+
+Success criteria:
+- framework workflows can be described, inspected, and validated without relying on implicit conventions alone
+
+### Phase 4 — Deploy Surface
+
+Goal:
+- let `agent.serve()` lead naturally into deployment
+
+Target scope:
+- deployment manifests
+- health and readiness conventions
+- secret mounts
+- checkpoint volumes
+- sandbox profiles
+
+Success criteria:
+- a user can go from local serve to a policy-shaped deployment story without inventing the entire deployment surface themselves
+
+## Research Alignment
+
+Three references are shaping this roadmap:
+
+- Agentic-MME
+- AI Agent Traps
+- AutoAgent
+
+Takeaways we are using:
+
+- process-level verification matters
+- environment traps and sandbox policy matter
+- iterative harness-driven development matters
+
+## Guardrails
+
+- keep PRs small and mergeable
+- do not jump straight to a large architectural refactor
+- build from examples toward contracts, not the reverse
+- prefer self-hosted and inspectable workflows over magic hosted abstractions
+- keep execution honest: preview first, execute second, mutate only behind explicit gates
+
+## Next Actions
+
+1. Get `#3` merged.
+2. Rebase `#4` and `#5` once `#3` lands.
+3. Open a maintainer discussion using `UPSTREAM_DISCUSSION.md`.
+4. Draft a narrow eval/sandbox RFC instead of a broad platform manifesto.

--- a/syrin/UPSTREAM_DISCUSSION.md
+++ b/syrin/UPSTREAM_DISCUSSION.md
@@ -1,0 +1,144 @@
+# Syrin × Agoragentic: Proposed Upstream Direction
+
+This note is a ready-to-post maintainer discussion draft for `syrin-python`.
+
+## Draft Discussion
+
+**Title:** Toward schema-native, self-hosted agent engineering workflows in Syrin
+
+I have been upstreaming a small Agoragentic integration into `syrin-python` and wanted to share the broader direction I think is worth discussing after the example PRs settle.
+
+Current contribution stack:
+
+- `#3` — Agoragentic third-party marketplace example
+- `#4` — Agoragentic third-party serving example
+- `#5` — Agoragentic process-verification example
+
+I kept those intentionally narrow because I think the right way to extend Syrin is to start from real workflows, not a big abstract refactor.
+
+My thesis is that Syrin already has many of the runtime primitives that matter:
+
+- model abstraction
+- budgets and rate controls
+- memory backends
+- hooks and checkpoints
+- serving
+- multimodal support
+- multi-agent patterns
+
+So the highest-leverage next step is not "add multimodality" or "add deployment" in isolation. It is closing the loop between:
+
+1. task specification
+2. tool contracts
+3. evals and process checkpoints
+4. sandbox policy
+5. deployment packaging
+
+That would move Syrin toward a more schema-native agent engineering model rather than only a runtime with tools.
+
+## Why The Current PR Stack Looks The Way It Does
+
+The three Agoragentic PRs are meant to establish the sequence first:
+
+1. show a safe-by-default third-party tool surface
+2. show that the same tool surface can be served cleanly
+3. show that the workflow can be process-verified with hooks, checkpoints, and traces
+
+That sequence matters because it keeps the work concrete and lets any future eval/sandbox conversation build on examples that already exist inside the repo.
+
+## Proposed Roadmap
+
+### Phase 0: Small mergeable examples
+
+Goal:
+- land practical third-party examples that demonstrate real agent workflows
+
+Scope:
+- execute-first routing
+- preview-first provider matching
+- durable memory search and learning notes
+- serving through `agent.serve()`
+- trace- and checkpoint-based workflow verification
+
+### Phase 1: Schema-native contracts
+
+Goal:
+- give agents, tooling, and evaluators explicit machine-readable contracts
+
+Potential primitives:
+- `TaskSpec`
+- `ToolSpec`
+- `EvalSpec`
+- `SandboxPolicy`
+- `DeploySpec`
+
+These could be Pydantic- or JSON-Schema-first, with a clean Python layer on top.
+
+### Phase 2: Self-hosted eval and sandbox surface
+
+Goal:
+- make sandboxed verification and process-level testing first-class workflows
+
+Possible direction:
+- `syrin eval`
+- `syrin sandbox`
+- local Docker-based or self-hosted runner support
+- artifact capture for traces, outputs, failures, and checkpoints
+- replayable eval packs
+
+Why this matters:
+- final-answer scoring is not enough for agent systems
+- the execution path and failure modes need explicit inspection
+- self-hosted workflows matter for teams that cannot ship agent traces or test inputs to third-party infrastructure
+
+### Phase 3: Deployment packaging
+
+Goal:
+- make "serve locally" naturally lead into "deploy safely"
+
+Potential artifacts:
+- container packaging
+- health and readiness conventions
+- secret mounts
+- checkpoint volumes
+- sandbox profiles
+- deployment manifests
+
+## Smallest Useful Follow-Up RFC
+
+If maintainers think the direction is interesting, the smallest useful follow-up after the example PRs would not be "full deployment" or "full multimodal platforming."
+
+It would be a narrow eval/sandbox RFC around:
+
+- a minimal `EvalSpec`
+- expected-vs-observed tool usage
+- checkpoint assertions
+- trace artifact capture
+- a simple self-hosted runner contract
+
+That seems like the most defensible bridge between the current Syrin runtime and a more complete agent engineering loop.
+
+## Why This Direction Feels Timely
+
+Three recent threads all point the same way:
+
+- Agentic-MME argues that multimodal agents need process-aware evaluation, not just end-result scoring.
+- Recent "AI Agent Traps" research highlights why adversarial environments and sandbox policy cannot stay implicit.
+- AutoAgent-style harnesses show the value of tight loops between mutation, benchmarking, and selection.
+
+Taken together, they suggest a framework should not stop at inference orchestration. It should help structure the full authoring, evaluation, and deployment loop.
+
+## Immediate Contribution I Can Continue With
+
+After the example PRs settle, I would be interested in helping with one or both of:
+
+- a focused RFC for schema-native eval + sandbox contracts
+- a small reference implementation for process verification with self-hosted artifact capture
+
+I would explicitly keep that incremental and avoid trying to force a large platform rewrite through examples.
+
+## Reference Links
+
+- Agentic-MME: https://arxiv.org/abs/2604.03016
+- AutoAgent: https://github.com/kevinrgu/autoagent
+- Syrin: https://github.com/syrin-labs/syrin-python

--- a/syrin/agoragentic_syrin.py
+++ b/syrin/agoragentic_syrin.py
@@ -3,7 +3,7 @@ Agoragentic × Syrin Integration — v1.0
 =======================================
 
 Agoragentic marketplace tools for Syrin agents.
-Route tasks, browse 200+ capabilities, manage memory, store secrets,
+Route tasks, browse 40+ verified capabilities, manage memory, store secrets,
 and verify identity — all with Syrin's built-in budget tracking.
 
 Install:
@@ -61,7 +61,7 @@ def agoragentic_execute(task: str, input_data: dict = None, max_cost: float = 1.
 
     Describe what you need in plain English. The router finds, scores, and
     invokes the highest-ranked provider. Payment is automatic in USDC on
-    Base L2 from your agent wallet. 200+ capabilities across 20+ categories.
+    Base L2 from your agent wallet. 40+ verified capabilities across 20+ categories.
 
     Args:
         task: What you need done (e.g., 'summarize this text')
@@ -135,7 +135,7 @@ def agoragentic_search(query: str = "", category: str = "",
                        *, _api_key: str = "") -> dict:
     """Search the Agoragentic marketplace for capabilities.
 
-    200+ capabilities across 20+ categories including ai-services,
+    40+ verified capabilities across 20+ categories including ai-services,
     data, devtools, search, security, memory, infrastructure.
 
     Args:
@@ -208,7 +208,7 @@ def agoragentic_invoke(capability_id: str, input_data: dict = None,
 
 
 def agoragentic_register(agent_name: str, intent: str = "both") -> dict:
-    """Register on Agoragentic and get an API key + free USDC credits.
+    """Register on Agoragentic and get an API key + a starter USDC balance.
 
     Use this FIRST if you don't have an API key.
 

--- a/syrin/starter_agent.py
+++ b/syrin/starter_agent.py
@@ -1,0 +1,63 @@
+"""
+Starter Syrin agent that uses Agoragentic as an execute-first capability router.
+
+Environment:
+    OPENAI_API_KEY=...
+    AGORAGENTIC_API_KEY=...
+
+Run:
+    python starter_agent.py
+    python starter_agent.py "Summarize the attached report and save a reusable lesson."
+"""
+
+import os
+import sys
+
+from syrin import Agent, Budget, Model
+from syrin.enums import ExceedPolicy
+
+from agoragentic_syrin import AgoragenticTools
+
+
+SYSTEM_PROMPT = """
+You are a marketplace-native software research and execution agent.
+
+Operating rules:
+- Prefer agoragentic_match before paid execution when task fit is unclear.
+- Prefer agoragentic_execute for real work instead of hard-coding provider IDs.
+- Use agoragentic_memory_search before repeating prior research.
+- Save durable takeaways with agoragentic_save_learning_note when you discover a reusable workflow lesson.
+- Use agoragentic_invoke only when the user explicitly wants a known listing.
+""".strip()
+
+
+class MarketplaceStarterAgent(Agent):
+    model = Model.OpenAI("gpt-4o-mini", api_key=os.environ.get("OPENAI_API_KEY", ""))
+    budget = Budget(max_cost=5.00, exceed_policy=ExceedPolicy.STOP)
+    system_prompt = SYSTEM_PROMPT
+    tools = AgoragenticTools(api_key=os.environ.get("AGORAGENTIC_API_KEY", ""))
+
+
+def main() -> None:
+    if not os.environ.get("OPENAI_API_KEY"):
+        raise RuntimeError("Set OPENAI_API_KEY before running this example.")
+    if not os.environ.get("AGORAGENTIC_API_KEY"):
+        raise RuntimeError("Set AGORAGENTIC_API_KEY before running this example.")
+
+    prompt = (
+        sys.argv[1]
+        if len(sys.argv) > 1
+        else (
+            "Find a strong marketplace provider for summarizing technical papers under $0.25, "
+            "run it on a short sample input, then save one reusable lesson about the workflow."
+        )
+    )
+
+    result = MarketplaceStarterAgent().run(prompt)
+    print(result.content)
+    if getattr(result, "cost", None) is not None:
+        print(f"\nSyrin tracked cost: ${result.cost:.6f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tempo-mpp/README.md
+++ b/tempo-mpp/README.md
@@ -1,0 +1,42 @@
+# Agoragentic x Tempo MPP
+
+This integration is the cleanest way to pair Agoragentic's x402 buyer flow with a Tempo-style payment handler.
+
+## Scope
+
+- Use `GET /api/x402/execute/match` to preview providers and quotes.
+- Use `POST /api/x402/execute` for the actual paid call.
+- Handle `PAYMENT-REQUIRED` through your Tempo-compatible payment callback.
+- Retry with either `Authorization: Payment ...` or `PAYMENT-SIGNATURE`.
+
+This wrapper is honest about the current stack: it is **header-compatible MPP on top of Agoragentic's x402 flow**, not a native Tempo session manager embedded inside the marketplace.
+
+## Example
+
+```typescript
+import { AgoragenticTempoMppClient } from "./agoragentic_tempo_mpp";
+
+const client = new AgoragenticTempoMppClient({
+  payChallenge: async (paymentRequired) => {
+    const payment = await tempoClient.pay(paymentRequired);
+    return {
+      authorizationHeader: `Payment ${payment.authorization}`,
+      receipt: payment,
+    };
+  },
+});
+
+const preview = await client.preview("summarize", { max_cost: 0.05 });
+const result = await client.executeQuote(preview.quote.quote_id, {
+  text: "Summarize this report",
+});
+
+console.log(result.payment_receipt);
+console.log(result.output || result.result);
+```
+
+## References
+
+- Public guide: [https://agoragentic.com/integrations/tempo-mpp/](https://agoragentic.com/integrations/tempo-mpp/)
+- x402 info: [https://agoragentic.com/api/x402/info](https://agoragentic.com/api/x402/info)
+- OpenAPI: [https://agoragentic.com/openapi.yaml](https://agoragentic.com/openapi.yaml)

--- a/tempo-mpp/agoragentic_tempo_mpp.ts
+++ b/tempo-mpp/agoragentic_tempo_mpp.ts
@@ -1,0 +1,116 @@
+/**
+ * Agoragentic x Tempo MPP
+ * =======================
+ *
+ * Honest scope:
+ * - Uses Agoragentic's existing x402 HTTP payment challenge flow.
+ * - Supports Tempo-style payment handlers around PAYMENT-REQUIRED.
+ * - Does not claim native Tempo session orchestration inside Agoragentic.
+ */
+
+const DEFAULT_BASE_URL = "https://agoragentic.com";
+
+type JsonRecord = Record<string, any>;
+
+type TempoPaymentResult = {
+    authorizationHeader?: string;
+    paymentSignature?: string;
+    receipt?: any;
+};
+
+type TempoPaymentHandler = (paymentRequired: string, request: {
+    url: string;
+    method: string;
+    body: JsonRecord;
+}) => Promise<TempoPaymentResult>;
+
+interface TempoClientOptions {
+    baseUrl?: string;
+    payChallenge: TempoPaymentHandler;
+}
+
+function buildQuery(params: Record<string, any>): string {
+    const query = new URLSearchParams();
+    for (const [key, value] of Object.entries(params)) {
+        if (value === undefined || value === null || value === "") continue;
+        query.set(key, String(value));
+    }
+    const qs = query.toString();
+    return qs ? `?${qs}` : "";
+}
+
+async function parseJson(response: Response): Promise<any> {
+    const text = await response.text();
+    return text ? JSON.parse(text) : {};
+}
+
+export class AgoragenticTempoMppClient {
+    private readonly baseUrl: string;
+    private readonly payChallenge: TempoPaymentHandler;
+
+    constructor(options: TempoClientOptions) {
+        if (!options?.payChallenge) {
+            throw new Error("payChallenge callback is required");
+        }
+        this.baseUrl = options.baseUrl || DEFAULT_BASE_URL;
+        this.payChallenge = options.payChallenge;
+    }
+
+    async getInfo(): Promise<any> {
+        const response = await fetch(`${this.baseUrl}/api/x402/info`);
+        return parseJson(response);
+    }
+
+    async preview(task: string, constraints: JsonRecord = {}): Promise<any> {
+        const response = await fetch(
+            `${this.baseUrl}/api/x402/execute/match${buildQuery({ task, ...constraints })}`
+        );
+        return parseJson(response);
+    }
+
+    async executeQuote(quoteId: string, input: JsonRecord = {}): Promise<any> {
+        const requestBody = { quote_id: quoteId, input };
+        const initial = await fetch(`${this.baseUrl}/api/x402/execute`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(requestBody),
+        });
+
+        if (initial.status !== 402) {
+            return parseJson(initial);
+        }
+
+        const paymentRequired = initial.headers.get("PAYMENT-REQUIRED");
+        if (!paymentRequired) {
+            throw new Error("Missing PAYMENT-REQUIRED header");
+        }
+
+        const payment = await this.payChallenge(paymentRequired, {
+            url: `${this.baseUrl}/api/x402/execute`,
+            method: "POST",
+            body: requestBody,
+        });
+
+        const retryHeaders: Record<string, string> = {
+            "Content-Type": "application/json",
+        };
+        if (payment.authorizationHeader) retryHeaders.Authorization = payment.authorizationHeader;
+        if (payment.paymentSignature) retryHeaders["PAYMENT-SIGNATURE"] = payment.paymentSignature;
+
+        const settled = await fetch(`${this.baseUrl}/api/x402/execute`, {
+            method: "POST",
+            headers: retryHeaders,
+            body: JSON.stringify(requestBody),
+        });
+
+        const payload = await parseJson(settled);
+        return {
+            ...payload,
+            payment_receipt: settled.headers.get("Payment-Receipt"),
+            payment_response_header: settled.headers.get("PAYMENT-RESPONSE"),
+            mpp_receipt: payment.receipt || null,
+        };
+    }
+}
+
+export default AgoragenticTempoMppClient;

--- a/u402/README.md
+++ b/u402/README.md
@@ -1,0 +1,57 @@
+# Agoragentic x u402
+
+Use u402 with Agoragentic when you want to check private-payment readiness or wrap the live x402 challenge flow with a private-payment-capable client.
+
+This wrapper keeps the current boundary explicit:
+
+- Agoragentic's live paid routes are still x402 challenge-response routes.
+- u402 is treated as a support-check and client-side payment handler layer.
+- This does not claim native private proof settlement inside Agoragentic today.
+
+## Install
+
+```bash
+npm install
+```
+
+Official surfaces:
+
+- Docs: <https://permissionless-technologies.com/docs/u402>
+- Starter repo: <https://github.com/permissionless-technologies/x402-upd-starter>
+
+## Example
+
+```ts
+import { AgoragenticU402Client } from "./agoragentic_u402";
+
+const client = new AgoragenticU402Client({
+  payChallenge: async (paymentRequired) => {
+    const payment = await someU402Client.pay(paymentRequired);
+    return {
+      authorizationHeader: `Payment ${payment.authorization}`,
+      receipt: payment
+    };
+  }
+});
+
+const support = await client.getSupport();
+const preview = await client.preview("summarize", { max_cost: 0.05 });
+const result = await client.executeQuote(preview.quote.quote_id, {
+  text: "Summarize this report."
+});
+
+console.log(support);
+console.log(result.payment_receipt);
+```
+
+## What this wrapper does
+
+- reports the current support boundary as `private_payments_supported: false` with explicit x402 fallback
+- previews routed x402 quotes through `/api/x402/execute/match`
+- retries paid execution through a caller-supplied payment handler
+
+## What it does not claim
+
+- native u402 proof validation inside Agoragentic
+- private settlement guarantees beyond the live x402 surfaces
+- replacement of Agoragentic receipts with third-party privacy receipts

--- a/u402/agoragentic_u402.ts
+++ b/u402/agoragentic_u402.ts
@@ -1,0 +1,120 @@
+/**
+ * Agoragentic x u402
+ *
+ * Honest boundary:
+ * - u402 is treated as a private-payment support checker around x402-compatible routes.
+ * - Agoragentic still exposes public x402 challenge-response flows today.
+ * - This wrapper keeps x402 fallback explicit instead of claiming native private settlement.
+ */
+
+type JsonObject = Record<string, unknown>;
+
+type U402PaymentResult = {
+  authorizationHeader?: string;
+  paymentSignature?: string;
+  receipt?: unknown;
+};
+
+type U402PaymentHandler = (paymentRequired: string, request: {
+  url: string;
+  method: string;
+  body: JsonObject;
+}) => Promise<U402PaymentResult>;
+
+interface U402ClientOptions {
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+  payChallenge?: U402PaymentHandler;
+}
+
+function buildQuery(params: Record<string, unknown>): string {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null || value === "") continue;
+    query.set(key, String(value));
+  }
+  const qs = query.toString();
+  return qs ? `?${qs}` : "";
+}
+
+async function parseJson(response: Response): Promise<JsonObject> {
+  const text = await response.text();
+  return text ? JSON.parse(text) : {};
+}
+
+export class AgoragenticU402Client {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly payChallenge?: U402PaymentHandler;
+
+  constructor(options: U402ClientOptions = {}) {
+    this.baseUrl = options.baseUrl || "https://agoragentic.com";
+    this.fetchImpl = options.fetchImpl || fetch;
+    this.payChallenge = options.payChallenge;
+  }
+
+  async getSupport(): Promise<JsonObject> {
+    const support = await this.fetchImpl(`${this.baseUrl}/api/x402/info`).then(parseJson);
+    return {
+      source: "agoragentic_x402",
+      private_payments_supported: false,
+      fallback_mode: "x402",
+      support
+    };
+  }
+
+  async preview(task: string, constraints: JsonObject = {}): Promise<JsonObject> {
+    const response = await this.fetchImpl(
+      `${this.baseUrl}/api/x402/execute/match${buildQuery({ task, ...constraints })}`
+    );
+    return parseJson(response);
+  }
+
+  async executeQuote(quoteId: string, input: JsonObject = {}): Promise<JsonObject> {
+    const requestBody = { quote_id: quoteId, input };
+    const initial = await this.fetchImpl(`${this.baseUrl}/api/x402/execute`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(requestBody)
+    });
+
+    if (initial.status !== 402) {
+      return parseJson(initial);
+    }
+    if (!this.payChallenge) {
+      throw new Error("payChallenge callback is required when retrying a PAYMENT-REQUIRED flow.");
+    }
+
+    const paymentRequired = initial.headers.get("PAYMENT-REQUIRED");
+    if (!paymentRequired) {
+      throw new Error("Missing PAYMENT-REQUIRED header");
+    }
+
+    const payment = await this.payChallenge(paymentRequired, {
+      url: `${this.baseUrl}/api/x402/execute`,
+      method: "POST",
+      body: requestBody
+    });
+
+    const retryHeaders: Record<string, string> = {
+      "Content-Type": "application/json"
+    };
+    if (payment.authorizationHeader) retryHeaders.Authorization = payment.authorizationHeader;
+    if (payment.paymentSignature) retryHeaders["PAYMENT-SIGNATURE"] = payment.paymentSignature;
+
+    const settled = await this.fetchImpl(`${this.baseUrl}/api/x402/execute`, {
+      method: "POST",
+      headers: retryHeaders,
+      body: JSON.stringify(requestBody)
+    });
+
+    return {
+      ...(await parseJson(settled)),
+      payment_receipt: settled.headers.get("Payment-Receipt"),
+      payment_response_header: settled.headers.get("PAYMENT-RESPONSE"),
+      u402_receipt: payment.receipt || null
+    };
+  }
+}
+
+export default AgoragenticU402Client;

--- a/x402scan/README.md
+++ b/x402scan/README.md
@@ -1,0 +1,53 @@
+# Agoragentic x x402scan
+
+Use x402scan with Agoragentic when you want explorer-style context around x402 discovery, receipts, and settlement metadata.
+
+This wrapper is intentionally honest:
+
+- Agoragentic remains the x402 marketplace and execution surface.
+- x402scan is treated as the explorer/reporting side.
+- This wrapper builds explorer context objects. It does not claim Agoragentic auto-publishes events into x402scan.
+
+## Install
+
+```bash
+npm install
+```
+
+Official surfaces:
+
+- Site: <https://www.x402scan.com/>
+- GitHub: <https://github.com/Merit-Systems/x402scan>
+
+## Example
+
+```ts
+import { AgoragenticX402ScanClient } from "./agoragentic_x402scan";
+
+const client = new AgoragenticX402ScanClient();
+const info = await client.getInfo();
+const discovery = await client.discover({ task: "summarize", max_cost: 0.05 });
+
+const explorerContext = client.buildExplorerContext({
+  info,
+  discovery,
+  paymentReceipt: "pay_123",
+  paymentResponseHeader: "base64-encoded-response",
+  invocationId: "inv_123",
+  listingId: "cap_123"
+});
+
+console.log(explorerContext);
+```
+
+## What this wrapper does
+
+- fetches live x402 support metadata from `/api/x402/info`
+- fetches live listing and quote context from `/api/x402/discover`
+- assembles a normalized explorer/reporting object around receipts and transaction metadata
+
+## What it does not claim
+
+- native x402scan indexing inside Agoragentic
+- third-party explorer availability guarantees
+- automatic lookup of transaction hashes without your own receipt context

--- a/x402scan/agoragentic_x402scan.ts
+++ b/x402scan/agoragentic_x402scan.ts
@@ -1,0 +1,75 @@
+/**
+ * Agoragentic x x402scan
+ *
+ * Honest boundary:
+ * - x402scan is treated as an explorer and reporting layer around x402 flows.
+ * - Agoragentic still handles discovery, execution, receipts, and settlement.
+ * - This wrapper builds explorer context; it does not claim Agoragentic auto-indexes into x402scan.
+ */
+
+type JsonObject = Record<string, unknown>;
+
+interface X402ScanClientOptions {
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+}
+
+interface DiscoverParams {
+  task?: string;
+  max_cost?: number;
+  payment_network?: string;
+  chain_id?: number;
+}
+
+function withQuery(baseUrl: string, path: string, params: DiscoverParams = {}): string {
+  const url = new URL(`${baseUrl}${path}`);
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null || value === "") continue;
+    url.searchParams.set(key, String(value));
+  }
+  return url.toString();
+}
+
+export class AgoragenticX402ScanClient {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: X402ScanClientOptions = {}) {
+    this.baseUrl = options.baseUrl || "https://agoragentic.com";
+    this.fetchImpl = options.fetchImpl || fetch;
+  }
+
+  async getInfo(): Promise<JsonObject> {
+    const response = await this.fetchImpl(`${this.baseUrl}/api/x402/info`);
+    return response.json();
+  }
+
+  async discover(params: DiscoverParams = {}): Promise<JsonObject> {
+    const response = await this.fetchImpl(withQuery(this.baseUrl, "/api/x402/discover", params));
+    return response.json();
+  }
+
+  buildExplorerContext(args: {
+    info?: JsonObject;
+    discovery?: JsonObject;
+    paymentReceipt?: string | null;
+    paymentResponseHeader?: string | null;
+    transactionHash?: string | null;
+    invocationId?: string | null;
+    listingId?: string | null;
+  }): JsonObject {
+    return {
+      network: "base",
+      source: "agoragentic_x402",
+      info: args.info || null,
+      discovery: args.discovery || null,
+      payment_receipt: args.paymentReceipt || null,
+      payment_response_header: args.paymentResponseHeader || null,
+      transaction_hash: args.transactionHash || null,
+      invocation_id: args.invocationId || null,
+      listing_id: args.listingId || null
+    };
+  }
+}
+
+export default AgoragenticX402ScanClient;


### PR DESCRIPTION
## Port: 20 framework integrations + honesty fixes

Brings ~20 framework integrations stranded on a diverged local branch onto a fresh base off `origin/main`, so it opens as a normal, conflict-free PR.

**Change profile: 44 files, +4,550 / -9 — 41 new files added + honesty edits to 3 files that already exist on `main`.** This is *not* a pure-additive port: `ACP_REGISTRY.md`, `smolagents/agoragentic_smolagents.py`, and `syrin/agoragentic_syrin.py` carried the same inflated claims and are corrected here too.

### Added (41 files, ~20 integrations)
- **Wallet / payment:** Coinbase Agentic Wallets, Safe, Reown, LiFi, Superfluid, u402, x402scan, Dfns
- **Agent frameworks:** Goose (Block), Haystack, ElizaOS, Kibble, Olas, AgentTax
- **Infrastructure:** n8n, Flowise, Paperclip v2, Tempo-MPP, MPPScan
- **Syrin:** toolkit + eval-sandbox RFC, roadmap, upstream discussion, starter agent

### Honesty fixes (across new + existing files)
1. **"174+ / 200+ AI capabilities" -> "40+ verified"** — live count: 46 total / 42 verified, 4 reachable.
2. **"free USDC credits" -> "starter USDC balance"** — accurate phrasing.

Applied in: `goose/agoragentic_goose.py`, `goose/README.md`, `syrin/agoragentic_syrin.py`, `smolagents/agoragentic_smolagents.py`, `ACP_REGISTRY.md`.