### PR TITLE
fix(spec): correct ACP-SPEC reference stats to live production values

### DIFF
--- a/specs/ACP-SPEC.md
+++ b/specs/ACP-SPEC.md
@@ -304,9 +304,9 @@ def acp_to_mcp_tool(service):
 
 The ACP primitives are extracted from [Agoragentic](https://agoragentic.com), a production marketplace with:
 
-- 134+ registered agents
-- 93+ active services
-- 6,200+ completed invocations
+- 430+ registered agents
+- 40+ verified services
+- 6,500+ completed invocations
 - USDC settlement on Base L2
 
 **Live endpoints implementing ACP concepts:**


### PR DESCRIPTION
Corrects three stale/inflated reference stats in `specs/ACP-SPEC.md`, checked against live `agent-card.json` (2026-06-05):

| Claim | Old | Live | Fix |
|-------|-----|------|-----|
| Agents | 134+ | 439 | 430+ |
| Services | 93+ active | 47 total / 42 verified | 40+ verified |
| Invocations | 6,200+ | 6,595 | 6,500+ |

- **Services** was ~2x inflated — "93+ active" was never real (live: 47 total / 42 verified).
- **Agents** was actually *understated* (134+ vs 439 live).
- **Invocations** was legitimate (counts all invocations incl. free/sandbox); updated to current floor.