### PR TITLE
feat: add Robinhood agentic trading guard integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased] - 2026-05-19
 
 ### Added
+- Added `robinhood-agentic-trading-guard/`, a public-safe Robinhood Agentic Trading MCP policy, approval, and receipt guard that is read-only/proposal-only by default and has no brokerage execution authority.
 - Added `hermes-agent/`, a public Hermes Agent bridge scaffold for Agoragentic MCP tooling, Agent OS handoff manifests, and review-gated self-improvement reflection packets with no live execution authority.
 - Added `rust-framework/`, a public Agoragentic Rust Framework HTTP runtime integration folder with TypeScript/Node and Python examples, a self-hosted Agent OS Harness packet example, and no-spend verification.
 - Added Rust Framework discovery pointers in `integrations.json`, `README.md`, `llms.txt`, `llms-full.txt`, and `SKILL.md` while keeping hosted Router / Marketplace SDK semantics unchanged.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The first call to this paid route returns an x402 payment challenge. A signed pa
 - Run local no-spend Harness Core proof, receipt, export, and listing-readiness checks before hosted launch
 - Run local release premortems, no-spend Golden Loop readiness checks, and additive self-heal plans before publishing an OSS agent
 - Connect Hermes Agent as a bounded MCP/client bridge with review-gated self-improvement packets
+- Wrap official Robinhood Agentic Trading MCP proposals with read-only policy, approval, and receipt guardrails without brokerage execution
 
 ## Live proof
 
@@ -166,6 +167,7 @@ The hosted Triptych OS (Agent OS) control plane is not a downloadable npm packag
 | [**Agent OS Control Plane**](agent-os/) | Javascript | ✅ Ready | `agent-os/agent_os_node.mjs` | [README](agent-os/README.md) |
 | [**Agoragentic Rust Framework HTTP Runtime**](rust-framework/) | Rust | Beta | `rust-framework/README.md` | [README](rust-framework/README.md) |
 | [**Robinhood Agent OS Scaffold**](robinhood/) | Json | Experimental | `robinhood/mcp.json` | [README](robinhood/README.md) |
+| [**Robinhood Agentic Trading Guard**](robinhood-agentic-trading-guard/) | Javascript | Experimental | `robinhood-agentic-trading-guard/guard-policy-preview.mjs` | [README](robinhood-agentic-trading-guard/README.md) |
 | [**Hermes Agent Bridge**](hermes-agent/) | Json | Beta | `hermes-agent/agent-os-bridge.manifest.json` | [README](hermes-agent/README.md) |
 | [**Financial Research Provider Lane**](financial-research/) | Json | Experimental | `financial-research/repo-intake.v1.json` | [README](financial-research/README.md) |
 | [**OpenFang**](openfang/) | Javascript | Beta | `openfang/agoragentic_openfang.mjs` | [README](openfang/README.md) |
@@ -402,6 +404,7 @@ Your Agent  →  Integration (tools/MCP)  →  Agent OS + Agoragentic API
 | Capability description | [`SKILL.md`](./SKILL.md) |
 | Agent OS public export | [`agent-os/README.md`](./agent-os/README.md) |
 | Agoragentic Rust Framework HTTP runtime examples | [`rust-framework/README.md`](./rust-framework/README.md) |
+| Robinhood Agentic Trading Guard | [`robinhood-agentic-trading-guard/README.md`](./robinhood-agentic-trading-guard/README.md) |
 | Hermes Agent bridge | [`hermes-agent/README.md`](./hermes-agent/README.md) |
 | OpenFang bridge | [`openfang/README.md`](./openfang/README.md) |
 | Premortem Golden Loop Agent | [`premortem-golden-loop/README.md`](./premortem-golden-loop/README.md) |

--- a/SKILL.md
+++ b/SKILL.md
@@ -161,9 +161,11 @@ For a working example, clone the summarizer agent:
 
 ### Public integration coverage
 
-The public integrations repo includes adapters and bridge patterns for LangChain, LangGraph, LangChain Deep Agents, CrewAI, AutoGen, OpenAI Agents SDK, Google ADK, Vercel AI SDK, Cloudflare Agents, Microsoft Semantic Kernel, n8n, Flowise, Zapier MCP, Composio, HumanLayer, Dify, MCP, ACP, A2A, OpenFang, Hermes Agent, Micro ECF, Harness Core, Premortem Golden Loop, Agent OS control-plane examples, Agoragentic Rust Framework HTTP examples, and an experimental Zoneless payout reference.
+The public integrations repo includes adapters and bridge patterns for LangChain, LangGraph, LangChain Deep Agents, CrewAI, AutoGen, OpenAI Agents SDK, Google ADK, Vercel AI SDK, Cloudflare Agents, Microsoft Semantic Kernel, n8n, Flowise, Zapier MCP, Composio, HumanLayer, Dify, MCP, ACP, A2A, OpenFang, Hermes Agent, Robinhood Agentic Trading Guard, Micro ECF, Harness Core, Premortem Golden Loop, Agent OS control-plane examples, Agoragentic Rust Framework HTTP examples, and an experimental Zoneless payout reference.
 
 `hermes-agent/` documents the public Hermes Agent bridge pattern: expose Agoragentic MCP tools to a Hermes-compatible host, use Micro ECF and Agent OS Harness artifacts for governed handoff, and emit Hermes-style self-improvement as owner-reviewable reflection packets. It does not grant autonomous skill mutation, GitHub write, deploy, wallet, x402, trust, or marketplace publication authority.
+
+`robinhood-agentic-trading-guard/` documents a public-safe policy, approval, and receipt guard for proposed Robinhood Agentic Trading MCP actions. It is read-only, dry-run, and proposal-only by default; it does not place orders, store credentials or private account data, use unofficial Robinhood APIs, or claim live trading support. Options and high-risk trades are blocked by default.
 
 `rust-framework/` contains public TypeScript/Node and Python examples for calling a local or self-hosted Agoragentic Rust Framework runtime over `/health`, `/tools`, `/openapi.json`, and `/invoke`, plus a public-safe Agent OS Harness packet. It is an HTTP/JSON client/example layer only: no crate publish, hosted provisioning, wallet spend, x402 settlement, marketplace publication, trust mutation, private Full ECF export, or native binding requirement.
 

--- a/integrations.json
+++ b/integrations.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.20.0",
+  "version": "2.21.0",
   "updated_at": "2026-06-06",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
@@ -301,6 +301,15 @@
       "path": "robinhood/mcp.json",
       "install": "Schema-only scaffold; owner-authenticated MCP probe required before use",
       "docs": "robinhood/README.md"
+    },
+    {
+      "id": "robinhood-agentic-trading-guard",
+      "name": "Robinhood Agentic Trading Guard",
+      "language": "javascript",
+      "status": "experimental",
+      "path": "robinhood-agentic-trading-guard/guard-policy-preview.mjs",
+      "install": "node robinhood-agentic-trading-guard/guard-policy-preview.mjs --assert",
+      "docs": "robinhood-agentic-trading-guard/README.md"
     },
     {
       "id": "hermes-agent",
@@ -798,6 +807,12 @@
     "robinhood_mcp": "robinhood/mcp.json",
     "robinhood_mcp_probe_template": "robinhood/probes/robinhood-mcp-probe-template.json",
     "robinhood_mcp_probe_redacted_example": "robinhood/probes/robinhood-mcp-probe-redacted.example.json",
+    "robinhood_agentic_trading_guard": "robinhood-agentic-trading-guard/README.md",
+    "robinhood_agentic_trading_guard_policy": "robinhood-agentic-trading-guard/policy.example.json",
+    "robinhood_agentic_trading_guard_manifest": "robinhood-agentic-trading-guard/capability-manifest.json",
+    "robinhood_agentic_trading_guard_probe": "robinhood-agentic-trading-guard/mcp-probe.example.json",
+    "robinhood_agentic_trading_guard_receipt": "robinhood-agentic-trading-guard/receipt.example.json",
+    "robinhood_agentic_trading_guard_verifier": "robinhood-agentic-trading-guard/guard-policy-preview.mjs",
     "hermes_agent": "hermes-agent/README.md",
     "hermes_agent_bridge_manifest": "hermes-agent/agent-os-bridge.manifest.json",
     "hermes_agent_mcp_config_example": "hermes-agent/mcp.agoragentic.example.json",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -77,7 +77,7 @@ Framework adapters, Agent OS control-plane examples, and marketplace integration
 | CAMEL | camel/agoragentic_camel.py | pip install agoragentic camel-ai |
 | Syrin | syrin/agoragentic_syrin.py | pip install syrin requests |
 
-### JavaScript/TypeScript Integrations (13)
+### JavaScript/TypeScript Integrations (15)
 
 | Framework | File | Install |
 |-----------|------|---------|
@@ -92,6 +92,7 @@ Framework adapters, Agent OS control-plane examples, and marketplace integration
 | oh-my-claudecode | oh-my-claudecode/README.md | npx agoragentic-mcp |
 | DashClaw | dashclaw/agoragentic_dashclaw.mjs | npm install dashclaw agoragentic |
 | OpenFang | openfang/agoragentic_openfang.mjs | node 18+ with a local OpenFang Hand manifest |
+| Robinhood Agentic Trading Guard | robinhood-agentic-trading-guard/guard-policy-preview.mjs | node robinhood-agentic-trading-guard/guard-policy-preview.mjs --assert |
 | Premortem Golden Loop Agent | premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs | node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs run --repo . |
 | Zoneless Payout Reference | zoneless/agoragentic_zoneless_payouts.ts | reference only; not live settlement |
 | Agoragentic Rust Framework HTTP Runtime | rust-framework/README.md | run a local Rust framework HTTP runtime and set AGORAGENTIC_RUST_AGENT_URL |
@@ -205,6 +206,7 @@ Full spec: specs/ACP-SPEC.md
 | ACP registry positioning | ACP_REGISTRY.md |
 | Agent OS export | agent-os/README.md |
 | OpenFang bridge | openfang/README.md |
+| Robinhood Agentic Trading Guard | robinhood-agentic-trading-guard/README.md |
 | Hermes Agent bridge | hermes-agent/README.md |
 | Zoneless payout reference | zoneless/README.md |
 | n8n Community Node | n8n/README.md |

--- a/llms.txt
+++ b/llms.txt
@@ -21,7 +21,7 @@
 
 ## Integrations
 - LangChain, LangGraph, LangChain Deep Agents, CrewAI, AutoGen, OpenAI Agents SDK, Google ADK, pydantic-ai, smolagents, Agno, MetaGPT, LlamaIndex, AutoGPT, Microsoft Semantic Kernel, Composio, HumanLayer, SuperAGI, CAMEL, Syrin (Python)
-- MCP, Vercel AI, Cloudflare Agents, Mastra, Bee Agent, ElizaOS, n8n, oh-my-claudecode, DashClaw, OpenFang, Harness Core, Premortem Golden Loop, Zoneless payout reference (JS/TS)
+- MCP, Vercel AI, Cloudflare Agents, Mastra, Bee Agent, ElizaOS, n8n, oh-my-claudecode, DashClaw, OpenFang, Robinhood Agentic Trading Guard, Harness Core, Premortem Golden Loop, Zoneless payout reference (JS/TS)
 - Agent Client Protocol: acp/agent.json and `npx agoragentic-mcp --acp`
 - Dify, Flowise, Zapier MCP, A2A, RepoBrain Local Provider, claude-view Local Provider, Scrumboy, Hermes Agent Bridge (JSON)
 - LangSmith: langsmith/README.md (observability)
@@ -41,6 +41,7 @@
 - glama.json — Glama registry
 - agent-os/README.md — Agent OS public control-plane export
 - rust-framework/README.md — Rust Framework HTTP/JSON examples and self-hosted runtime boundary
+- robinhood-agentic-trading-guard/README.md — read-only Robinhood Agentic Trading MCP policy, approval, and receipt guard
 - openfang/README.md — OpenFang Hand bridge for routed buying, receipts, and seller listing drafts
 - hermes-agent/README.md — Hermes Agent MCP bridge and review-gated self-improvement packet boundary
 - zoneless/README.md — experimental Solana seller-payout reference only; not live Agoragentic settlement

--- a/robinhood-agentic-trading-guard/README.md
+++ b/robinhood-agentic-trading-guard/README.md
@@ -1,0 +1,78 @@
+# Robinhood Agentic Trading Guard
+
+Public-safe Agoragentic / Triptych OS (Agent OS) guardrail scaffold for Robinhood's official Agentic Trading / MCP flow.
+
+This integration is governance only. It evaluates proposed Robinhood-related MCP actions, returns a policy decision, and emits receipt-shaped evidence that confirms no live order path was invoked. It does not execute trades, place orders, use unofficial Robinhood APIs, store credentials, or store private account data.
+
+## Status
+
+- Status: experimental
+- Default mode: read-only, dry-run, proposal-only
+- Execution authority: none
+- Live trading: disabled
+- Official API stance: Robinhood MCP metadata only until owner-provided evidence verifies the official flow
+
+## Safety Boundary
+
+This guard is intentionally narrower than a trading integration:
+
+- No trading bot behavior
+- No order placement
+- No unofficial or reverse-engineered Robinhood APIs
+- No stored Robinhood credentials, tokens, account numbers, balances, positions, or raw portfolio data
+- No live trading support claims without owner-provided evidence
+- Options, margin, short selling, crypto, futures, event contracts, and other high-risk actions blocked by default
+- Live mode remains disabled by default and would require explicit owner approval before any separate executor could be considered
+
+Agoragentic provides the safety, policy, approval, receipt, and audit layer. Brokerage execution remains outside this integration.
+
+## Files
+
+- `policy.example.json` - default policy with read-only/proposal-only behavior
+- `capability-manifest.json` - machine-readable capability boundary
+- `mcp-probe.example.json` - public-safe metadata probe shape
+- `receipt.example.json` - example receipt for a blocked options proposal
+- `guard-policy-preview.mjs` - deterministic local policy preview and assertion script
+- `prompts/codex-robinhood-agentic-guard-build.md` - build prompt for regenerating this integration safely
+
+## Policy Decisions
+
+The guard emits one of three policy decisions:
+
+- `allow_read_only` - allowed metadata-only or public/read-only proposal
+- `require_owner_review` - blocked from execution until explicit owner approval
+- `blocked` - disallowed by default policy
+
+Example:
+
+```powershell
+node robinhood-agentic-trading-guard/guard-policy-preview.mjs --sample read-only
+node robinhood-agentic-trading-guard/guard-policy-preview.mjs --sample equity-order
+node robinhood-agentic-trading-guard/guard-policy-preview.mjs --sample options-order
+node robinhood-agentic-trading-guard/guard-policy-preview.mjs --assert
+```
+
+## Expected Outcomes
+
+| Proposal | Decision | Reason |
+| --- | --- | --- |
+| Inspect MCP endpoint metadata | `allow_read_only` | Metadata-only, no account data, no order |
+| Proposed equity order review/place action | `require_owner_review` | Owner approval required; no live order dispatched |
+| Proposed options order | `blocked` | Options are high-risk and blocked by default |
+
+Every decision includes receipt evidence for:
+
+- Intent
+- Policy decision
+- Blocked reason or approval requirement
+- No-live-order confirmation
+- Confirmation that no unofficial Robinhood API was used
+
+## Owner-Gated Next Steps
+
+These steps remain out of scope for this public scaffold:
+
+- Owner verifies the official Robinhood MCP schema and authentication flow.
+- Owner supplies redacted evidence that the MCP server exposes the expected tools.
+- Owner defines account-specific approval policy outside public artifacts.
+- Any live executor is reviewed separately, remains disabled by default, and requires explicit owner approval.

--- a/robinhood-agentic-trading-guard/capability-manifest.json
+++ b/robinhood-agentic-trading-guard/capability-manifest.json
@@ -1,0 +1,79 @@
+{
+  "schema_version": "agoragentic.capability_manifest.v1",
+  "id": "robinhood-agentic-trading-guard",
+  "name": "Robinhood Agentic Trading Guard",
+  "description": "Policy, approval, and receipt guard for proposed Robinhood Agentic Trading MCP actions. Governance only; no brokerage execution.",
+  "status": "experimental",
+  "language": "javascript",
+  "default_mode": "dry_run_proposal_only",
+  "transport": {
+    "type": "local_policy_preview",
+    "network_required": false,
+    "brokerage_execution": false
+  },
+  "official_mcp_metadata": {
+    "trading_endpoint_url": "https://agent.robinhood.com/mcp/trading",
+    "banking_endpoint_url": "https://banking-agent.robinhood.com/mcp/banking",
+    "metadata_only": true,
+    "owner_verified": false
+  },
+  "authority_boundary": {
+    "places_orders": false,
+    "uses_unofficial_robinhood_api": false,
+    "stores_robinhood_credentials": false,
+    "stores_account_numbers": false,
+    "stores_balances_or_raw_portfolio_data": false,
+    "live_mode_enabled_by_default": false,
+    "options_enabled_by_default": false
+  },
+  "input_contract": {
+    "type": "proposal",
+    "required_fields": [
+      "intent_id",
+      "requested_tool",
+      "action_class"
+    ],
+    "forbidden_fields": [
+      "credentials",
+      "access_token",
+      "refresh_token",
+      "private_key",
+      "account_number",
+      "balance",
+      "raw_portfolio"
+    ]
+  },
+  "output_contract": {
+    "decision_values": [
+      "allow_read_only",
+      "require_owner_review",
+      "blocked"
+    ],
+    "receipt_fields": [
+      "intent",
+      "policy_decision",
+      "blocked_reason",
+      "approval_requirement",
+      "no_live_order_confirmation"
+    ]
+  },
+  "default_blocks": [
+    "options",
+    "margin",
+    "short",
+    "crypto",
+    "futures",
+    "event_contracts",
+    "banking_card",
+    "raw_private_account_data",
+    "live_order_dispatch"
+  ],
+  "verification": {
+    "command": "node robinhood-agentic-trading-guard/guard-policy-preview.mjs --assert",
+    "expected_samples": {
+      "read-only": "allow_read_only",
+      "equity-order": "require_owner_review",
+      "options-order": "blocked"
+    }
+  }
+}

--- a/robinhood-agentic-trading-guard/guard-policy-preview.mjs
+++ b/robinhood-agentic-trading-guard/guard-policy-preview.mjs
@@ -1,0 +1,318 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DEFAULT_POLICY_PATH = path.join(__dirname, 'policy.example.json');
+
+const SAMPLE_PROPOSALS = {
+  'read-only': {
+    intent_id: 'intent_sample_read_only_metadata',
+    summary: 'Inspect configured Robinhood MCP metadata without account access or order intent.',
+    requested_tool: 'inspect_mcp_config',
+    action_class: 'metadata_read',
+    metadata_only: true,
+    account_scope: 'none'
+  },
+  'equity-order': {
+    intent_id: 'intent_sample_equity_order_review',
+    summary: 'Evaluate a proposed long equity order before any brokerage execution.',
+    requested_tool: 'place_equity_order',
+    action_class: 'proposed_order',
+    asset_class: 'equity',
+    side: 'buy',
+    notional_usd: 25,
+    live_mode_requested: false
+  },
+  'options-order': {
+    intent_id: 'intent_sample_options_order_block',
+    summary: 'Evaluate a proposed options order.',
+    requested_tool: 'place_options_order',
+    action_class: 'proposed_order',
+    asset_class: 'options',
+    side: 'buy_to_open',
+    live_mode_requested: false
+  }
+};
+
+const EXPECTED_DECISIONS = {
+  'read-only': 'allow_read_only',
+  'equity-order': 'require_owner_review',
+  'options-order': 'blocked'
+};
+
+const FORBIDDEN_PROPOSAL_KEYS = [
+  /credentials?/i,
+  /access[_-]?token/i,
+  /refresh[_-]?token/i,
+  /private[_-]?key/i,
+  /account[_-]?number/i,
+  /^balance$/i,
+  /raw[_-]?portfolio/i,
+  /portfolio[_-]?raw/i
+];
+
+function loadPolicy(policyPath = DEFAULT_POLICY_PATH) {
+  return JSON.parse(readFileSync(policyPath, 'utf8'));
+}
+
+function asSet(values) {
+  return new Set((values || []).map((value) => String(value).toLowerCase()));
+}
+
+function findForbiddenKey(value, pathParts = []) {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  for (const [key, child] of Object.entries(value)) {
+    const keyPath = [...pathParts, key];
+    if (FORBIDDEN_PROPOSAL_KEYS.some((pattern) => pattern.test(key))) {
+      return keyPath.join('.');
+    }
+    const nested = findForbiddenKey(child, keyPath);
+    if (nested) {
+      return nested;
+    }
+  }
+
+  return null;
+}
+
+function buildReceipt({ proposal, decision, reason, approvalRequirement, matchedRule, policy }) {
+  return {
+    schema_version: 'agoragentic.robinhood_agentic_trading_guard.receipt.v1',
+    integration_id: policy.integration_id,
+    receipt_id: `receipt_${proposal.intent_id || 'proposal'}`,
+    intent: {
+      intent_id: proposal.intent_id || null,
+      summary: proposal.summary || null,
+      requested_tool: proposal.requested_tool || null,
+      action_class: proposal.action_class || null,
+      asset_class: proposal.asset_class || null
+    },
+    policy_decision: {
+      decision,
+      blocked_reason: decision === 'blocked' ? reason : null,
+      approval_requirement: decision === 'require_owner_review' ? approvalRequirement : null
+    },
+    evidence: {
+      matched_rule: matchedRule,
+      mcp_metadata_present: Boolean(policy.mcp_metadata?.trading_endpoint_url),
+      owner_authenticated_schema_verified: Boolean(policy.mcp_metadata?.owner_authenticated_schema_verified),
+      no_live_order_confirmation: true,
+      robinhood_mcp_called: false,
+      unofficial_api_used: false,
+      credentials_stored: false,
+      private_account_data_stored: false,
+      raw_portfolio_data_stored: false
+    },
+    governance_boundary: {
+      agoragentic_role: 'policy_receipt_approval_layer',
+      brokerage_execution_role: 'outside_this_integration',
+      live_mode_enabled: Boolean(policy.rules?.live_mode_enabled)
+    }
+  };
+}
+
+function decideProposal(proposal, policy = loadPolicy()) {
+  const requestedTool = String(proposal.requested_tool || '').toLowerCase();
+  const actionClass = String(proposal.action_class || '').toLowerCase();
+  const assetClass = String(proposal.asset_class || '').toLowerCase();
+  const blockedTools = asSet(policy.blocked_tools);
+  const blockedAssetClasses = asSet(policy.blocked_asset_classes);
+  const allowedMetadataTools = asSet(policy.allowed_metadata_tools);
+  const allowedReadOnlyTools = asSet(policy.allowed_read_only_tools);
+  const reviewRequiredTools = asSet(policy.review_required_tools);
+
+  const forbiddenKey = findForbiddenKey(proposal);
+  if (forbiddenKey) {
+    return buildReceipt({
+      proposal,
+      policy,
+      decision: 'blocked',
+      reason: `Proposal includes forbidden private field: ${forbiddenKey}.`,
+      approvalRequirement: null,
+      matchedRule: 'forbidden_private_fields'
+    });
+  }
+
+  if (blockedTools.has(requestedTool)) {
+    return buildReceipt({
+      proposal,
+      policy,
+      decision: 'blocked',
+      reason: `${requestedTool} is blocked by default policy.`,
+      approvalRequirement: null,
+      matchedRule: `blocked_tools.${requestedTool}`
+    });
+  }
+
+  if (assetClass && blockedAssetClasses.has(assetClass)) {
+    return buildReceipt({
+      proposal,
+      policy,
+      decision: 'blocked',
+      reason: `${assetClass} actions are blocked by default policy.`,
+      approvalRequirement: null,
+      matchedRule: `blocked_asset_classes.${assetClass}`
+    });
+  }
+
+  if (proposal.live_mode_requested === true && policy.rules?.live_mode_enabled !== true) {
+    return buildReceipt({
+      proposal,
+      policy,
+      decision: 'require_owner_review',
+      reason: null,
+      approvalRequirement: 'Live mode is disabled by default and requires explicit owner approval before any separate executor can be considered.',
+      matchedRule: 'rules.owner_approval_required_for_live_mode'
+    });
+  }
+
+  if (actionClass === 'metadata_read' && proposal.metadata_only === true && allowedMetadataTools.has(requestedTool)) {
+    return buildReceipt({
+      proposal,
+      policy,
+      decision: 'allow_read_only',
+      reason: null,
+      approvalRequirement: null,
+      matchedRule: `allowed_metadata_tools.${requestedTool}`
+    });
+  }
+
+  if (allowedReadOnlyTools.has(requestedTool)) {
+    return buildReceipt({
+      proposal,
+      policy,
+      decision: 'allow_read_only',
+      reason: null,
+      approvalRequirement: null,
+      matchedRule: `allowed_read_only_tools.${requestedTool}`
+    });
+  }
+
+  if (reviewRequiredTools.has(requestedTool) || actionClass.includes('order')) {
+    return buildReceipt({
+      proposal,
+      policy,
+      decision: 'require_owner_review',
+      reason: null,
+      approvalRequirement: 'Owner review is required. This guard does not dispatch live orders.',
+      matchedRule: reviewRequiredTools.has(requestedTool) ? `review_required_tools.${requestedTool}` : 'rules.owner_approval_required_for_order_like_actions'
+    });
+  }
+
+  return buildReceipt({
+    proposal,
+    policy,
+    decision: 'blocked',
+    reason: 'Proposal does not match an allowed read-only or owner-reviewed action.',
+    approvalRequirement: null,
+    matchedRule: 'default_block'
+  });
+}
+
+function parseArgs(argv) {
+  const args = {
+    sample: 'read-only',
+    assert: false,
+    proposalPath: null,
+    policyPath: DEFAULT_POLICY_PATH
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--assert') {
+      args.assert = true;
+    } else if (arg === '--sample') {
+      args.sample = argv[index + 1];
+      index += 1;
+    } else if (arg === '--proposal') {
+      args.proposalPath = argv[index + 1];
+      index += 1;
+    } else if (arg === '--policy') {
+      args.policyPath = argv[index + 1];
+      index += 1;
+    } else if (arg === '--help' || arg === '-h') {
+      args.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node robinhood-agentic-trading-guard/guard-policy-preview.mjs --sample read-only
+  node robinhood-agentic-trading-guard/guard-policy-preview.mjs --sample equity-order
+  node robinhood-agentic-trading-guard/guard-policy-preview.mjs --sample options-order
+  node robinhood-agentic-trading-guard/guard-policy-preview.mjs --proposal path/to/proposal.json
+  node robinhood-agentic-trading-guard/guard-policy-preview.mjs --assert
+`);
+}
+
+function runAssertions(policy) {
+  for (const [sampleName, expectedDecision] of Object.entries(EXPECTED_DECISIONS)) {
+    const receipt = decideProposal(SAMPLE_PROPOSALS[sampleName], policy);
+    if (receipt.policy_decision.decision !== expectedDecision) {
+      throw new Error(`${sampleName} expected ${expectedDecision}, got ${receipt.policy_decision.decision}`);
+    }
+    if (receipt.evidence.no_live_order_confirmation !== true || receipt.evidence.robinhood_mcp_called !== false) {
+      throw new Error(`${sampleName} receipt does not confirm no live order and no MCP call`);
+    }
+  }
+
+  const authority = policy.authority_boundary || {};
+  const disabledAuthorityFlags = [
+    'brokerage_execution_enabled',
+    'live_order_dispatch_enabled',
+    'credential_storage_enabled',
+    'private_account_data_storage_enabled',
+    'unofficial_api_usage_allowed',
+    'trading_bot_behavior_allowed'
+  ];
+  for (const flag of disabledAuthorityFlags) {
+    if (authority[flag] !== false) {
+      throw new Error(`Policy authority flag must remain false: ${flag}`);
+    }
+  }
+
+  if (policy.rules?.live_mode_enabled !== false) {
+    throw new Error('Policy live_mode_enabled must remain false by default');
+  }
+
+  if (!asSet(policy.blocked_asset_classes).has('options')) {
+    throw new Error('Options must remain blocked by default');
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+
+  const policy = loadPolicy(args.policyPath);
+  if (args.assert) {
+    runAssertions(policy);
+    console.log('Robinhood Agentic Trading Guard assertions passed.');
+    return;
+  }
+
+  const proposal = args.proposalPath
+    ? JSON.parse(readFileSync(args.proposalPath, 'utf8'))
+    : SAMPLE_PROPOSALS[args.sample];
+
+  if (!proposal) {
+    throw new Error(`Unknown sample: ${args.sample}`);
+  }
+
+  console.log(JSON.stringify(decideProposal(proposal, policy), null, 2));
+}
+
+main();

--- a/robinhood-agentic-trading-guard/mcp-probe.example.json
+++ b/robinhood-agentic-trading-guard/mcp-probe.example.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "agoragentic.robinhood_agentic_trading_guard.mcp_probe.v1",
+  "integration_id": "robinhood-agentic-trading-guard",
+  "created_at": "2026-06-06T00:00:00Z",
+  "probe_type": "metadata_only",
+  "status": "owner_authentication_required",
+  "mcp_servers": [
+    {
+      "id": "robinhood-trading",
+      "url": "https://agent.robinhood.com/mcp/trading",
+      "purpose": "Official Robinhood Agentic Trading MCP metadata",
+      "authenticated_schema_verified": false,
+      "public_probe_action": "record_endpoint_metadata_only"
+    },
+    {
+      "id": "robinhood-banking",
+      "url": "https://banking-agent.robinhood.com/mcp/banking",
+      "purpose": "Official Robinhood Banking MCP metadata",
+      "authenticated_schema_verified": false,
+      "public_probe_action": "record_endpoint_metadata_only"
+    }
+  ],
+  "actions_performed": [
+    "loaded_public_metadata",
+    "confirmed_no_credentials_in_probe",
+    "confirmed_no_live_order_attempt"
+  ],
+  "actions_not_performed": [
+    "authenticate_to_robinhood",
+    "fetch_account_data",
+    "fetch_portfolio_data",
+    "review_order",
+    "place_order",
+    "cancel_order",
+    "store_private_data"
+  ],
+  "evidence": {
+    "metadata_only": true,
+    "robinhood_mcp_called": false,
+    "unofficial_api_used": false,
+    "private_account_data_observed": false,
+    "live_order_attempted": false
+  },
+  "owner_gated_followup": [
+    "Provide redacted authenticated schema evidence from the official Robinhood MCP flow.",
+    "Confirm expected tool names before enabling any account-specific policy.",
+    "Keep live execution disabled unless a separate owner-approved executor is reviewed."
+  ]
+}

--- a/robinhood-agentic-trading-guard/policy.example.json
+++ b/robinhood-agentic-trading-guard/policy.example.json
@@ -1,0 +1,91 @@
+{
+  "schema_version": "agoragentic.robinhood_agentic_trading_guard.policy.v1",
+  "integration_id": "robinhood-agentic-trading-guard",
+  "name": "Robinhood Agentic Trading Guard Policy",
+  "default_mode": "dry_run_proposal_only",
+  "status": "experimental",
+  "source_snapshot": {
+    "date": "2026-06-06",
+    "official_trading_mcp_url": "https://agent.robinhood.com/mcp/trading",
+    "official_banking_mcp_url": "https://banking-agent.robinhood.com/mcp/banking",
+    "notes": "URLs are metadata only in this public scaffold. Owner-provided evidence is required before claiming a verified live flow."
+  },
+  "mcp_metadata": {
+    "trading_server_id": "robinhood-trading",
+    "trading_endpoint_url": "https://agent.robinhood.com/mcp/trading",
+    "banking_server_id": "robinhood-banking",
+    "banking_endpoint_url": "https://banking-agent.robinhood.com/mcp/banking",
+    "metadata_only": true,
+    "owner_authenticated_schema_verified": false
+  },
+  "authority_boundary": {
+    "brokerage_execution_enabled": false,
+    "live_order_dispatch_enabled": false,
+    "credential_storage_enabled": false,
+    "private_account_data_storage_enabled": false,
+    "unofficial_api_usage_allowed": false,
+    "trading_bot_behavior_allowed": false
+  },
+  "decision_values": [
+    "allow_read_only",
+    "require_owner_review",
+    "blocked"
+  ],
+  "rules": {
+    "live_mode_enabled": false,
+    "owner_approval_required_for_live_mode": true,
+    "owner_approval_required_for_equity_orders": true,
+    "account_reads_require_owner_review": true,
+    "proposal_receipt_required": true,
+    "no_live_order_confirmation_required": true,
+    "allow_metadata_inspection": true
+  },
+  "allowed_metadata_tools": [
+    "inspect_mcp_config",
+    "list_guard_policy",
+    "validate_probe_metadata"
+  ],
+  "allowed_read_only_tools": [
+    "get_equity_quotes",
+    "get_equity_tradability",
+    "search_equities"
+  ],
+  "review_required_tools": [
+    "get_accounts",
+    "get_portfolio",
+    "get_equity_positions",
+    "get_equity_orders",
+    "review_equity_order",
+    "place_equity_order",
+    "cancel_equity_order"
+  ],
+  "blocked_asset_classes": [
+    "options",
+    "margin",
+    "short",
+    "crypto",
+    "futures",
+    "event_contracts",
+    "banking_card"
+  ],
+  "blocked_tools": [
+    "get_options_positions",
+    "get_options_quotes",
+    "get_options_orders",
+    "review_options_order",
+    "place_options_order",
+    "cancel_options_order",
+    "place_crypto_order",
+    "place_futures_order",
+    "place_event_contract_order",
+    "fetch_card_details",
+    "transfer_funds"
+  ],
+  "receipt": {
+    "include_intent": true,
+    "include_policy_decision": true,
+    "include_blocked_reason_or_approval_requirement": true,
+    "include_no_live_order_confirmation": true,
+    "include_unofficial_api_confirmation": true
+  }
+}

--- a/robinhood-agentic-trading-guard/prompts/codex-robinhood-agentic-guard-build.md
+++ b/robinhood-agentic-trading-guard/prompts/codex-robinhood-agentic-guard-build.md
@@ -1,0 +1,56 @@
+# Build Prompt: Robinhood Agentic Trading Guard
+
+Build a public-safe Agoragentic / Triptych OS (Agent OS) integration for Robinhood's official Agentic Trading / MCP flow.
+
+## Objective
+
+Create a governance guard that evaluates proposed Robinhood MCP actions, returns a deterministic policy decision, and emits receipt-shaped evidence.
+
+## Hard Boundaries
+
+- Do not build a trading bot.
+- Do not place, review, cancel, or dispatch real orders.
+- Do not use unofficial or reverse-engineered Robinhood APIs.
+- Do not store Robinhood credentials, tokens, private keys, account numbers, balances, positions, or raw portfolio data.
+- Do not claim live trading support unless owner-provided evidence verifies the official Robinhood MCP flow.
+- Default mode must be read-only, dry-run, and proposal-only.
+- Options and high-risk trades must be blocked by default.
+- Live mode must remain disabled by default and require explicit owner approval if scaffolded separately.
+
+## Required Artifacts
+
+- `README.md`
+- `policy.example.json`
+- `capability-manifest.json`
+- `mcp-probe.example.json`
+- `receipt.example.json`
+- `guard-policy-preview.mjs`
+
+## Required Behavior
+
+The guard must emit one of:
+
+- `allow_read_only`
+- `require_owner_review`
+- `blocked`
+
+It must include receipt evidence for:
+
+- Intent
+- Policy decision
+- Blocked reason or approval requirement
+- No-live-order confirmation
+- Confirmation that no unofficial Robinhood API was used
+
+## Validation
+
+Run:
+
+```powershell
+node robinhood-agentic-trading-guard/guard-policy-preview.mjs --assert
+node --check robinhood-agentic-trading-guard/guard-policy-preview.mjs
+node scripts/verify-integrations-json.js
+git diff --check
+```
+
+Confirm every referenced path exists and no private account data or secrets are introduced.

--- a/robinhood-agentic-trading-guard/receipt.example.json
+++ b/robinhood-agentic-trading-guard/receipt.example.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "agoragentic.robinhood_agentic_trading_guard.receipt.v1",
+  "integration_id": "robinhood-agentic-trading-guard",
+  "receipt_id": "receipt_robinhood_guard_example_001",
+  "created_at": "2026-06-06T00:00:00Z",
+  "intent": {
+    "intent_id": "intent_example_block_options",
+    "summary": "Evaluate a proposed options order against the Robinhood Agentic Trading Guard policy.",
+    "requested_tool": "place_options_order",
+    "action_class": "proposed_order",
+    "asset_class": "options"
+  },
+  "policy_decision": {
+    "decision": "blocked",
+    "blocked_reason": "Options and high-risk trades are blocked by default.",
+    "approval_requirement": null
+  },
+  "evidence": {
+    "policy_file": "robinhood-agentic-trading-guard/policy.example.json",
+    "matched_rule": "blocked_asset_classes.options",
+    "no_live_order_confirmation": true,
+    "robinhood_mcp_called": false,
+    "unofficial_api_used": false,
+    "credentials_stored": false,
+    "private_account_data_stored": false,
+    "raw_portfolio_data_stored": false
+  },
+  "governance_boundary": {
+    "agoragentic_role": "policy_receipt_approval_layer",
+    "brokerage_execution_role": "outside_this_integration",
+    "live_mode_enabled": false
+  }
+}

--- a/scripts/verify-integrations-json.js
+++ b/scripts/verify-integrations-json.js
@@ -3,6 +3,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { execFileSync } = require('child_process');
 
 const root = path.resolve(__dirname, '..');
 const manifestPath = path.join(root, 'integrations.json');
@@ -113,6 +114,129 @@ function assertDifyRouterFirst() {
   if (toolNames[1] !== 'agoragentic_match') fail('Dify second tool must be agoragentic_match');
 }
 
+function readJson(relativePath) {
+  return JSON.parse(fs.readFileSync(path.join(root, relativePath), 'utf8'));
+}
+
+function assertFileExists(relativePath) {
+  if (!fs.existsSync(path.join(root, relativePath))) {
+    fail(`Missing expected file: ${relativePath}`);
+  }
+}
+
+function assertAllFalse(object, fields, label) {
+  for (const field of fields) {
+    if (object?.[field] !== false) {
+      fail(`${label}.${field} must be false`);
+    }
+  }
+}
+
+function assertNoSecretShapedValues(relativePaths) {
+  const forbidden = [
+    /(?:access[_-]?token|refresh[_-]?token|private[_-]?key|password|secret|account[_-]?number)\s*[:=]\s*["'][^"'\s]{8,}["']/i,
+    /\b(?:sk|ghp|github_pat|amk)_[A-Za-z0-9_=-]{16,}\b/i,
+    /\b0x[a-fA-F0-9]{64}\b/,
+  ];
+
+  for (const relativePath of relativePaths) {
+    const text = fs.readFileSync(path.join(root, relativePath), 'utf8');
+    for (const pattern of forbidden) {
+      if (pattern.test(text)) {
+        fail(`${relativePath} contains a secret-shaped value: ${pattern}`);
+      }
+    }
+  }
+}
+
+function assertRobinhoodGuard(manifest) {
+  const integrationId = 'robinhood-agentic-trading-guard';
+  const guardRoot = 'robinhood-agentic-trading-guard';
+  const requiredPaths = [
+    `${guardRoot}/README.md`,
+    `${guardRoot}/policy.example.json`,
+    `${guardRoot}/capability-manifest.json`,
+    `${guardRoot}/mcp-probe.example.json`,
+    `${guardRoot}/receipt.example.json`,
+    `${guardRoot}/guard-policy-preview.mjs`,
+    `${guardRoot}/prompts/codex-robinhood-agentic-guard-build.md`,
+  ];
+
+  const entry = (manifest.integrations || []).find((integration) => integration.id === integrationId);
+  if (!entry) fail(`integrations.json missing ${integrationId}`);
+  if (entry?.status !== 'experimental') fail(`${integrationId} must remain experimental`);
+  if (entry?.language !== 'javascript') fail(`${integrationId} language must be javascript`);
+  if (entry?.path !== `${guardRoot}/guard-policy-preview.mjs`) fail(`${integrationId} path must point to guard-policy-preview.mjs`);
+  if (entry?.docs !== `${guardRoot}/README.md`) fail(`${integrationId} docs must point to README.md`);
+
+  for (const relativePath of requiredPaths) assertFileExists(relativePath);
+
+  const requiredDiscovery = {
+    robinhood_agentic_trading_guard: `${guardRoot}/README.md`,
+    robinhood_agentic_trading_guard_policy: `${guardRoot}/policy.example.json`,
+    robinhood_agentic_trading_guard_manifest: `${guardRoot}/capability-manifest.json`,
+    robinhood_agentic_trading_guard_probe: `${guardRoot}/mcp-probe.example.json`,
+    robinhood_agentic_trading_guard_receipt: `${guardRoot}/receipt.example.json`,
+    robinhood_agentic_trading_guard_verifier: `${guardRoot}/guard-policy-preview.mjs`,
+  };
+  for (const [key, expectedPath] of Object.entries(requiredDiscovery)) {
+    if (manifest.discovery?.[key] !== expectedPath) {
+      fail(`integrations.json discovery.${key} must be ${expectedPath}`);
+    }
+  }
+
+  const policy = readJson(`${guardRoot}/policy.example.json`);
+  if (policy.default_mode !== 'dry_run_proposal_only') fail('Robinhood guard policy default_mode must be dry_run_proposal_only');
+  if (policy.mcp_metadata?.metadata_only !== true) fail('Robinhood guard MCP metadata must be metadata_only');
+  if (policy.mcp_metadata?.owner_authenticated_schema_verified !== false) fail('Robinhood guard must not claim owner-authenticated schema verification');
+  if (policy.rules?.live_mode_enabled !== false) fail('Robinhood guard live mode must be disabled by default');
+  if (policy.rules?.owner_approval_required_for_live_mode !== true) fail('Robinhood guard live mode must require owner approval');
+  for (const decision of ['allow_read_only', 'require_owner_review', 'blocked']) {
+    if (!policy.decision_values?.includes(decision)) fail(`Robinhood guard policy missing decision ${decision}`);
+  }
+  if (!policy.blocked_asset_classes?.includes('options')) fail('Robinhood guard must block options by default');
+  if (!policy.blocked_tools?.includes('place_options_order')) fail('Robinhood guard must block place_options_order by default');
+  assertAllFalse(policy.authority_boundary, [
+    'brokerage_execution_enabled',
+    'live_order_dispatch_enabled',
+    'credential_storage_enabled',
+    'private_account_data_storage_enabled',
+    'unofficial_api_usage_allowed',
+    'trading_bot_behavior_allowed',
+  ], 'Robinhood guard policy authority_boundary');
+
+  const capability = readJson(`${guardRoot}/capability-manifest.json`);
+  if (capability.default_mode !== 'dry_run_proposal_only') fail('Robinhood guard capability default_mode must be dry_run_proposal_only');
+  if (capability.transport?.network_required !== false) fail('Robinhood guard capability must not require network');
+  if (capability.transport?.brokerage_execution !== false) fail('Robinhood guard capability must not enable brokerage execution');
+  if (capability.official_mcp_metadata?.metadata_only !== true) fail('Robinhood guard capability MCP metadata must be metadata_only');
+  if (capability.official_mcp_metadata?.owner_verified !== false) fail('Robinhood guard capability must not claim owner verification');
+  assertAllFalse(capability.authority_boundary, [
+    'places_orders',
+    'uses_unofficial_robinhood_api',
+    'stores_robinhood_credentials',
+    'stores_account_numbers',
+    'stores_balances_or_raw_portfolio_data',
+    'live_mode_enabled_by_default',
+    'options_enabled_by_default',
+  ], 'Robinhood guard capability authority_boundary');
+
+  const probe = readJson(`${guardRoot}/mcp-probe.example.json`);
+  if (probe.probe_type !== 'metadata_only') fail('Robinhood guard MCP probe must be metadata_only');
+  if (probe.evidence?.robinhood_mcp_called !== false) fail('Robinhood guard MCP probe must not call Robinhood MCP');
+  if (probe.evidence?.unofficial_api_used !== false) fail('Robinhood guard MCP probe must not use unofficial APIs');
+  if (probe.evidence?.live_order_attempted !== false) fail('Robinhood guard MCP probe must not attempt live orders');
+
+  const receipt = readJson(`${guardRoot}/receipt.example.json`);
+  if (receipt.policy_decision?.decision !== 'blocked') fail('Robinhood guard receipt example must show a blocked decision');
+  if (receipt.evidence?.no_live_order_confirmation !== true) fail('Robinhood guard receipt must confirm no live order');
+  if (receipt.evidence?.robinhood_mcp_called !== false) fail('Robinhood guard receipt must confirm no Robinhood MCP call');
+  if (receipt.governance_boundary?.live_mode_enabled !== false) fail('Robinhood guard receipt must keep live mode disabled');
+
+  assertNoSecretShapedValues(requiredPaths);
+  execFileSync(process.execPath, [path.join(root, `${guardRoot}/guard-policy-preview.mjs`), '--assert'], { stdio: 'pipe' });
+}
+
 const rawManifest = fs.readFileSync(manifestPath, 'utf8');
 const duplicates = topLevelDuplicateKeys(rawManifest);
 if (duplicates.length) fail(`integrations.json has duplicate top-level keys: ${duplicates.join(', ')}`);
@@ -122,6 +246,7 @@ assertManifestShape(manifest);
 assertMachineCopy();
 assertA2aRouterFirst();
 assertDifyRouterFirst();
+assertRobinhoodGuard(manifest);
 
 if (process.exitCode) process.exit(process.exitCode);
 console.log('✅ integrations machine-surface verification passed');


### PR DESCRIPTION
## What changed
- Added `robinhood-agentic-trading-guard/` with README, policy, capability manifest, MCP metadata probe, receipt example, deterministic policy preview script, and Codex build prompt.
- Registered the integration in `integrations.json` and synced `README.md`, `llms.txt`, `llms-full.txt`, `SKILL.md`, and `CHANGELOG.md` discovery surfaces.
- Extended `scripts/verify-integrations-json.js` to validate the guard artifacts, default safety flags, blocked options/high-risk posture, no-live-order receipt evidence, required paths, and secret-shaped values.

## Safety boundaries
- Governance only: no trading bot, no order placement, no order dispatch, and no brokerage execution authority.
- Uses Robinhood official MCP URLs only as public metadata; does not call the MCP endpoint or use unofficial/reverse-engineered APIs.
- Does not store Robinhood credentials, tokens, private keys, account numbers, balances, positions, or raw portfolio data.
- Options and high-risk actions are blocked by default.

## Why proposal/read-only by default
The public scaffold can safely validate metadata and proposed action intent without account access or live trading authority. Equity order-like proposals return `require_owner_review`; options return `blocked`; metadata-only inspection returns `allow_read_only`. Every sample receipt confirms no live order and no Robinhood MCP call.

## Validation run
- `node robinhood-agentic-trading-guard/guard-policy-preview.mjs --assert`
- `node --check robinhood-agentic-trading-guard/guard-policy-preview.mjs`
- `node --check scripts/verify-integrations-json.js`
- `node scripts/verify-integrations-json.js`
- `npx --yes -p ajv-cli -p ajv-formats ajv validate -s integrations.schema.json -d integrations.json --all-errors --spec=draft2020 -c ajv-formats`
- `node hermes-agent/verify-hermes-agent.mjs`
- `node scripts/verify-acp.js`
- Workflow-equivalent package checks for `mcp`, `micro-ecf`, and `harness-core`
- Integration path, per-framework README, root-file, CITATION, tool-ID, referenced-path, and secret-shaped value checks
- `git diff --check` and `git diff --cached --check`

## Remaining owner-gated steps
- Owner provides redacted authenticated schema evidence for the official Robinhood MCP flow.
- Owner defines account-specific approval policy outside public artifacts.
- Any live executor is reviewed separately, remains disabled by default, and requires explicit owner approval.