### PR TITLE
feat: add LangGraph PII pipeline guard demo

### DIFF
--- a/examples/langgraph_pii_pipeline_guard/.gitignore
+++ b/examples/langgraph_pii_pipeline_guard/.gitignore
@@ -1,0 +1,4 @@
+out/
+.venv/
+__pycache__/
+*.pyc

--- a/examples/langgraph_pii_pipeline_guard/README.md
+++ b/examples/langgraph_pii_pipeline_guard/README.md
@@ -1,0 +1,136 @@
+# LangGraph PII Pipeline Guard Demo
+
+This demo proves that Agoragentic can wrap an existing LangGraph-style data pipeline with privacy, policy, approval gates, and run receipts without forcing a stack migration.
+
+Do not rebuild your graph. Wrap it with Agoragentic.
+
+## What This Demo Proves
+
+- LangGraph can stay responsible for orchestration.
+- A local Agoragentic-style guard runs before simulated model and tool calls.
+- Direct identifiers are masked before model input.
+- Capability policy decides which tools can run.
+- Raw export is denied.
+- External send requires approval and does not execute automatically.
+- Every run emits a public-safe JSON receipt.
+
+The demo is local-only. It does not call Agoragentic hosted APIs, external email, Slack, export services, model providers, wallets, x402 rails, or marketplace publication endpoints.
+
+## Why This Is Not A LangGraph Replacement
+
+LangGraph remains the workflow layer: graph state, node sequence, branches, checkpoints, and supervisor logic still belong there. Agoragentic is demonstrated here as the control layer around the run: policy contracts, PII masking, capability permissions, approval gates, and receipts.
+
+If your graph already works, the hard part may be governance around the run rather than orchestration. This example keeps that boundary clear.
+
+## Architecture
+
+```text
+customer CSV row
+  -> classify_record node
+     -> guard_model_input masks PII before simulated model input
+  -> summarize_record node
+     -> simulated model sees masked state only
+  -> route_action node
+     -> guard_tool_call checks capability policy before mock tool execution
+  -> receipt.json
+     -> redacted evidence of masking, decisions, approvals, and denied actions
+```
+
+`src/pipeline.py` uses LangGraph when the `langgraph` package is installed. If it is not installed, the same three logical nodes run through a deterministic fallback so tests remain local and dependency-light.
+
+## Policy File
+
+`policies/pipeline_policy.yaml` defines:
+
+- `pii_masking_required: true`
+- `raw_pii_export_allowed: false`
+- `summarize_ticket`, `classify_risk`, and `escalate_to_manager` as allowed after masking
+- `send_email_to_customer` as `approval_required`
+- `export_raw_rows` as denied
+- receipt fields that must be emitted
+
+## PII Masking
+
+The guard masks:
+
+- email -> `[EMAIL_REDACTED]`
+- phone -> `[PHONE_REDACTED]`
+- account ID -> `[ACCOUNT_ID_REDACTED]`
+- customer ID -> `[CUSTOMER_ID_REDACTED]`
+- name -> `[NAME_REDACTED]`
+
+Tests prove raw identifiers do not appear in guarded model inputs, summaries, tool payloads, or receipts.
+
+## Run Locally
+
+```bash
+cd examples/langgraph_pii_pipeline_guard
+python -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+python src/pipeline.py
+```
+
+On Windows PowerShell:
+
+```powershell
+cd examples/langgraph_pii_pipeline_guard
+python -m venv .venv
+.\\.venv\\Scripts\\Activate.ps1
+pip install -r requirements.txt
+python src\\pipeline.py
+```
+
+The run writes:
+
+```text
+out/receipt.json
+```
+
+## Test Locally
+
+```bash
+cd examples/langgraph_pii_pipeline_guard
+pytest tests
+```
+
+From the repository root:
+
+```bash
+python -m pytest examples/langgraph_pii_pipeline_guard/tests
+```
+
+## Receipt Example
+
+The exact counts depend on the sample records, but the receipt shape is stable:
+
+```json
+{
+  "pipeline_name": "langgraph_customer_ticket_guard_demo",
+  "run_id": "example_run_id",
+  "policy_version": "local_demo_v1",
+  "records_processed": 10,
+  "pii_detected": true,
+  "redactions_applied": {
+    "account_id": 10,
+    "customer_id": 10,
+    "email": 10,
+    "name": 10,
+    "phone": 10
+  },
+  "model_calls_guarded": 20,
+  "approval_required": true,
+  "denied_actions": 2,
+  "external_services_called": false,
+  "raw_pii_exported": false,
+  "receipt_hash": "sha256:..."
+}
+```
+
+The receipt intentionally excludes raw customer records, raw model prompts, raw tool outputs, provider credentials, account data, payment payloads, wallet-private fields, and private platform internals.
+
+## Product Positioning
+
+This demo answers a practical developer question: if LangGraph or CrewAI is already mostly working, should you migrate just to get guardrails?
+
+The safer first test is to keep your graph and wrap the run. Agoragentic is positioned here as a framework-agnostic control layer around agent and pipeline execution, where every run can produce evidence of what data was touched, what was masked, what tools were allowed, what tools were denied, and what required approval.

--- a/examples/langgraph_pii_pipeline_guard/data/customers.csv
+++ b/examples/langgraph_pii_pipeline_guard/data/customers.csv
@@ -1,0 +1,11 @@
+customer_id,name,email,phone,account_id,ticket_text,ticket_priority,requested_action
+CUST-001,Ava Morgan,ava.morgan@example.test,555-010-1001,ACCT-1001,"Ava Morgan cannot access account ACCT-1001 and asked for a status summary.",high,summarize_ticket
+CUST-002,Ben Carter,ben.carter@example.test,555-010-1002,ACCT-1002,"Ben Carter says invoice emails are going to ben.carter@example.test and wants risk classification.",medium,classify_risk
+CUST-003,Chloe Rivera,chloe.rivera@example.test,555-010-1003,ACCT-1003,"Chloe Rivera requested raw export of ACCT-1003 ticket rows.",high,export_raw_rows
+CUST-004,Diego Lee,diego.lee@example.test,555-010-1004,ACCT-1004,"Diego Lee wants a support email sent about cancellation risk.",high,send_email_to_customer
+CUST-005,Emma Patel,emma.patel@example.test,555-010-1005,ACCT-1005,"Emma Patel reported a billing dispute and needs manager escalation.",high,escalate_to_manager
+CUST-006,Farah Chen,farah.chen@example.test,555-010-1006,ACCT-1006,"Farah Chen asked for a concise operational summary for CUST-006.",low,summarize_ticket
+CUST-007,Grace Kim,grace.kim@example.test,555-010-1007,ACCT-1007,"Grace Kim has repeated login failures and account access complaints.",medium,classify_risk
+CUST-008,Hugo Silva,hugo.silva@example.test,555-010-1008,ACCT-1008,"Hugo Silva wants all raw rows exported to a spreadsheet.",high,export_raw_rows
+CUST-009,Iris Novak,iris.novak@example.test,555-010-1009,ACCT-1009,"Iris Novak requested an external customer follow up.",medium,send_email_to_customer
+CUST-010,Jamal Brooks,jamal.brooks@example.test,555-010-1010,ACCT-1010,"Jamal Brooks has an operational issue and asks for escalation.",medium,escalate_to_manager

--- a/examples/langgraph_pii_pipeline_guard/policies/pipeline_policy.yaml
+++ b/examples/langgraph_pii_pipeline_guard/policies/pipeline_policy.yaml
@@ -1,0 +1,29 @@
+pipeline_name: langgraph_customer_ticket_guard_demo
+policy_version: local_demo_v1
+privacy:
+  pii_masking_required: true
+  external_model_calls_allowed: true
+  raw_pii_export_allowed: false
+capabilities:
+  summarize_ticket:
+    decision: allow
+    requires_masking: true
+  classify_risk:
+    decision: allow
+    requires_masking: true
+  escalate_to_manager:
+    decision: allow
+    requires_masking: true
+  send_email_to_customer:
+    decision: approval_required
+    requires_masking: false
+    reason: External send requires human approval
+  export_raw_rows:
+    decision: deny
+    reason: Raw PII export is not allowed by policy
+receipt:
+  emit_json: true
+  include_policy_version: true
+  include_masking_summary: true
+  include_tool_decisions: true
+  include_approval_events: true

--- a/examples/langgraph_pii_pipeline_guard/requirements.txt
+++ b/examples/langgraph_pii_pipeline_guard/requirements.txt
@@ -1,0 +1,3 @@
+langgraph>=0.2.0
+langchain-core>=0.2.0
+pytest>=8.0.0

--- a/examples/langgraph_pii_pipeline_guard/src/agoragentic_guard.py
+++ b/examples/langgraph_pii_pipeline_guard/src/agoragentic_guard.py
@@ -1,0 +1,46 @@
+"""Agoragentic-style local guard layer for a LangGraph pipeline run."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+try:
+    from .capabilities import guard_tool_decision
+    from .pii import mask_record
+    from .receipts import create_run_receipt
+except ImportError:  # pragma: no cover - supports running pipeline.py directly.
+    from capabilities import guard_tool_decision
+    from pii import mask_record
+    from receipts import create_run_receipt
+
+
+def guard_model_input(record: Dict[str, str], policy: Dict[str, Any]) -> Dict[str, Any]:
+    """Return masked input and evidence metadata before a simulated model call."""
+    if policy.get("privacy", {}).get("pii_masking_required") is not True:
+        return {
+            "allowed": False,
+            "reason": "PII masking is required for this demo policy",
+            "masked_input": {},
+            "evidence": {"pii_detected": False, "redactions": {}},
+        }
+
+    masked = mask_record(record)
+    return {
+        "allowed": True,
+        "reason": "PII masked before simulated model call",
+        "masked_input": masked["masked_record"],
+        "evidence": {
+            "pii_detected": masked["pii_detected"],
+            "redactions": masked["redactions"],
+        },
+    }
+
+
+def guard_tool_call(tool_name: str, payload: Dict[str, Any], policy: Dict[str, Any]) -> Dict[str, Any]:
+    """Return an allow, deny, or approval_required decision before tool execution."""
+    return guard_tool_decision(tool_name, payload, policy)
+
+
+def create_receipt(run_state: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the final public-safe receipt for the guarded run."""
+    return create_run_receipt(run_state)

--- a/examples/langgraph_pii_pipeline_guard/src/capabilities.py
+++ b/examples/langgraph_pii_pipeline_guard/src/capabilities.py
@@ -1,0 +1,86 @@
+"""Capability policy loading and tool-call decisions for the local demo."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+
+def _parse_scalar(value: str) -> Any:
+    value = value.strip()
+    if value.lower() == "true":
+        return True
+    if value.lower() == "false":
+        return False
+    if (value.startswith('"') and value.endswith('"')) or (value.startswith("'") and value.endswith("'")):
+        return value[1:-1]
+    return value
+
+
+def load_policy(policy_path: Path | str) -> Dict[str, Any]:
+    """Load the demo YAML policy using a tiny parser for this fixed file shape."""
+    root: Dict[str, Any] = {}
+    stack = [(-1, root)]
+    for raw_line in Path(policy_path).read_text(encoding="utf-8").splitlines():
+        if not raw_line.strip() or raw_line.lstrip().startswith("#"):
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        key, separator, value = raw_line.strip().partition(":")
+        if not separator:
+            raise ValueError(f"Invalid policy line: {raw_line}")
+        while stack and indent <= stack[-1][0]:
+            stack.pop()
+        parent = stack[-1][1]
+        if value.strip():
+            parent[key] = _parse_scalar(value)
+        else:
+            child: Dict[str, Any] = {}
+            parent[key] = child
+            stack.append((indent, child))
+    return root
+
+
+def guard_tool_decision(tool_name: str, payload: Dict[str, Any], policy: Dict[str, Any]) -> Dict[str, Any]:
+    """Return allow, deny, or approval_required before a mock tool can run."""
+    capabilities = policy.get("capabilities", {})
+    rule = capabilities.get(tool_name)
+    if not rule:
+        return {
+            "tool_name": tool_name,
+            "decision": "deny",
+            "reason": "Unknown tools are denied by default",
+            "executed": False,
+        }
+
+    decision = rule.get("decision", "deny")
+    requires_masking = rule.get("requires_masking") is True
+    if requires_masking and payload.get("_masking_applied") is not True:
+        return {
+            "tool_name": tool_name,
+            "decision": "deny",
+            "reason": "Masked payload required before this tool can execute",
+            "executed": False,
+        }
+
+    if decision == "allow":
+        return {
+            "tool_name": tool_name,
+            "decision": "allow",
+            "reason": "Allowed by local demo policy",
+            "executed": True,
+        }
+
+    if decision == "approval_required":
+        return {
+            "tool_name": tool_name,
+            "decision": "approval_required",
+            "reason": rule.get("reason", "Human approval required"),
+            "executed": False,
+        }
+
+    return {
+        "tool_name": tool_name,
+        "decision": "deny",
+        "reason": rule.get("reason", "Denied by local demo policy"),
+        "executed": False,
+    }

--- a/examples/langgraph_pii_pipeline_guard/src/mock_tools.py
+++ b/examples/langgraph_pii_pipeline_guard/src/mock_tools.py
@@ -1,0 +1,45 @@
+"""Local-only simulated model and tool calls for the demo pipeline."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def simulated_model_call(kind: str, masked_record: Dict[str, Any]) -> Dict[str, str]:
+    """Return deterministic model-like output from masked input only."""
+    text = f"{masked_record.get('ticket_text', '')} {masked_record.get('requested_action', '')}".lower()
+    if kind == "classify_record":
+        if "billing" in text or "invoice" in text:
+            category = "billing"
+        elif "access" in text or "login" in text:
+            category = "account access"
+        elif "cancellation" in text or "complaint" in text:
+            category = "cancellation risk"
+        elif "operational" in text or "escalation" in text:
+            category = "operational issue"
+        else:
+            category = "complaint"
+        return {"classification": category}
+
+    if kind == "summarize_record":
+        return {
+            "summary": (
+                f"{masked_record.get('customer_id')} has a {masked_record.get('ticket_priority')} "
+                f"priority {masked_record.get('requested_action')} request. Direct identifiers are masked."
+            )
+        }
+
+    raise ValueError(f"Unsupported simulated model call: {kind}")
+
+
+def run_mock_tool(tool_name: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Execute only local mock tools after policy has allowed the action."""
+    return {
+        "tool_name": tool_name,
+        "status": "mock_executed",
+        "external_service_called": False,
+        "payload_summary": {
+            "classification": payload.get("classification"),
+            "summary_present": bool(payload.get("summary")),
+        },
+    }

--- a/examples/langgraph_pii_pipeline_guard/src/pii.py
+++ b/examples/langgraph_pii_pipeline_guard/src/pii.py
@@ -1,0 +1,98 @@
+"""Deterministic PII masking for the LangGraph guard demo."""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from typing import Dict, Iterable, Tuple
+
+
+MASKS = {
+    "email": "[EMAIL_REDACTED]",
+    "phone": "[PHONE_REDACTED]",
+    "account_id": "[ACCOUNT_ID_REDACTED]",
+    "customer_id": "[CUSTOMER_ID_REDACTED]",
+    "name": "[NAME_REDACTED]",
+}
+
+EMAIL_RE = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE)
+PHONE_RE = re.compile(r"\b(?:\+?1[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)\d{3}[-.\s]?\d{4}\b")
+ACCOUNT_RE = re.compile(r"\bACCT-\d{4,}\b")
+CUSTOMER_RE = re.compile(r"\bCUST-\d{3,}\b")
+
+
+def raw_pii_values(record: Dict[str, str]) -> Dict[str, str]:
+    """Return direct identifier values from a source record."""
+    return {
+        key: str(record.get(key, "")).strip()
+        for key in ("email", "phone", "account_id", "customer_id", "name")
+        if str(record.get(key, "")).strip()
+    }
+
+
+def _replace_known_value(text: str, value: str, token: str) -> Tuple[str, int]:
+    if not value:
+        return text, 0
+    count = text.count(value)
+    if count:
+        text = text.replace(value, token)
+    return text, count
+
+
+def mask_text(text: str, record: Dict[str, str]) -> Tuple[str, Counter]:
+    """Mask PII in arbitrary text using record-aware values and regex fallback."""
+    masked = str(text)
+    counts: Counter = Counter()
+    raw_values = raw_pii_values(record)
+
+    for kind, field in (
+        ("email", "email"),
+        ("phone", "phone"),
+        ("account_id", "account_id"),
+        ("customer_id", "customer_id"),
+        ("name", "name"),
+    ):
+        masked, replaced = _replace_known_value(masked, raw_values.get(field, ""), MASKS[kind])
+        counts[kind] += replaced
+
+    regexes = (
+        ("email", EMAIL_RE, MASKS["email"]),
+        ("phone", PHONE_RE, MASKS["phone"]),
+        ("account_id", ACCOUNT_RE, MASKS["account_id"]),
+        ("customer_id", CUSTOMER_RE, MASKS["customer_id"]),
+    )
+    for kind, pattern, token in regexes:
+        masked, replaced = pattern.subn(token, masked)
+        counts[kind] += replaced
+
+    return masked, counts
+
+
+def mask_record(record: Dict[str, str]) -> Dict[str, object]:
+    """Return a masked record and redaction metadata without storing raw values."""
+    masked: Dict[str, str] = {}
+    redactions: Counter = Counter()
+
+    for key, value in record.items():
+        if key in ("email", "phone", "account_id", "customer_id", "name"):
+            masked[key] = MASKS[key]
+            if str(value).strip():
+                redactions[key] += 1
+            continue
+
+        masked_value, counts = mask_text(str(value), record)
+        masked[key] = masked_value
+        redactions.update(counts)
+
+    masked["_masking_applied"] = True
+    return {
+        "masked_record": masked,
+        "redactions": dict(redactions),
+        "pii_detected": any(count > 0 for count in redactions.values()),
+    }
+
+
+def contains_raw_pii(text: object, raw_values: Iterable[str]) -> bool:
+    """Check whether any known raw identifier is present in a public-safe value."""
+    serialized = str(text)
+    return any(value and value in serialized for value in raw_values)

--- a/examples/langgraph_pii_pipeline_guard/src/pipeline.py
+++ b/examples/langgraph_pii_pipeline_guard/src/pipeline.py
@@ -1,0 +1,140 @@
+"""Three-node LangGraph customer ticket pipeline wrapped by local guard policy."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+try:
+    from .agoragentic_guard import create_receipt, guard_model_input, guard_tool_call
+    from .capabilities import load_policy
+    from .mock_tools import run_mock_tool, simulated_model_call
+except ImportError:  # pragma: no cover - supports `python src/pipeline.py`.
+    from agoragentic_guard import create_receipt, guard_model_input, guard_tool_call
+    from capabilities import load_policy
+    from mock_tools import run_mock_tool, simulated_model_call
+
+
+BASE_DIR = Path(__file__).resolve().parents[1]
+
+
+def load_records(data_path: Path | str) -> List[Dict[str, str]]:
+    with Path(data_path).open("r", encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def classify_record_node(state: Dict[str, Any]) -> Dict[str, Any]:
+    guarded = guard_model_input(state["record"], state["policy"])
+    if not guarded["allowed"]:
+        raise RuntimeError(guarded["reason"])
+    masked_record = guarded["masked_input"]
+    model_result = simulated_model_call("classify_record", masked_record)
+    return {
+        **state,
+        "masked_record": masked_record,
+        "classification": model_result["classification"],
+        "nodes_executed": state.get("nodes_executed", []) + ["classify_record"],
+        "model_inputs": state.get("model_inputs", []) + [masked_record],
+        "redaction_events": state.get("redaction_events", []) + [guarded["evidence"]["redactions"]],
+    }
+
+
+def summarize_record_node(state: Dict[str, Any]) -> Dict[str, Any]:
+    model_result = simulated_model_call("summarize_record", state["masked_record"])
+    return {
+        **state,
+        "summary": model_result["summary"],
+        "nodes_executed": state.get("nodes_executed", []) + ["summarize_record"],
+        "model_inputs": state.get("model_inputs", []) + [state["masked_record"]],
+        "summaries": state.get("summaries", []) + [model_result["summary"]],
+    }
+
+
+def route_action_node(state: Dict[str, Any]) -> Dict[str, Any]:
+    tool_name = state["masked_record"].get("requested_action", "unknown")
+    payload = {
+        "_masking_applied": state["masked_record"].get("_masking_applied") is True,
+        "customer_id": state["masked_record"].get("customer_id"),
+        "classification": state["classification"],
+        "summary": state["summary"],
+    }
+    decision = guard_tool_call(tool_name, payload, state["policy"])
+    tool_result = run_mock_tool(tool_name, payload) if decision["decision"] == "allow" else None
+    return {
+        **state,
+        "nodes_executed": state.get("nodes_executed", []) + ["route_action"],
+        "tool_payloads": state.get("tool_payloads", []) + [payload],
+        "tool_decisions": state.get("tool_decisions", []) + [decision],
+        "tool_results": state.get("tool_results", []) + ([tool_result] if tool_result else []),
+    }
+
+
+def _run_sequential_graph(state: Dict[str, Any]) -> Dict[str, Any]:
+    state = classify_record_node(state)
+    state = summarize_record_node(state)
+    return route_action_node(state)
+
+
+def _run_langgraph_or_fallback(state: Dict[str, Any]) -> Dict[str, Any]:
+    try:
+        from langgraph.graph import StateGraph
+    except Exception:
+        return _run_sequential_graph(state)
+
+    graph = StateGraph(dict)
+    graph.add_node("classify_record", classify_record_node)
+    graph.add_node("summarize_record", summarize_record_node)
+    graph.add_node("route_action", route_action_node)
+    graph.set_entry_point("classify_record")
+    graph.add_edge("classify_record", "summarize_record")
+    graph.add_edge("summarize_record", "route_action")
+    graph.set_finish_point("route_action")
+    return graph.compile().invoke(state)
+
+
+def run_pipeline(
+    data_path: Path | str = BASE_DIR / "data" / "customers.csv",
+    policy_path: Path | str = BASE_DIR / "policies" / "pipeline_policy.yaml",
+    receipt_path: Path | str = BASE_DIR / "out" / "receipt.json",
+    run_id: str = "example_run_id",
+) -> Dict[str, Any]:
+    policy = load_policy(policy_path)
+    records = load_records(data_path)
+    aggregate_state: Dict[str, Any] = {
+        "pipeline_name": policy["pipeline_name"],
+        "policy_version": policy["policy_version"],
+        "run_id": run_id,
+        "records_processed": len(records),
+        "model_inputs": [],
+        "summaries": [],
+        "tool_payloads": [],
+        "tool_decisions": [],
+        "tool_results": [],
+        "redaction_events": [],
+        "nodes_executed": [],
+    }
+
+    for record in records:
+        record_state = _run_langgraph_or_fallback({"record": record, "policy": policy})
+        for key in ("model_inputs", "summaries", "tool_payloads", "tool_decisions", "tool_results", "redaction_events"):
+            aggregate_state[key].extend(record_state.get(key, []))
+        aggregate_state["nodes_executed"].append(record_state.get("nodes_executed", []))
+
+    receipt = create_receipt(aggregate_state)
+    receipt_output = Path(receipt_path)
+    receipt_output.parent.mkdir(parents=True, exist_ok=True)
+    receipt_output.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    aggregate_state["receipt"] = receipt
+    aggregate_state["receipt_path"] = str(receipt_output)
+    return aggregate_state
+
+
+def main() -> None:
+    state = run_pipeline()
+    print(json.dumps(state["receipt"], indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/langgraph_pii_pipeline_guard/src/receipts.py
+++ b/examples/langgraph_pii_pipeline_guard/src/receipts.py
@@ -1,0 +1,56 @@
+"""Public-safe receipt generation for the LangGraph guard demo."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from typing import Any, Dict, Iterable, List
+
+
+def _stable_hash(payload: Dict[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _compact_decisions(decisions: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    compact: List[Dict[str, Any]] = []
+    seen = set()
+    for decision in decisions:
+        key = (decision.get("tool_name"), decision.get("decision"), decision.get("reason"))
+        if key in seen:
+            continue
+        seen.add(key)
+        compact.append(
+            {
+                "tool_name": decision.get("tool_name"),
+                "decision": decision.get("decision"),
+                "reason": decision.get("reason"),
+            }
+        )
+    return compact
+
+
+def create_run_receipt(run_state: Dict[str, Any]) -> Dict[str, Any]:
+    """Create a deterministic, redacted receipt for the pipeline run."""
+    redaction_totals: Counter = Counter()
+    for counts in run_state.get("redaction_events", []):
+        redaction_totals.update(counts)
+
+    tool_decisions = list(run_state.get("tool_decisions", []))
+    receipt = {
+        "pipeline_name": run_state["pipeline_name"],
+        "run_id": run_state["run_id"],
+        "policy_version": run_state["policy_version"],
+        "records_processed": run_state["records_processed"],
+        "pii_detected": bool(redaction_totals),
+        "redactions_applied": dict(sorted(redaction_totals.items())),
+        "model_calls_guarded": len(run_state.get("model_inputs", [])),
+        "tool_decisions": _compact_decisions(tool_decisions),
+        "approval_required": any(item.get("decision") == "approval_required" for item in tool_decisions),
+        "denied_actions": sum(1 for item in tool_decisions if item.get("decision") == "deny"),
+        "external_services_called": False,
+        "raw_pii_exported": False,
+    }
+    receipt["receipt_hash"] = _stable_hash(receipt)
+    return receipt

--- a/examples/langgraph_pii_pipeline_guard/tests/test_approval_gate.py
+++ b/examples/langgraph_pii_pipeline_guard/tests/test_approval_gate.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from agoragentic_guard import guard_tool_call
+from capabilities import load_policy
+
+
+def test_external_send_requires_approval_and_does_not_execute():
+    policy = load_policy(ROOT / "policies" / "pipeline_policy.yaml")
+    decision = guard_tool_call(
+        "send_email_to_customer",
+        {"_masking_applied": True, "summary": "masked summary"},
+        policy,
+    )
+
+    assert decision["decision"] == "approval_required"
+    assert decision["executed"] is False
+    assert "human approval" in decision["reason"].lower()

--- a/examples/langgraph_pii_pipeline_guard/tests/test_capability_policy.py
+++ b/examples/langgraph_pii_pipeline_guard/tests/test_capability_policy.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from capabilities import guard_tool_decision, load_policy
+
+
+POLICY = load_policy(ROOT / "policies" / "pipeline_policy.yaml")
+
+
+def test_allowed_tool_requires_masked_payload():
+    denied = guard_tool_decision("summarize_ticket", {"_masking_applied": False}, POLICY)
+    allowed = guard_tool_decision("summarize_ticket", {"_masking_applied": True}, POLICY)
+
+    assert denied["decision"] == "deny"
+    assert allowed["decision"] == "allow"
+    assert allowed["executed"] is True
+
+
+def test_raw_export_and_unknown_tools_are_denied():
+    export_decision = guard_tool_decision("export_raw_rows", {"_masking_applied": True}, POLICY)
+    unknown_decision = guard_tool_decision("upload_all_rows", {"_masking_applied": True}, POLICY)
+
+    assert export_decision["decision"] == "deny"
+    assert "Raw PII export" in export_decision["reason"]
+    assert unknown_decision["decision"] == "deny"
+    assert unknown_decision["executed"] is False

--- a/examples/langgraph_pii_pipeline_guard/tests/test_pii_masking.py
+++ b/examples/langgraph_pii_pipeline_guard/tests/test_pii_masking.py
@@ -1,0 +1,32 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from pii import contains_raw_pii, mask_record, raw_pii_values
+
+
+def test_masks_direct_identifiers_and_ticket_text():
+    record = {
+        "customer_id": "CUST-999",
+        "name": "Test Person",
+        "email": "test.person@example.test",
+        "phone": "555-010-9999",
+        "account_id": "ACCT-9999",
+        "ticket_text": "Test Person at test.person@example.test asked about ACCT-9999.",
+        "ticket_priority": "high",
+        "requested_action": "summarize_ticket",
+    }
+
+    result = mask_record(record)
+    masked = result["masked_record"]
+    raw_values = raw_pii_values(record).values()
+
+    assert masked["email"] == "[EMAIL_REDACTED]"
+    assert masked["phone"] == "[PHONE_REDACTED]"
+    assert masked["account_id"] == "[ACCOUNT_ID_REDACTED]"
+    assert masked["customer_id"] == "[CUSTOMER_ID_REDACTED]"
+    assert masked["name"] == "[NAME_REDACTED]"
+    assert not contains_raw_pii(masked, raw_values)
+    assert result["pii_detected"] is True

--- a/examples/langgraph_pii_pipeline_guard/tests/test_pipeline_end_to_end.py
+++ b/examples/langgraph_pii_pipeline_guard/tests/test_pipeline_end_to_end.py
@@ -1,0 +1,37 @@
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from pii import contains_raw_pii, raw_pii_values
+from pipeline import load_records, run_pipeline
+
+
+def test_pipeline_processes_three_nodes_and_keeps_pii_out_of_public_artifacts(tmp_path):
+    data_path = ROOT / "data" / "customers.csv"
+    receipt_path = tmp_path / "receipt.json"
+    state = run_pipeline(
+        data_path=data_path,
+        policy_path=ROOT / "policies" / "pipeline_policy.yaml",
+        receipt_path=receipt_path,
+    )
+    records = load_records(data_path)
+    raw_values = []
+    for record in records:
+        raw_values.extend(raw_pii_values(record).values())
+
+    public_artifacts = {
+        "model_inputs": state["model_inputs"],
+        "summaries": state["summaries"],
+        "tool_payloads": state["tool_payloads"],
+        "receipt": state["receipt"],
+    }
+    assert state["records_processed"] == 10
+    assert all(nodes == ["classify_record", "summarize_record", "route_action"] for nodes in state["nodes_executed"])
+    assert not contains_raw_pii(json.dumps(public_artifacts, sort_keys=True), raw_values)
+    assert any(decision["decision"] == "deny" and decision["tool_name"] == "export_raw_rows" for decision in state["tool_decisions"])
+    assert any(decision["decision"] == "approval_required" and decision["tool_name"] == "send_email_to_customer" for decision in state["tool_decisions"])
+    assert receipt_path.exists()
+    assert json.loads(receipt_path.read_text(encoding="utf-8")) == state["receipt"]

--- a/examples/langgraph_pii_pipeline_guard/tests/test_receipt_schema.py
+++ b/examples/langgraph_pii_pipeline_guard/tests/test_receipt_schema.py
@@ -1,0 +1,41 @@
+import copy
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from receipts import create_run_receipt
+
+
+def _run_state():
+    return {
+        "pipeline_name": "langgraph_customer_ticket_guard_demo",
+        "run_id": "example_run_id",
+        "policy_version": "local_demo_v1",
+        "records_processed": 2,
+        "redaction_events": [{"email": 2, "phone": 2, "account_id": 2, "customer_id": 2, "name": 2}],
+        "model_inputs": [{"masked": True}, {"masked": True}, {"masked": True}, {"masked": True}],
+        "tool_decisions": [
+            {"tool_name": "export_raw_rows", "decision": "deny", "reason": "Raw PII export is not allowed by policy"},
+            {"tool_name": "send_email_to_customer", "decision": "approval_required", "reason": "External send requires human approval"},
+        ],
+    }
+
+
+def test_receipt_schema_and_hash_are_stable():
+    receipt = create_run_receipt(_run_state())
+    repeated = create_run_receipt(copy.deepcopy(_run_state()))
+
+    assert receipt == repeated
+    assert receipt["pipeline_name"] == "langgraph_customer_ticket_guard_demo"
+    assert receipt["run_id"] == "example_run_id"
+    assert receipt["policy_version"] == "local_demo_v1"
+    assert receipt["records_processed"] == 2
+    assert receipt["pii_detected"] is True
+    assert receipt["model_calls_guarded"] == 4
+    assert receipt["approval_required"] is True
+    assert receipt["denied_actions"] == 1
+    assert receipt["external_services_called"] is False
+    assert receipt["raw_pii_exported"] is False
+    assert receipt["receipt_hash"].startswith("sha256:")


### PR DESCRIPTION
## Summary

Closes #49 when merged.

Adds a runnable local demo at `examples/langgraph_pii_pipeline_guard/` showing how Agoragentic can wrap an existing LangGraph-style data pipeline with policy, PII masking, capability permissions, approval gates, and public-safe run receipts without replacing LangGraph.

## What changed

- Added fake customer-ticket CSV data with direct identifiers only from reserved/example domains.
- Added a YAML policy for PII masking, allowed tools, denied raw export, approval-required external send, and receipt fields.
- Added deterministic Python guard modules for masking, policy decisions, mock tools, and receipt hashing.
- Added a three-node pipeline: classify record, summarize record, route action.
- Uses LangGraph when installed; falls back to the same deterministic three-node sequence so tests remain local-only.
- Added pytest coverage for PII masking, capability policy, approval gate, receipt schema/hash, and end-to-end no-raw-PII leakage.
- Added README positioning: “Do not rebuild your graph. Wrap it with Agoragentic.”

## Safety boundaries

- No hosted Agoragentic API calls.
- No real model/provider calls.
- No real email, Slack, export, or external service calls.
- No real customer data.
- No secrets or credentials.
- No wallet, x402, marketplace publication, live execution, or settlement behavior.
- Receipts are public-safe and exclude raw customer records, raw prompts, raw tool outputs, provider credentials, account data, payment payloads, wallet-private fields, and private platform internals.

## Validation

- `python -m py_compile examples\langgraph_pii_pipeline_guard\src\pii.py examples\langgraph_pii_pipeline_guard\src\capabilities.py examples\langgraph_pii_pipeline_guard\src\mock_tools.py examples\langgraph_pii_pipeline_guard\src\receipts.py examples\langgraph_pii_pipeline_guard\src\agoragentic_guard.py examples\langgraph_pii_pipeline_guard\src\pipeline.py`
- `python -m pytest examples\langgraph_pii_pipeline_guard\tests` — 6 passed
- `python src\pipeline.py` from `examples\langgraph_pii_pipeline_guard` — generated redacted receipt
- `node scripts\verify-integrations-json.js`
- `git diff --cached --check`
- `git diff --check`
