### PR TITLE
fix: exclude generated Micro ECF artifacts from source stats

### DIFF
--- a/micro-ecf/schema/source-map.schema.json
+++ b/micro-ecf/schema/source-map.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://agoragentic.com/schema/micro-ecf-source-map.v1.json",
   "title": "Micro ECF Source Map v1",
-  "description": "Local source inventory with hashes, summaries, blocked-path reasons, and citation ids.",
+  "description": "Local source inventory with hashes, summaries, blocked-path reasons, generated-artifact exclusions, and citation ids.",
   "type": "object",
   "required": ["schema", "generated_at", "sources", "blocked", "stats"],
   "properties": {
@@ -30,6 +30,15 @@
     },
     "blocked": {
       "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["path", "reason"],
+        "additionalProperties": true
+      }
+    },
+    "generated": {
+      "type": "array",
+      "description": "Self-generated Micro ECF / ECF artifact paths excluded from source counts.",
       "items": {
         "type": "object",
         "required": ["path", "reason"],

--- a/micro-ecf/src/core.mjs
+++ b/micro-ecf/src/core.mjs
@@ -105,6 +105,12 @@ const DEFAULT_BLOCK_SUFFIXES = [
   '.pfx',
 ];
 
+const GENERATED_ROOT_ARTIFACTS = new Set([
+  'ECF.md',
+  'AGENTS.md',
+  'MICRO_ECF_LLM_BOOTSTRAP.md',
+]);
+
 const LEARNING_REVIEW_STATUSES = Object.freeze(['blocked', 'manual_review', 'proposal_ready']);
 
 export function buildLearningMemoryBoundary() {
@@ -142,7 +148,27 @@ export function createDefaultPolicy(projectName = 'local-agent') {
     context_policy: {
       allowed_sources: ['local_repo', 'local_docs', 'local_database_summaries'],
       denied_sources: ['secrets', 'private_keys', 'wallet_seeds', 'raw_credentials'],
-      local_allow: ['docs/**', 'src/**', '*.md', '*.json', '*.yaml', '*.yml'],
+      local_allow: [
+        'docs/**',
+        'src/**',
+        'app/**',
+        'lib/**',
+        'server/**',
+        'scripts/**',
+        'test/**',
+        'tests/**',
+        '*.js',
+        '*.mjs',
+        '*.ts',
+        '*.tsx',
+        '*.py',
+        '*.go',
+        '*.rs',
+        '*.md',
+        '*.json',
+        '*.yaml',
+        '*.yml',
+      ],
       local_block: ['.env*', 'secrets/**', 'customer_private/**'],
       retention: 'local_only_until_export',
       redaction: 'secrets_reference_only',
@@ -572,9 +598,16 @@ export function indexSources(inputPath, options = {}) {
   const now = new Date().toISOString();
   const sources = [];
   const blocked = [];
+  const generated = [];
 
   walk(root, (filePath) => {
     const rel = relativePortable(root, filePath);
+    const generatedReason = getGeneratedArtifactReason(filePath, rel);
+    if (generatedReason) {
+      generated.push({ path: rel, reason: generatedReason });
+      return;
+    }
+
     const blockReason = getBlockReason(rel, policy);
     if (blockReason) {
       blocked.push({ path: rel, reason: blockReason });
@@ -632,9 +665,11 @@ export function indexSources(inputPath, options = {}) {
     },
     sources,
     blocked,
+    generated,
     stats: {
       included_sources: sources.length,
       blocked_paths: blocked.length,
+      generated_sources_excluded: generated.length,
     },
   };
 
@@ -681,6 +716,25 @@ function getBlockReason(relPath, policy) {
   if (localAllow.length > 0 && !localAllow.some((pattern) => matchesPattern(normalized, pattern))) {
     return 'not_in_policy_allowlist';
   }
+
+  return null;
+}
+
+function getGeneratedArtifactReason(filePath, relPath) {
+  const normalized = relPath.replace(/\\/g, '/');
+  const lower = normalized.toLowerCase();
+  const segments = lower.split('/');
+
+  if (segments.some((segment) => segment === '.ecf' || segment === '.ecf-core' || segment.startsWith('.ecf-'))) {
+    return 'generated_ecf_artifact';
+  }
+
+  if (!GENERATED_ROOT_ARTIFACTS.has(normalized)) return null;
+
+  const text = fs.readFileSync(filePath, 'utf8').slice(0, 8192);
+  if (normalized === 'MICRO_ECF_LLM_BOOTSTRAP.md') return 'generated_micro_ecf_bootstrap';
+  if (normalized === 'ECF.md' && /Micro ECF Contract|micro[-_\s]ecf/i.test(text)) return 'generated_micro_ecf_contract';
+  if (normalized === 'AGENTS.md' && /Micro ECF|\.micro-ecf/i.test(text)) return 'generated_micro_ecf_agent_instructions';
 
   return null;
 }

--- a/micro-ecf/src/core.mjs
+++ b/micro-ecf/src/core.mjs
@@ -768,6 +768,11 @@ function classifySource(filePath) {
 }
 
 function summarizeText(text, ext) {
+  if (['.md', '.mdx'].includes(ext)) {
+    const markdownSummary = summarizeMarkdownText(text);
+    if (markdownSummary) return markdownSummary;
+  }
+
   const clean = text
     .replace(/\r\n/g, '\n')
     .split('\n')
@@ -790,6 +795,37 @@ function summarizeText(text, ext) {
   }
 
   return clean || 'Text source with no non-empty preview lines.';
+}
+
+function summarizeMarkdownText(text) {
+  const lines = text
+    .replace(/\r\n/g, '\n')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const headingIndex = lines.findIndex((line) => /^#{1,6}\s+/.test(line));
+  if (headingIndex < 0) return null;
+
+  const heading = cleanMarkdownLine(lines[headingIndex].replace(/^#{1,6}\s+/, ''));
+  const body = lines
+    .slice(headingIndex + 1)
+    .find((line) => !/^#{1,6}\s+/.test(line));
+  if (!heading && !body) return null;
+  if (!body) return truncateSummary(heading);
+  return truncateSummary(`${heading}: ${cleanMarkdownLine(body)}`);
+}
+
+function cleanMarkdownLine(line) {
+  return String(line || '')
+    .replace(/^>\s*/, '')
+    .replace(/^[-*+]\s+/, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function truncateSummary(value) {
+  const clean = String(value || '').replace(/\s+/g, ' ').trim();
+  return clean.length > 420 ? clean.slice(0, 420) : clean;
 }
 
 export function buildPolicySummary(policy) {

--- a/micro-ecf/test/cli.test.mjs
+++ b/micro-ecf/test/cli.test.mjs
@@ -32,8 +32,10 @@ test('micro-ecf CLI initializes, indexes, builds, and exports bounded local arti
 
   try {
     write(path.join(tmp, 'docs', 'api.md'), '# API\n\nThis local service exposes a support workflow.');
+    write(path.join(tmp, 'agent.js'), 'export const rootAgent = true;\n');
     write(path.join(tmp, 'src', 'agent.js'), 'export function handler(input) { return { ok: true, input }; }\n');
     write(path.join(tmp, '.env'), 'SECRET=do-not-export\n');
+    write(path.join(tmp, '.ecf-core', 'agent-os-import.json'), '{"generated":true}\n');
     write(path.join(tmp, 'node_modules', 'ignored', 'index.js'), 'module.exports = "ignored";\n');
 
     const init = run(['init', '--dir', tmp], microEcfRoot);
@@ -58,11 +60,16 @@ test('micro-ecf CLI initializes, indexes, builds, and exports bounded local arti
 
     const index = run(['index', tmp, '--output-dir', path.join(tmp, '.micro-ecf')], microEcfRoot);
     assert.equal(index.ok, true);
-    assert.equal(index.stats.included_sources, 5);
+    assert.equal(index.stats.included_sources, 3);
+    assert.equal(index.stats.generated_sources_excluded >= 4, true);
     assert.ok(index.stats.blocked_paths >= 1);
 
     const sourceMap = readJson(path.join(tmp, '.micro-ecf', 'source-map.json'));
-    assert.deepEqual(sourceMap.sources.map((source) => source.path).sort(), ['AGENTS.md', 'ECF.md', 'MICRO_ECF_LLM_BOOTSTRAP.md', 'docs/api.md', 'src/agent.js']);
+    assert.deepEqual(sourceMap.sources.map((source) => source.path).sort(), ['agent.js', 'docs/api.md', 'src/agent.js']);
+    assert.ok(sourceMap.generated.some((entry) => entry.path === 'ECF.md'));
+    assert.ok(sourceMap.generated.some((entry) => entry.path === 'AGENTS.md'));
+    assert.ok(sourceMap.generated.some((entry) => entry.path === 'MICRO_ECF_LLM_BOOTSTRAP.md'));
+    assert.ok(sourceMap.generated.some((entry) => entry.path === '.ecf-core/agent-os-import.json'));
     assert.ok(sourceMap.blocked.some((entry) => entry.path === '.env'));
     assert.equal(JSON.stringify(sourceMap).includes('do-not-export'), false);
     assert.equal(JSON.stringify(sourceMap).includes(tmp.replace(/\\/g, '/')), false);
@@ -76,7 +83,7 @@ test('micro-ecf CLI initializes, indexes, builds, and exports bounded local arti
     const contextPacket = readJson(path.join(tmp, '.micro-ecf', 'context-packet.json'));
     assert.equal(contextPacket.schema, 'agoragentic.micro-ecf.context-packet.v1');
     assert.equal(contextPacket.export_boundary.raw_content_exported, false);
-    assert.equal(contextPacket.citations.length, 5);
+    assert.equal(contextPacket.citations.length, 3);
 
     const preview = readJson(path.join(tmp, '.micro-ecf', 'deployment-preview.json'));
     assert.equal(preview.marketplace_policy.can_buy, false);

--- a/micro-ecf/test/cli.test.mjs
+++ b/micro-ecf/test/cli.test.mjs
@@ -66,6 +66,7 @@ test('micro-ecf CLI initializes, indexes, builds, and exports bounded local arti
 
     const sourceMap = readJson(path.join(tmp, '.micro-ecf', 'source-map.json'));
     assert.deepEqual(sourceMap.sources.map((source) => source.path).sort(), ['agent.js', 'docs/api.md', 'src/agent.js']);
+    assert.equal(sourceMap.sources.find((source) => source.path === 'docs/api.md').summary, 'API: This local service exposes a support workflow.');
     assert.ok(sourceMap.generated.some((entry) => entry.path === 'ECF.md'));
     assert.ok(sourceMap.generated.some((entry) => entry.path === 'AGENTS.md'));
     assert.ok(sourceMap.generated.some((entry) => entry.path === 'MICRO_ECF_LLM_BOOTSTRAP.md'));


### PR DESCRIPTION
## Summary
- include common root code files such as agent.js in the default Micro ECF allowlist
- exclude generated Micro ECF / .ecf* artifacts from source inventory counts
- expose generated exclusions in source-map.json and cover the behavior in CLI tests

## Validation
- npm test
- npm run check
- git diff --check

Closes rhein1/agent-marketplace#619 once merged and released.