### PR TITLE
fix: print executable Micro ECF Agent OS handoff

### DIFF
--- a/micro-ecf/bin/micro-ecf.mjs
+++ b/micro-ecf/bin/micro-ecf.mjs
@@ -180,6 +180,8 @@ function commandExport(flags) {
   const outputDir = flags['output-dir'] || DEFAULT_OUTPUT_DIR;
   const outputPath = flags.output || path.join(outputDir, 'harness-export.json');
   const policyPath = flags.policy || path.join(outputDir, 'policy.json');
+  const baseUrl = flags['base-url'] || DEFAULT_BASE_URL;
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, '');
   const artifactRefs = {
     context_packet: flags['context-packet'] || `${DEFAULT_OUTPUT_DIR}/context-packet.json`,
     policy_summary: flags['policy-summary'] || `${DEFAULT_OUTPUT_DIR}/policy-summary.json`,
@@ -190,14 +192,20 @@ function commandExport(flags) {
   const { output: written } = exportAgentOsHarness({
     policyPath,
     outputPath,
-    baseUrl: flags['base-url'] || DEFAULT_BASE_URL,
+    baseUrl,
     artifactRefs,
   });
+  const relativeOutput = path.relative(process.cwd(), written).replace(/\\/g, '/');
 
   return {
     ok: true,
-    output: path.relative(process.cwd(), written).replace(/\\/g, '/'),
-    next_step: `npx agoragentic-os preview ${path.relative(process.cwd(), written).replace(/\\/g, '/')}`,
+    output: relativeOutput,
+    next_step: `AGORAGENTIC_API_KEY=amk_your_api_key npx agoragentic-os deploy preview --file ${relativeOutput}`,
+    key_recovery: {
+      cli: 'npx agoragentic-os quickstart --name my-agent --type both',
+      curl: `curl -sS -X POST ${normalizedBaseUrl}/api/quickstart -H "Content-Type: application/json" -d '{"name":"my-agent","type":"both"}'`,
+      guide: `${normalizedBaseUrl}/guides/agent-os-quickstart/`,
+    },
   };
 }
 

--- a/micro-ecf/test/cli.test.mjs
+++ b/micro-ecf/test/cli.test.mjs
@@ -87,6 +87,10 @@ test('micro-ecf CLI initializes, indexes, builds, and exports bounded local arti
 
     const exported = run(['export', '--agent-os', '--policy', path.join(tmp, '.micro-ecf', 'policy.json'), '--output', path.join(tmp, '.micro-ecf', 'harness-export.json')], microEcfRoot);
     assert.equal(exported.ok, true);
+    assert.match(exported.next_step, /AGORAGENTIC_API_KEY=amk_your_api_key npx agoragentic-os deploy preview --file .*\.micro-ecf\/harness-export\.json/);
+    assert.equal(exported.key_recovery.cli, 'npx agoragentic-os quickstart --name my-agent --type both');
+    assert.match(exported.key_recovery.curl, /curl -sS -X POST https:\/\/agoragentic\.com\/api\/quickstart/);
+    assert.equal(exported.key_recovery.guide, 'https://agoragentic.com/guides/agent-os-quickstart/');
 
     const healthy = run(['doctor', '--dir', tmp], microEcfRoot);
     assert.equal(healthy.ok, true);


### PR DESCRIPTION
## Summary
- Change Micro ECF `export --agent-os` output to print the canonical hosted handoff command: `AGORAGENTIC_API_KEY=... npx agoragentic-os deploy preview --file .micro-ecf/harness-export.json`.
- Include the same key recovery command, curl, and guide URL used by the hosted Agent OS CLI.
- Add regression coverage for the executable next step and recovery metadata.

## Validation
- `npm test` in `micro-ecf` -> 6 passed, 0 failed
- `npm run check` in `micro-ecf`
- `git diff --check`
- Manual temp export smoke prints `deploy preview --file .micro-ecf/harness-export.json` plus `npx agoragentic-os quickstart`, `curl /api/quickstart`, and the quickstart guide URL.

Complements rhein1/agent-marketplace#620.
