### PR TITLE
chore: resolve duplicate-npm-name publish hazards (premortem + micro-ecf)

### DIFF
--- a/.github/workflows/publish-micro-ecf.yml
+++ b/.github/workflows/publish-micro-ecf.yml
@@ -1,8 +1,11 @@
 name: Publish Micro ECF to npm
 
+# DISABLED: agoragentic-micro-ecf now publishes from its standalone repo
+# https://github.com/rhein1/agoragentic-micro-ecf . This monorepo subdir is a
+# vendored mirror (micro-ecf/package.json is private:true) and must not publish.
+# Reduced to manual-only (workflow_dispatch) to prevent dual-publish; safe to delete.
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/micro-ecf/package.json
+++ b/micro-ecf/package.json
@@ -1,6 +1,8 @@
 {
   "name": "agoragentic-micro-ecf",
   "version": "0.1.3",
+  "private": true,
+  "_comment": "Vendored copy. Canonical source + npm publisher is https://github.com/rhein1/agoragentic-micro-ecf . Marked private so this monorepo copy can never publish agoragentic-micro-ecf.",
   "description": "Local-first context layer and policy packets for safer agents before Agent OS deployment preview.",
   "type": "module",
   "license": "Apache-2.0",

--- a/premortem-golden-loop/package.json
+++ b/premortem-golden-loop/package.json
@@ -1,6 +1,8 @@
 {
   "name": "agoragentic-premortem-golden-loop",
   "version": "0.1.0",
+  "private": true,
+  "_comment": "Vendored copy. Canonical source + npm publisher is https://github.com/rhein1/agoragentic-premortem-golden-loop (npm latest 0.1.6). Marked private so this monorepo copy can never publish agoragentic-premortem-golden-loop.",
   "description": "Free local OSS premortem, self-heal, and no-spend Golden Loop readiness CLI for plans, launches, and installable AI agent repositories.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Two monorepo subpackages declare the SAME npm names as standalone repos that already publish them, creating publish-collision hazards (a monorepo publish could clobber/regress the canonical package).

- `micro-ecf/` and `premortem-golden-loop/` -> `private: true` so neither can publish from here. Canonical publishers: [agoragentic-micro-ecf](https://github.com/rhein1/agoragentic-micro-ecf) and [agoragentic-premortem-golden-loop](https://github.com/rhein1/agoragentic-premortem-golden-loop) (npm latest 0.1.6).
- Disable `publish-micro-ecf.yml` auto-trigger (Micro ECF now publishes from its standalone repo).

No runtime/code changes. Pairs with the standalone Micro ECF repo split-out.