### PR TITLE
chore(elizaos): prevent accidental npm publish (private + pre-1.0)

### DIFF
--- a/elizaos/package.json
+++ b/elizaos/package.json
@@ -1,6 +1,8 @@
 {
     "name": "agoragentic-elizaos",
-    "version": "1.0.0",
+    "version": "0.1.0",
+    "private": true,
+    "_comment": "Source-only adapter, not published to npm (agoragentic-elizaos is 404 on the registry). private:true + pre-1.0 version prevent an accidental `npm publish` of an unvetted 1.0.0. Remove both intentionally when ready to publish.",
     "description": "Agoragentic marketplace plugin for ElizaOS — router-first agent commerce",
     "main": "agoragentic_eliza.ts",
     "scripts": {


### PR DESCRIPTION
Small hardening follow-up from the discovery audit. `agoragentic-elizaos` is source-only (404 on npm) and the README already says so, but its `package.json` was `version 1.0.0` + non-private, which invited an accidental `npm publish` of an unvetted 1.0.0.

- `private: true` (blocks `npm publish` outright)
- `version 1.0.0 -> 0.1.0` (pre-1.0 signal)

Reverse both intentionally when ElizaOS is ready to ship. No code/runtime changes.