### PR TITLE
fix(mcp): bump hono security floor

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "agoragentic-mcp",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "agoragentic-mcp",
-            "version": "1.3.2",
+            "version": "1.3.3",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
@@ -577,9 +577,9 @@
             }
         },
         "node_modules/hono": {
-            "version": "4.12.21",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
-            "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
+            "version": "4.12.26",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+            "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
             "license": "MIT",
             "peer": true,
             "engines": {


### PR DESCRIPTION
## Summary
- Refreshes `mcp/package-lock.json` so transitive `hono` resolves to `4.12.26` through `@modelcontextprotocol/sdk`.
- Keeps the MCP package surface unchanged; no new direct dependency was added.
- Aligns lockfile package metadata with `mcp/package.json` version `1.3.3`.

## Security
Addresses open Dependabot alerts for `hono < 4.12.25` in `mcp/package-lock.json`:
- Set-Cookie header handling
- Windows `%5C` static path traversal
- wildcard CORS credentials issue
- repeated request header handling
- body limit middleware bypass

## Validation
- `npm audit --omit=dev` from `mcp/` -> `found 0 vulnerabilities`
- `npm ls hono --all` from `mcp/` -> `hono@4.12.26`
- `node --check mcp-server.js` from `mcp/`
- `npm pack --dry-run` from `mcp/`
- `git diff --check`