### PR TITLE
[Growth Agent] create PR in rhein1/agoragentic-integrations to add a working x402 paid-call receipt checklist with execute() buyer retry example

### DIFF
--- a/examples/agoragentic-growth/2026-06-23-x402-execute-receipt-checklist-demo-mjs-71cdeaf151/x402_execute_receipt_checklist_demo.mjs
+++ b/examples/agoragentic-growth/2026-06-23-x402-execute-receipt-checklist-demo-mjs-71cdeaf151/x402_execute_receipt_checklist_demo.mjs
@@ -1,0 +1,450 @@
+// demo — moves no real funds
+
+import crypto from "node:crypto";
+
+function makeIdempotencyKey(prefix = "x402-demo") {
+  return `${prefix}-${crypto.randomUUID()}`;
+}
+
+function sha256(text) {
+  return crypto.createHash("sha256").update(String(text)).digest("hex");
+}
+
+class HeadersBag {
+  constructor(init = {}) {
+    this.map = new Map();
+    if (init instanceof HeadersBag) {
+      for (const [k, v] of init.entries()) this.set(k, v);
+      return;
+    }
+    if (typeof Headers !== "undefined" && init instanceof Headers) {
+      for (const [k, v] of init.entries()) this.set(k, v);
+      return;
+    }
+    if (Array.isArray(init)) {
+      for (const [k, v] of init) this.set(k, v);
+      return;
+    }
+    for (const [k, v] of Object.entries(init || {})) this.set(k, v);
+  }
+
+  set(key, value) {
+    this.map.set(String(key).toLowerCase(), String(value));
+  }
+
+  get(key) {
+    return this.map.get(String(key).toLowerCase()) ?? null;
+  }
+
+  has(key) {
+    return this.map.has(String(key).toLowerCase());
+  }
+
+  entries() {
+    return this.map.entries();
+  }
+
+  toObject() {
+    return Object.fromEntries(this.map.entries());
+  }
+}
+
+class SimpleResponse {
+  constructor(status, body, headers = {}) {
+    this.status = status;
+    this.ok = status >= 200 && status < 300;
+    this._body = typeof body === "string" ? body : JSON.stringify(body);
+    this.headers = new HeadersBag(headers);
+  }
+
+  async text() {
+    return this._body;
+  }
+
+  async json() {
+    return JSON.parse(this._body);
+  }
+}
+
+async function readResponseBody(response) {
+  const text = await response.text();
+  try {
+    return { text, json: JSON.parse(text) };
+  } catch {
+    return { text, json: null };
+  }
+}
+
+function extractChallenge(response, parsedBody) {
+  const headerValue = response.headers?.get?.("x-x402-challenge");
+  if (headerValue) {
+    try {
+      return JSON.parse(headerValue);
+    } catch {
+      return { raw: headerValue };
+    }
+  }
+  if (parsedBody?.json?.challenge) return parsedBody.json.challenge;
+  return null;
+}
+
+function normalizeFetchResult(result) {
+  if (!result || typeof result.status !== "number") {
+    throw new Error("x402Fetch did not return a Response-like object");
+  }
+  return result.response && typeof result.response.status === "number" ? result.response : result;
+}
+
+function networkError(message, details = {}) {
+  const err = new Error(message);
+  err.name = "X402NetworkError";
+  err.classification = "network_error";
+  Object.assign(err, details);
+  return err;
+}
+
+async function fallbackX402Fetch(url, options = {}) {
+  const {
+    fetchImpl = globalThis.fetch,
+    pay,
+    idempotencyKey,
+    method = "POST",
+    headers = {},
+    body,
+    maxNetworkRetries = 1,
+  } = options;
+
+  if (typeof fetchImpl !== "function") {
+    throw new Error("No fetch implementation available");
+  }
+  if (!idempotencyKey) {
+    throw new Error("idempotencyKey is required");
+  }
+
+  const baseHeaders = new HeadersBag(headers);
+  baseHeaders.set("x-idempotency-key", idempotencyKey);
+
+  let authorization = null;
+  let challengeFingerprint = null;
+  let lastNetworkError = null;
+
+  for (let attempt = 0; attempt <= maxNetworkRetries + 1; attempt += 1) {
+    const requestHeaders = new HeadersBag(baseHeaders);
+    if (authorization) requestHeaders.set("x-x402-authorization", authorization);
+
+    let response;
+    try {
+      response = await fetchImpl(url, {
+        method,
+        headers: requestHeaders.toObject(),
+        body,
+      });
+    } catch (error) {
+      lastNetworkError = error;
+      if (attempt < maxNetworkRetries + 1) {
+        continue;
+      }
+      throw networkError("Network error during x402 paid call", {
+        cause: error,
+        url,
+        method,
+        idempotencyKey,
+        authorizationReused: Boolean(authorization),
+      });
+    }
+
+    if (response.status === 402) {
+      if (typeof pay !== "function") {
+        throw new Error("Server requested payment (HTTP 402) but no pay callback was provided");
+      }
+
+      const parsed402 = await readResponseBody(response);
+      const challenge = extractChallenge(response, parsed402);
+      if (!challenge) {
+        throw new Error("HTTP 402 response did not include a payment challenge");
+      }
+
+      const fingerprint = sha256(JSON.stringify(challenge));
+      if (!authorization || fingerprint !== challengeFingerprint) {
+        const payment = await pay({
+          url,
+          method,
+          idempotencyKey,
+          challenge,
+        });
+        const token = typeof payment === "string" ? payment : payment?.authorization;
+        if (!token) {
+          throw new Error("pay callback must return an authorization string or { authorization }");
+        }
+        authorization = token;
+        challengeFingerprint = fingerprint;
+      }
+
+      continue;
+    }
+
+    if (!response.ok) {
+      const failure = new Error(`HTTP failure from paid call: ${response.status}`);
+      failure.name = "X402HttpFailure";
+      failure.classification = "http_failure";
+      failure.status = response.status;
+      failure.idempotencyKey = idempotencyKey;
+      throw failure;
+    }
+
+    response.x402Meta = {
+      idempotencyKey,
+      authorizationReused: Boolean(authorization),
+      hadPriorNetworkError: Boolean(lastNetworkError),
+    };
+    return response;
+  }
+
+  throw new Error("x402Fetch exhausted retries without a terminal result");
+}
+
+async function loadX402Fetch() {
+  const candidates = [
+    "agoragentic/x402-client",
+    "../lib/x402-client.mjs",
+    "../src/x402-client.mjs",
+    "../../lib/x402-client.mjs",
+    "../../src/x402-client.mjs",
+  ];
+
+  for (const specifier of candidates) {
+    try {
+      const mod = await import(specifier);
+      if (typeof mod.x402Fetch === "function") {
+        return { x402Fetch: mod.x402Fetch, source: specifier };
+      }
+    } catch {
+      // fall through to next candidate
+    }
+  }
+
+  return { x402Fetch: fallbackX402Fetch, source: "inline-demo-fallback" };
+}
+
+function buildReceiptChecklist({ response, payload, idempotencyKey }) {
+  const receiptHeader = response.headers?.get?.("x-x402-receipt");
+  const challengeIdHeader = response.headers?.get?.("x-x402-challenge-id");
+  const receipt = payload?.receipt ?? null;
+  const challengeId = challengeIdHeader ?? receipt?.challengeId ?? null;
+
+  return [
+    {
+      item: "Request used an idempotency key",
+      pass: typeof idempotencyKey === "string" && idempotencyKey.length > 0,
+      evidence: idempotencyKey,
+    },
+    {
+      item: "Paid call completed with HTTP 2xx",
+      pass: response.ok,
+      evidence: `status=${response.status}`,
+    },
+    {
+      item: "Response included a receipt handle",
+      pass: Boolean(receiptHeader || receipt?.id),
+      evidence: receiptHeader || receipt?.id || "missing",
+    },
+    {
+      item: "Receipt is linked to a paid challenge",
+      pass: Boolean(challengeId),
+      evidence: challengeId || "missing",
+    },
+    {
+      item: "Receipt data is structurally present in the body",
+      pass: Boolean(receipt && typeof receipt === "object"),
+      evidence: receipt ? JSON.stringify(receipt) : "missing",
+    },
+    {
+      item: "Demo does not claim settlement beyond returned receipt fields",
+      pass: !receipt?.settledAt && receipt?.note === "demo - no real funds moved",
+      evidence: receipt?.note || "missing",
+    },
+  ];
+}
+
+export async function execute(url, options = {}) {
+  const {
+    fetchImpl = globalThis.fetch,
+    pay,
+    idempotencyKey = makeIdempotencyKey(),
+    method = "POST",
+    headers = {},
+    body,
+    maxNetworkRetries = 1,
+  } = options;
+
+  const { x402Fetch, source } = await loadX402Fetch();
+  const rawResponse = await x402Fetch(url, {
+    fetchImpl,
+    pay,
+    idempotencyKey,
+    method,
+    headers,
+    body,
+    maxNetworkRetries,
+  });
+
+  const response = normalizeFetchResult(rawResponse);
+  const { text, json } = await readResponseBody(response);
+  const payload = json ?? { raw: text };
+
+  return {
+    helperSource: source,
+    idempotencyKey,
+    response,
+    payload,
+    checklist: buildReceiptChecklist({ response, payload, idempotencyKey }),
+  };
+}
+
+function makeDemoFetch() {
+  const state = {
+    requestCount: 0,
+    payCalls: 0,
+    challengeId: "ch_demo_receipt_001",
+    receiptId: "rcpt_demo_001",
+    authorizationSeen: [],
+    idempotencyKeys: [],
+    networkFailedOnce: false,
+  };
+
+  const fetchImpl = async (_url, init = {}) => {
+    state.requestCount += 1;
+    const headers = new HeadersBag(init.headers || {});
+    const auth = headers.get("x-x402-authorization");
+    const idempotencyKey = headers.get("x-idempotency-key");
+
+    state.authorizationSeen.push(auth);
+    state.idempotencyKeys.push(idempotencyKey);
+
+    if (!auth) {
+      return new SimpleResponse(
+        402,
+        {
+          error: "payment required",
+          challenge: {
+            id: state.challengeId,
+            asset: "demo-usdc",
+            amount: "1000",
+            note: "demo only",
+          },
+        },
+        {
+          "content-type": "application/json",
+          "x-x402-challenge": JSON.stringify({
+            id: state.challengeId,
+            asset: "demo-usdc",
+            amount: "1000",
+            note: "demo only",
+          }),
+        },
+      );
+    }
+
+    if (!state.networkFailedOnce) {
+      state.networkFailedOnce = true;
+      throw new Error("simulated transient network failure after payment authorization");
+    }
+
+    return new SimpleResponse(
+      200,
+      {
+        ok: true,
+        receipt: {
+          id: state.receiptId,
+          challengeId: state.challengeId,
+          authorizationHash: sha256(auth).slice(0, 16),
+          note: "demo - no real funds moved",
+        },
+      },
+      {
+        "content-type": "application/json",
+        "x-x402-receipt": state.receiptId,
+        "x-x402-challenge-id": state.challengeId,
+      },
+    );
+  };
+
+  const pay = async ({ challenge, idempotencyKey }) => {
+    state.payCalls += 1;
+    return {
+      authorization: `demo-auth:${challenge.id}:${idempotencyKey}`,
+    };
+  };
+
+  return { state, fetchImpl, pay };
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(`Assertion failed: ${message}`);
+  }
+}
+
+async function main() {
+  const { state, fetchImpl, pay } = makeDemoFetch();
+
+  const result = await execute("https://example.invalid/paid/execute", {
+    fetchImpl,
+    pay,
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      op: "execute",
+      buyer: "demo",
+    }),
+    idempotencyKey: "demo-idempotency-key-001",
+    maxNetworkRetries: 1,
+  });
+
+  assert(result.payload.ok === true, "execute() should succeed");
+  assert(state.payCalls === 1, "payment should be authorized exactly once");
+  assert(state.requestCount === 3, "demo should perform 402 -> network retry -> success");
+  assert(
+    state.idempotencyKeys.every((k) => k === "demo-idempotency-key-001"),
+    "all retries should reuse the same idempotency key",
+  );
+  assert(
+    state.authorizationSeen[1] && state.authorizationSeen[1] === state.authorizationSeen[2],
+    "authorization should be reused after transient failure",
+  );
+  assert(
+    result.checklist.every((item) => item.pass),
+    "receipt checklist should pass in the demo",
+  );
+
+  const summary = {
+    helperSource: result.helperSource,
+    requestCount: state.requestCount,
+    payCalls: state.payCalls,
+    idempotencyKey: result.idempotencyKey,
+    authorizationReused: state.authorizationSeen[1] === state.authorizationSeen[2],
+    checklist: result.checklist,
+    receipt: result.payload.receipt,
+  };
+
+  console.log(JSON.stringify(summary, null, 2));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(
+      JSON.stringify(
+        {
+          error: error.message,
+          name: error.name,
+          classification: error.classification || null,
+        },
+        null,
+        2,
+      ),
+    );
+    process.exitCode = 1;
+  });
+}

--- a/examples/agoragentic-growth/2026-06-23-x402-execute-receipt-checklist-demo-mjs-71cdeaf151/x402_execute_receipt_checklist_demo.mjs
+++ b/examples/agoragentic-growth/2026-06-23-x402-execute-receipt-checklist-demo-mjs-71cdeaf151/x402_execute_receipt_checklist_demo.mjs
@@ -1,6 +1,7 @@
 // demo — moves no real funds
 
 import crypto from "node:crypto";
+import { pathToFileURL } from "node:url";
 
 function makeIdempotencyKey(prefix = "x402-demo") {
   return `${prefix}-${crypto.randomUUID()}`;
@@ -8,6 +9,28 @@ function makeIdempotencyKey(prefix = "x402-demo") {
 
 function sha256(text) {
   return crypto.createHash("sha256").update(String(text)).digest("hex");
+}
+
+function parseJsonOrBase64Json(value) {
+  if (!value) return null;
+  const text = String(value);
+  try {
+    return JSON.parse(text);
+  } catch {
+    try {
+      return JSON.parse(Buffer.from(text, "base64").toString("utf8"));
+    } catch {
+      return null;
+    }
+  }
+}
+
+function firstHeader(headers, names) {
+  for (const name of names) {
+    const value = headers?.get?.(name);
+    if (value) return value;
+  }
+  return null;
 }
 
 class HeadersBag {
@@ -76,23 +99,24 @@ async function readResponseBody(response) {
 }
 
 function extractChallenge(response, parsedBody) {
-  const headerValue = response.headers?.get?.("x-x402-challenge");
+  const headerValue = firstHeader(response.headers, [
+    "payment-required",
+    "PAYMENT-REQUIRED",
+    "x-payment-required",
+    "X-Payment-Required",
+    "x-x402-challenge",
+  ]);
   if (headerValue) {
-    try {
-      return JSON.parse(headerValue);
-    } catch {
-      return { raw: headerValue };
-    }
+    return parseJsonOrBase64Json(headerValue) ?? { raw: headerValue };
   }
   if (parsedBody?.json?.challenge) return parsedBody.json.challenge;
   return null;
 }
 
 function normalizeFetchResult(result) {
-  if (!result || typeof result.status !== "number") {
-    throw new Error("x402Fetch did not return a Response-like object");
-  }
-  return result.response && typeof result.response.status === "number" ? result.response : result;
+  if (result?.response && typeof result.response.status === "number") return result.response;
+  if (result && typeof result.status === "number") return result;
+  throw new Error("x402Fetch did not return a Response-like object");
 }
 
 function networkError(message, details = {}) {
@@ -130,7 +154,7 @@ async function fallbackX402Fetch(url, options = {}) {
 
   for (let attempt = 0; attempt <= maxNetworkRetries + 1; attempt += 1) {
     const requestHeaders = new HeadersBag(baseHeaders);
-    if (authorization) requestHeaders.set("x-x402-authorization", authorization);
+    if (authorization) requestHeaders.set("PAYMENT-SIGNATURE", authorization);
 
     let response;
     try {
@@ -165,20 +189,31 @@ async function fallbackX402Fetch(url, options = {}) {
       }
 
       const fingerprint = sha256(JSON.stringify(challenge));
-      if (!authorization || fingerprint !== challengeFingerprint) {
-        const payment = await pay({
-          url,
-          method,
+      if (authorization) {
+        const err = createHttpPaymentError("Paid retry was rejected with another HTTP 402", {
+          status: 402,
           idempotencyKey,
           challenge,
+          previousChallengeFingerprint: challengeFingerprint,
+          repeatedChallengeFingerprint: fingerprint,
         });
-        const token = typeof payment === "string" ? payment : payment?.authorization;
-        if (!token) {
-          throw new Error("pay callback must return an authorization string or { authorization }");
-        }
-        authorization = token;
-        challengeFingerprint = fingerprint;
+        throw err;
       }
+
+      const payment = await pay({
+        url,
+        method,
+        idempotencyKey,
+        challenge,
+      });
+      const token = typeof payment === "string"
+        ? payment
+        : payment?.authorization ?? payment?.paymentSignature ?? payment?.payment_signature;
+      if (!token) {
+        throw new Error("pay callback must return an authorization string, paymentSignature, or { authorization }");
+      }
+      authorization = token;
+      challengeFingerprint = fingerprint;
 
       continue;
     }
@@ -201,6 +236,14 @@ async function fallbackX402Fetch(url, options = {}) {
   }
 
   throw new Error("x402Fetch exhausted retries without a terminal result");
+}
+
+function createHttpPaymentError(message, details = {}) {
+  const err = new Error(message);
+  err.name = "X402PaymentRejected";
+  err.classification = "payment_rejected";
+  Object.assign(err, details);
+  return err;
 }
 
 async function loadX402Fetch() {
@@ -227,16 +270,44 @@ async function loadX402Fetch() {
 }
 
 function buildReceiptChecklist({ response, payload, idempotencyKey }) {
-  const receiptHeader = response.headers?.get?.("x-x402-receipt");
-  const challengeIdHeader = response.headers?.get?.("x-x402-challenge-id");
+  const receiptHeader = firstHeader(response.headers, [
+    "payment-receipt",
+    "Payment-Receipt",
+    "x-payment-receipt",
+    "X-Payment-Receipt",
+    "x-x402-receipt",
+  ]);
+  const challengeIdHeader = firstHeader(response.headers, [
+    "payment-challenge-id",
+    "Payment-Challenge-Id",
+    "x-payment-challenge-id",
+    "X-Payment-Challenge-Id",
+    "x-x402-challenge-id",
+  ]);
   const receipt = payload?.receipt ?? null;
-  const challengeId = challengeIdHeader ?? receipt?.challengeId ?? null;
+  const receiptFromHeader = parseJsonOrBase64Json(receiptHeader);
+  const receiptRecord = receipt && typeof receipt === "object" ? receipt : receiptFromHeader;
+  const challengeId = challengeIdHeader ?? receiptRecord?.challengeId ?? receiptRecord?.challenge_id ?? null;
+  const receiptIdempotencyKey = receiptRecord?.idempotencyKey
+    ?? receiptRecord?.idempotency_key
+    ?? payload?.idempotencyKey
+    ?? payload?.idempotency_key
+    ?? null;
+  const claimsSettlement = Boolean(
+    receiptRecord?.settled
+    || receiptRecord?.settledAt
+    || receiptRecord?.settled_at
+    || receiptRecord?.settlementStatus === "settled"
+    || receiptRecord?.settlement_status === "settled"
+  );
 
   return [
     {
-      item: "Request used an idempotency key",
-      pass: typeof idempotencyKey === "string" && idempotencyKey.length > 0,
-      evidence: idempotencyKey,
+      item: "Request and receipt use the same idempotency key",
+      pass: typeof idempotencyKey === "string"
+        && idempotencyKey.length > 0
+        && receiptIdempotencyKey === idempotencyKey,
+      evidence: `request=${idempotencyKey || "missing"} receipt=${receiptIdempotencyKey || "missing"}`,
     },
     {
       item: "Paid call completed with HTTP 2xx",
@@ -245,8 +316,8 @@ function buildReceiptChecklist({ response, payload, idempotencyKey }) {
     },
     {
       item: "Response included a receipt handle",
-      pass: Boolean(receiptHeader || receipt?.id),
-      evidence: receiptHeader || receipt?.id || "missing",
+      pass: Boolean(receiptHeader || receiptRecord?.id),
+      evidence: receiptHeader || receiptRecord?.id || "missing",
     },
     {
       item: "Receipt is linked to a paid challenge",
@@ -255,13 +326,13 @@ function buildReceiptChecklist({ response, payload, idempotencyKey }) {
     },
     {
       item: "Receipt data is structurally present in the body",
-      pass: Boolean(receipt && typeof receipt === "object"),
-      evidence: receipt ? JSON.stringify(receipt) : "missing",
+      pass: Boolean(receiptRecord && typeof receiptRecord === "object"),
+      evidence: receiptRecord ? JSON.stringify(receiptRecord) : "missing",
     },
     {
-      item: "Demo does not claim settlement beyond returned receipt fields",
-      pass: !receipt?.settledAt && receipt?.note === "demo - no real funds moved",
-      evidence: receipt?.note || "missing",
+      item: "Demo receipt does not claim settlement",
+      pass: !claimsSettlement,
+      evidence: claimsSettlement ? "settlement claimed" : "no settlement claim",
     },
   ];
 }
@@ -315,7 +386,7 @@ function makeDemoFetch() {
   const fetchImpl = async (_url, init = {}) => {
     state.requestCount += 1;
     const headers = new HeadersBag(init.headers || {});
-    const auth = headers.get("x-x402-authorization");
+    const auth = headers.get("PAYMENT-SIGNATURE");
     const idempotencyKey = headers.get("x-idempotency-key");
 
     state.authorizationSeen.push(auth);
@@ -335,12 +406,12 @@ function makeDemoFetch() {
         },
         {
           "content-type": "application/json",
-          "x-x402-challenge": JSON.stringify({
+          "payment-required": Buffer.from(JSON.stringify({
             id: state.challengeId,
             asset: "demo-usdc",
             amount: "1000",
             note: "demo only",
-          }),
+          })).toString("base64"),
         },
       );
     }
@@ -357,14 +428,15 @@ function makeDemoFetch() {
         receipt: {
           id: state.receiptId,
           challengeId: state.challengeId,
+          idempotencyKey,
           authorizationHash: sha256(auth).slice(0, 16),
           note: "demo - no real funds moved",
         },
       },
       {
         "content-type": "application/json",
-        "x-x402-receipt": state.receiptId,
-        "x-x402-challenge-id": state.challengeId,
+        "Payment-Receipt": state.receiptId,
+        "X-Payment-Challenge-Id": state.challengeId,
       },
     );
   };
@@ -432,7 +504,7 @@ async function main() {
   console.log(JSON.stringify(summary, null, 2));
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   main().catch((error) => {
     console.error(
       JSON.stringify(


### PR DESCRIPTION
## Runnable example

File: `examples/agoragentic-growth/2026-06-23-x402-execute-receipt-checklist-demo-mjs-71cdeaf151/x402_execute_receipt_checklist_demo.mjs` — working code with an inline self-test.

a working x402 paid-call receipt checklist with a runnable execute() buyer retry example

**Value to target:** This gives integrators a ready-to-use, actionable template for handling paid API calls with receipts and retry logic, reducing onboarding friction and ensuring compliance with x402 payment rails.

---
_Contributed by the Agoragentic Agent-OS Growth Agent. Owner review required before merge._