### PR TITLE
[codex] Add Interchange builder package

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ The hosted Triptych OS (Agent OS) control plane is not a downloadable npm packag
 | [**n8n Community Node**](n8n/) | Typescript | Beta | `n8n/nodes/Agoragentic/Agoragentic.node.ts` | [README](n8n/README.md) |
 | [**Open Wallet Standard**](ows/) | Javascript | Beta | `ows/example-node.mjs` | [README](ows/README.md) |
 | [**x402 Buyer Integration**](x402/) | Javascript | ✅ Ready | `x402/buyer-demo.js` | [README](x402/README.md) |
+| [**Agent Commerce Interchange Builder Package**](interchange/) | Javascript | Experimental | `interchange/README.md` | [README](interchange/README.md) |
 | [**Micro ECF**](micro-ecf/) | Javascript | Beta | `micro-ecf/bin/micro-ecf.mjs` | [README](micro-ecf/README.md) |
 | [**Agoragentic Harness Core**](harness-core/) | Javascript | Beta | `harness-core/bin/agoragentic-harness.mjs` | [README](harness-core/README.md) |
 | [**Premortem Golden Loop Agent**](premortem-golden-loop/) | Javascript | Beta | `premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs` | [README](premortem-golden-loop/README.md) |
@@ -376,6 +377,9 @@ Your Agent  →  Integration (tools/MCP)  →  Agent OS + Agoragentic API
 | Agent instructions | [`AGENTS.md`](./AGENTS.md) |
 | ACP registry positioning | [`ACP_REGISTRY.md`](./ACP_REGISTRY.md) |
 | Agent Client Protocol adapter | [`acp/agent.json`](./acp/agent.json) |
+| Agent Commerce Interchange builder package | [`interchange/README.md`](./interchange/README.md) |
+| Agent Commerce Interchange spec | [`interchange/SPEC.md`](./interchange/SPEC.md) |
+| Agent Commerce Interchange status | [`interchange/STATUS.md`](./interchange/STATUS.md) |
 | LLM bootstrap | [`llms.txt`](./llms.txt) |
 | LLM full context | [`llms-full.txt`](./llms-full.txt) |
 | Capability description | [`SKILL.md`](./SKILL.md) |

--- a/integrations.json
+++ b/integrations.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.23.0",
-  "updated_at": "2026-06-11",
+  "version": "2.24.0",
+  "updated_at": "2026-06-25",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
   "packages": {
@@ -373,6 +373,15 @@
       "path": "x402/buyer-demo.js",
       "install": "node x402/buyer-demo.js",
       "docs": "x402/README.md"
+    },
+    {
+      "id": "interchange",
+      "name": "Agent Commerce Interchange Builder Package",
+      "language": "javascript",
+      "status": "experimental",
+      "path": "interchange/README.md",
+      "install": "node 18+; examples are no-spend by default",
+      "docs": "interchange/README.md"
     },
     {
       "id": "micro-ecf",
@@ -867,6 +876,12 @@
       "name": "Agent Commerce Protocol",
       "version": "0.1.0",
       "path": "specs/ACP-SPEC.md"
+    },
+    {
+      "id": "interchange",
+      "name": "Agent Commerce Interchange",
+      "version": "0.1.0",
+      "path": "interchange/SPEC.md"
     }
   ],
   "discovery": {
@@ -903,6 +918,12 @@
     "n8n": "n8n/README.md",
     "open_wallet_standard": "ows/README.md",
     "x402_buyer": "x402/README.md",
+    "interchange": "interchange/README.md",
+    "interchange_spec": "interchange/SPEC.md",
+    "interchange_status": "interchange/STATUS.md",
+    "interchange_x402_receipt_reconciliation_example": "interchange/examples/x402-receipt-reconciliation/README.md",
+    "interchange_verify_receipt_example": "interchange/examples/verify-receipt/README.md",
+    "interchange_federation_handshake_simulated_example": "interchange/examples/federation-handshake-simulated/README.md",
     "paperclip": "paperclip/README.md",
     "pinchtab": "pinchtab/README.md",
     "orbination": "orbination/README.md",

--- a/interchange/README.md
+++ b/interchange/README.md
@@ -1,0 +1,80 @@
+# Agoragentic Interchange Builder Package
+
+The Agent Commerce Interchange is Agoragentic's public receipt and federation
+surface for agent-to-agent commerce. This folder gives builders the human docs,
+wire contract, current status, and runnable examples needed to inspect or
+integrate with the public parts safely.
+
+Start with the human page:
+
+- Hub: <https://agoragentic.com/interchange/>
+- Receipt verifier: <https://agoragentic.com/interchange/verify/>
+- Machine manifest: <https://agoragentic.com/.well-known/agent-commerce.json>
+- Surface index: <https://agoragentic.com/api/commerce/interchange>
+- x402 service index: <https://x402.agoragentic.com/services/index.json>
+
+## What is live today
+
+- Anonymous x402 buyers can call stable Agoragentic edge resources with USDC on
+  Base L2.
+- The `receipt-reconciliation` x402 resource is live at
+  `https://x402.agoragentic.com/v1/receipt-reconciliation`.
+- Public receipt verification is live and read-only at
+  `POST https://agoragentic.com/api/commerce/interchange/receipts/verify`.
+- The federation and referral rails are implemented in the private Agoragentic
+  runtime, but they are default-off and require a consenting partner and owner
+  activation before any real counterparty uses them.
+
+## What is not claimed
+
+- This is not a claim that Agoragentic is connected to all agent marketplaces.
+- This is not a claim of live external federation with a real partner.
+- This is not a claim of organic external demand or a paying partner.
+- The federation protocol is v0 and experimental until a real partner pilot is
+  activated.
+
+## Examples
+
+All examples are Node 18+ and safe by default.
+
+| Example | What it does | Spend? |
+|---|---|---|
+| [`examples/x402-receipt-reconciliation`](./examples/x402-receipt-reconciliation/) | Gets the unpaid 402 challenge from the live receipt-reconciliation edge URL and prints the payment requirements. | No |
+| [`examples/verify-receipt`](./examples/verify-receipt/) | Calls the public receipt verifier with a supplied receipt id or JSON, or a demo missing id. | No |
+| [`examples/federation-handshake-simulated`](./examples/federation-handshake-simulated/) | Simulates the post-pin Ed25519 signing contract locally. | No |
+
+Run the no-spend x402 preflight:
+
+```bash
+node interchange/examples/x402-receipt-reconciliation/preflight.mjs
+```
+
+Run a safe verifier probe:
+
+```bash
+node interchange/examples/verify-receipt/verify.mjs --demo-missing
+```
+
+Run the local signing simulation:
+
+```bash
+node interchange/examples/federation-handshake-simulated/simulate.mjs
+```
+
+## Builder path
+
+1. Read [`STATUS.md`](./STATUS.md) so you know what is live versus built but
+   default-off.
+2. Read [`SPEC.md`](./SPEC.md) for the public methods, x402 receipt flow, and
+   post-pin signing contract.
+3. Use the examples to verify your client can read the live x402 challenge,
+   verify receipts, and sign the local canonical message.
+4. For a real federation pilot, coordinate with the Agoragentic owner. A first
+   pin is TOFU/operator-reviewed key control, not independent identity proof.
+
+## Safety model
+
+The examples never read private keys, never sign payments, never submit registry
+listings, never mutate trust state, and never contact another agent. The only
+network calls are public read-only probes unless you deliberately replace the
+preflight example with a wallet-enabled x402 client in your own runtime.

--- a/interchange/SPEC.md
+++ b/interchange/SPEC.md
@@ -1,0 +1,171 @@
+# Agent Commerce Interchange v0 Spec
+
+Status: experimental builder contract. The public x402 and receipt-verifier
+surfaces are live. Federation/referral methods are implemented in Agoragentic's
+runtime but default-off until a partner pilot is owner-armed.
+
+## Public surfaces
+
+| Surface | URL | Status |
+|---|---|---|
+| Human hub | `https://agoragentic.com/interchange/` | Live |
+| Public receipt verifier | `https://agoragentic.com/interchange/verify/` | Live |
+| Receipt verify API | `POST https://agoragentic.com/api/commerce/interchange/receipts/verify` | Live, read-only |
+| Commerce manifest | `https://agoragentic.com/.well-known/agent-commerce.json` | Live |
+| Interchange surface index | `https://agoragentic.com/api/commerce/interchange` | Live |
+| x402 service index | `https://x402.agoragentic.com/services/index.json` | Live |
+| Receipt reconciliation edge | `POST https://x402.agoragentic.com/v1/receipt-reconciliation` | Live x402 resource |
+
+## x402 receipt reconciliation
+
+The receipt reconciliation resource uses HTTP 402 with USDC on Base L2.
+
+Unpaid request:
+
+```http
+POST /v1/receipt-reconciliation HTTP/1.1
+Host: x402.agoragentic.com
+Content-Type: application/json
+
+{
+  "declared_intent": {
+    "action": "summarize_customer_email",
+    "expected_result": "A short summary with action items"
+  },
+  "receipt": {
+    "receipt_id": "rcpt_inv_example",
+    "invocation_id": "inv_example",
+    "settlement_status": "settled",
+    "cost_usdc": 0.1
+  },
+  "payment_response": {
+    "invocation_id": "inv_example",
+    "amount_usdc": 0.1,
+    "settlement_status": "settled"
+  },
+  "observed_output": {
+    "summary": "Customer asked for a refund.",
+    "action_items": ["review order status"]
+  }
+}
+```
+
+The unpaid response is `402 Payment Required` and includes an x402 v2
+challenge. Current live requirements use:
+
+- `network`: `eip155:8453`
+- `asset`: Base USDC, `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
+- `amount`: `10000` atomic units, or `0.01` USDC
+- `resource`: `https://x402.agoragentic.com/v1/receipt-reconciliation`
+
+Do not send private keys to Agoragentic. Use a wallet-aware x402 client or HSM
+in your own runtime to sign and retry if you choose to make a paid request.
+
+## Receipt verification
+
+Receipt verification is public and read-only:
+
+```http
+POST /api/commerce/interchange/receipts/verify HTTP/1.1
+Host: agoragentic.com
+Content-Type: application/json
+
+{ "receipt_id": "areceipt2_..." }
+```
+
+or:
+
+```json
+{
+  "receipt": {
+    "schema": "agoragentic.agent-commerce.receipt.v2"
+  }
+}
+```
+
+The verifier recomputes the receipt hash and checks its signature. It does not
+spend funds, invoke providers, or mutate trust.
+
+## Federation methods
+
+These method names are the public v0 contract. They are not advertised as a live
+network until a partner pilot is armed.
+
+| Method | Purpose | Current status |
+|---|---|---|
+| `federation/propose` | Partner proposes a relationship and evidence card. | Built, default-off |
+| `federation/challenge-response` | Partner proves control of the pinned remote key. | Built, default-off |
+| `federation/refresh` | Re-fetch reviewed evidence and downgrade stale or changed trust. | Built, default-off |
+| `federation/revoke` | Deactivate a relationship or remote key binding. | Built, default-off |
+| `federation/declare-need` | Record inert capability demand metadata. | Built, default-off |
+| `federation/wallet-link-claim` | Submit a dual-signed relationship/wallet link claim. | Built, default-off |
+| `federation/get-referral` | Read one public-safe referral reference. | Built, default-off |
+| `federation/verify-referral` | Verify one referral token without following it. | Built, default-off |
+| `federation/follow-referral` | Record a signed post-pin follow by a distinct relationship. | Built, default-off |
+
+## Post-pin request signing
+
+After a relationship has an active remote key pin, maintenance and referral
+methods are authenticated by Ed25519 signatures from that pinned key.
+
+The signed canonical message is:
+
+```text
+<method>
+<relationship_id>
+<remote_origin>
+<nonce>
+<timestamp>
+sha256:<stable-json-sha256-of-params-without-auth>
+```
+
+Rules:
+
+- `method` is the advertised wire method, for example
+  `federation/follow-referral`.
+- `relationship_id` is the pinned relationship id.
+- `remote_origin` is the normalized partner origin, for example
+  `https://partner.example`.
+- `nonce` is single-use for that relationship and method.
+- `timestamp` is the exact timestamp value the signer sends in `auth.timestamp`.
+- `params-without-auth` is the full snake_case wire object after removing only
+  the `auth` envelope. Do not sign camelCase aliases.
+- The params hash uses stable JSON serialization with sorted object keys and a
+  `sha256:` prefix.
+
+Example `federation/follow-referral` params:
+
+```json
+{
+  "method": "federation/follow-referral",
+  "relationship_id": "fed_partner_123",
+  "remote_origin": "https://partner.example",
+  "referral_id": "agx_fedref_123",
+  "auth": {
+    "nonce": "nonce-123",
+    "timestamp": 1710000000000,
+    "signature_algorithm": "ed25519",
+    "signature": "<base64 signature over the canonical message>"
+  }
+}
+```
+
+## Trust vocabulary
+
+Use only these runtime trust labels:
+
+- `verified`
+- `reachable`
+- `failed`
+
+`verified_federation` in the v0 federation design proves pinned-key control for
+a reviewed origin. It is not independent operator identity proof. The first pin
+is TOFU/operator-reviewed until a stronger identity lane is added.
+
+## Non-goals
+
+- No claim of being connected to all agent marketplaces.
+- No automatic outbound contact.
+- No automatic registry submission.
+- No automatic spend.
+- No independent identity attestation in v0.

--- a/interchange/STATUS.md
+++ b/interchange/STATUS.md
@@ -1,0 +1,51 @@
+# Interchange Status
+
+Last updated: 2026-06-25
+
+This status page is intentionally conservative. It distinguishes live public
+surfaces from built default-off rails and from things Agoragentic does not claim.
+
+## Live
+
+| Capability | Evidence |
+|---|---|
+| Human Interchange hub | `https://agoragentic.com/interchange/` |
+| Public receipt verifier page | `https://agoragentic.com/interchange/verify/` |
+| Receipt verify API | `POST https://agoragentic.com/api/commerce/interchange/receipts/verify` |
+| x402 receipt-reconciliation edge | `POST https://x402.agoragentic.com/v1/receipt-reconciliation` |
+| x402 v2 network format | Live challenge uses `eip155:8453` |
+| Commerce manifest | `https://agoragentic.com/.well-known/agent-commerce.json` |
+| x402 service index | `https://x402.agoragentic.com/services/index.json` |
+
+## Built, default-off
+
+| Capability | Status |
+|---|---|
+| Federation propose / accept / first-pin flow | Built, owner-gated, default-off |
+| Challenge-response promotion | Built, default-off |
+| Refresh / revoke / declare-need | Built, default-off |
+| Wallet-link claim and commerce attribution | Built, default-off |
+| Referral get / verify / follow | Built, default-off |
+| Autonomous discovery / observe tooling | Built; read-only runs are owner-armed |
+| Diplomat / outbound A2A contact tooling | Built, default-off; not part of this package |
+
+## Pending a real partner
+
+- A real external federation partner.
+- Owner first-pin for that partner.
+- Partner challenge-response over the live route.
+- Any real referral propagation with an external relationship.
+- Any `REFERRED_AGENT_PAID` signal from a distinct organic external payer.
+
+## Not claimed
+
+- Agoragentic is not claiming it is connected to all agent marketplaces.
+- Agoragentic is not claiming a live external federation network.
+- Agoragentic is not claiming organic external demand from the Interchange.
+- The simulated federation example is not a production federation run.
+
+## Safe default
+
+The examples in this folder do not spend, sign payments, publish listings,
+submit registry records, or mutate trust. The only live network examples are
+public read-only probes.

--- a/interchange/examples/federation-handshake-simulated/README.md
+++ b/interchange/examples/federation-handshake-simulated/README.md
@@ -1,0 +1,18 @@
+# Federation Handshake Simulation
+
+This example simulates the post-pin Ed25519 signing contract locally. It does
+not call Agoragentic, does not pin a key, does not contact a partner, and does
+not mutate trust.
+
+```bash
+node interchange/examples/federation-handshake-simulated/simulate.mjs
+```
+
+The simulation signs the advertised `federation/follow-referral` method and the
+full snake_case wire params after removing only the `auth` envelope. It also
+shows that a legacy method string (`referral.follow`) does not verify against the
+same signature.
+
+This proves client-side canonicalization only. A real federation pilot still
+requires a consenting partner, owner first-pin, live route activation, durable
+nonce storage, and server-side verification.

--- a/interchange/examples/federation-handshake-simulated/simulate.mjs
+++ b/interchange/examples/federation-handshake-simulated/simulate.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+import {
+  createHash,
+  generateKeyPairSync,
+  sign,
+  verify,
+} from 'node:crypto';
+
+function stableStringify(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  return `{${Object.keys(value)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`)
+    .join(',')}}`;
+}
+
+function hashRef(value) {
+  return `sha256:${createHash('sha256').update(stableStringify(value || {})).digest('hex')}`;
+}
+
+function withoutAuth(params) {
+  const { auth: _auth, ...rest } = params || {};
+  return rest;
+}
+
+function canonicalPostPinMessage({ method, relationshipId, remoteOrigin, nonce, timestamp, params }) {
+  return [
+    method,
+    relationshipId,
+    remoteOrigin,
+    nonce,
+    String(timestamp),
+    hashRef(params || {}),
+  ].join('\n');
+}
+
+const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+
+const method = 'federation/follow-referral';
+const relationshipId = 'fed_partner_demo';
+const remoteOrigin = 'https://partner.example';
+const timestamp = 1710000000000;
+const nonce = 'demo-nonce-001';
+
+const wireParams = {
+  relationship_id: relationshipId,
+  remote_origin: remoteOrigin,
+  referral_id: 'agx_fedref_demo',
+  auth: {
+    nonce,
+    timestamp,
+    signature_algorithm: 'ed25519',
+    signature: '<filled after signing>',
+  },
+};
+
+const actionParams = withoutAuth(wireParams);
+const message = canonicalPostPinMessage({
+  method,
+  relationshipId,
+  remoteOrigin,
+  nonce,
+  timestamp,
+  params: actionParams,
+});
+const signature = sign(null, Buffer.from(message), privateKey).toString('base64');
+const ok = verify(null, Buffer.from(message), publicKey, Buffer.from(signature, 'base64'));
+
+const legacyMessage = canonicalPostPinMessage({
+  method: 'referral.follow',
+  relationshipId,
+  remoteOrigin,
+  nonce,
+  timestamp,
+  params: { referralId: wireParams.referral_id },
+});
+const legacyOk = verify(null, Buffer.from(legacyMessage), publicKey, Buffer.from(signature, 'base64'));
+
+console.log(JSON.stringify({
+  simulated_only: true,
+  method,
+  params_hash: hashRef(actionParams),
+  canonical_message: message,
+  signature_algorithm: 'ed25519',
+  signature_base64: signature,
+  verifies_with_advertised_method_and_snake_case_params: ok,
+  verifies_with_legacy_method_and_camel_case_params: legacyOk,
+  public_key_spki_der_base64: publicKey.export({ type: 'spki', format: 'der' }).toString('base64'),
+  note: 'This is a local signing simulation only; no live federation route was called.',
+}, null, 2));
+
+if (!ok || legacyOk) {
+  process.exitCode = 1;
+}

--- a/interchange/examples/verify-receipt/README.md
+++ b/interchange/examples/verify-receipt/README.md
@@ -1,0 +1,26 @@
+# Public Receipt Verify Example
+
+This example calls the live public receipt verifier. It is read-only and does
+not spend or mutate trust.
+
+Run a safe missing-receipt probe:
+
+```bash
+node interchange/examples/verify-receipt/verify.mjs --demo-missing
+```
+
+Verify a receipt id:
+
+```bash
+AGORAGENTIC_RECEIPT_ID=areceipt2_... \
+node interchange/examples/verify-receipt/verify.mjs
+```
+
+Verify receipt JSON from a file:
+
+```bash
+AGORAGENTIC_RECEIPT_JSON_FILE=./receipt.json \
+node interchange/examples/verify-receipt/verify.mjs
+```
+
+The verifier accepts either `{ "receipt_id": "..." }` or `{ "receipt": { ... } }`.

--- a/interchange/examples/verify-receipt/verify.mjs
+++ b/interchange/examples/verify-receipt/verify.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+
+const endpoint = process.env.AGORAGENTIC_RECEIPT_VERIFY_URL
+  || 'https://agoragentic.com/api/commerce/interchange/receipts/verify';
+
+function usage() {
+  console.log(`Usage:
+  AGORAGENTIC_RECEIPT_ID=areceipt2_... node interchange/examples/verify-receipt/verify.mjs
+  AGORAGENTIC_RECEIPT_JSON_FILE=./receipt.json node interchange/examples/verify-receipt/verify.mjs
+  node interchange/examples/verify-receipt/verify.mjs --demo-missing
+
+This example is read-only. It never spends funds or mutates trust.`);
+}
+
+function parseReceiptJson() {
+  if (process.env.AGORAGENTIC_RECEIPT_JSON) {
+    return JSON.parse(process.env.AGORAGENTIC_RECEIPT_JSON);
+  }
+  if (process.env.AGORAGENTIC_RECEIPT_JSON_FILE) {
+    return JSON.parse(fs.readFileSync(process.env.AGORAGENTIC_RECEIPT_JSON_FILE, 'utf8'));
+  }
+  return null;
+}
+
+const args = new Set(process.argv.slice(2));
+let body;
+
+if (args.has('--demo-missing')) {
+  body = { receipt_id: 'areceipt2_demo_missing_read_only' };
+} else if (process.env.AGORAGENTIC_RECEIPT_ID) {
+  body = { receipt_id: process.env.AGORAGENTIC_RECEIPT_ID };
+} else {
+  const receipt = parseReceiptJson();
+  if (receipt) body = { receipt };
+}
+
+if (!body) {
+  usage();
+  process.exit(0);
+}
+
+const response = await fetch(endpoint, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(body),
+});
+
+const text = await response.text();
+let json;
+try {
+  json = JSON.parse(text);
+} catch {
+  json = { raw: text };
+}
+
+console.log(JSON.stringify({
+  endpoint,
+  status: response.status,
+  safe_default: 'read-only receipt verification',
+  result: json,
+}, null, 2));
+
+if (response.status >= 500) {
+  process.exitCode = 1;
+}

--- a/interchange/examples/x402-receipt-reconciliation/README.md
+++ b/interchange/examples/x402-receipt-reconciliation/README.md
@@ -1,0 +1,18 @@
+# x402 Receipt Reconciliation Preflight
+
+This example performs the safe first step of an x402 buyer flow: it sends an
+unpaid request to the live `receipt-reconciliation` resource and prints the 402
+payment challenge.
+
+It does not sign a payment, does not read a private key, and does not spend.
+
+```bash
+node interchange/examples/x402-receipt-reconciliation/preflight.mjs
+```
+
+Expected result: HTTP `402`, `network: eip155:8453`, and a `10000` atomic USDC
+requirement for `https://x402.agoragentic.com/v1/receipt-reconciliation`.
+
+To make a real paid call, replace this preflight with your own wallet-aware x402
+client and keep the signer in your wallet, HSM, or managed-wallet runtime. Do
+not send private keys to Agoragentic.

--- a/interchange/examples/x402-receipt-reconciliation/preflight.mjs
+++ b/interchange/examples/x402-receipt-reconciliation/preflight.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+import { Buffer } from 'node:buffer';
+
+const endpoint = process.env.AGORAGENTIC_INTERCHANGE_X402_URL
+  || 'https://x402.agoragentic.com/v1/receipt-reconciliation';
+
+const payload = {
+  declared_intent: {
+    action: 'summarize_customer_email',
+    expected_result: 'A short summary with action items',
+    max_cost_usdc: 0.01,
+  },
+  receipt: {
+    receipt_id: 'rcpt_inv_example',
+    invocation_id: 'inv_example',
+    settlement_status: 'settled',
+    cost_usdc: 0.1,
+  },
+  payment_response: {
+    invocation_id: 'inv_example',
+    amount_usdc: 0.1,
+    settlement_status: 'settled',
+  },
+  observed_output: {
+    summary: 'Customer asked for a refund.',
+    action_items: ['review order status'],
+  },
+};
+
+function parseJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function parsePaymentRequiredHeader(value) {
+  if (!value) return null;
+  const raw = Array.isArray(value) ? value[0] : value;
+  if (!raw) return null;
+  const direct = parseJson(raw);
+  if (direct) return direct;
+  try {
+    return JSON.parse(Buffer.from(raw, 'base64').toString('utf8'));
+  } catch {
+    return null;
+  }
+}
+
+const response = await fetch(endpoint, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(payload),
+});
+
+const bodyText = await response.text();
+const body = parseJson(bodyText);
+const headerChallenge = parsePaymentRequiredHeader(response.headers.get('payment-required'));
+const challenge = body || headerChallenge || {};
+const accept = Array.isArray(challenge.accepts) ? challenge.accepts[0] : null;
+
+const summary = {
+  endpoint,
+  status: response.status,
+  safe_default: 'no payment signed or sent',
+  x402_version: challenge.x402Version ?? null,
+  network: accept?.network || challenge.payment?.network || null,
+  asset: accept?.asset || challenge.payment?.asset || null,
+  pay_to: accept?.payTo || challenge.payment?.recipient || null,
+  amount_atomic: accept?.amount || accept?.maxAmountRequired || challenge.payment?.atomic_amount || null,
+  price_usdc: challenge.price_usdc ?? challenge.payment?.amount ?? null,
+  resource: accept?.resource || challenge.resource?.url || endpoint,
+  message: challenge.message || null,
+};
+
+console.log(JSON.stringify(summary, null, 2));
+
+if (response.status !== 402) {
+  console.error(`Expected an unpaid x402 preflight to return 402; got ${response.status}.`);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## What changed

Adds a public Agent Commerce Interchange builder package under `interchange/`:

- `README.md` for the human builder path and safety model
- `SPEC.md` for live public surfaces, x402 receipt reconciliation, receipt verification, and the v0 federation signing contract
- `STATUS.md` with explicit Live / Built default-off / Pending / Not claimed sections
- no-spend Node 18 examples:
  - `x402-receipt-reconciliation/preflight.mjs`
  - `verify-receipt/verify.mjs`
  - `federation-handshake-simulated/simulate.mjs`

Also indexes the package in `integrations.json` and the root README.

## Honesty / safety boundaries

- Does not claim Agoragentic is connected to all agent marketplaces.
- Does not claim live external federation or organic external demand.
- Labels federation/referral rails as built, default-off, and pending a real partner pilot.
- Examples do not spend, sign payments, submit registries, contact agents, or mutate trust.
- The x402 example stops at the unpaid 402 challenge.

## Validation

- `node --check interchange/examples/x402-receipt-reconciliation/preflight.mjs`
- `node --check interchange/examples/verify-receipt/verify.mjs`
- `node --check interchange/examples/federation-handshake-simulated/simulate.mjs`
- `node scripts/verify-integrations-json.js`
- `python -m json.tool integrations.json`
- `python -c "import json, pathlib, jsonschema; root=pathlib.Path('.'); schema=json.loads((root/'integrations.schema.json').read_text()); data=json.loads((root/'integrations.json').read_text()); jsonschema.Draft202012Validator(schema).validate(data); print('jsonschema validation passed')"`
- `git diff --cached --check`
- `node interchange/examples/x402-receipt-reconciliation/preflight.mjs` -> HTTP 402, `network=eip155:8453`, `amount_atomic=10000`
- `node interchange/examples/verify-receipt/verify.mjs --demo-missing` -> public read-only `not_found` with safety flags
- `node interchange/examples/federation-handshake-simulated/simulate.mjs` -> advertised method verifies; legacy method does not