### PR TITLE
test(growth): gate generated x402 examples

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,6 +11,8 @@ on:
       - 'micro-ecf/**'
       - 'harness-core/**'
       - 'scripts/**'
+      - 'examples/agoragentic-growth/**'
+      - 'test/**'
       - '*/README.md'
       - 'README.md'
       - 'AGENTS.md'
@@ -25,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -143,6 +147,12 @@ jobs:
 
       - name: Verify ACP adapter
         run: node scripts/verify-acp.js
+
+      - name: Test growth example validator
+        run: node --test test/validate-growth-examples.test.mjs
+
+      - name: Validate growth-generated examples
+        run: node scripts/validate-growth-examples.mjs --base origin/main
 
       - name: Summary
         run: |

--- a/examples/agoragentic-growth/2026-07-02-x402-execute-buyer-retry-receipt-checkli-836e05b04d/x402_execute_buyer_retry_receipt_checklist.mjs
+++ b/examples/agoragentic-growth/2026-07-02-x402-execute-buyer-retry-receipt-checkli-836e05b04d/x402_execute_buyer_retry_receipt_checklist.mjs
@@ -75,7 +75,7 @@ function canonicalReceipt(payload = {}, response) {
 }
 
 function parsePaymentRequiredHeader(headerValue) {
-  if (!headerValue) return {};
+  if (!headerValue) return null;
   const raw = String(headerValue).trim();
   const candidates = [raw];
   try {
@@ -87,12 +87,12 @@ function parsePaymentRequiredHeader(headerValue) {
   for (const candidate of candidates) {
     try {
       const parsed = JSON.parse(candidate);
-      return parsed && typeof parsed === "object" ? parsed : {};
+      return parsed && typeof parsed === "object" ? parsed : null;
     } catch {
       // Try the next representation.
     }
   }
-  return {};
+  return null;
 }
 
 function makeHttpError(message, response, kind = "http_after_authorization") {
@@ -164,7 +164,13 @@ export async function x402Fetch(url, options = {}) {
       "x-payment-required",
       "x-payment-challenge",
     ]);
+    if (!paymentRequiredHeader) {
+      throw makeHttpError("Received HTTP 402 without payment-required header", firstResponse, "payment_required_challenge_missing");
+    }
     const challenge = parsePaymentRequiredHeader(paymentRequiredHeader);
+    if (!challenge) {
+      throw makeHttpError("HTTP 402 did not include a valid payment-required challenge", firstResponse, "payment_required_challenge_invalid");
+    }
     const challengeFingerprint = crypto
       .createHash("sha256")
       .update(JSON.stringify(challenge) || String(paymentRequiredHeader ?? "missing"))

--- a/scripts/validate-growth-examples.mjs
+++ b/scripts/validate-growth-examples.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+const ROOT = process.cwd();
+const GROWTH_PREFIX = "examples/agoragentic-growth/";
+const JS_EXTENSIONS = new Set([".js", ".mjs", ".cjs", ".ts", ".mts", ".cts"]);
+const VALIDATED_EXTENSIONS = new Set([...JS_EXTENSIONS, ".py"]);
+
+function toPosix(filePath) {
+  return filePath.split(path.sep).join("/");
+}
+
+function repoRelative(filePath, root = ROOT) {
+  return toPosix(path.relative(root, filePath));
+}
+
+function isGrowthExample(filePath) {
+  const rel = toPosix(filePath);
+  return rel.startsWith(GROWTH_PREFIX) && VALIDATED_EXTENSIONS.has(path.extname(rel));
+}
+
+function walkFiles(dir, root = ROOT, out = []) {
+  if (!fs.existsSync(dir)) return out;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkFiles(fullPath, root, out);
+    } else if (entry.isFile() && isGrowthExample(repoRelative(fullPath, root))) {
+      out.push(fullPath);
+    }
+  }
+  return out;
+}
+
+function changedGrowthFiles(baseRef, root = ROOT) {
+  const output = execFileSync(
+    "git",
+    ["diff", "--name-only", "--diff-filter=ACMRT", `${baseRef}...HEAD`, "--", GROWTH_PREFIX],
+    { cwd: root, encoding: "utf8" },
+  );
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((file) => isGrowthExample(file))
+    .map((file) => path.join(root, file))
+    .filter((file) => fs.existsSync(file));
+}
+
+function lineNumberForOffset(source, offset) {
+  return source.slice(0, offset).split(/\r?\n/).length;
+}
+
+function resolveRelativeModule(importerPath, specifier) {
+  const base = path.resolve(path.dirname(importerPath), specifier);
+  const candidates = [base];
+  if (!path.extname(base)) {
+    candidates.push(
+      `${base}.mjs`,
+      `${base}.js`,
+      `${base}.cjs`,
+      `${base}.ts`,
+      `${base}.mts`,
+      `${base}.cts`,
+      `${base}.json`,
+      path.join(base, "index.mjs"),
+      path.join(base, "index.js"),
+      path.join(base, "index.cjs"),
+      path.join(base, "index.ts"),
+    );
+  }
+  return candidates.some((candidate) => fs.existsSync(candidate));
+}
+
+function checkStaticRelativeImports(filePath, source, root = ROOT) {
+  const findings = [];
+  if (!JS_EXTENSIONS.has(path.extname(filePath))) return findings;
+
+  const checks = [
+    {
+      kind: "missing_static_relative_import",
+      // Matches static ESM imports, including side-effect imports and import type.
+      regex: /^[ \t]*import(?:\s+type)?(?:[\s\S]*?\s+from\s+|\s*)["'](\.{1,2}\/[^"']+)["']/gm,
+    },
+    {
+      kind: "missing_static_relative_require",
+      regex: /\brequire\s*\(\s*["'](\.{1,2}\/[^"']+)["']\s*\)/g,
+    },
+  ];
+
+  for (const check of checks) {
+    for (const match of source.matchAll(check.regex)) {
+      const specifier = match[1];
+      if (!resolveRelativeModule(filePath, specifier)) {
+        findings.push({
+          code: check.kind,
+          file: repoRelative(filePath, root),
+          line: lineNumberForOffset(source, match.index ?? 0),
+          message: `Static relative module "${specifier}" does not exist next to the generated example.`,
+        });
+      }
+    }
+  }
+
+  return findings;
+}
+
+function looksLikeGeneratedX402Buyer(source, relPath) {
+  const lowerSource = source.toLowerCase();
+  const lowerPath = relPath.toLowerCase();
+  return lowerPath.includes("x402")
+    && lowerSource.includes("402")
+    && lowerSource.includes("payment-required")
+    && /\bpay\s*\(/.test(source)
+    && /x402fetch|createinlinex402fetch|createfallbackx402fetch|authorizationheader|paymentsignature/i.test(source);
+}
+
+function checkX402Safety(filePath, source, root = ROOT) {
+  const findings = [];
+  const rel = repoRelative(filePath, root);
+  if (!JS_EXTENSIONS.has(path.extname(filePath)) || !looksLikeGeneratedX402Buyer(source, rel)) {
+    return findings;
+  }
+
+  const hasMissingChallengeGuard =
+    /without\s+(?:a\s+)?payment-required/i.test(source)
+    || /did not include\s+(?:a\s+valid\s+)?payment-required/i.test(source)
+    || /invalid\s+payment-required/i.test(source)
+    || /missing\s+payment-required/i.test(source)
+    || /payment-required\s+(?:header\s+)?(?:missing|challenge\s+missing|is\s+required)/i.test(source);
+
+  if (!hasMissingChallengeGuard) {
+    findings.push({
+      code: "x402_missing_challenge_not_fail_closed",
+      file: rel,
+      line: 1,
+      message: "Generated x402 buyer example must fail closed when HTTP 402 omits or corrupts payment-required.",
+    });
+  }
+
+  const hasSecond402Guard =
+    /paid request (?:received|was rejected).*?(?:another\s+)?(?:HTTP\s+)?402/i.test(source)
+    || /another\s+(?:HTTP\s+)?402 challenge/i.test(source)
+    || /refusing to re-authorize payment/i.test(source)
+    || /paid_request_rejected/i.test(source)
+    || /paid_retry_rejected/i.test(source);
+
+  if (!hasSecond402Guard) {
+    findings.push({
+      code: "x402_paid_retry_reauthorizes_or_replays",
+      file: rel,
+      line: 1,
+      message: "Generated x402 buyer example must reject a second HTTP 402 after payment instead of replaying or re-authorizing.",
+    });
+  }
+
+  return findings;
+}
+
+export function validateGrowthExampleFile(filePath, options = {}) {
+  const root = options.root ?? ROOT;
+  const source = fs.readFileSync(filePath, "utf8");
+  return [
+    ...checkStaticRelativeImports(filePath, source, root),
+    ...checkX402Safety(filePath, source, root),
+  ];
+}
+
+export function validateGrowthExampleFiles(files, options = {}) {
+  return files.flatMap((file) => validateGrowthExampleFile(file, options));
+}
+
+function parseArgs(argv) {
+  const args = {
+    all: false,
+    base: "origin/main",
+    files: [],
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--all") {
+      args.all = true;
+    } else if (arg === "--base") {
+      args.base = argv[++index];
+      if (!args.base) throw new Error("--base requires a git ref");
+    } else if (arg === "--file") {
+      const file = argv[++index];
+      if (!file) throw new Error("--file requires a path");
+      args.files.push(file);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return args;
+}
+
+function filesForArgs(args, root = ROOT) {
+  if (args.files.length > 0) {
+    return args.files
+      .map((file) => path.resolve(root, file))
+      .filter((file) => fs.existsSync(file) && isGrowthExample(repoRelative(file, root)));
+  }
+  if (args.all) {
+    return walkFiles(path.join(root, "examples", "agoragentic-growth"), root);
+  }
+  return changedGrowthFiles(args.base, root);
+}
+
+export function formatFinding(finding) {
+  return `${finding.file}:${finding.line} ${finding.code}: ${finding.message}`;
+}
+
+export async function main(argv = process.argv.slice(2), root = ROOT) {
+  const args = parseArgs(argv);
+  const files = filesForArgs(args, root);
+  const findings = validateGrowthExampleFiles(files, { root });
+
+  if (findings.length > 0) {
+    console.error("Generated growth example validation failed:");
+    for (const finding of findings) {
+      console.error(`- ${formatFinding(finding)}`);
+    }
+    process.exitCode = 1;
+    return { files, findings };
+  }
+
+  console.log(`✅ Generated growth examples validated (${files.length} file${files.length === 1 ? "" : "s"})`);
+  return { files, findings };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error.stack || error.message || String(error));
+    process.exitCode = 1;
+  });
+}

--- a/test/validate-growth-examples.test.mjs
+++ b/test/validate-growth-examples.test.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { validateGrowthExampleFile } from "../scripts/validate-growth-examples.mjs";
+
+function makeFixture(source, name = "x402_execute_fixture.mjs") {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "growth-validator-"));
+  const dir = path.join(root, "examples", "agoragentic-growth", "fixture");
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, source, "utf8");
+  return { root, file };
+}
+
+function findingCodes(source, name) {
+  const fixture = makeFixture(source, name);
+  return validateGrowthExampleFile(fixture.file, { root: fixture.root }).map((finding) => finding.code);
+}
+
+test("accepts guarded x402 paid retry examples", () => {
+  const codes = findingCodes(`
+    export async function x402Fetch(url, { fetchImpl, pay }) {
+      const first = await fetchImpl(url);
+      if (first.status !== 402) return first;
+      const paymentRequired = first.headers.get("payment-required");
+      if (!paymentRequired) {
+        throw new Error("Received HTTP 402 without payment-required header");
+      }
+      const payment = await pay(paymentRequired, { challenge: JSON.parse(paymentRequired) });
+      const paid = await fetchImpl(url, { headers: { authorization: payment.authorizationHeader } });
+      if (paid.status === 402) {
+        throw new Error("Paid request received another HTTP 402 challenge; refusing to re-authorize payment");
+      }
+      return paid;
+    }
+  `);
+
+  assert.deepEqual(codes, []);
+});
+
+test("rejects static relative imports that point at missing generated siblings", () => {
+  const codes = findingCodes(`
+    import { helper } from "./missing-sibling.mjs";
+    export function demo() {
+      return helper();
+    }
+  `);
+
+  assert.deepEqual(codes, ["missing_static_relative_import"]);
+});
+
+test("does not reject optional fallback import specifier strings", () => {
+  const codes = findingCodes(`
+    export async function loadOptionalClient() {
+      const candidates = ["../lib/x402-client.mjs"];
+      for (const specifier of candidates) {
+        try {
+          const mod = await import(specifier);
+          if (mod.x402Fetch) return mod.x402Fetch;
+        } catch {}
+      }
+      return null;
+    }
+  `);
+
+  assert.deepEqual(codes, []);
+});
+
+test("rejects paid x402 flows that do not fail closed on missing payment-required", () => {
+  const codes = findingCodes(`
+    export async function x402Fetch(url, { fetchImpl, pay }) {
+      const first = await fetchImpl(url);
+      if (first.status !== 402) return first;
+      const paymentRequired = first.headers.get("payment-required");
+      const payment = await pay(paymentRequired, {});
+      const paid = await fetchImpl(url, { headers: { "payment-signature": payment.paymentSignature } });
+      if (paid.status === 402) {
+        throw new Error("Paid request received another HTTP 402 challenge; refusing to re-authorize payment");
+      }
+      return paid;
+    }
+  `);
+
+  assert(codes.includes("x402_missing_challenge_not_fail_closed"));
+});
+
+test("rejects paid x402 flows that allow a second 402 after authorization", () => {
+  const codes = findingCodes(`
+    export async function x402Fetch(url, { fetchImpl, pay }) {
+      const first = await fetchImpl(url);
+      if (first.status !== 402) return first;
+      const paymentRequired = first.headers.get("payment-required");
+      if (!paymentRequired) {
+        throw new Error("Received HTTP 402 without payment-required header");
+      }
+      const payment = await pay(paymentRequired, {});
+      return fetchImpl(url, { headers: { authorization: payment.authorizationHeader } });
+    }
+  `);
+
+  assert(codes.includes("x402_paid_retry_reauthorizes_or_replays"));
+});


### PR DESCRIPTION
## Summary
- add a deterministic growth-generated example validator to the main validation workflow
- gate changed `examples/agoragentic-growth/**` files for missing static sibling imports, missing/invalid x402 payment-required fail-closed handling, and second-402-after-payment replay/re-authorization
- fix the latest x402 buyer retry checklist example so missing/unparsable payment-required fails closed before `pay()`

## Verification
- `node --test test/validate-growth-examples.test.mjs` -> 5/0
- `node scripts/validate-growth-examples.mjs --base origin/main` -> 1 changed file validated
- `node examples/agoragentic-growth/2026-07-02-x402-execute-buyer-retry-receipt-checkli-836e05b04d/x402_execute_buyer_retry_receipt_checklist.mjs` -> self-test ok
- `node --check scripts/validate-growth-examples.mjs; node --check test/validate-growth-examples.test.mjs; node scripts/verify-integrations-json.js`
- `git diff --cached --check` before commit

## Notes
The CI gate scans changed growth examples against `origin/main`, so it blocks new/regenerated bad output without making the historical example corpus a retroactive blocker. A local `--all` audit still surfaces legacy examples that predate this gate and can be cleaned up separately.