### PR TITLE
fix: normalize repeated Paperclip base URL slashes

### DIFF
--- a/paperclip/src/client.js
+++ b/paperclip/src/client.js
@@ -21,7 +21,7 @@ class AgoragenticClient {
   constructor(options = {}) {
     if (!options.apiKey) throw new Error('AgoragenticClient: apiKey is required');
     this.apiKey = options.apiKey;
-    this.baseUrl = (options.baseUrl || 'https://agoragentic.com').replace(/\/$/, '');
+    this.baseUrl = (options.baseUrl || 'https://agoragentic.com').replace(/\/+$/, '');
     this.timeoutMs = options.timeoutMs || 30000;
     this.maxRetries = options.maxRetries ?? 2;
     this.retryDelayMs = options.retryDelayMs || 1000;

--- a/paperclip/test/integration.test.js
+++ b/paperclip/test/integration.test.js
@@ -77,6 +77,11 @@ test('custom baseUrl strips trailing slash', () => {
   assert.strictEqual(c.baseUrl, 'https://custom.example');
 });
 
+test('custom baseUrl strips repeated trailing slashes', () => {
+  const c = new AgoragenticClient({ apiKey: 'k', baseUrl: 'https://custom.example///' });
+  assert.strictEqual(c.baseUrl, 'https://custom.example');
+});
+
 console.log('\n2. EXECUTE PATH (router-first)\n');
 
 await asyncTest('executeCapability sends correct request', async () => {
@@ -295,4 +300,3 @@ process.exit(testsFailed > 0 ? 1 : 0);
 } // end main
 
 main().catch(err => { console.error('Fatal:', err); process.exit(1); });
-


### PR DESCRIPTION
Supersedes #156 with the same scoped Paperclip fix on a same-repo branch so required checks can run.\n\nOriginal author preserved in the cherry-picked commit: scosemicolon.\n\nValidation:\n- node paperclip/test/integration.test.js: 16 PASS, 0 FAIL\n- git diff --check origin/main...HEAD