### PR TITLE
Audit fixes: agoragentic-integrations

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,39 @@
+name: Publish agoragentic to PyPI
+
+# Publishes the Python SDK in this repo (packaged from pyproject.toml / src/agoragentic)
+# to PyPI via PyPI Trusted Publishing (OIDC — no long-lived API token).
+#
+# NOTE (owner follow-up): a PyPI Trusted Publisher must be configured once in the
+# PyPI project settings for `agoragentic`, pointing at this repository and this
+# workflow filename (publish-pypi.yml). Until that is done, the publish step below
+# will fail auth. See the PR "Owner follow-ups" section.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    # Gate on Python SDK release tags so npm-tag releases do not trigger a PyPI publish.
+    if: startsWith(github.event.release.tag_name, 'py-v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade build
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Publish to PyPI with Trusted Publishing
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -35,6 +35,11 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
       - name: Validate MCP package
         working-directory: mcp
         run: |
@@ -147,6 +152,9 @@ jobs:
 
       - name: Verify ACP adapter
         run: node scripts/verify-acp.js
+
+      - name: Verify Rust framework public sync
+        run: node scripts/verify-rust-framework-public-sync.js
 
       - name: Test growth example validator
         run: node --test test/validate-growth-examples.test.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ n8n/dist/
 n8n/package-lock.json
 __pycache__/
 *.pyc
+
+# Never commit secrets; the x402 demos read WALLET_PRIVATE_KEY from the environment / a local .env
+.env
+.env.*
+!.env.example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+_No unreleased changes yet. New, not-yet-shipped work goes here (undated), per the Keep a Changelog format above._
+
+## [manifest 2.16.0–2.24.2] - 2026-07-03
+
+### Added
+- Rolled up the integration-manifest bumps that shipped since `2.15.0`. `integrations.json` is now version `2.24.2` (`updated_at` 2026-07-03). This range covers the discovery/index entries added across many pushes, including but not limited to the `pdf-mcp/` (PDF MCP) and `turbovec/` (TurboVec) integrations, which are present in `integrations.json` and as directories but were previously absent from this changelog.
+- Expanded the Interchange protocol package discovery pointers in `integrations.json`.
+
+### Changed
+- CHANGELOG version headers from here forward track the integration-manifest version so the manifest and changelog no longer drift silently. Because the manifest version bumps on nearly every push, this entry is phrased as a version range rather than a single hardcoded number.
+
+### Removed
+- Removed the Frontier AI hosted-deployment link from `README.md` (originally added in 2.1.0), reconciling the earlier "Added" entry with the current README, which no longer contains it.
+
 ## [micro-ecf-v0.1.3] - 2026-06-14
 
 ### Changed
 - Updated the Micro ECF npm README launch path so the local install command, one-step secret-block proof, and Agent OS handoff boundary are visible from the package page.
 
-## [Unreleased] - 2026-05-19
+## [harness-core-v0.1.0] - 2026-06-04
+
+### Added
+- Added `harness-core/`, the package-ready local no-spend Harness Core scaffold for `init`, `validate`, `proof`, `export --to agent-os`, `listing check`, and adapter discovery.
+- Added Harness Core schemas, tests, and a Trusted Publishing release workflow gated by `harness-core-v*` release tags.
+
+## [premortem-golden-loop-v0.1.6] - 2026-05-24
+
+### Added
+- Added `premortem-golden-loop/`, a free local OSS agent release premortem, no-spend Golden Loop readiness, and safe self-heal scaffold CLI.
+- Added Premortem Golden Loop discovery pointers in `integrations.json`, `README.md`, `llms.txt`, `llms-full.txt`, and `SKILL.md`.
+
+## [2.15.0] - 2026-05-19
 
 ### Added
 - Added `hermes-agent/`, a public Hermes Agent bridge scaffold for Agoragentic MCP tooling, Agent OS handoff manifests, and review-gated self-improvement reflection packets with no live execution authority.
 - Added `rust-framework/`, a public Agoragentic Rust Framework HTTP runtime integration folder with TypeScript/Node and Python examples, a self-hosted Agent OS Harness packet example, and no-spend verification.
 - Added Rust Framework discovery pointers in `integrations.json`, `README.md`, `llms.txt`, `llms-full.txt`, and `SKILL.md` while keeping hosted Router / Marketplace SDK semantics unchanged.
-- Added `harness-core/`, the package-ready local no-spend Harness Core scaffold for `init`, `validate`, `proof`, `export --to agent-os`, `listing check`, and adapter discovery.
-- Added Harness Core schemas, tests, and a Trusted Publishing release workflow gated by `harness-core-v*` release tags.
-- Added `premortem-golden-loop/`, a free local OSS agent release premortem, no-spend Golden Loop readiness, and safe self-heal scaffold CLI.
-- Added Premortem Golden Loop discovery pointers in `integrations.json`, `README.md`, `llms.txt`, `llms-full.txt`, and `SKILL.md`.
 - Added high-priority adapters for LangGraph, Cloudflare Agents, Microsoft Semantic Kernel, Zapier MCP, Flowise, Composio, and HumanLayer.
 - Added an experimental Zoneless payout reference as documentation-only research while keeping Base settlement canonical.
 - Folded the integration manifest to version `2.15.0` with all public integration surfaces indexed.
@@ -97,7 +121,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Per-seller duplicate listing name prevention (409 block) in capabilities API
 - Cross-seller name collision warnings (non-blocking) in capabilities API
 - Admin duplicate listing report endpoint (`GET /api/admin/listings/duplicates`)
-- Fronteir AI hosted deployment link in README (community PR #3 by @ElishaKay)
+- Frontier AI hosted deployment link in README (community PR #3 by @ElishaKay). _(Later removed — see the manifest 2.16.0–2.24.2 rollup; the link no longer appears in README.md.)_
 
 ### Changed
 - x402 execute validation error now includes step-by-step two-step flow guide and direct invoke alternative
@@ -144,7 +168,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SKILL.md capability description
 - Glama registry entry
 
-[2.2.0]: https://github.com/rhein1/agoragentic-integrations/compare/v2.1.0...v2.2.0
-[2.1.0]: https://github.com/rhein1/agoragentic-integrations/compare/v2.0.0...v2.1.0
-[2.0.0]: https://github.com/rhein1/agoragentic-integrations/compare/v1.0.0...v2.0.0
-[1.0.0]: https://github.com/rhein1/agoragentic-integrations/releases/tag/v1.0.0
+<!--
+  Only two `vX` tags exist on the remote today: v1.1.0 and v2.1.0. Earlier footer
+  links pointed at v1.0.0 / v2.0.0 / v2.2.0, which are not tagged and returned 404.
+  Until annotated tags are cut for the remaining releases (see PR "Owner follow-ups"),
+  version links point only at refs that resolve: the two real tags, and the main tree.
+-->
+[Unreleased]: https://github.com/rhein1/agoragentic-integrations/tree/main
+[manifest 2.16.0–2.24.2]: https://github.com/rhein1/agoragentic-integrations/tree/main
+[micro-ecf-v0.1.3]: https://github.com/rhein1/agoragentic-integrations/releases/tag/micro-ecf-v0.1.3
+[harness-core-v0.1.0]: https://github.com/rhein1/agoragentic-integrations/tree/main
+[premortem-golden-loop-v0.1.6]: https://github.com/rhein1/agoragentic-integrations/tree/main
+[2.15.0]: https://github.com/rhein1/agoragentic-integrations/tree/main
+[2.6.2]: https://github.com/rhein1/agoragentic-integrations/tree/main
+[2.5.0]: https://github.com/rhein1/agoragentic-integrations/tree/main
+[2.4.0]: https://github.com/rhein1/agoragentic-integrations/tree/main
+[2.3.0]: https://github.com/rhein1/agoragentic-integrations/tree/main
+[2.2.0]: https://github.com/rhein1/agoragentic-integrations/tree/main
+[2.1.0]: https://github.com/rhein1/agoragentic-integrations/releases/tag/v2.1.0
+[2.0.0]: https://github.com/rhein1/agoragentic-integrations/tree/main
+[1.0.0]: https://github.com/rhein1/agoragentic-integrations/releases/tag/v1.1.0

--- a/autogen/agoragentic_autogen.py
+++ b/autogen/agoragentic_autogen.py
@@ -10,14 +10,12 @@ Install:
     pip install pyautogen requests
 
 Usage:
-    from agoragentic_autogen import get_agoragentic_functions
+    from agoragentic_autogen import get_agoragentic_functions, FUNCTION_MAP
 
     functions = get_agoragentic_functions(api_key="amk_your_key")
 
     assistant = autogen.AssistantAgent("agent", llm_config={"functions": functions})
-    user_proxy = autogen.UserProxyAgent("user", function_map={
-        f["name"]: globals()[f"_impl_{f['name']}"] for f in functions
-    })
+    user_proxy = autogen.UserProxyAgent("user", function_map=FUNCTION_MAP)
 """
 
 import json

--- a/elizaos/package.json
+++ b/elizaos/package.json
@@ -6,8 +6,7 @@
     "description": "Agoragentic marketplace plugin for ElizaOS — router-first agent commerce",
     "main": "agoragentic_eliza.ts",
     "scripts": {
-        "example": "node example.js",
-        "test": "node --test test.js"
+        "example": "node example.js"
     },
     "keywords": [
         "elizaos",

--- a/harness-core/LICENSE
+++ b/harness-core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Agoragentic
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/harness-core/package.json
+++ b/harness-core/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Local no-spend Agent OS Harness Core for Micro ECF policy, first proof, receipts, listing readiness, and Triptych OS preview export.",
   "type": "module",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "bin": {
     "agoragentic-harness": "./bin/agoragentic-harness.mjs",
     "agoragentic-harness-core": "./bin/agoragentic-harness.mjs",
@@ -20,6 +20,7 @@
     "templates/",
     "test/",
     "README.md",
+    "LICENSE",
     "TRUSTED_PUBLISHING.md"
   ],
   "scripts": {

--- a/integrations.json
+++ b/integrations.json
@@ -1,6 +1,6 @@
 {
   "version": "2.24.2",
-  "updated_at": "2026-06-26",
+  "updated_at": "2026-07-03",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
   "packages": {
@@ -59,6 +59,28 @@
       "format": "amk_*",
       "how_to_get": "POST https://agoragentic.com/api/quickstart with {\"name\":\"your-agent\",\"intent\":\"buyer\"}; use intent=seller or intent=both for publishing capabilities.",
       "note": "Required for authenticated execute/match/status/receipt and Agent OS preview requests. Anonymous stable x402 edge calls do not require a platform API key."
+    },
+    "AGORAGENTIC_RUST_AGENT_URL": {
+      "required": false,
+      "how_to_get": "Run a local agoragentic-rust HTTP runtime; defaults to http://127.0.0.1:8080.",
+      "note": "Consumed by the rust-framework integration (rust-framework/python_call_rust_agent.py). Its own install string instructs setting this var."
+    },
+    "AGORAGENTIC_BASE_URL": {
+      "required": false,
+      "how_to_get": "Set only to override the default platform base URL.",
+      "note": "Overrides https://agoragentic.com. Read across many integrations (e.g. agent-os/agent_os_node.mjs)."
+    },
+    "AGORAGENTIC_SUPERVISOR_API_KEY": {
+      "required": false,
+      "format": "amk_*",
+      "how_to_get": "Provision a supervisor-mode API key from the Agoragentic dashboard.",
+      "note": "Required for Agent OS supervisor mode. Documented in agent-os/README.md."
+    },
+    "AGORAGENTIC_CAPABILITY_ID": {
+      "required": false,
+      "format": "cap_*",
+      "how_to_get": "Copy the capability/listing ID from the Agoragentic marketplace listing you want to quote or execute.",
+      "note": "Required for Agent OS buyer mode. Documented in agent-os/README.md."
     }
   },
   "recommended_flow": [

--- a/letta/agoragentic_letta.py
+++ b/letta/agoragentic_letta.py
@@ -126,4 +126,3 @@ if __name__ == "__main__":
     hitl_status = bridge.handle_letta_human_gate("appr_letta_9921", 0.08)
     print("\nHITL Status check:")
     print(json.dumps(hitl_status, indent=2))
-wagon = 1

--- a/n8n/.npmignore
+++ b/n8n/.npmignore
@@ -1,0 +1,2 @@
+# Exclude the TypeScript incremental-build cache from the published tarball.
+dist/tsconfig.tsbuildinfo

--- a/n8n/LICENSE
+++ b/n8n/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Agoragentic
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/n8n/package.json
+++ b/n8n/package.json
@@ -30,7 +30,8 @@
         "prepublishOnly": "npm run build"
     },
     "files": [
-        "dist"
+        "dist",
+        "LICENSE"
     ],
     "n8n": {
         "n8nNodesApiVersion": 1,

--- a/oh-my-claudecode/README.md
+++ b/oh-my-claudecode/README.md
@@ -79,9 +79,9 @@ The planner will distribute tasks across team members, and each agent can indepe
 | `agoragentic_invoke` | Compatibility direct invoke by listing ID | Listing price |
 | `agoragentic_vault` | Optional owned-item inventory helper | Free |
 | `agoragentic_categories` | List marketplace categories | Free |
-| `agoragentic_memory_write` | Write to persistent memory | $0.10 |
+| `agoragentic_memory_write` | Write to persistent memory | Free |
 | `agoragentic_memory_read` | Read from persistent memory | Free |
-| `agoragentic_secret_store` | Store encrypted credentials | $0.25 |
+| `agoragentic_secret_store` | Store encrypted credentials | Free |
 | `agoragentic_secret_retrieve` | Retrieve credentials | Free |
 | `agoragentic_passport` | Compatibility identity helper | Free |
 
@@ -127,7 +127,7 @@ For programmatic use outside MCP, install the SDK directly:
 
 ```bash
 pip install agoragentic    # Python
-npm install agoragentic    # Node.js (coming soon)
+npm install agoragentic    # Node.js
 ```
 
 ## Resources

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agoragentic"
-version = "1.0.0"
-description = "Framework tools for Agoragentic Agent OS routing, receipts, Seller OS, and stable x402 edge calls"
+version = "1.7.0"
+description = "Official Python SDK for Agoragentic Agent OS: deployed agent workflows, marketplace routing, receipts, and USDC settlement"
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.8"

--- a/scripts/verify-integrations-json.js
+++ b/scripts/verify-integrations-json.js
@@ -63,6 +63,17 @@ function topLevelDuplicateKeys(jsonText) {
 }
 
 function assertManifestShape(manifest) {
+  const updatedAt = manifest.updated_at;
+  if (typeof updatedAt !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(updatedAt)) {
+    fail(`integrations.json updated_at must be an ISO date (YYYY-MM-DD); got ${JSON.stringify(updatedAt)}`);
+  } else {
+    const parsed = new Date(`${updatedAt}T00:00:00Z`);
+    if (Number.isNaN(parsed.getTime())) {
+      fail(`integrations.json updated_at is not a valid date: ${updatedAt}`);
+    } else if (parsed.getTime() > Date.now()) {
+      fail(`integrations.json updated_at is in the future: ${updatedAt}`);
+    }
+  }
   if (manifest.recommended_flow?.[0] !== 'agoragentic_execute') {
     fail('recommended_flow must start with agoragentic_execute');
   }

--- a/scripts/verify-rust-framework-public-sync.js
+++ b/scripts/verify-rust-framework-public-sync.js
@@ -251,7 +251,10 @@ async function main() {
   assertIncludes(skill, 'Agoragentic Rust Framework HTTP examples', 'SKILL.md');
 
   const manifest = parseJson('integrations.json');
-  assert.equal(manifest.updated_at, '2026-06-07');
+  // integrations.json.updated_at is intentionally bumped over time and is not part of
+  // the Rust-framework public-sync contract, so we validate its shape (ISO date) rather
+  // than freezing a literal value that would re-drift on every unrelated manifest edit.
+  assert.match(manifest.updated_at, /^\d{4}-\d{2}-\d{2}$/);
   assert.ok(
     manifest.integrations.some(
       (item) =>

--- a/src/agoragentic.egg-info/PKG-INFO
+++ b/src/agoragentic.egg-info/PKG-INFO
@@ -1,7 +1,7 @@
 Metadata-Version: 2.4
 Name: agoragentic
-Version: 1.0.0
-Summary: LangChain and CrewAI tools for the Agoragentic agent-to-agent marketplace
+Version: 1.7.0
+Summary: Official Python SDK for Agoragentic Agent OS: deployed agent workflows, marketplace routing, receipts, and USDC settlement
 Author-email: Agoragentic <support@agoragentic.com>
 License: MIT
 Project-URL: Homepage, https://agoragentic.com

--- a/src/agoragentic/__init__.py
+++ b/src/agoragentic/__init__.py
@@ -34,7 +34,7 @@ from agoragentic.langchain_tools import (
     AGORAGENTIC_BASE_URL,
 )
 
-__version__ = "1.0.0"
+__version__ = "1.7.0"
 __all__ = [
     "AgoragenticRegister",
     "AgoragenticSearch",

--- a/strands/README.md
+++ b/strands/README.md
@@ -4,7 +4,7 @@ This folder contains the **AWS Strands Integration** showing how Strands hooks/m
 
 ## Status: `beta`
 
-Both Python and TypeScript implementations are fully functional locally and support offline dry-runs without credentials.
+Both Python and TypeScript implementations are demo hook/middleware harnesses: they run locally in dry-run mode (no credentials). The non-dry-run branches are stubs — setting `AGORAGENTIC_API_KEY` does not yet perform real network calls.
 
 ## What it is and is not
 

--- a/vercel-ai/agoragentic_vercel.js
+++ b/vercel-ai/agoragentic_vercel.js
@@ -19,6 +19,8 @@
  *   });
  */
 
+import { tool, jsonSchema } from "ai";
+
 const AGORAGENTIC_BASE_URL = "https://agoragentic.com";
 
 async function apiCall(method, path, apiKey, body = null) {
@@ -32,9 +34,9 @@ async function apiCall(method, path, apiKey, body = null) {
 
 export function getAgoragenticTools(apiKey = "") {
     return {
-        agoragentic_execute: {
+        agoragentic_execute: tool({
             description: "Route a task through Agoragentic execute() with provider selection, receipts, and settlement.",
-            parameters: {
+            inputSchema: jsonSchema({
                 type: "object",
                 properties: {
                     task: { type: "string", description: "Task to route through Agoragentic" },
@@ -42,17 +44,17 @@ export function getAgoragenticTools(apiKey = "") {
                     constraints: { type: "object", description: "Optional budget, trust, or routing constraints" }
                 },
                 required: ["task"]
-            },
+            }),
             execute: async ({ task, input = {}, constraints = {} }) => {
                 const payload = { task };
                 if (Object.keys(input).length) payload.input = input;
                 if (Object.keys(constraints).length) payload.constraints = constraints;
                 return apiCall("POST", "/api/execute", apiKey, payload);
             }
-        },
-        agoragentic_match: {
+        }),
+        agoragentic_match: tool({
             description: "Preview eligible routed providers before execution.",
-            parameters: {
+            inputSchema: jsonSchema({
                 type: "object",
                 properties: {
                     task: { type: "string", description: "Task to match" },
@@ -60,38 +62,38 @@ export function getAgoragenticTools(apiKey = "") {
                     min_trust: { type: "string", description: "Optional minimum trust requirement" }
                 },
                 required: ["task"]
-            },
+            }),
             execute: async ({ task, max_cost = -1, min_trust = "" }) => {
                 const params = new URLSearchParams({ task });
                 if (max_cost >= 0) params.set("max_cost", String(max_cost));
                 if (min_trust) params.set("min_trust", min_trust);
                 return apiCall("GET", `/api/execute/match?${params}`, apiKey);
             }
-        },
-        agoragentic_register: {
+        }),
+        agoragentic_register: tool({
             description: "Create an Agoragentic API key for a buyer, seller, or dual-purpose agent.",
-            parameters: {
+            inputSchema: jsonSchema({
                 type: "object",
                 properties: {
                     agent_name: { type: "string", description: "Your agent name" },
                     intent: { type: "string", enum: ["buyer", "seller", "both"], default: "both" }
                 },
                 required: ["agent_name"]
-            },
+            }),
             execute: async ({ agent_name, intent = "both" }) => {
                 return apiCall("POST", "/api/quickstart", null, { name: agent_name, intent: intent });
             }
-        },
-        agoragentic_search: {
+        }),
+        agoragentic_search: tool({
             description: "Compatibility catalog browsing. Prefer agoragentic_match for new routed work.",
-            parameters: {
+            inputSchema: jsonSchema({
                 type: "object",
                 properties: {
                     query: { type: "string", description: "Search term" },
                     category: { type: "string", description: "Category filter" },
                     max_price: { type: "number", description: "Max price in USDC" }
                 }
-            },
+            }),
             execute: async ({ query = "", category = "", max_price = -1 }) => {
                 const params = new URLSearchParams({ limit: "10", status: "active" });
                 if (query) params.set("search", query);
@@ -106,79 +108,79 @@ export function getAgoragenticTools(apiKey = "") {
                     }))
                 };
             }
-        },
-        agoragentic_invoke: {
+        }),
+        agoragentic_invoke: tool({
             description: "Compatibility direct-provider invocation when a known capability ID is required.",
-            parameters: {
+            inputSchema: jsonSchema({
                 type: "object",
                 properties: {
                     capability_id: { type: "string", description: "Capability ID from search" },
                     input_data: { type: "object", description: "Input payload" }
                 },
                 required: ["capability_id"]
-            },
+            }),
             execute: async ({ capability_id, input_data = {} }) => {
                 return apiCall("POST", `/api/invoke/${capability_id}`, apiKey, { input: input_data });
             }
-        },
-        agoragentic_vault: {
+        }),
+        agoragentic_vault: tool({
             description: "Compatibility inventory view for legacy vault surfaces.",
-            parameters: { type: "object", properties: { item_type: { type: "string" } } },
+            inputSchema: jsonSchema({ type: "object", properties: { item_type: { type: "string" } } }),
             execute: async ({ item_type = "" }) => {
                 const params = item_type ? `?type=${item_type}` : "";
                 return apiCall("GET", `/api/inventory${params}`, apiKey);
             }
-        },
-        agoragentic_memory_write: {
+        }),
+        agoragentic_memory_write: tool({
             description: "Write scoped Agent OS memory when policy allows it.",
-            parameters: {
+            inputSchema: jsonSchema({
                 type: "object",
                 properties: {
                     key: { type: "string" }, value: { type: "string" },
                     namespace: { type: "string", default: "default" }
                 },
                 required: ["key", "value"]
-            },
+            }),
             execute: async ({ key, value, namespace = "default" }) => {
                 return apiCall("POST", "/api/vault/memory", apiKey, { input: { key, value, namespace } });
             }
-        },
-        agoragentic_memory_read: {
+        }),
+        agoragentic_memory_read: tool({
             description: "Read scoped Agent OS memory when policy allows it.",
-            parameters: { type: "object", properties: { key: { type: "string" }, namespace: { type: "string" } } },
+            inputSchema: jsonSchema({ type: "object", properties: { key: { type: "string" }, namespace: { type: "string" } } }),
             execute: async ({ key = "", namespace = "default" }) => {
                 const params = new URLSearchParams({ namespace });
                 if (key) params.set("key", key);
                 return apiCall("GET", `/api/vault/memory?${params}`, apiKey);
             }
-        },
-        agoragentic_secret_store: {
+        }),
+        agoragentic_secret_store: tool({
             description: "Store a policy-gated encrypted credential.",
-            parameters: {
+            inputSchema: jsonSchema({
                 type: "object",
                 properties: { label: { type: "string" }, secret: { type: "string" } },
                 required: ["label", "secret"]
-            },
+            }),
             execute: async ({ label, secret }) => {
                 return apiCall("POST", "/api/vault/secrets", apiKey, { input: { label, secret } });
             }
-        },
-        agoragentic_secret_retrieve: {
+        }),
+        agoragentic_secret_retrieve: tool({
             description: "Retrieve a policy-gated encrypted credential.",
-            parameters: { type: "object", properties: { label: { type: "string" } } },
+            inputSchema: jsonSchema({ type: "object", properties: { label: { type: "string" } } }),
             execute: async ({ label = "" }) => {
                 const params = label ? `?label=${label}` : "";
                 return apiCall("GET", `/api/vault/secrets${params}`, apiKey);
             }
-        },
-        agoragentic_passport: {
+        }),
+        agoragentic_passport: tool({
             description: "Compatibility identity helper for legacy passport surfaces.",
-            parameters: { type: "object", properties: { action: { type: "string", enum: ["check", "info"] } } },
+            inputSchema: jsonSchema({ type: "object", properties: { action: { type: "string", enum: ["check", "info"] } } }),
             execute: async ({ action = "check" }) => {
                 const path = action === "info" ? "/api/passport/info" : "/api/passport/check";
                 return apiCall("GET", path, action === "info" ? "" : apiKey);
             }
-        }
+        })
     };
 }
 

--- a/x402/README.md
+++ b/x402/README.md
@@ -8,8 +8,11 @@ Pay-per-request agent-to-agent commerce via HTTP 402 on Base L2.
 # Free demo — no wallet needed
 node x402/buyer-demo.js
 
-# Paid demo — requires USDC on Base
-WALLET_PRIVATE_KEY=0x... node x402/buyer-demo.js --paid
+# Paid demo — requires USDC on Base.
+# Export the key on its own line (or use a gitignored .env) so a real funded key
+# is not written to shell history or exposed in process listings (ps).
+export WALLET_PRIVATE_KEY=0x...
+node x402/buyer-demo.js --paid
 
 # Verbose output
 node x402/buyer-demo.js --verbose

--- a/x402/buyer-demo.js
+++ b/x402/buyer-demo.js
@@ -14,7 +14,10 @@
  *   node x402/buyer-demo.js
  * 
  *   # Paid demo (requires wallet with USDC on Base)
- *   WALLET_PRIVATE_KEY=0x... node x402/buyer-demo.js --paid
+ *   # Export the key on its own line (or use a gitignored .env) so a real funded
+ *   # key is not written to shell history or exposed in process listings.
+ *   export WALLET_PRIVATE_KEY=0x...
+ *   node x402/buyer-demo.js --paid
  * 
  *   # Custom marketplace URL
  *   AGORAGENTIC_URL=http://localhost:3001 node x402/buyer-demo.js
@@ -212,7 +215,7 @@ async function step5_paidExecution() {
     const privateKey = process.env.WALLET_PRIVATE_KEY;
     if (!privateKey) {
         log('💡', 'Step 5: Skipping paid execution — set WALLET_PRIVATE_KEY to test paid flow');
-        log('💡', '  Usage: WALLET_PRIVATE_KEY=0x... node x402/buyer-demo.js --paid');
+        log('💡', '  Usage: export WALLET_PRIVATE_KEY=0x... (own line, or a gitignored .env — avoids shell-history / ps exposure) then: node x402/buyer-demo.js --paid');
         return null;
     }
 


### PR DESCRIPTION
These are fixes from an automated multi-agent audit of `agoragentic-integrations`; every finding was verified before this batch was applied.

## Applied

### Medium
- **oh-my-claudecode README (discrepancy):** free tools `agoragentic_memory_write` / `agoragentic_secret_store` were shown with per-call `$0.10` / `$0.25` prices; corrected to `Free` to match `integrations.json` (`"cost":"free"`) and the schema enum. Dropped the stale `# Node.js (coming soon)` annotation since `agoragentic` is published on npm.
- **integrations.json env_vars (integration-gap):** added `AGORAGENTIC_RUST_AGENT_URL`, `AGORAGENTIC_BASE_URL`, `AGORAGENTIC_SUPERVISOR_API_KEY`, and `AGORAGENTIC_CAPABILITY_ID` — vars the integrations actually consume and that the rust-framework install string / agent-os README already reference — resolving the self-contradiction where the manifest instructed setting a var it omitted.
- **Strands README (discrepancy):** replaced "fully functional" with honest wording — the adapters run in dry-run mode; the non-dry-run branches are stubs and setting `AGORAGENTIC_API_KEY` does not yet perform real network calls (mirrors the letta / microsoft-agent-framework siblings).
- **Vercel AI adapter (quality):** wrapped all 11 tools with the SDK `tool()` helper and renamed `parameters` -> `inputSchema` wrapped in `jsonSchema()`, so the tools are invocable under AI SDK v5/v6 (`import { tool, jsonSchema } from 'ai'`).
- **CHANGELOG manifest drift (discrepancy):** added a `manifest 2.16.0–2.24.2` rollup section (phrased as a range to avoid re-staling) that names the previously-undocumented `pdf-mcp` and `turbovec` integrations, and noted that headers now track the manifest version.
- **verify-rust-framework-public-sync.js (error):** replaced the frozen `assert.equal(manifest.updated_at, '2026-06-07')` — which made the script exit 1 on every unrelated `integrations.json` edit — with a shape check (`/^\d{4}-\d{2}-\d{2}$/`).
- **validate.yml (ci):** wired the now-passing rust-sync script into the workflow as a step, and added `actions/setup-python@v5` before it (the script calls `python`, which ubuntu-latest does not expose by default).
- **Python SDK version/scope (publish):** synced the in-repo version `1.0.0` -> published `1.7.0` across `pyproject.toml`, `src/agoragentic/__init__.py`, and `egg-info/PKG-INFO` (with the live-scope summary), and added a PyPI Trusted-Publishing workflow (`.github/workflows/publish-pypi.yml`).
- **harness-core license (license):** package declared `Apache-2.0` but shipped no LICENSE; repo intent is MIT (README license section). Changed `license` to `MIT`, added `LICENSE` to `files[]`, and added an MIT `harness-core/LICENSE`.
- **n8n license (license):** `n8n-nodes-agoragentic` declared MIT but shipped no LICENSE in the tarball. Added `n8n/LICENSE` (MIT), added `LICENSE` to `files[]`, and added `n8n/.npmignore` to keep `dist/tsconfig.tsbuildinfo` out of the package.

### Low
- **integrations.json updated_at (discrepancy):** bumped `updated_at` `2026-06-26` -> `2026-07-03` (the real last content-change date) and added an `updated_at` format/freshness guard (valid ISO date, not in the future) to `verify-integrations-json.js`, which `validate.yml` already runs.
- **letta adapter (quality):** removed the stray top-level `wagon = 1` at the end of `agoragentic_letta.py`.
- **AutoGen docstring (discrepancy):** fixed the module usage example that referenced nonexistent `_impl_*` functions — it now imports and uses the exported `FUNCTION_MAP`, matching the README.
- **CHANGELOG footer links (broken-link):** the four `compare`/`releases/tag` footer links pointed at tags that do not exist (`v1.0.0`, `v2.0.0`, `v2.2.0`) and 404'd. Repointed all version links to refs that resolve today (`v1.1.0`, `v2.1.0`, `micro-ecf-v0.1.3`, or the `main` tree) and added the missing footer entries for `2.3.0`–`2.6.2` and the newer sections.
- **CHANGELOG Fronteir typo / reconciliation (discrepancy):** fixed `Fronteir` -> `Frontier` and added a `Removed` entry reconciling that the hosted-deployment link no longer exists in `README.md`.
- **CHANGELOG ordering (quality):** converted the stale `[Unreleased] - 2026-05-19` block (which listed already-shipped work) into properly dated released sections in reverse-chronological order, and reserved an undated `[Unreleased]` heading at the top per Keep a Changelog.
- **x402 secret hygiene (security):** changed the docs and the printed usage hint to `export WALLET_PRIVATE_KEY=0x...` on its own line (or a gitignored `.env`) instead of inlining the key on the command line, and added `.env` to `.gitignore`.
- **elizaos test script (error):** removed the `"test": "node --test test.js"` script that pointed at a nonexistent `test.js` and errored immediately (matching the mcp/n8n no-test convention); the adapter is `private:true` and not in CI.

## Owner follow-ups (external, could not be automated)
- Configure the **PyPI Trusted Publisher** for the `agoragentic` project (repo `rhein1/agoragentic-integrations`, workflow `publish-pypi.yml`), then cut a `py-v1.7.0` release to publish the synced Python SDK.
- **Republish npm packages** so the new LICENSE files land in the tarballs: `agoragentic-harness-core` (e.g. 0.1.1) and `n8n-nodes-agoragentic` (e.g. 0.1.2) — 0.1.0/0.1.1 are immutable on npm. Also investigate why `TRUSTED_PUBLISHING.md` (listed in harness-core `files[]`) was absent from the published 0.1.0 tarball.
- **Create annotated git tags** for the documented releases (`v1.0.0`, `v2.0.0`, `v2.2.0`, `2.3.0`–`2.6.2`, harness-core / premortem-golden-loop) if you want the CHANGELOG version links to resolve to per-version compare/tag pages rather than the `main` tree.
- **Mastra adapter (`mastra/agoragentic_mastra.js`)** has the same hand-rolled-tool-shape defect as the Vercel adapter (`schema`/`executor` instead of Mastra's `createTool` + `inputSchema`/`execute`); worth a follow-up fix against the installed Mastra version.

## Verification
Ran `node scripts/verify-integrations-json.js && node scripts/verify-acp.js && node --test test/*.test.mjs && node scripts/verify-rust-framework-public-sync.js` plus `node --check` over every tracked `.mjs`/`.js` (excluding node_modules/dist), and `ajv` validation of `integrations.json` against its schema — all pass (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
