### PR TITLE
fix(mastra): return createTool-shaped Agent OS tools

### DIFF
--- a/mastra/README.md
+++ b/mastra/README.md
@@ -18,10 +18,18 @@ npm install
 
 ```javascript
 import { AgoragenticIntegration } from './agoragentic_mastra';
+import { Agent } from '@mastra/core/agent';
 
 const integration = new AgoragenticIntegration({ apiKey: 'amk_your_key' });
 const tools = integration.getTools();
-// Use tools in your Mastra agent
+
+const agent = new Agent({
+  id: 'marketplace-agent',
+  name: 'Marketplace Agent',
+  instructions: 'Route external work through Agoragentic execute().',
+  model: 'openai/gpt-4o-mini',
+  tools,
+});
 ```
 
 ## Files

--- a/mastra/agoragentic_mastra.js
+++ b/mastra/agoragentic_mastra.js
@@ -14,7 +14,10 @@
  *   // Use in your Mastra agent
  */
 
+import { createTool } from "@mastra/core/tools";
+
 const AGORAGENTIC_BASE_URL = "https://agoragentic.com";
+const ANY_JSON_OBJECT_SCHEMA = { type: "object", additionalProperties: true };
 
 async function apiCall(method, path, apiKey, body = null) {
     const headers = { "Content-Type": "application/json" };
@@ -23,6 +26,16 @@ async function apiCall(method, path, apiKey, body = null) {
     if (body) opts.body = JSON.stringify(body);
     const resp = await fetch(`${AGORAGENTIC_BASE_URL}${path}`, opts);
     return resp.json();
+}
+
+function mastraTool({ id, description, inputSchema, execute }) {
+    return createTool({
+        id,
+        description,
+        inputSchema,
+        outputSchema: ANY_JSON_OBJECT_SCHEMA,
+        execute
+    });
 }
 
 export class AgoragenticIntegration {
@@ -34,103 +47,103 @@ export class AgoragenticIntegration {
     getTools() {
         const apiKey = this.apiKey;
         return {
-            agoragentic_execute: {
-                label: "Execute Routed Task",
+            agoragentic_execute: mastraTool({
+                id: "agoragentic_execute",
                 description: "Route a task through Agoragentic execute() with provider selection, receipts, and settlement.",
-                schema: { type: "object", properties: { task: { type: "string" }, input: { type: "object" }, constraints: { type: "object" } }, required: ["task"] },
-                executor: async ({ task, input = {}, constraints = {} }) => {
+                inputSchema: { type: "object", properties: { task: { type: "string" }, input: { type: "object" }, constraints: { type: "object" } }, required: ["task"] },
+                execute: async ({ task, input = {}, constraints = {} }) => {
                     const payload = { task };
                     if (Object.keys(input).length) payload.input = input;
                     if (Object.keys(constraints).length) payload.constraints = constraints;
                     return apiCall("POST", "/api/execute", apiKey, payload);
                 }
-            },
-            agoragentic_match: {
-                label: "Preview Routed Providers",
+            }),
+            agoragentic_match: mastraTool({
+                id: "agoragentic_match",
                 description: "Preview eligible routed providers before execution.",
-                schema: { type: "object", properties: { task: { type: "string" }, max_cost: { type: "number" }, min_trust: { type: "string" } }, required: ["task"] },
-                executor: async ({ task, max_cost = -1, min_trust = "" }) => {
+                inputSchema: { type: "object", properties: { task: { type: "string" }, max_cost: { type: "number" }, min_trust: { type: "string" } }, required: ["task"] },
+                execute: async ({ task, max_cost = -1, min_trust = "" }) => {
                     const params = new URLSearchParams({ task });
                     if (max_cost >= 0) params.set("max_cost", String(max_cost));
                     if (min_trust) params.set("min_trust", min_trust);
                     return apiCall("GET", `/api/execute/match?${params}`, apiKey);
                 }
-            },
-            agoragentic_register: {
-                label: "Register on Agoragentic",
+            }),
+            agoragentic_register: mastraTool({
+                id: "agoragentic_register",
                 description: "Create an Agoragentic API key for a buyer, seller, or dual-purpose agent.",
-                schema: { type: "object", properties: { agent_name: { type: "string" }, intent: { type: "string", default: "both" } }, required: ["agent_name"] },
-                executor: async ({ agent_name, intent = "both" }) =>
+                inputSchema: { type: "object", properties: { agent_name: { type: "string" }, intent: { type: "string", default: "both" } }, required: ["agent_name"] },
+                execute: async ({ agent_name, intent = "both" }) =>
                     apiCall("POST", "/api/quickstart", null, { name: agent_name, intent: intent })
-            },
-            agoragentic_search: {
-                label: "Search Marketplace",
+            }),
+            agoragentic_search: mastraTool({
+                id: "agoragentic_search",
                 description: "Compatibility catalog browsing. Prefer agoragentic_match for new routed work.",
-                schema: { type: "object", properties: { query: { type: "string" }, category: { type: "string" }, max_price: { type: "number" } } },
-                executor: async ({ query = "", category = "" }) => {
+                inputSchema: { type: "object", properties: { query: { type: "string" }, category: { type: "string" }, max_price: { type: "number" } } },
+                execute: async ({ query = "", category = "" }) => {
                     const params = new URLSearchParams({ limit: "10", status: "active" });
                     if (query) params.set("search", query);
                     if (category) params.set("category", category);
                     return apiCall("GET", `/api/capabilities?${params}`, apiKey);
                 }
-            },
-            agoragentic_invoke: {
-                label: "Invoke Capability",
+            }),
+            agoragentic_invoke: mastraTool({
+                id: "agoragentic_invoke",
                 description: "Compatibility direct-provider invocation when a known capability ID is required.",
-                schema: { type: "object", properties: { capability_id: { type: "string" }, input_data: { type: "object" } }, required: ["capability_id"] },
-                executor: async ({ capability_id, input_data = {} }) =>
+                inputSchema: { type: "object", properties: { capability_id: { type: "string" }, input_data: { type: "object" } }, required: ["capability_id"] },
+                execute: async ({ capability_id, input_data = {} }) =>
                     apiCall("POST", `/api/invoke/${capability_id}`, apiKey, { input: input_data })
-            },
-            agoragentic_vault: {
-                label: "View Vault",
+            }),
+            agoragentic_vault: mastraTool({
+                id: "agoragentic_vault",
                 description: "Compatibility inventory view for legacy vault surfaces.",
-                schema: { type: "object", properties: { item_type: { type: "string" } } },
-                executor: async ({ item_type = "" }) => {
+                inputSchema: { type: "object", properties: { item_type: { type: "string" } } },
+                execute: async ({ item_type = "" }) => {
                     const params = item_type ? `?type=${item_type}` : "";
                     return apiCall("GET", `/api/inventory${params}`, apiKey);
                 }
-            },
-            agoragentic_memory_write: {
-                label: "Write to Memory",
+            }),
+            agoragentic_memory_write: mastraTool({
+                id: "agoragentic_memory_write",
                 description: "Write scoped Agent OS memory when policy allows it.",
-                schema: { type: "object", properties: { key: { type: "string" }, value: { type: "string" } }, required: ["key", "value"] },
-                executor: async ({ key, value }) =>
+                inputSchema: { type: "object", properties: { key: { type: "string" }, value: { type: "string" } }, required: ["key", "value"] },
+                execute: async ({ key, value }) =>
                     apiCall("POST", "/api/vault/memory", apiKey, { input: { key, value } })
-            },
-            agoragentic_memory_read: {
-                label: "Read from Memory",
+            }),
+            agoragentic_memory_read: mastraTool({
+                id: "agoragentic_memory_read",
                 description: "Read scoped Agent OS memory when policy allows it.",
-                schema: { type: "object", properties: { key: { type: "string" } } },
-                executor: async ({ key = "" }) => {
+                inputSchema: { type: "object", properties: { key: { type: "string" } } },
+                execute: async ({ key = "" }) => {
                     const params = key ? `?key=${key}` : "";
                     return apiCall("GET", `/api/vault/memory?namespace=default${params ? "&" + params.slice(1) : ""}`, apiKey);
                 }
-            },
-            agoragentic_secret_store: {
-                label: "Store Secret",
+            }),
+            agoragentic_secret_store: mastraTool({
+                id: "agoragentic_secret_store",
                 description: "Store a policy-gated encrypted credential.",
-                schema: { type: "object", properties: { label: { type: "string" }, secret: { type: "string" } }, required: ["label", "secret"] },
-                executor: async ({ label, secret }) =>
+                inputSchema: { type: "object", properties: { label: { type: "string" }, secret: { type: "string" } }, required: ["label", "secret"] },
+                execute: async ({ label, secret }) =>
                     apiCall("POST", "/api/vault/secrets", apiKey, { input: { label, secret } })
-            },
-            agoragentic_secret_retrieve: {
-                label: "Retrieve Secret",
+            }),
+            agoragentic_secret_retrieve: mastraTool({
+                id: "agoragentic_secret_retrieve",
                 description: "Retrieve a policy-gated encrypted credential.",
-                schema: { type: "object", properties: { label: { type: "string" } } },
-                executor: async ({ label = "" }) => {
+                inputSchema: { type: "object", properties: { label: { type: "string" } } },
+                execute: async ({ label = "" }) => {
                     const params = label ? `?label=${label}` : "";
                     return apiCall("GET", `/api/vault/secrets${params}`, apiKey);
                 }
-            },
-            agoragentic_passport: {
-                label: "Check Passport",
+            }),
+            agoragentic_passport: mastraTool({
+                id: "agoragentic_passport",
                 description: "Compatibility identity helper for legacy passport surfaces.",
-                schema: { type: "object", properties: { action: { type: "string" } } },
-                executor: async ({ action = "check" }) => {
+                inputSchema: { type: "object", properties: { action: { type: "string" } } },
+                execute: async ({ action = "check" }) => {
                     const path = action === "info" ? "/api/passport/info" : "/api/passport/check";
                     return apiCall("GET", path, action === "info" ? "" : apiKey);
                 }
-            }
+            })
         };
     }
 }

--- a/test/mastra-tool-shape.test.mjs
+++ b/test/mastra-tool-shape.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+
+function makeMastraFixture() {
+  const fixture = fs.mkdtempSync(path.join(os.tmpdir(), "mastra-tool-shape-"));
+  const adapterDir = path.join(fixture, "mastra");
+  const packageDir = path.join(fixture, "node_modules", "@mastra", "core");
+  fs.mkdirSync(adapterDir, { recursive: true });
+  fs.mkdirSync(packageDir, { recursive: true });
+  fs.copyFileSync(
+    path.join(root, "mastra", "agoragentic_mastra.js"),
+    path.join(adapterDir, "agoragentic_mastra.js"),
+  );
+  fs.writeFileSync(
+    path.join(fixture, "package.json"),
+    JSON.stringify({ type: "module" }, null, 2),
+  );
+  fs.writeFileSync(
+    path.join(packageDir, "package.json"),
+    JSON.stringify({ type: "module", exports: { "./tools": "./tools.js" } }, null, 2),
+  );
+  fs.writeFileSync(
+    path.join(packageDir, "tools.js"),
+    "export function createTool(options) { return { __mastraTool: true, ...options }; }\n",
+  );
+  return fixture;
+}
+
+test("Mastra integration returns createTool-shaped tools", async () => {
+  const fixture = makeMastraFixture();
+  const mod = await import(pathToFileURL(path.join(fixture, "mastra", "agoragentic_mastra.js")));
+  const integration = new mod.AgoragenticIntegration({ apiKey: "amk_test" });
+  const tools = integration.getTools();
+
+  assert.equal(tools.agoragentic_execute.__mastraTool, true);
+  assert.equal(tools.agoragentic_execute.id, "agoragentic_execute");
+  assert.equal(typeof tools.agoragentic_execute.description, "string");
+  assert.equal(tools.agoragentic_execute.inputSchema.required[0], "task");
+  assert.equal(tools.agoragentic_execute.outputSchema.type, "object");
+  assert.equal(typeof tools.agoragentic_execute.execute, "function");
+  assert.equal("schema" in tools.agoragentic_execute, false);
+  assert.equal("executor" in tools.agoragentic_execute, false);
+  assert.equal("label" in tools.agoragentic_execute, false);
+});
+
+test("Mastra execute tool still calls Agent OS execute", async () => {
+  const fixture = makeMastraFixture();
+  const mod = await import(pathToFileURL(path.join(fixture, "mastra", "agoragentic_mastra.js")));
+  const integration = new mod.AgoragenticIntegration({ apiKey: "amk_test" });
+  const tools = integration.getTools();
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, options) => {
+    calls.push({ url, options });
+    return {
+      async json() {
+        return { ok: true };
+      },
+    };
+  };
+  try {
+    const result = await tools.agoragentic_execute.execute({
+      task: "summarize",
+      input: { text: "hello" },
+      constraints: { max_cost: 0.01 },
+    });
+
+    assert.deepEqual(result, { ok: true });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, "https://agoragentic.com/api/execute");
+    assert.equal(calls[0].options.method, "POST");
+    assert.equal(calls[0].options.headers.Authorization, "Bearer amk_test");
+    assert.deepEqual(JSON.parse(calls[0].options.body), {
+      task: "summarize",
+      input: { text: "hello" },
+      constraints: { max_cost: 0.01 },
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary
- Convert the Mastra adapter from inert `label/schema/executor` objects to real Mastra `createTool({ id, description, inputSchema, outputSchema, execute })` tools.
- Keep the public `AgoragenticIntegration#getTools()` surface stable while returning tool instances Mastra agents can consume.
- Update the README quickstart to pass the returned tools into a Mastra `Agent`.
- Add a regression test that imports the adapter with a stubbed `@mastra/core/tools` package and proves `agoragentic_execute` is createTool-shaped and still calls `POST /api/execute` with the bearer key.

## Verification
- `node --check mastra/agoragentic_mastra.js`
- `node --test test/mastra-tool-shape.test.mjs test/validate-growth-examples.test.mjs` → 7/0
- `node scripts/verify-integrations-json.js`
- `node scripts/verify-acp.js`
- `git diff --check`

## Note
A broader `node --test` run started green but hung in the existing `pdf-mcp/test-stub-server.mjs` child; I stopped that process tree and relied on the scoped test + machine-surface validators for this Mastra-only change.