### PR TITLE
chore: bump harness and n8n publish versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Use this chooser before picking a framework wrapper:
 | Call a self-hosted Rust framework runtime from TypeScript or Python | `AGORAGENTIC_RUST_AGENT_URL=http://127.0.0.1:8080` plus `rust-framework/` examples | HTTP/JSON runtime contract |
 | Expose Agoragentic tools inside MCP-native hosts | `npx agoragentic-mcp@latest` | MCP stdio relay |
 | Prepare local context, policy, source maps, and Harness exports before hosted deployment | `npx agoragentic-micro-ecf@latest` | Micro ECF local wedge |
-| Build no-spend local proof, receipt, Agent OS export, and listing-readiness artifacts | `npx agoragentic-harness-core@latest` (or `node harness-core/bin/agoragentic-harness.mjs`) | Harness Core (published as npm `agoragentic-harness-core` v0.1.0) |
+| Build no-spend local proof, receipt, Agent OS export, and listing-readiness artifacts | `npx agoragentic-harness-core@latest` (or `node harness-core/bin/agoragentic-harness.mjs`) | Harness Core (published as npm `agoragentic-harness-core` v0.1.1) |
 | Run a local release premortem and safe self-heal plan before publishing an OSS agent | [`agoragentic-premortem-golden-loop`](https://github.com/rhein1/agoragentic-premortem-golden-loop) · `node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs` | Premortem Golden Loop source scaffold |
 | Run a self-hosted context-governance compiler without hosted wallets or marketplace execution | [`agoragentic-ecf-core`](https://github.com/rhein1/agoragentic-ecf-core) · `npx agoragentic-ecf-core@latest` | ECF Core |
 | Add quote, x402, execute, and receipt steps to n8n workflows | `npm install n8n-nodes-agoragentic` | n8n community node |

--- a/harness-core/TRUSTED_PUBLISHING.md
+++ b/harness-core/TRUSTED_PUBLISHING.md
@@ -23,7 +23,7 @@ Publish only after:
 
 1. Configure npm Trusted Publishing for the package.
 2. Merge the release-ready PR.
-3. Create a GitHub release with a tag like `harness-core-v0.1.0`.
+3. Create a GitHub release with a tag like `harness-core-v0.1.1`.
 4. The workflow publishes from `harness-core/`.
 
 Do not add `NPM_TOKEN` for this package unless Trusted Publishing is unavailable and the token has been scoped, rotated, and documented.

--- a/harness-core/package.json
+++ b/harness-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agoragentic-harness-core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Local no-spend Agent OS Harness Core for Micro ECF policy, first proof, receipts, listing readiness, and Triptych OS preview export.",
   "type": "module",
   "license": "MIT",

--- a/harness-core/src/index.mjs
+++ b/harness-core/src/index.mjs
@@ -238,7 +238,7 @@ export function buildAgentOsExport(project, options = {}) {
     generated_at: generatedAt,
     generated_from: {
       source: 'agoragentic-harness-core',
-      package_version: '0.1.0',
+      package_version: '0.1.1',
       local_only: true,
     },
     schema_artifacts: {

--- a/harness-core/test/cli.test.cjs
+++ b/harness-core/test/cli.test.cjs
@@ -47,7 +47,7 @@ function validateSchema(schemaRelPath, payload) {
 test('Harness Core package exposes local no-spend CLI bins', () => {
   const pkg = readJson(path.join(packageRoot, 'package.json'));
   assert.equal(pkg.name, 'agoragentic-harness-core');
-  assert.equal(pkg.version, '0.1.0');
+  assert.equal(pkg.version, '0.1.1');
   assert.equal(pkg.bin['agoragentic-harness'], './bin/agoragentic-harness.mjs');
   assert.equal(pkg.bin['agora-harness'], './bin/agoragentic-harness.mjs');
   assert.match(pkg.description, /Local no-spend Agent OS Harness Core/);

--- a/n8n/package.json
+++ b/n8n/package.json
@@ -1,6 +1,6 @@
 {
     "name": "n8n-nodes-agoragentic",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "n8n community node for Agoragentic Triptych OS (Agent OS) Router / Marketplace and x402 edge workflows.",
     "license": "MIT",
     "homepage": "https://agoragentic.com",


### PR DESCRIPTION
## Summary
- Bump `agoragentic-harness-core` from `0.1.0` to `0.1.1` so the merged LICENSE/package fixes can ship to npm.
- Bump `n8n-nodes-agoragentic` from `0.1.1` to `0.1.2` for the same immutable-version publish requirement.
- Sync Harness Core's public version surfaces: root README, trusted-publishing tag example, emitted `package_version`, and the pinned CLI package test.

## Validation
- `npm test` in `harness-core/` (7/0)
- `npm run build` in `n8n/`
- `npm pack --dry-run` in `harness-core/` confirms `agoragentic-harness-core@0.1.1` and includes `LICENSE`
- `npm pack --dry-run` in `n8n/` confirms `n8n-nodes-agoragentic@0.1.2` and includes `LICENSE`
- `node scripts/verify-integrations-json.js`
- `node scripts/verify-acp.js`
- `git diff --check`

## Publish note
This PR does not publish. After merge, publish through the existing release workflows with tags `harness-core-v0.1.1` and `n8n-v0.1.2`, assuming npm Trusted Publishing is configured for each package.
