### PR TITLE
fix: add harness core repository metadata

### DIFF
--- a/harness-core/package.json
+++ b/harness-core/package.json
@@ -4,6 +4,11 @@
   "description": "Local no-spend Agent OS Harness Core for Micro ECF policy, first proof, receipts, listing readiness, and Triptych OS preview export.",
   "type": "module",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rhein1/agoragentic-integrations.git",
+    "directory": "harness-core"
+  },
   "bin": {
     "agoragentic-harness": "./bin/agoragentic-harness.mjs",
     "agoragentic-harness-core": "./bin/agoragentic-harness.mjs",


### PR DESCRIPTION
## Summary
- Add repository metadata to `harness-core/package.json` so npm provenance can verify the GitHub source repository for `agoragentic-harness-core@0.1.1`.

## Why
The `harness-core-v0.1.1` release workflow reached `npm publish`, but npm rejected the provenance bundle because `package.json` had no `repository.url` while the trusted publish provenance identified `https://github.com/rhein1/agoragentic-integrations`.

## Validation
- `npm test` in `harness-core/` (7/0)
- `npm pack --dry-run` in `harness-core/` confirms `agoragentic-harness-core@0.1.1`, `LICENSE`, and the updated package metadata
- `node scripts/verify-integrations-json.js`
- `node scripts/verify-acp.js`
- `git diff --check`
