### PR TITLE
feat(mcp): add keyless x402 route preview fallback tool

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -214,6 +214,12 @@
       "replacement": "agoragentic_match for task routing, or stable x402 service browsing for anonymous paid resources"
     },
     {
+      "id": "agoragentic_preview_x402",
+      "description": "Preview route-first x402 providers for a task with no API key, registration, execution, or USDC spend; may return an expiring quote_id",
+      "cost": "free",
+      "recommended": true
+    },
+    {
       "id": "agoragentic_invoke",
       "description": "Compatibility direct-provider invocation by known listing ID",
       "cost": "listing_price",

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -120,6 +120,7 @@ The package relays the remote MCP server when possible, so the exact tool list i
 
 - `agoragentic_register`
 - `agoragentic_search`
+- `agoragentic_preview_x402`
 - `agoragentic_match`
 - `agoragentic_execute`
 - `agoragentic_execute_status`
@@ -155,6 +156,16 @@ The anonymous paid flow is:
 3. `agoragentic_call_service`
 
 The first unpaid call returns an MCP payment-required error with the decoded x402 challenge and retry instructions. Retry the same tool call with `payment_signature` to complete the paid execution and receive the JSON result plus `Payment-Receipt`.
+
+## Keyless Route Preview
+
+When the remote MCP server is unavailable, agents can still preview route-first x402 providers without an API key:
+
+1. `agoragentic_preview_x402`
+2. inspect `selected_provider`, `quote`, `payment_required`, and `execute`
+3. complete the paid call with an x402-capable HTTP client, or use authenticated Router tools after registration
+
+This preview path does not register an agent, execute a provider, or spend USDC. It may return an expiring `quote_id` for a later x402 payment flow.
 
 ## Router Flow
 

--- a/mcp/mcp-server.js
+++ b/mcp/mcp-server.js
@@ -158,6 +158,28 @@ function buildFallbackToolList() {
             },
         },
         {
+            name: 'agoragentic_preview_x402',
+            description:
+                'Preview route-first x402-eligible providers for a task WITHOUT registration, an API key, provider execution, or USDC spend. ' +
+                'Calls the public GET /api/x402/execute/match endpoint and may return an expiring quote_id for a later x402 paid retry. ' +
+                'Use this before agoragentic_register or authenticated agoragentic_match when the buyer has an external Base USDC wallet or wants a zero-auth preview. ' +
+                'This is NOT read-only in the catalog sense: it can mint an expiring quote_id. It is still safe because it does not register an agent, execute a provider, move wallet funds, or settle payment. ' +
+                'Returns JSON with matched providers, selected_provider, quote (including any quote_id), payment rails, and next-step execution metadata.',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    task: { type: 'string', description: 'Natural-language task to preview, e.g. "receipt reconciliation" or "audit agent discovery for a domain"' },
+                    max_cost: { type: 'number', description: 'Maximum acceptable USDC price per call. Defaults server-side when omitted.' },
+                    category: { type: 'string', description: 'Optional marketplace category filter.' },
+                    max_latency_ms: { type: 'number', description: 'Optional maximum acceptable provider latency in milliseconds.' },
+                    prefer_trusted: { type: 'boolean', description: 'When true, ask the router to prefer trusted providers when ranking.', default: false },
+                    payment_network: { type: 'string', description: 'Optional requested payment network, e.g. "base" or "eip155:8453".' },
+                    payment_asset: { type: 'string', description: 'Optional requested payment asset. Defaults to USDC server-side.' },
+                },
+                required: ['task'],
+            },
+        },
+        {
             name: 'agoragentic_match',
             description:
                 'Preview which providers the Agoragentic Router would select for a given task, without executing or spending USDC. ' +
@@ -275,6 +297,27 @@ async function executeFallbackTool(name, args = {}) {
         if (args.category) params.set('category', args.category);
         if (args.limit !== undefined) params.set('limit', String(args.limit));
         const data = await apiCall('GET', `/api/capabilities?${params.toString()}`);
+        return buildJsonContent(data);
+    }
+
+    if (name === 'agoragentic_preview_x402') {
+        const task = String(args.task || '').trim();
+        if (!task) {
+            return buildJsonContent({
+                ok: false,
+                error: 'missing_task',
+                message: 'task is required for agoragentic_preview_x402',
+            });
+        }
+        const params = new URLSearchParams();
+        params.set('task', task);
+        if (args.max_cost !== undefined) params.set('max_cost', String(args.max_cost));
+        if (args.category) params.set('category', args.category);
+        if (args.max_latency_ms !== undefined) params.set('max_latency_ms', String(args.max_latency_ms));
+        if (args.prefer_trusted !== undefined) params.set('prefer_trusted', args.prefer_trusted ? 'true' : 'false');
+        if (args.payment_network) params.set('payment_network', args.payment_network);
+        if (args.payment_asset) params.set('payment_asset', args.payment_asset);
+        const data = await apiCall('GET', `/api/x402/execute/match?${params.toString()}`);
         return buildJsonContent(data);
     }
 

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "agoragentic-mcp",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "agoragentic-mcp",
-            "version": "1.3.3",
+            "version": "1.3.4",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "agoragentic-mcp",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "mcpName": "io.github.rhein1/agoragentic",
     "description": "Stdio relay and fallback MCP server for Agoragentic's hosted Triptych OS (Agent OS) Router / Marketplace. Exposes registration, search, provider preview, paid execution, and receipt-backed status tools.",
     "main": "mcp-server.js",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -6,12 +6,12 @@
         "url": "https://github.com/rhein1/agoragentic-integrations",
         "source": "github"
     },
-    "version": "1.3.3",
+    "version": "1.3.4",
     "packages": [
         {
             "registryType": "npm",
             "identifier": "agoragentic-mcp",
-            "version": "1.3.3",
+            "version": "1.3.4",
             "transport": {
                 "type": "stdio"
             },


### PR DESCRIPTION
## What
Adds **`agoragentic_preview_x402`** to the local `agoragentic-mcp` fallback tool surface. It calls the **public** `GET /api/x402/execute/match` route so an agent can preview x402-eligible providers (and get an optional expiring `quote_id`) **without registration, an API key, provider execution, or USDC spend**.

## Why
`agoragentic_search` is already keyless, but task-level routed preview only existed via `agoragentic_match`, which calls `requireApiKey()` in the fallback path — forcing an agent to **register before it can decide whether Agoragentic is even useful**. This adds a zero-auth decision step:

`search or task → agoragentic_preview_x402 → inspect selected_provider / quote / next step → pay externally or fall back to native`

It's a thin wrapper over an existing public endpoint, **not** a new marketplace feature.

## How it wires in
Added only to `buildFallbackToolList()`, so the change propagates automatically:
- **`tools/list`** — appears via `mergeFallbackTools()` when the remote relay is up, and via the fallback list when it's down.
- **`tools/call`** — routes to `executeFallbackTool()` because `FALLBACK_TOOL_NAMES.has(name) && !hasRemoteTool(name)` (the remote does not expose it).
- **Not** added to `ACP_TOOLS`: ACP `tools/call` forwards to the remote client, so a local-only tool there would advertise something ACP cannot execute.

Handler mirrors the existing `agoragentic_match` dispatch, minus the `requireApiKey()` gate (`apiCall` only sends `Authorization` when `AGORAGENTIC_API_KEY` is set, so this is genuinely keyless).

## Safety wording (deliberate)
This is **not** "read-only" in the catalog sense — it can mint an expiring `quote_id`. It is still safe because it does **not** register an agent, execute a provider, move wallet funds, or settle payment. The tool description says *no registration / no execution / no spend*, not "no side effects."

## Version
Bumps `agoragentic-mcp` **1.3.3 → 1.3.4** (`package.json`, `package-lock.json`, `server.json`) because the published fallback tool surface changed. Only the package's own version fields changed in the lockfile (dependencies untouched).

## Verification
- `node --check mcp/mcp-server.js` → OK
- `npm pack --dry-run` (mcp) → exit 0
- `package.json` ↔ `package-lock.json` version in sync (so CI `npm ci --omit=dev` passes)
- **Live keyless smoke:** `GET https://agoragentic.com/api/x402/execute/match?task=receipt%20reconciliation&max_cost=0.02` with **no auth** → **HTTP 200 `success:true`**, echoing the exact query params this handler emits (`max_cost`, `prefer_trusted`, `payment_network`, `payment_asset`).
- Not run here: the interactive stdin `tools/list`/`tools/call` drive (the ephemeral worktree has no `node_modules`); the wiring is derived entirely from `buildFallbackToolList()` and exercised by the existing fallback tools, and CI runs `npm ci` + `node --check` + `npm pack`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
