### PR TITLE
Add Gortex local code intelligence adapter

### DIFF
--- a/gortex/README.md
+++ b/gortex/README.md
@@ -1,0 +1,77 @@
+# Gortex + Agoragentic
+
+**Status: Beta**
+
+Gortex is a local code-intelligence MCP and CLI for code-working agents. Use it
+beside Agoragentic when an agent needs local repository graph context before it
+plans a change, reviews a diff, or prepares an Agent OS harness/export packet.
+
+This adapter is a local integration contract only. It does not call hosted
+Agoragentic services, create listings, change trust state, route paid work, or
+settle x402 payments.
+
+## Source Check
+
+| Field | Evidence |
+|-------|----------|
+| Upstream | `https://github.com/zzet/gortex` |
+| License | Apache-2.0 |
+| Verified commit | `7d309e77fe4c42b1fbf7173e209193a3d4c4d58c` |
+| Local mode | Single binary with CLI, daemon, and MCP surfaces |
+
+The upstream token-reduction figures are vendor benchmark claims. Treat them as
+planning context, not as a guaranteed Agoragentic performance promise.
+
+## Install
+
+Install Gortex with the upstream installer for your operating system, then
+initialize the local agent/MCP configuration.
+
+```bash
+gortex install
+gortex daemon start --detach
+gortex track .
+gortex init
+```
+
+## MCP Config
+
+Use the example config in [`gortex.mcp.example.json`](./gortex.mcp.example.json)
+when you want an agent to use a bounded Gortex tool surface.
+
+The default example starts Gortex over stdio with the `readonly` preset so the
+agent can inspect symbols, files, and graph relationships without mutating the
+repository through Gortex.
+
+## Agoragentic Mapping
+
+```text
+Agent task
+  -> Micro ECF source and policy boundary
+  -> Gortex local graph context
+  -> Agent OS preview, local harness packet, or human-reviewed plan
+  -> execute(task, input, constraints) only when paid external work is needed
+```
+
+Gortex provides repository context. Agoragentic owns routing, procurement,
+receipts, spend policy, and marketplace trust semantics.
+
+## Safety Boundary
+
+- Keep repository contents local unless the owner explicitly exports a bounded
+  context packet.
+- Use `readonly` or another explicit tool preset for default agent sessions.
+- Do not put secrets, API keys, private connector internals, or Full ECF
+  material in prompts, listings, or public adapter metadata.
+- Route paid work through Agoragentic `execute()` after policy, approval, and
+  budget checks.
+- Do not treat Gortex scan output as a trust badge, verification result, or
+  seller reputation signal by itself.
+
+## Quick Local Check
+
+```bash
+gortex --version
+gortex daemon status
+gortex mcp --tools readonly
+```

--- a/gortex/gortex.mcp.example.json
+++ b/gortex/gortex.mcp.example.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "gortex": {
+      "command": "gortex",
+      "args": ["mcp", "--tools", "readonly"],
+      "env": {
+        "GORTEX_TOOLS_MODE": "hide"
+      }
+    }
+  }
+}

--- a/integrations.json
+++ b/integrations.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.24.2",
-  "updated_at": "2026-07-03",
+  "version": "2.25.0",
+  "updated_at": "2026-07-04",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
   "packages": {
@@ -883,6 +883,15 @@
       "docs": "turbovec/README.md"
     },
     {
+      "id": "gortex",
+      "name": "Gortex Local Code-Intelligence MCP",
+      "language": "json",
+      "status": "beta",
+      "path": "gortex/gortex.mcp.example.json",
+      "install": "Install Gortex locally, then run gortex install && gortex daemon start --detach && gortex track .",
+      "docs": "gortex/README.md"
+    },
+    {
       "id": "pdf-mcp",
       "name": "pdf-mcp MCP Stdio Adapter",
       "language": "javascript",
@@ -1003,6 +1012,8 @@
     "chatkit_renderer": "chatkit/agoragentic-chatkit-tool.example.ts",
     "turbovec": "turbovec/README.md",
     "turbovec_adapter": "turbovec/agoragentic_turbovec.py",
+    "gortex": "gortex/README.md",
+    "gortex_mcp_config": "gortex/gortex.mcp.example.json",
     "pdf_mcp": "pdf-mcp/README.md",
     "pdf_mcp_adapter": "pdf-mcp/agoragentic_pdf_mcp.mjs"
   }


### PR DESCRIPTION
## Summary

- Adds a Gortex public integration entry and discovery keys.
- Adds a local read-only setup guide plus MCP config example that hides mutating tools.
- Records source, license, commit, and safety boundary; upstream token-savings claims are treated as vendor claims, not Agoragentic proof.

## Evidence

- Upstream: https://github.com/zzet/gortex
- License observed: Apache-2.0
- Commit checked: 7d309e77fe4c42b1fbf7173e209193a3d4c4d58c
- Integration entry: integrations.json
- Docs/config: gortex/README.md, gortex/gortex.mcp.example.json

## Validation

- node scripts\verify-integrations-json.js
- git diff --check
- Manifest probe for gortex entry

## Boundaries

- Local code intelligence only.
- No wallet, x402, settlement, hosted credential, trust, or routing authority.
- Does not claim upstream benchmark/token-savings results as production proof.