### PR TITLE
Add SkillSpector admission scan adapter

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -892,6 +892,15 @@
       "docs": "gortex/README.md"
     },
     {
+      "id": "skillspector",
+      "name": "SkillSpector Skill Admission Scan",
+      "language": "json",
+      "status": "beta",
+      "path": "skillspector/skillspector.admission.example.json",
+      "install": "pip install git+https://github.com/NVIDIA/SkillSpector.git@dde36f258729b5aec7c835295a9556e64a2def0c",
+      "docs": "skillspector/README.md"
+    },
+    {
       "id": "pdf-mcp",
       "name": "pdf-mcp MCP Stdio Adapter",
       "language": "javascript",
@@ -1014,6 +1023,8 @@
     "turbovec_adapter": "turbovec/agoragentic_turbovec.py",
     "gortex": "gortex/README.md",
     "gortex_mcp_config": "gortex/gortex.mcp.example.json",
+    "skillspector": "skillspector/README.md",
+    "skillspector_admission_example": "skillspector/skillspector.admission.example.json",
     "pdf_mcp": "pdf-mcp/README.md",
     "pdf_mcp_adapter": "pdf-mcp/agoragentic_pdf_mcp.mjs"
   }

--- a/skillspector/README.md
+++ b/skillspector/README.md
@@ -1,0 +1,74 @@
+# SkillSpector + Agoragentic
+
+**Status: Beta**
+
+SkillSpector is a local security scanner for agent skills. Use it as an
+admission scan before a skill is listed, installed into a governed agent
+workspace, or attached to an Agent OS harness/export packet.
+
+This adapter is a local scan contract only. It does not publish skills, create
+trust badges, mutate seller reputation, call hosted providers, or move funds.
+
+## Source Check
+
+| Field | Evidence |
+|-------|----------|
+| Upstream | `https://github.com/NVIDIA/SkillSpector` |
+| License | Apache-2.0 |
+| Verified commit | `dde36f258729b5aec7c835295a9556e64a2def0c` |
+| Release state | No upstream git tags were present when this adapter was added |
+
+Because no tagged release was present, pin the commit above until upstream
+publishes a stable release.
+
+## Install
+
+```bash
+pip install git+https://github.com/NVIDIA/SkillSpector.git@dde36f258729b5aec7c835295a9556e64a2def0c
+```
+
+## Local Scan
+
+```bash
+skillspector-scan --skill-path ./skills/example --output-format json
+```
+
+Use the example contract in
+[`skillspector.admission.example.json`](./skillspector.admission.example.json)
+to normalize a scan into Agoragentic admission evidence.
+
+## Agoragentic Mapping
+
+```text
+Candidate skill
+  -> local SkillSpector scan
+  -> normalized admission evidence packet
+  -> existing Agent OS scorecard/canary evidence fields
+  -> human or policy decision before listing/install
+```
+
+SkillSpector risk output should compose with the existing Agoragentic scorecard
+and canary evidence model. Do not create a parallel trust vocabulary or publish
+`verified` status from SkillSpector alone.
+
+## Admission Fields
+
+| Field | Meaning |
+|-------|---------|
+| `scanner` | Scanner name and pinned upstream commit |
+| `skill_ref` | Local path, repo, or immutable artifact reference for the scanned skill |
+| `risk_score` | Normalized 0-100 score, where higher means riskier |
+| `risk_level` | `low`, `medium`, `high`, or `critical` |
+| `findings` | Bounded finding summaries safe to store as admission evidence |
+| `scorecard_target` | Existing Agoragentic target type the scan should attach to |
+
+## Safety Boundary
+
+- Scan locally; do not upload private skill source unless the owner explicitly
+  approves an export.
+- Store bounded finding summaries, not full private source files or secrets.
+- Treat results as advisory admission evidence until a human or policy gate
+  accepts them.
+- Keep the runtime trust vocabulary stable: `verified`, `reachable`, `failed`.
+- Do not use this adapter to bypass sandbox verification, canary evidence, or
+  owner approval.

--- a/skillspector/skillspector.admission.example.json
+++ b/skillspector/skillspector.admission.example.json
@@ -1,0 +1,28 @@
+{
+  "scanner": {
+    "id": "skillspector",
+    "name": "SkillSpector",
+    "upstream": "https://github.com/NVIDIA/SkillSpector",
+    "commit": "dde36f258729b5aec7c835295a9556e64a2def0c",
+    "license": "Apache-2.0"
+  },
+  "skill_ref": {
+    "type": "local_path",
+    "value": "./skills/example"
+  },
+  "risk_score": 37,
+  "risk_level": "medium",
+  "findings": [
+    {
+      "id": "example.network.egress",
+      "severity": "medium",
+      "summary": "Skill declares network-capable behavior; require owner approval before install."
+    }
+  ],
+  "scorecard_target": {
+    "target_type": "agent_template",
+    "target_id": "skill:example",
+    "evidence_state": "insufficient_evidence"
+  },
+  "admission_recommendation": "review_required"
+}


### PR DESCRIPTION
## Summary

- Adds a SkillSpector public integration entry and discovery keys.
- Adds a local admission-scan setup guide and example scan receipt shape.
- Records source, license, commit, no-tags status, and the boundary that SkillSpector feeds advisory evidence only.

## Evidence

- Upstream: https://github.com/NVIDIA/SkillSpector
- License observed: Apache-2.0
- Commit checked: dde36f258729b5aec7c835295a9556e64a2def0c
- Tags: none observed from git ls-remote --tags
- Integration entry: integrations.json
- Docs/example: skillspector/README.md, skillspector/skillspector.admission.example.json

## Validation

- node scripts\verify-integrations-json.js
- git diff --check
- Manifest probe for skillspector entry

## Boundaries

- Local skill admission scanning only.
- Does not mutate trust, listing readiness, routing, memory approval, wallet, x402, or settlement state.
- Does not retain raw skill content in public scorecard evidence.