### PR TITLE
Add Fable/ECF workflow contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,13 @@ Framework integrations must export tools matching these IDs:
 - Break the `integrations.json` schema
 - Add Full ECF, router ranking, trust/fraud scoring, wallet settlement, hosted provisioning, private connector, broker, or operator internals to `micro-ecf/`
 
+## Fable / ECF Workflow Discipline
+
+- Use [docs/agent-workflow-contracts.md](docs/agent-workflow-contracts.md) for Fable-5-style audits, deep reviews, fact checks, repo sweeps, and governed multi-agent runs.
+- Use [docs/fable-review-contract.md](docs/fable-review-contract.md) when writing PR-review findings.
+- Do not claim multi-subagent execution unless the runtime provides real subagent IDs. If no subagent runtime is available, report `subagents: none_available`.
+- Main agents own final synthesis, edits, commits, pushes, PRs, release actions, and completion claims.
+
 ## Discovery
 
 | Surface | URL |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Receipt-backed public tools for agents. Discover a tool, execute it, and verify 
 
 Home: **[agoragentic.com](https://agoragentic.com)** · all packages: `npm view <name>`
 
+Agent workflow contracts: [governed agent runs](./docs/agent-workflow-contracts.md) and [Fable review output](./docs/fable-review-contract.md).
+
 ## Live Tools
 
 4 vetted public API wrappers are live and free to call through the marketplace router:

--- a/docs/agent-workflow-contracts.md
+++ b/docs/agent-workflow-contracts.md
@@ -73,4 +73,3 @@ Workflow Trace
 ## ECF Handoff
 
 Use Micro ECF artifacts for lightweight local policy/source boundaries and ECF Core artifacts for richer self-hosted context governance when they exist in the target repo. Inspect `ECF.md`, `.micro-ecf/*`, or `.ecf-core/*` only as public/local context aids, then verify claims against live source files before editing or reporting.
-

--- a/docs/agent-workflow-contracts.md
+++ b/docs/agent-workflow-contracts.md
@@ -1,0 +1,76 @@
+# Agent Workflow Contracts
+
+Use this contract when a coding agent runs a Fable-5-style audit, deep review, fact check, repo sweep, or ECF-governed implementation pass in this repository.
+
+## Public Boundary
+
+This is a public OSS repository. Keep agent work inside the public Micro ECF / ECF Core boundary:
+
+- Do not add Full ECF private runtime internals, private connector code, customer evidence, operator prompts, wallet material, secrets, or hosted platform internals.
+- Do not claim hosted deployment, marketplace publication, x402 settlement, production mutation, or enterprise readiness unless the repo contains current public evidence.
+- Treat generated context artifacts as navigation aids. Real source files, tests, and runtime probes remain the source of truth.
+
+## Run Contract
+
+Before starting a governed run, state the contract in the working notes or final report:
+
+- `scope`: exact files, directories, PRs, branch, or behavior under review.
+- `mode`: `read_only`, `validation_only`, `docs_only`, `implementation`, or `release`.
+- `authority`: what the agent may change, run, publish, spend, deploy, or comment on.
+- `lenses`: independent review angles assigned to agents or passes.
+- `evidence`: files, tests, commands, logs, and runtime probes that can support findings.
+- `subagents`: real subagent IDs when the runtime exposes them, or `none_available`.
+- `verification`: commands or checks that must pass before the run is complete.
+
+## Subagent Contract
+
+When the runtime supports subagents, use them for independent lenses instead of treating one transcript as a swarm. Preserve their identifiers in the trace.
+
+Subagents may:
+
+- map source and docs
+- inspect specific risk lenses
+- propose findings or implementation options
+- run read-only searches and safe validation commands within the declared authority
+
+Subagents must not:
+
+- commit, push, merge, approve, publish, deploy, spend, rotate secrets, or contact external services unless the main agent explicitly has that authority and delegates it in the run contract
+- claim a finding without file, command, or runtime evidence
+- expose secrets or private data in findings
+
+The main agent owns synthesis, final findings, writes, commits, pushes, PRs, release actions, and any statement that work is complete.
+
+If no real subagent runtime is available, run separate named lenses in the main agent and report `subagents: none_available`. Do not claim multi-subagent execution.
+
+## Recommended Lenses
+
+- `security_privacy`: secrets, auth, data exposure, permission boundaries
+- `correctness`: logic errors, edge cases, invariants, failure paths
+- `integration`: API contracts, provider assumptions, external service behavior
+- `data_contract`: schemas, migrations, serialization, backward compatibility
+- `operations_release`: install, CI, packaging, deploy, rollback, owner gates
+- `tests_docs`: test coverage, docs-vs-reality, examples, status claims
+- `repo_consistency`: naming, generated surfaces, package metadata, discovery files
+
+## Trace Template
+
+```text
+Workflow Trace
+- scope:
+- mode:
+- authority:
+- subagents:
+  - id:
+    lens:
+    evidence:
+    result:
+- main-agent synthesis:
+- verification:
+- residual unknowns:
+```
+
+## ECF Handoff
+
+Use Micro ECF artifacts for lightweight local policy/source boundaries and ECF Core artifacts for richer self-hosted context governance when they exist in the target repo. Inspect `ECF.md`, `.micro-ecf/*`, or `.ecf-core/*` only as public/local context aids, then verify claims against live source files before editing or reporting.
+

--- a/docs/fable-review-contract.md
+++ b/docs/fable-review-contract.md
@@ -46,4 +46,3 @@ Do not print secret values. State the secret class, file, line, and count if nee
 - Preserve rejected candidates when they explain why an apparent issue is not real.
 - Separate target-system failures from runner/tooling failures.
 - State residual unknowns when the evidence is incomplete.
-

--- a/docs/fable-review-contract.md
+++ b/docs/fable-review-contract.md
@@ -1,0 +1,49 @@
+# Fable Review Contract
+
+Use this contract for PR reviews, deep reviews, audits, and reviewer-bot-compatible findings.
+
+## Verdict
+
+The first line of the review must be exactly one of:
+
+```text
+LGTM
+Needs Updates
+```
+
+Use `Needs Updates` when any blocking correctness, security, privacy, data, integration, release, or docs-vs-reality issue remains. Use `LGTM` only when no blocking issue survives the review.
+
+## Required Sections
+
+Include these sections in order:
+
+```text
+### Needs Fixing
+### Requires Human Review
+### Recommended Optional
+### Create Follow-up Issue
+```
+
+`Needs Fixing` and `Requires Human Review` are blocking. `Recommended Optional` and `Create Follow-up Issue` are non-blocking unless explicitly promoted with evidence.
+
+## Finding Shape
+
+Each blocking finding must include:
+
+- severity: `P0`, `P1`, or `P2`
+- file and line citation when source-backed
+- the failing invariant
+- a concrete failure scenario
+- the safest next fix
+- validation that would prove the fix
+
+Do not print secret values. State the secret class, file, line, and count if needed.
+
+## Review Discipline
+
+- Review the actual diff/source, not only summaries.
+- Keep docs claims tied to source, tests, package metadata, or runtime evidence.
+- Preserve rejected candidates when they explain why an apparent issue is not real.
+- Separate target-system failures from runner/tooling failures.
+- State residual unknowns when the evidence is incomplete.
+


### PR DESCRIPTION
## Summary
- Add a public agent workflow contract for Fable-5-style audits, deep reviews, fact checks, repo sweeps, and ECF-governed implementation runs.
- Add a Fable review contract with explicit LGTM / Needs Updates verdicts, required review sections, evidence requirements, and secret-safe finding rules.
- Wire README / AGENTS discovery so Codex and other IDE agents can find the workflow contracts.

## Validation
- `git diff --check`
- `python -m json.tool integrations.json`
- `python -m json.tool integrations.schema.json`

## Notes
- Public boundary only: Micro ECF / ECF Core language, no Full ECF internals, private connector material, hosted provisioning, wallet settlement, or production mutation.
- Multi-subagent claims now require real runtime subagent IDs; otherwise agents must report subagents: none_available.