### PR TITLE
fix: harden payment authorization contracts

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,6 +10,8 @@ on:
       - 'mcp/**'
       - 'micro-ecf/**'
       - 'harness-core/**'
+      - 'coinbase-agentic-wallets/**'
+      - 'x402/**'
       - 'scripts/**'
       - 'examples/agoragentic-growth/**'
       - 'test/**'
@@ -21,6 +23,9 @@ on:
       - 'llms-full.txt'
   pull_request:
     branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
   validate:
@@ -171,3 +176,16 @@ jobs:
           echo "Root files: all present"
           echo "CITATION.cff: valid"
           echo "Tool naming: consistent"
+
+  payment-contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node 24 for native TypeScript contract tests
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Test payment safety contracts
+        run: node --experimental-strip-types --test test/payment-safety-contracts.test.mjs
+      - name: Test x402 buyer demo preflight behavior
+        run: node --test test/x402-buyer-demo-preflight.test.mjs

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Receipt-backed public tools for agents. Discover a tool, execute it, and verify 
 |---|---|
 | **[agoragentic-integrations](https://github.com/rhein1/agoragentic-integrations)** | 50+ agent-framework adapters + SDK & MCP server (npm `agoragentic-mcp`) |
 | [agoragentic-ecf-core](https://github.com/rhein1/agoragentic-ecf-core) | Self-hosted context-governance runtime (npm `agoragentic-ecf-core`) |
-| [Micro ECF](https://github.com/rhein1/agoragentic-integrations/tree/main/micro-ecf) | Open local context wedge (npm `agoragentic-micro-ecf`) |
+| [Micro ECF](https://github.com/rhein1/agoragentic-micro-ecf) | Open local context wedge (npm `agoragentic-micro-ecf`) |
 | [agoragentic-premortem-golden-loop](https://github.com/rhein1/agoragentic-premortem-golden-loop) | Pre-launch release-readiness CLI (npm `agoragentic-premortem-golden-loop`) |
 | [agoragentic-summarizer-agent](https://github.com/rhein1/agoragentic-summarizer-agent) | Python example: route `summarize` via `execute()` |
 | [agoragentic-openai-agents-example](https://github.com/rhein1/agoragentic-openai-agents-example) | OpenAI Agents SDK marketplace example |
@@ -72,7 +72,7 @@ curl "https://agoragentic.com/api/commerce/receipts/rcpt_YOUR_RECEIPT" \
 | x402 service card | [/.well-known/x402/service.json](https://agoragentic.com/.well-known/x402/service.json) |
 | OpenAPI spec | [/openapi.yaml](https://agoragentic.com/openapi.yaml) |
 | LLM instructions | [/llms.txt](https://agoragentic.com/llms.txt) |
-| Proof script | `scripts/execute-path-proof.mjs` (run `node scripts/execute-path-proof.mjs https://agoragentic.com` against the live API) |
+| Offline machine-surface check | `node scripts/verify-integrations-json.js` |
 
 ## What Agoragentic Does
 

--- a/coinbase-agentic-wallets/README.md
+++ b/coinbase-agentic-wallets/README.md
@@ -23,12 +23,16 @@ const client = new AgoragenticAgenticWalletClient({
 });
 
 const preview = await client.match("summarize", { max_cost: 0.05 });
-console.log(preview.selected_provider);
+console.log(preview.providers?.[0] || null);
 
 const result = await client.execute(
   "summarize",
   { text: "Long document here" },
-  { max_cost: 0.05 }
+  {
+    max_cost: 0.05,
+    payment_authorized: true,
+    idempotency_key: "registered-summarize-001"
+  }
 );
 
 console.log(result.output);
@@ -40,10 +44,11 @@ console.log(result.output);
 import { AgoragenticAgenticWalletClient } from "./agoragentic_agentic_wallet";
 
 const client = new AgoragenticAgenticWalletClient({
-  payChallenge: async (paymentRequired) => {
+  payChallenge: async (paymentRequired, request) => {
     // Plug your wallet-specific payment flow in here.
+    // Enforce request.authorization again inside the wallet policy layer.
     // Return either Authorization: Payment ... or PAYMENT-SIGNATURE.
-    const signature = await settleWithWallet(paymentRequired);
+    const signature = await settleWithWallet(paymentRequired, request.authorization);
     return {
       authorizationHeader: `Payment ${signature}`,
       receipt: { provider: "wallet-sdk" }
@@ -52,13 +57,29 @@ const client = new AgoragenticAgenticWalletClient({
 });
 
 const match = await client.x402ExecuteMatch("summarize", { max_cost: 0.05 });
-const result = await client.x402Execute(match.quote.quote_id, {
-  text: "Long document here"
-});
+if (!process.env.EXPECTED_X402_USDC || !process.env.EXPECTED_X402_PAY_TO) {
+  throw new Error("operator-approved x402 asset and recipient are required");
+}
+const result = await client.x402Execute(
+  match.quote,
+  { text: "Long document here" },
+  {
+    payment_authorized: true,
+    max_amount_usdc: 0.05,
+    expected_network: "eip155:8453",
+    expected_asset: process.env.EXPECTED_X402_USDC,
+    expected_pay_to: process.env.EXPECTED_X402_PAY_TO,
+    idempotency_key: "x402-summarize-001"
+  }
+);
 
 console.log(result.payment_receipt);
 console.log(result.result || result.output);
 ```
+
+The wrapper validates the complete quote and decoded `PAYMENT-REQUIRED` challenge before calling the wallet callback. It binds the exact-transfer scheme, resource URL, amount, Base network, USDC asset, and operator-approved recipient; rejects non-execution-ready quotes; requires a caller-supplied idempotency key; sends only the protocol-required challenge/paid-retry pair; fails on another 402; and requires both payment-response and receipt proof headers before returning success. A client instance permits only one signed x402 payment attempt, and reused keys are blocked locally. Obtain the expected asset and recipient through an independently reviewed operator configuration, not from the challenge being authorized.
+
+The registered path strips local authorization fields before sending the canonical nested `constraints` payload. A positive ceiling, explicit authorization, and caller-supplied idempotency key are mandatory because the deployed router treats numeric zero as an absent ceiling. Keys are one-attempt guards within one client instance and are deliberately not presented as server deduplication: `POST /api/execute` does not promise router-level retry deduplication, so this wrapper never retries it automatically. Retire the key and inspect account activity or receipts after an ambiguous result before creating a newly authorized client.
 
 ## References
 

--- a/coinbase-agentic-wallets/agoragentic_agentic_wallet.ts
+++ b/coinbase-agentic-wallets/agoragentic_agentic_wallet.ts
@@ -19,10 +19,32 @@ type ChallengePaymentResult = {
     receipt?: any;
 };
 
+export type X402Quote = {
+    quote_id: string;
+    quoted_price_usdc: number | string;
+    payment_network?: string;
+    payment_network_caip2?: string;
+    settlement_network?: string;
+    settlement_network_caip2?: string;
+    settlement_asset_address?: string;
+    execution_ready: boolean;
+};
+
+export type X402PaymentAuthorization = {
+    payment_authorized: true;
+    max_amount_usdc: number;
+    expected_network: string;
+    expected_asset: string;
+    expected_pay_to: string;
+    idempotency_key: string;
+};
+
 type ChallengePaymentHandler = (paymentRequired: string, request: {
     url: string;
     method: string;
     body: JsonRecord;
+    quote: X402Quote;
+    authorization: X402PaymentAuthorization;
 }) => Promise<ChallengePaymentResult>;
 
 interface ClientOptions {
@@ -46,13 +68,109 @@ async function parseJson(response: Response): Promise<any> {
     return text ? JSON.parse(text) : {};
 }
 
+function requireFiniteNonNegative(value: unknown, name: string): number {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+        throw new Error(`${name} must be a finite, non-negative number`);
+    }
+    return parsed;
+}
+
+function requireIdempotencyKey(value: unknown): string {
+    const key = String(value || "").trim();
+    if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,199}$/.test(key)) {
+        throw new Error("idempotency_key must be 1-200 letters, numbers, dots, underscores, colons, or hyphens");
+    }
+    return key;
+}
+
+function normalizeNetwork(value: unknown): string {
+    const network = String(value || "").trim().toLowerCase();
+    if (network === "base") return "eip155:8453";
+    if (network === "base-sepolia") return "eip155:84532";
+    return network;
+}
+
+function decodeBase64JsonHeader(value: string, label: string): any {
+    const encoded = value.trim();
+    if (!encoded || encoded.length > 131_072 || !/^[A-Za-z0-9+/_=-]+$/.test(encoded)) {
+        throw new Error(`${label} header is missing or malformed`);
+    }
+    const normalized = encoded.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+    try {
+        const binary = globalThis.atob(padded);
+        const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+        return JSON.parse(new TextDecoder().decode(bytes));
+    } catch {
+        throw new Error(`${label} header is not valid base64-encoded JSON`);
+    }
+}
+
+function validatePaymentChallenge(
+    headerValue: string,
+    requestUrl: string,
+    quote: X402Quote,
+    authorization: X402PaymentAuthorization,
+): void {
+    const challenge = decodeBase64JsonHeader(headerValue, "PAYMENT-REQUIRED");
+    if (challenge?.x402Version !== 2) {
+        throw new Error("PAYMENT-REQUIRED challenge is not x402 version 2");
+    }
+    const expectedUrl = new URL(requestUrl).toString();
+    let challengeUrl: string;
+    try {
+        challengeUrl = new URL(String(challenge?.resource?.url || "")).toString();
+    } catch {
+        throw new Error("PAYMENT-REQUIRED challenge has an invalid resource URL");
+    }
+    if (challengeUrl !== expectedUrl) {
+        throw new Error("PAYMENT-REQUIRED resource does not match the requested execute URL");
+    }
+
+    const accepts = challenge?.accepts;
+    if (!Array.isArray(accepts) || accepts.length === 0) {
+        throw new Error("PAYMENT-REQUIRED challenge has no payment requirements");
+    }
+    const quotedPrice = requireFiniteNonNegative(quote.quoted_price_usdc, "quoted_price_usdc");
+    const expectedAmount = Math.round(quotedPrice * 1_000_000);
+    const maxAmount = Math.floor(requireFiniteNonNegative(authorization.max_amount_usdc, "max_amount_usdc") * 1_000_000);
+    const expectedNetwork = normalizeNetwork(authorization.expected_network);
+    const expectedAsset = String(authorization.expected_asset || "").trim().toLowerCase();
+    const expectedPayTo = String(authorization.expected_pay_to || "").trim().toLowerCase();
+    if (!expectedNetwork || !/^0x[a-f0-9]{40}$/.test(expectedAsset) || !/^0x[a-f0-9]{40}$/.test(expectedPayTo)) {
+        throw new Error("expected network, asset, and payment recipient are required before payment");
+    }
+
+    for (const requirement of accepts) {
+        if (String(requirement?.scheme || "").trim().toLowerCase() !== "exact") {
+            throw new Error("PAYMENT-REQUIRED scheme is not the authorized exact-transfer scheme");
+        }
+        const amount = Number(requirement?.amount);
+        if (!Number.isSafeInteger(amount) || amount < 0 || amount !== expectedAmount || amount > maxAmount) {
+            throw new Error("PAYMENT-REQUIRED amount does not match the authorized quote and ceiling");
+        }
+        if (normalizeNetwork(requirement?.network) !== expectedNetwork) {
+            throw new Error("PAYMENT-REQUIRED network does not match the authorized network");
+        }
+        if (String(requirement?.asset || "").trim().toLowerCase() !== expectedAsset) {
+            throw new Error("PAYMENT-REQUIRED asset does not match the quoted settlement asset");
+        }
+        if (String(requirement?.payTo || "").trim().toLowerCase() !== expectedPayTo) {
+            throw new Error("PAYMENT-REQUIRED recipient does not match the authorized recipient");
+        }
+    }
+}
+
 export class AgoragenticAgenticWalletClient {
     private baseUrl: string;
     private apiKey: string | null;
     private payChallenge?: ChallengePaymentHandler;
+    private x402PaymentAttempted = false;
+    private usedIdempotencyKeys = new Set<string>();
 
     constructor(options: ClientOptions = {}) {
-        this.baseUrl = options.baseUrl || DEFAULT_BASE_URL;
+        this.baseUrl = (options.baseUrl || DEFAULT_BASE_URL).replace(/\/+$/, "");
         this.apiKey = options.apiKey || null;
         this.payChallenge = options.payChallenge;
     }
@@ -68,7 +186,11 @@ export class AgoragenticAgenticWalletClient {
 
     async match(task: string, constraints: JsonRecord = {}): Promise<any> {
         if (!this.apiKey) throw new Error("API key required for execute/match");
-        const response = await fetch(`${this.baseUrl}/api/execute/match${queryString({ task, ...constraints })}`, {
+        const maxCost = requireFiniteNonNegative(constraints.max_cost, "max_cost");
+        if (maxCost <= 0) {
+            throw new Error("match max_cost must be positive; the deployed router treats zero as an absent ceiling");
+        }
+        const response = await fetch(`${this.baseUrl}/api/execute/match${queryString({ task, ...constraints, max_cost: maxCost })}`, {
             headers: { Authorization: `Bearer ${this.apiKey}` },
         });
         return parseJson(response);
@@ -76,15 +198,36 @@ export class AgoragenticAgenticWalletClient {
 
     async execute(task: string, input: JsonRecord = {}, constraints: JsonRecord = {}): Promise<any> {
         if (!this.apiKey) throw new Error("API key required for execute");
+        const maxCost = requireFiniteNonNegative(constraints.max_cost, "max_cost");
+        if (maxCost <= 0) {
+            throw new Error("max_cost must be positive; the deployed router treats zero as an absent ceiling");
+        }
+        if (constraints.payment_authorized !== true) {
+            throw new Error("paid execute requires payment_authorized: true after reviewing max_cost");
+        }
+        const idempotencyKey = requireIdempotencyKey(constraints.idempotency_key);
+        if (this.usedIdempotencyKeys.has(idempotencyKey)) {
+            throw new Error("idempotency_key was already attempted by this client");
+        }
+        const routerConstraints = { ...constraints, max_cost: maxCost };
+        delete routerConstraints.payment_authorized;
+        delete routerConstraints.idempotency_key;
+        this.usedIdempotencyKeys.add(idempotencyKey);
         const response = await fetch(`${this.baseUrl}/api/execute`, {
             method: "POST",
             headers: {
                 Authorization: `Bearer ${this.apiKey}`,
                 "Content-Type": "application/json",
             },
-            body: JSON.stringify({ task, input, ...constraints }),
+            body: JSON.stringify({
+                task,
+                input,
+                constraints: routerConstraints,
+            }),
         });
-        return parseJson(response);
+        const data = await parseJson(response);
+        if (!response.ok) throw new Error(`execute failed with HTTP ${response.status}`);
+        return data;
     }
 
     async x402ExecuteMatch(task: string, constraints: JsonRecord = {}): Promise<any> {
@@ -92,27 +235,82 @@ export class AgoragenticAgenticWalletClient {
         return parseJson(response);
     }
 
-    async x402Execute(quoteId: string, input: JsonRecord = {}): Promise<any> {
-        const requestBody = { quote_id: quoteId, input };
-        const initial = await fetch(`${this.baseUrl}/api/x402/execute`, {
+    async x402Execute(
+        quote: X402Quote,
+        input: JsonRecord = {},
+        authorization: X402PaymentAuthorization,
+    ): Promise<any> {
+        if (!quote || typeof quote !== "object" || !String(quote.quote_id || "").trim()) {
+            throw new Error("x402Execute requires the complete quote returned by x402ExecuteMatch");
+        }
+        if (this.x402PaymentAttempted) {
+            throw new Error("this client has already attempted an x402 payment; inspect receipt state before creating a newly authorized client");
+        }
+        if (!authorization || authorization.payment_authorized !== true) {
+            throw new Error("x402 payment requires explicit payment_authorized: true");
+        }
+        const idempotencyKey = requireIdempotencyKey(authorization.idempotency_key);
+        if (this.usedIdempotencyKeys.has(idempotencyKey)) {
+            throw new Error("idempotency_key was already attempted by this client");
+        }
+        if (quote.execution_ready !== true) {
+            throw new Error("x402 quote is not execution-ready on the requested payment rail");
+        }
+        const quotedPrice = requireFiniteNonNegative(quote.quoted_price_usdc, "quoted_price_usdc");
+        const maxAmount = requireFiniteNonNegative(authorization.max_amount_usdc, "max_amount_usdc");
+        if (quotedPrice > maxAmount) {
+            throw new Error(`quoted price ${quotedPrice} USDC exceeds authorized maximum ${maxAmount} USDC`);
+        }
+        const quoteNetwork = String(
+            quote.settlement_network_caip2
+            || quote.settlement_network
+            || quote.payment_network_caip2
+            || quote.payment_network
+            || "",
+        ).trim();
+        if (!authorization.expected_network || normalizeNetwork(quoteNetwork) !== normalizeNetwork(authorization.expected_network)) {
+            throw new Error(`quote network ${quoteNetwork || "unknown"} does not match expected network ${authorization.expected_network}`);
+        }
+        if (String(quote.settlement_asset_address || "").trim().toLowerCase()
+            !== String(authorization.expected_asset || "").trim().toLowerCase()) {
+            throw new Error("quote settlement asset does not match the authorized asset");
+        }
+        this.usedIdempotencyKeys.add(idempotencyKey);
+        const requestBody = {
+            quote_id: String(quote.quote_id).trim(),
+            input,
+        };
+        const requestUrl = `${this.baseUrl}/api/x402/execute`;
+        const initial = await fetch(requestUrl, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(requestBody),
         });
 
         if (initial.status !== 402) {
-            return parseJson(initial);
+            const data = await parseJson(initial);
+            if (!initial.ok) throw new Error(`x402 execute failed with HTTP ${initial.status}`);
+            return data;
         }
 
-        const paymentRequired = initial.headers.get("PAYMENT-REQUIRED");
+        const paymentRequired = initial.headers.get("PAYMENT-REQUIRED")
+            || initial.headers.get("X-PAYMENT-REQUIRED");
         if (!paymentRequired) throw new Error("Missing PAYMENT-REQUIRED header");
         if (!this.payChallenge) throw new Error("No payChallenge handler configured for x402");
+        validatePaymentChallenge(paymentRequired, requestUrl, quote, authorization);
+        this.x402PaymentAttempted = true;
 
         const payment = await this.payChallenge(paymentRequired, {
-            url: `${this.baseUrl}/api/x402/execute`,
+            url: requestUrl,
             method: "POST",
             body: requestBody,
+            quote,
+            authorization,
         });
+
+        if (!payment.authorizationHeader && !payment.paymentSignature) {
+            throw new Error("payChallenge returned no payment authorization or signature");
+        }
 
         const retryHeaders: Record<string, string> = {
             "Content-Type": "application/json",
@@ -120,17 +318,42 @@ export class AgoragenticAgenticWalletClient {
         if (payment.authorizationHeader) retryHeaders.Authorization = payment.authorizationHeader;
         if (payment.paymentSignature) retryHeaders["PAYMENT-SIGNATURE"] = payment.paymentSignature;
 
-        const settled = await fetch(`${this.baseUrl}/api/x402/execute`, {
+        const settled = await fetch(requestUrl, {
             method: "POST",
             headers: retryHeaders,
             body: JSON.stringify(requestBody),
         });
 
         const payload = await parseJson(settled);
+        if (settled.status === 402) {
+            throw new Error("payment was not accepted; the server returned another payment challenge");
+        }
+        if (!settled.ok) throw new Error(`paid x402 execute failed with HTTP ${settled.status}`);
+        const paymentResponse = settled.headers.get("PAYMENT-RESPONSE")
+            || settled.headers.get("X-PAYMENT-RESPONSE");
+        const paymentReceipt = settled.headers.get("Payment-Receipt");
+        if (!paymentResponse || !paymentReceipt) {
+            throw new Error("paid x402 execute returned no complete payment response and receipt proof");
+        }
+        const paymentResponsePayload = decodeBase64JsonHeader(paymentResponse, "PAYMENT-RESPONSE");
+        const responseAmount = requireFiniteNonNegative(paymentResponsePayload?.amount_usdc, "payment response amount_usdc");
+        if (String(paymentResponsePayload?.receipt_id || "") !== paymentReceipt) {
+            throw new Error("PAYMENT-RESPONSE receipt does not match Payment-Receipt");
+        }
+        if (String(paymentResponsePayload?.quote_id || "") !== String(quote.quote_id)) {
+            throw new Error("PAYMENT-RESPONSE quote does not match the authorized quote");
+        }
+        if (paymentResponsePayload?.settlement_status !== "settled") {
+            throw new Error("PAYMENT-RESPONSE does not prove final settled status");
+        }
+        if (Math.round(responseAmount * 1_000_000) !== Math.round(quotedPrice * 1_000_000)) {
+            throw new Error("PAYMENT-RESPONSE amount does not match the authorized quote");
+        }
         return {
             ...payload,
-            payment_receipt: settled.headers.get("Payment-Receipt"),
-            payment_response_header: settled.headers.get("PAYMENT-RESPONSE"),
+            payment_receipt: paymentReceipt,
+            payment_response_header: paymentResponse,
+            payment_response: paymentResponsePayload,
             wallet_receipt: payment.receipt || null,
         };
     }

--- a/test/payment-safety-contracts.test.mjs
+++ b/test/payment-safety-contracts.test.mjs
@@ -1,0 +1,293 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+import { AgoragenticAgenticWalletClient } from '../coinbase-agentic-wallets/agoragentic_agentic_wallet.ts';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const read = (path) => readFileSync(join(root, path), 'utf8');
+const asset = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
+const payTo = '0x1111111111111111111111111111111111111111';
+
+const quote = (overrides = {}) => ({
+  quote_id: 'quote_test',
+  quoted_price_usdc: 0.02,
+  payment_network_caip2: 'eip155:8453',
+  settlement_network_caip2: 'eip155:8453',
+  settlement_asset_address: asset,
+  execution_ready: true,
+  ...overrides,
+});
+
+const authorization = (overrides = {}) => ({
+  payment_authorized: true,
+  max_amount_usdc: 0.02,
+  expected_network: 'eip155:8453',
+  expected_asset: asset,
+  expected_pay_to: payTo,
+  idempotency_key: 'x402-test-intent',
+  ...overrides,
+});
+
+function challengeHeader({
+  amount = '20000',
+  network = 'base',
+  challengeAsset = asset,
+  challengePayTo = payTo,
+  scheme = 'exact',
+  topLevelResource = 'https://example.test/api/x402/execute',
+} = {}) {
+  return Buffer.from(JSON.stringify({
+    x402Version: 2,
+    resource: { url: topLevelResource },
+    accepts: [{ scheme, network, amount, asset: challengeAsset, payTo: challengePayTo }],
+  })).toString('base64');
+}
+
+function paymentResponseHeader(overrides = {}) {
+  return Buffer.from(JSON.stringify({
+    receipt_id: 'payment-receipt-proof',
+    quote_id: 'quote_test',
+    settlement_status: 'settled',
+    amount_usdc: 0.02,
+    ...overrides,
+  })).toString('base64');
+}
+
+test('registered execute rejects zero and sends a canonical positive ceiling', async () => {
+  const calls = [];
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async (url, options) => {
+    calls.push({ url, options });
+    return new Response(JSON.stringify({ status: 'success' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+
+  try {
+    const client = new AgoragenticAgenticWalletClient({ baseUrl: 'https://example.test', apiKey: 'amk_test' });
+    await assert.rejects(client.match('summarize', { max_cost: 0 }), /router treats zero as an absent ceiling/);
+    await assert.rejects(
+      client.execute('summarize', {}, { max_cost: 0, payment_authorized: true, idempotency_key: 'zero-test' }),
+      /router treats zero as an absent ceiling/,
+    );
+    assert.equal(calls.length, 0);
+
+    await client.execute('summarize', { text: 'hello' }, {
+      max_cost: 0.02,
+      payment_authorized: true,
+      idempotency_key: 'registered-test-intent',
+    });
+    assert.equal(calls.length, 1);
+    const body = JSON.parse(calls[0].options.body);
+    assert.deepEqual(body, {
+      task: 'summarize',
+      input: { text: 'hello' },
+      constraints: { max_cost: 0.02 },
+    });
+    assert.equal(calls[0].options.headers['Idempotency-Key'], undefined);
+    await assert.rejects(
+      client.execute('summarize', { text: 'hello' }, {
+        max_cost: 0.02,
+        payment_authorized: true,
+        idempotency_key: 'registered-test-intent',
+      }),
+      /already attempted by this client/,
+    );
+    assert.equal(calls.length, 1);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('x402 rejects an over-cap challenge before the wallet callback', async () => {
+  let payCallbacks = 0;
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async () => new Response(JSON.stringify({ error: 'payment_required' }), {
+    status: 402,
+    headers: {
+      'Content-Type': 'application/json',
+      'PAYMENT-REQUIRED': challengeHeader({ amount: '10000000' }),
+    },
+  });
+
+  try {
+    const client = new AgoragenticAgenticWalletClient({
+      baseUrl: 'https://example.test',
+      payChallenge: async () => {
+        payCallbacks += 1;
+        return { paymentSignature: 'should-not-be-used' };
+      },
+    });
+    await assert.rejects(client.x402Execute(quote(), {}, authorization()), /amount does not match/);
+    assert.equal(payCallbacks, 0);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('x402 binds scheme, resource, network, asset, and recipient before signing', async () => {
+  const cases = [
+    { options: { scheme: 'upto' }, error: /scheme/ },
+    { options: { topLevelResource: 'https://example.test/api/x402/invoke/other' }, error: /resource does not match/ },
+    { options: { network: 'eip155:1' }, error: /network/ },
+    { options: { challengeAsset: '0x2222222222222222222222222222222222222222' }, error: /asset/ },
+    { options: { challengePayTo: '0x3333333333333333333333333333333333333333' }, error: /recipient/ },
+  ];
+  const previousFetch = globalThis.fetch;
+
+  try {
+    for (const entry of cases) {
+      let payCallbacks = 0;
+      globalThis.fetch = async () => new Response(JSON.stringify({ error: 'payment_required' }), {
+        status: 402,
+        headers: {
+          'Content-Type': 'application/json',
+          'PAYMENT-REQUIRED': challengeHeader(entry.options),
+        },
+      });
+      const client = new AgoragenticAgenticWalletClient({
+        baseUrl: 'https://example.test',
+        payChallenge: async () => {
+          payCallbacks += 1;
+          return { paymentSignature: 'should-not-be-used' };
+        },
+      });
+      await assert.rejects(client.x402Execute(quote(), {}, authorization()), entry.error);
+      assert.equal(payCallbacks, 0);
+    }
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('x402 fails closed on a second 402', async () => {
+  let calls = 0;
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return new Response(JSON.stringify({ error: 'payment_required_again' }), {
+      status: 402,
+      headers: {
+        'Content-Type': 'application/json',
+        'PAYMENT-REQUIRED': challengeHeader(),
+      },
+    });
+  };
+
+  try {
+    const client = new AgoragenticAgenticWalletClient({
+      baseUrl: 'https://example.test',
+      payChallenge: async () => ({ paymentSignature: 'signed-payment' }),
+    });
+    await assert.rejects(client.x402Execute(quote(), {}, authorization()), /another payment challenge/);
+    assert.equal(calls, 2);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('x402 blocks reuse after an ambiguous signed retry failure', async () => {
+  let calls = 0;
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    calls += 1;
+    if (calls === 1) {
+      return new Response(JSON.stringify({ error: 'payment_required' }), {
+        status: 402,
+        headers: { 'Content-Type': 'application/json', 'PAYMENT-REQUIRED': challengeHeader() },
+      });
+    }
+    throw new Error('network failed after signing');
+  };
+
+  try {
+    const client = new AgoragenticAgenticWalletClient({
+      baseUrl: 'https://example.test',
+      payChallenge: async () => ({ paymentSignature: 'signed-payment' }),
+    });
+    await assert.rejects(client.x402Execute(quote(), {}, authorization()), /network failed after signing/);
+    await assert.rejects(client.x402Execute(quote(), {}, authorization()), /already attempted an x402 payment/);
+    assert.equal(calls, 2);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('x402 returns only a successful paid response with both proof headers', async () => {
+  const responses = [
+    new Response(JSON.stringify({ error: 'payment_required' }), {
+      status: 402,
+      headers: { 'Content-Type': 'application/json', 'PAYMENT-REQUIRED': challengeHeader() },
+    }),
+    new Response(JSON.stringify({ status: 'success' }), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'PAYMENT-RESPONSE': paymentResponseHeader(),
+        'Payment-Receipt': 'payment-receipt-proof',
+      },
+    }),
+  ];
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async () => responses.shift();
+
+  try {
+    const client = new AgoragenticAgenticWalletClient({
+      baseUrl: 'https://example.test',
+      payChallenge: async () => ({ paymentSignature: 'signed-payment' }),
+    });
+    const result = await client.x402Execute(quote(), {}, authorization());
+    assert.equal(result.status, 'success');
+    assert.equal(result.payment_response.receipt_id, 'payment-receipt-proof');
+    assert.equal(result.payment_receipt, 'payment-receipt-proof');
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('x402 rejects inconsistent payment proof headers', async () => {
+  const responses = [
+    new Response(JSON.stringify({ error: 'payment_required' }), {
+      status: 402,
+      headers: { 'Content-Type': 'application/json', 'PAYMENT-REQUIRED': challengeHeader() },
+    }),
+    new Response(JSON.stringify({ status: 'success' }), {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'PAYMENT-RESPONSE': paymentResponseHeader({ receipt_id: 'different-receipt' }),
+        'Payment-Receipt': 'payment-receipt-proof',
+      },
+    }),
+  ];
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async () => responses.shift();
+
+  try {
+    const client = new AgoragenticAgenticWalletClient({
+      baseUrl: 'https://example.test',
+      payChallenge: async () => ({ paymentSignature: 'signed-payment' }),
+    });
+    await assert.rejects(client.x402Execute(quote(), {}, authorization()), /receipt does not match/);
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test('buyer demo is an honest keyless preflight', () => {
+  const source = read('x402/buyer-demo.js');
+  assert.match(source, /--paid-preflight/);
+  assert.match(source, /stops here without signing or retrying/);
+  assert.doesNotMatch(source, /process\.env\.WALLET_PRIVATE_KEY/);
+  assert.doesNotMatch(source, /require\(['"]ethers['"]\)/);
+});
+
+test('root README references an existing offline verification command', () => {
+  const readme = read('README.md');
+  assert.match(readme, /node scripts\/verify-integrations-json\.js/);
+  assert.doesNotMatch(readme, /scripts\/execute-path-proof\.mjs/);
+});

--- a/test/x402-buyer-demo-preflight.test.mjs
+++ b/test/x402-buyer-demo-preflight.test.mjs
@@ -1,0 +1,237 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const demoPath = join(root, 'x402', 'buyer-demo.js');
+const asset = '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913';
+const payTo = '0x1111111111111111111111111111111111111111';
+
+function canonicalEnvelope({ paymentRequired, priceUsdc, quoteId = 'quote_behavioral' }) {
+  return {
+    quote: {
+      quote_id: quoteId,
+      quoted_price_usdc: priceUsdc,
+      payment_required: paymentRequired,
+      next_step: {
+        method: 'POST',
+        url: '/api/x402/execute',
+        body: { quote_id: quoteId, input: {} },
+      },
+    },
+    selected_provider: { id: 'listing_behavioral', name: 'Behavioral Mock Provider' },
+    quote_id: quoteId,
+  };
+}
+
+function challengeHeader() {
+  return Buffer.from(JSON.stringify({
+    x402Version: 2,
+    resource: { url: '/api/x402/execute' },
+    accepts: [{ scheme: 'exact', network: 'base', amount: '50000', asset, payTo }],
+  })).toString('base64');
+}
+
+function startMockRouter(analyzeMatchBody, options = {}) {
+  const state = { executePosts: [] };
+  const executeHeaders = Object.hasOwn(options, 'executeHeaders')
+    ? options.executeHeaders
+    : { 'PAYMENT-REQUIRED': challengeHeader() };
+  const server = createServer((req, res) => {
+    const chunks = [];
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('end', () => {
+      const url = new URL(req.url, 'http://127.0.0.1');
+      const respond = (status, body, headers = {}) => {
+        res.writeHead(status, { 'Content-Type': 'application/json', ...headers });
+        res.end(JSON.stringify(body));
+      };
+      if (req.method === 'GET' && url.pathname === '/api/x402/info') {
+        return respond(200, { name: 'Mock x402 Gateway', protocol: 'x402', network: 'eip155:8453', currency: 'USDC' });
+      }
+      if (req.method === 'GET' && url.pathname === '/api/x402/listings') {
+        return respond(200, { listings: [] });
+      }
+      if (req.method === 'GET' && url.pathname === '/api/x402/execute/match') {
+        if (url.searchParams.get('task') === 'analyze') {
+          return respond(200, analyzeMatchBody);
+        }
+        return respond(200, { quote: null, selected_provider: null, quote_id: null });
+      }
+      if (req.method === 'POST' && url.pathname === '/api/x402/test/echo') {
+        return respond(200, { method: 'echo', echoed: Buffer.concat(chunks).toString() });
+      }
+      if (req.method === 'POST' && url.pathname === '/api/x402/execute') {
+        state.executePosts.push({
+          headers: { ...req.headers },
+          body: Buffer.concat(chunks).toString(),
+        });
+        return respond(402, { error: 'payment_required', price_usdc: 0.05 }, executeHeaders);
+      }
+      return respond(404, { error: 'not_found' });
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      resolve({ server, state, baseUrl: `http://127.0.0.1:${server.address().port}` });
+    });
+  });
+}
+
+function stopMockRouter(mock) {
+  return new Promise((resolve) => {
+    mock.server.closeAllConnections();
+    mock.server.close(resolve);
+  });
+}
+
+function runPreflight(baseUrl) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [demoPath, '--paid-preflight'], {
+      cwd: root,
+      env: { ...process.env, AGORAGENTIC_URL: baseUrl },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('error', reject);
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+test('paid preflight posts exactly once, reports the 402, and never sends payment headers', async () => {
+  const mock = await startMockRouter(canonicalEnvelope({ paymentRequired: true, priceUsdc: 0.05 }));
+  try {
+    const result = await runPreflight(mock.baseUrl);
+    assert.equal(result.code, 0, `expected clean exit, stderr: ${result.stderr}`);
+
+    assert.equal(mock.state.executePosts.length, 1, 'exactly one POST must reach the paid execute route (no retry after the 402)');
+    const post = mock.state.executePosts[0];
+    assert.equal(JSON.parse(post.body).quote_id, 'quote_behavioral');
+    for (const header of Object.keys(post.headers)) {
+      assert.doesNotMatch(header, /payment|authorization|signature/i, `unsigned preflight sent a payment header: ${header}`);
+    }
+
+    assert.match(result.stdout, /Matched paid listing: "Behavioral Mock Provider" — \$0\.05 USDC \(payment_required=true\)/);
+    assert.match(result.stdout, /402 Payment Required received \(challenge header present\); preflight stops here without signing or retrying\./);
+    assert.doesNotMatch(result.stdout, /Matched listing is free/);
+    assert.doesNotMatch(result.stdout, /no payment needed/);
+  } finally {
+    await stopMockRouter(mock);
+  }
+});
+
+test('a genuinely free canonical quote is reported free and never posts a payment', async () => {
+  const mock = await startMockRouter(canonicalEnvelope({ paymentRequired: false, priceUsdc: 0 }));
+  try {
+    const result = await runPreflight(mock.baseUrl);
+    assert.equal(result.code, 0, `expected clean exit, stderr: ${result.stderr}`);
+    assert.match(result.stdout, /Matched listing is free \(payment_required=false\) — no payment needed/);
+    assert.equal(mock.state.executePosts.length, 0, 'a free quote must never reach the paid execute route in preflight');
+  } finally {
+    await stopMockRouter(mock);
+  }
+});
+
+test('an unrecognized match envelope fails closed instead of claiming free', async () => {
+  const mock = await startMockRouter({ quote_id: 'legacy_quote', match: { name: 'Legacy Listing', price_usdc: 0.05 } });
+  try {
+    const result = await runPreflight(mock.baseUrl);
+    assert.notEqual(result.code, 0, 'unrecognized envelope must exit non-zero');
+    assert.match(result.stdout, /missing "quote" field/);
+    assert.doesNotMatch(result.stdout, /Matched listing is free/);
+    assert.doesNotMatch(result.stdout, /no payment needed/);
+    assert.equal(mock.state.executePosts.length, 0);
+  } finally {
+    await stopMockRouter(mock);
+  }
+});
+
+test('a quote without the payment_required boolean fails closed instead of claiming free', async () => {
+  const envelope = canonicalEnvelope({ paymentRequired: true, priceUsdc: 0.05 });
+  delete envelope.quote.payment_required;
+  const mock = await startMockRouter(envelope);
+  try {
+    const result = await runPreflight(mock.baseUrl);
+    assert.notEqual(result.code, 0, 'missing payment_required must exit non-zero');
+    assert.match(result.stdout, /"quote\.payment_required"/);
+    assert.doesNotMatch(result.stdout, /Matched listing is free/);
+    assert.equal(mock.state.executePosts.length, 0);
+  } finally {
+    await stopMockRouter(mock);
+  }
+});
+
+test('a hostile protocol-relative next_step.url cannot redirect the POST off-origin', async () => {
+  const envelope = canonicalEnvelope({ paymentRequired: true, priceUsdc: 0.05 });
+  envelope.quote.next_step.url = '//attacker.example/api/x402/execute';
+  const mock = await startMockRouter(envelope);
+  try {
+    const result = await runPreflight(mock.baseUrl);
+    assert.equal(result.code, 0, `expected clean exit, stderr: ${result.stderr}`);
+    assert.equal(mock.state.executePosts.length, 1, 'the POST must land on the same-origin fallback route, not the foreign host');
+    assert.match(result.stdout, /402 Payment Required received/);
+  } finally {
+    await stopMockRouter(mock);
+  }
+});
+
+test('a slash-backslash next_step.url cannot redirect the POST off-origin', async () => {
+  const foreignState = { posts: 0 };
+  const foreignServer = createServer((req, res) => {
+    if (req.method === 'POST') foreignState.posts += 1;
+    res.writeHead(402, { 'Content-Type': 'application/json', 'PAYMENT-REQUIRED': challengeHeader() });
+    res.end(JSON.stringify({ error: 'payment_required' }));
+  });
+  await new Promise((resolve) => foreignServer.listen(0, '127.0.0.1', resolve));
+
+  const envelope = canonicalEnvelope({ paymentRequired: true, priceUsdc: 0.05 });
+  envelope.quote.next_step.url = `/\\127.0.0.1:${foreignServer.address().port}/capture`;
+  const mock = await startMockRouter(envelope);
+  try {
+    const result = await runPreflight(mock.baseUrl);
+    assert.equal(result.code, 0, `expected clean exit, stderr: ${result.stderr}`);
+    assert.equal(mock.state.executePosts.length, 1, 'the POST must use the same-origin execute fallback');
+    assert.equal(foreignState.posts, 0, 'a backslash-normalized authority must never receive the POST');
+    assert.match(result.stdout, /402 Payment Required received/);
+  } finally {
+    await stopMockRouter(mock);
+    foreignServer.closeAllConnections();
+    await new Promise((resolve) => foreignServer.close(resolve));
+  }
+});
+
+test('HTTP 402 without PAYMENT-REQUIRED fails the preflight', async () => {
+  const mock = await startMockRouter(
+    canonicalEnvelope({ paymentRequired: true, priceUsdc: 0.05 }),
+    { executeHeaders: {} },
+  );
+  try {
+    const result = await runPreflight(mock.baseUrl);
+    assert.notEqual(result.code, 0, 'a missing challenge header must fail the process');
+    assert.equal(mock.state.executePosts.length, 1, 'the unsigned preflight still makes only its initial POST');
+    assert.match(result.stdout, /HTTP 402 without PAYMENT-REQUIRED/);
+    assert.doesNotMatch(result.stdout, /✅  402 Payment Required received/);
+  } finally {
+    await stopMockRouter(mock);
+  }
+});
+
+test('a paid quote with an unparseable price fails closed instead of guessing', async () => {
+  const envelope = canonicalEnvelope({ paymentRequired: true, priceUsdc: 0.05 });
+  envelope.quote.quoted_price_usdc = 'not-a-number';
+  const mock = await startMockRouter(envelope);
+  try {
+    const result = await runPreflight(mock.baseUrl);
+    assert.notEqual(result.code, 0, 'unparseable price must exit non-zero');
+    assert.match(result.stdout, /"quote\.quoted_price_usdc"/);
+    assert.doesNotMatch(result.stdout, /Matched listing is free/);
+    assert.equal(mock.state.executePosts.length, 0);
+  } finally {
+    await stopMockRouter(mock);
+  }
+});

--- a/x402/README.md
+++ b/x402/README.md
@@ -8,11 +8,9 @@ Pay-per-request agent-to-agent commerce via HTTP 402 on Base L2.
 # Free demo — no wallet needed
 node x402/buyer-demo.js
 
-# Paid demo — requires USDC on Base.
-# Export the key on its own line (or use a gitignored .env) so a real funded key
-# is not written to shell history or exposed in process listings (ps).
-export WALLET_PRIVATE_KEY=0x...
-node x402/buyer-demo.js --paid
+# Paid-route preflight — receives the 402 challenge, then stops.
+# It never reads a wallet key, signs, retries, or spends.
+node x402/buyer-demo.js --paid-preflight
 
 # Verbose output
 node x402/buyer-demo.js --verbose
@@ -54,89 +52,82 @@ node x402/buyer-demo.js --verbose
 
 ## SDK Integration
 
-### Using @x402/client (Recommended)
+### Current Coinbase x402 client
 
-```javascript
-const { httpClient } = require('@x402/client');
-const { createWalletClient, http } = require('viem');
-const { base } = require('viem/chains');
-const { privateKeyToAccount } = require('viem/accounts');
+Use Coinbase's primary-source examples rather than older snippets built around APIs that are not part of Coinbase's current x402 client distribution. The current TypeScript client uses `x402Client`, `wrapFetchWithPayment`, and `x402HTTPClient` from `@x402/fetch`, with payment schemes from `@x402/evm`. See the [official fetch client at the revision audited here](https://github.com/coinbase/x402/blob/dd927a26cfefc98c24b3ec38b3a8f204dad0c60d/examples/typescript/clients/fetch/index.ts) and its [payment-creation policy hook](https://github.com/coinbase/x402/blob/dd927a26cfefc98c24b3ec38b3a8f204dad0c60d/examples/typescript/clients/advanced/hooks.ts).
 
-// 1. Create wallet
-const account = privateKeyToAccount(process.env.WALLET_PRIVATE_KEY);
-const walletClient = createWalletClient({
-    account,
-    chain: base,
-    transport: http(),
-});
-
-// 2. Create x402 client (handles 402→sign→retry automatically)
-const client = httpClient('https://agoragentic.com', walletClient);
-
-// 3. Execute a service
-const res = await client.post('/api/x402/execute', {
-    task: 'analyze this code for bugs',
-    input: { code: 'function add(a, b) { return a - b; }' },
-});
-
-console.log(res.data); // { success: true, result: { ... }, cost: 0.10 }
-```
-
-### Using the Agoragentic SDK
-
-```javascript
-const { execute } = require('agoragentic');
-
-const result = await execute('analyze this code', {
-    input: { code: '...' },
-    max_cost: 1.00,
-    api_key: 'amk_...',  // Or use x402 with wallet
-});
-```
+Do not hand an automatic signing client an unreviewed challenge. First obtain a complete route quote and reject a missing/non-finite price, `execution_ready !== true`, a price over the operator ceiling, or a settlement network/asset mismatch. At payment-creation time, bind every selected requirement to x402 v2, the exact-transfer scheme, the same resource URL, atomic amount, Base network, USDC contract, and independently configured recipient. The Coinbase wrapper in `coinbase-agentic-wallets/` implements those checks before its wallet callback.
 
 ### Manual Flow (No SDK)
 
+`GET /api/x402/execute/match` answers with the canonical envelope: `quote.payment_required` (the authoritative free-vs-paid boolean), `quote.quoted_price_usdc` (number, USDC), `quote.quote_id`, `quote.next_step`, and a top-level `selected_provider`. When no provider matches, `quote` and `selected_provider` are `null`. Never infer "free" from a missing or unparseable price — if `payment_required` is not a boolean, fail closed.
+
 ```javascript
-// Step 1: Find a service
-const match = await fetch('https://agoragentic.com/api/x402/execute/match?task=echo');
-const { quote_id, match: listing } = await match.json();
+// Step 1: Find and validate a service without signing.
+const matchResponse = await fetch('https://agoragentic.com/api/x402/execute/match?task=echo&max_cost=0.10');
+const match = await matchResponse.json();
+const quote = match.quote;
+const intentKey = process.env.X402_IDEMPOTENCY_KEY || '';
+if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,199}$/.test(intentKey)) {
+    throw new Error('caller-supplied local idempotency key required');
+}
+if (typeof quote?.payment_required !== 'boolean') {
+    throw new Error('quote missing the payment_required boolean; never assume a route is free');
+}
+const quoted = quote.quoted_price_usdc;
+if (!quote.quote_id || typeof quoted !== 'number' || !Number.isFinite(quoted) || quoted < 0 || quoted > 0.10) {
+    throw new Error('quote missing, malformed, or above the reviewed ceiling');
+}
+if (quote.execution_ready !== true || quote.settlement_network_caip2 !== 'eip155:8453') {
+    throw new Error('quote is not ready for the approved Base settlement rail');
+}
 
 // Step 2: Execute (returns 402 if paid)
 const res = await fetch('https://agoragentic.com/api/x402/execute', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ quote_id, input: { text: 'hello' } }),
+    body: JSON.stringify({
+        quote_id: quote.quote_id,
+        input: { text: 'hello' },
+        idempotency_key: intentKey,
+    }),
 });
 
 if (res.status === 402) {
     // Read payment requirements from header
-    const payReq = JSON.parse(
-        Buffer.from(res.headers.get('payment-required'), 'base64').toString()
-    );
-    console.log('Payment required:', payReq[0].maxAmountRequired, 'micro-USDC');
-    console.log('Sign a USDC TransferWithAuthorization and retry with PAYMENT-SIGNATURE header');
+    const encoded = res.headers.get('payment-required');
+    if (!encoded) throw new Error('missing PAYMENT-REQUIRED header');
+    const payReq = JSON.parse(Buffer.from(encoded, 'base64').toString('utf8'));
+    if (payReq.x402Version !== 2 || !Array.isArray(payReq.accepts) || payReq.accepts.length === 0) {
+        throw new Error('unexpected payment challenge shape');
+    }
+    console.log('Payment required:', payReq.accepts[0].amount, 'atomic USDC units');
+    console.log('Validate every requirement with an operator policy before signing; this example stops here.');
 }
 ```
+
+The key above records caller intent, but `/api/x402/execute` does not promise key-based route deduplication. This manual example stops before signing and never retries. The hardened Coinbase wrapper additionally blocks reused keys and a second signed payment attempt within one client instance.
 
 ## Environment Variables
 
 | Variable            | Default                          | Description                              |
 |---------------------|----------------------------------|------------------------------------------|
 | AGORAGENTIC_URL     | https://agoragentic.com          | Marketplace URL                          |
-| WALLET_PRIVATE_KEY  | —                                | Wallet private key for paid executions   |
+| X402_IDEMPOTENCY_KEY | —                               | Required caller intent key; local guard only, not server retry deduplication |
+| Wallet credential configured by your signing provider | — | External signer only; `buyer-demo.js` never reads wallet credentials |
 
 ## Payment Flow Details
 
 - **Currency**: USDC on Base L2 (EIP-155 chain 8453)
 - **Protocol**: x402 (HTTP 402 Payment Required)
 - **Settlement**: TransferWithAuthorization (EIP-3009)
-- **Facilitator**: https://facilitator.payai.network (mainnet)
-- **Platform Fee**: 3% of transaction value
+- **Facilitator**: inspect the current `/api/x402/info` response and issued challenge; do not hardcode it
+- **Platform Fee**: inspect the current quote/receipt; promotions and policy can change the effective fee
 - **Escrow**: Lock→execute→release/refund pattern
 
 ## Invocation Proofs
 
-Every paid invocation generates a decision hash (SHA-256) that can be verified on-chain:
+Every paid invocation returns a decision hash plus an on-chain submission status. Only `on_chain.status === 'verified'` confirms that proof on-chain:
 
 ```javascript
 // Check proof for an invocation

--- a/x402/buyer-demo.js
+++ b/x402/buyer-demo.js
@@ -3,27 +3,23 @@
  * Agoragentic x402 Buyer Demo Script
  * ===================================
  * 
- * Self-contained Node.js script demonstrating the full x402 payment flow:
+ * Self-contained Node.js script demonstrating x402 discovery and preflight:
  *   1. Discover available services
  *   2. Get a quote via execute/match
  *   3. Free-tier execution (echo test)
- *   4. Paid execution with USDC signing (requires wallet)
+ *   4. Optional paid-route preflight that stops at the 402 challenge
  * 
  * Usage:
  *   # Free demo (no wallet needed)
  *   node x402/buyer-demo.js
  * 
- *   # Paid demo (requires wallet with USDC on Base)
- *   # Export the key on its own line (or use a gitignored .env) so a real funded
- *   # key is not written to shell history or exposed in process listings.
- *   export WALLET_PRIVATE_KEY=0x...
- *   node x402/buyer-demo.js --paid
+ *   # Paid-route preflight (never reads a key, signs, retries, or spends)
+ *   node x402/buyer-demo.js --paid-preflight
  * 
  *   # Custom marketplace URL
  *   AGORAGENTIC_URL=http://localhost:3001 node x402/buyer-demo.js
  * 
- * Prerequisites:
- *   npm install @x402/client @x402/core @x402/evm ethers
+ * Prerequisite: Node.js 18+
  * 
  * Learn more:
  *   https://agoragentic.com/api/x402/info
@@ -35,8 +31,13 @@ const http = require('http');
 
 // ─── Configuration ──────────────────────────────────────
 const BASE_URL = process.env.AGORAGENTIC_URL || 'https://agoragentic.com';
-const isPaid = process.argv.includes('--paid');
+const isPaidPreflight = process.argv.includes('--paid-preflight');
 const isVerbose = process.argv.includes('--verbose') || process.argv.includes('-v');
+
+if (process.argv.includes('--paid')) {
+    console.error('The old --paid mode never signed a payment. Use --paid-preflight for an honest no-spend 402 challenge check.');
+    process.exit(2);
+}
 
 // ─── Helpers ────────────────────────────────────────────
 function log(emoji, message, data = null) {
@@ -96,6 +97,65 @@ function request(method, path, body = null) {
     });
 }
 
+// ─── Canonical match envelope ───────────────────────────
+// GET /api/x402/execute/match returns:
+//   body.quote.payment_required   ← authoritative free-vs-paid boolean
+//   body.quote.quoted_price_usdc  ← price (number, USDC)
+//   body.quote.quote_id, body.quote.next_step { method, url, body }
+//   body.selected_provider        ← provider object (null when no match)
+// Free-vs-paid is decided ONLY by payment_required === false. A missing
+// boolean, missing price, or unrecognized envelope fails closed. next_step.url
+// is honored only when URL resolution keeps it on the configured origin.
+function sameOriginExecutePath(candidate) {
+    const fallback = '/api/x402/execute';
+    if (typeof candidate !== 'string' || candidate.length === 0) {
+        return fallback;
+    }
+    try {
+        const baseUrl = new URL(BASE_URL);
+        const resolved = new URL(candidate, baseUrl);
+        if (resolved.origin !== baseUrl.origin) {
+            return fallback;
+        }
+        return `${resolved.pathname}${resolved.search}`;
+    } catch {
+        return fallback;
+    }
+}
+
+function parseMatchEnvelope(body) {
+    if (!body || typeof body !== 'object') {
+        throw new Error('Match response is not a JSON object; refusing to guess payment terms');
+    }
+    if (!('quote' in body)) {
+        throw new Error('Unrecognized match envelope: missing "quote" field; refusing to treat the route as free');
+    }
+    if (body.quote === null) {
+        return null;
+    }
+    const quote = body.quote;
+    if (typeof quote !== 'object') {
+        throw new Error('Unrecognized match envelope: "quote" is not an object; refusing to treat the route as free');
+    }
+    if (typeof quote.payment_required !== 'boolean') {
+        throw new Error('Quote is missing the boolean "quote.payment_required"; refusing to assume the route is free');
+    }
+    if (typeof quote.quoted_price_usdc !== 'number' || !Number.isFinite(quote.quoted_price_usdc) || quote.quoted_price_usdc < 0) {
+        throw new Error('Quote is missing a finite "quote.quoted_price_usdc"; refusing to assume the route is free');
+    }
+    if (typeof quote.quote_id !== 'string' || quote.quote_id.length === 0) {
+        throw new Error('Quote is missing "quote.quote_id"');
+    }
+    const executePath = sameOriginExecutePath(quote.next_step?.url);
+    return {
+        quoteId: quote.quote_id,
+        paymentRequired: quote.payment_required,
+        priceUsdc: quote.quoted_price_usdc,
+        executePath,
+        provider: body.selected_provider || null,
+    };
+}
+
 // ─── Step 1: Gateway Info ───────────────────────────────
 async function step1_gatewayInfo() {
     log('ℹ️', 'Step 1: Checking x402 gateway info...');
@@ -147,10 +207,15 @@ async function step3_executeMatch(task = 'echo') {
         return null;
     }
 
-    const match = res.body;
-    log('✅', `Best match: "${match.match?.name || match.name}" — $${match.match?.price_usdc || match.price_usdc} USDC`, {
-        quote_id: match.quote_id,
-        listing_id: match.match?.id || match.id,
+    const match = parseMatchEnvelope(res.body);
+    if (!match) {
+        log('⚠️', `No provider matched "${task}" — this is normal if no free listings match`);
+        return null;
+    }
+
+    log('✅', `Best match: "${match.provider?.name || 'unnamed provider'}" — $${match.priceUsdc} USDC (${match.paymentRequired ? 'paid' : 'free'})`, {
+        quote_id: match.quoteId,
+        listing_id: match.provider?.id,
     });
 
     return match;
@@ -158,14 +223,18 @@ async function step3_executeMatch(task = 'echo') {
 
 // ─── Step 4A: Free Execution ────────────────────────────
 async function step4a_freeExecution(match) {
-    if (!match?.quote_id) {
+    if (!match) {
         log('⚠️', 'Step 4a: Skipping free execution — no quote available');
         return null;
     }
+    if (match.paymentRequired !== false) {
+        log('⚠️', 'Step 4a: Skipping free execution — the matched quote requires payment');
+        return null;
+    }
 
-    log('🚀', `Step 4a: Executing free task (quote: ${match.quote_id})...`);
-    const res = await request('POST', '/api/x402/execute', {
-        quote_id: match.quote_id,
+    log('🚀', `Step 4a: Executing free task (quote: ${match.quoteId})...`);
+    const res = await request('POST', match.executePath, {
+        quote_id: match.quoteId,
         input: {
             text: 'Hello from the x402 buyer demo! This is a test invocation.',
             timestamp: new Date().toISOString(),
@@ -210,81 +279,51 @@ async function step4b_testEcho() {
     return res.body;
 }
 
-// ─── Step 5: Paid Execution (requires wallet) ───────────
-async function step5_paidExecution() {
-    const privateKey = process.env.WALLET_PRIVATE_KEY;
-    if (!privateKey) {
-        log('💡', 'Step 5: Skipping paid execution — set WALLET_PRIVATE_KEY to test paid flow');
-        log('💡', '  Usage: export WALLET_PRIVATE_KEY=0x... (own line, or a gitignored .env — avoids shell-history / ps exposure) then: node x402/buyer-demo.js --paid');
-        return null;
-    }
-
-    log('💰', 'Step 5: Paid execution flow...');
+// ─── Step 5: Paid-route preflight (no signing or spend) ─
+async function step5_paidPreflight() {
+    log('🧾', 'Step 5: Paid-route preflight (stops before signing)...');
 
     // Find a paid listing
     const matchRes = await request('GET', '/api/x402/execute/match?task=analyze&max_cost=1');
-    if (matchRes.status !== 200 || !matchRes.body?.quote_id) {
+    if (matchRes.status !== 200) {
         log('⚠️', 'No paid listing found for "analyze" — skipping paid demo');
         return null;
     }
 
-    const quote = matchRes.body;
-    const priceUsdc = quote.match?.price_usdc || quote.price_usdc || 0;
-
-    if (priceUsdc <= 0) {
-        log('ℹ️', 'Matched listing is free — no payment needed');
+    const match = parseMatchEnvelope(matchRes.body);
+    if (!match) {
+        log('⚠️', 'No provider matched "analyze" — skipping paid demo');
         return null;
     }
 
-    log('💳', `Matched paid listing: "${quote.match?.name}" — $${priceUsdc} USDC`);
+    if (match.paymentRequired === false) {
+        log('ℹ️', 'Matched listing is free (payment_required=false) — no payment needed');
+        return null;
+    }
 
-    try {
-        // Dynamic import of x402 client
-        const { ethers } = require('ethers');
+    log('💳', `Matched paid listing: "${match.provider?.name || 'unnamed provider'}" — $${match.priceUsdc} USDC (payment_required=true)`);
 
-        // IMPORTANT: The x402 client handles the 402→sign→retry cycle automatically.
-        // When you POST to the execute endpoint:
-        //   1. Server returns HTTP 402 with PAYMENT-REQUIRED header
-        //   2. x402 client reads the payment requirements
-        //   3. Client signs a USDC TransferWithAuthorization (EIP-3009)
-        //   4. Client retries with PAYMENT-SIGNATURE header
-        //   5. Server verifies payment → executes the service → returns result
+    const executeRes = await request('POST', match.executePath, {
+        quote_id: match.quoteId,
+        input: { text: 'x402 paid-route preflight test' },
+    });
 
-        log('🔑', 'Signing USDC payment with wallet...');
-        log('📝', 'In production, use @x402/client for automatic 402→sign→retry:');
-        log('   ', '  const { httpClient } = require("@x402/client");');
-        log('   ', '  const client = httpClient("https://agoragentic.com", walletClient);');
-        log('   ', '  const res = await client.post("/api/x402/execute", { quote_id, input });');
-
-        // For this demo, we show the manual flow
-        const executeRes = await request('POST', '/api/x402/execute', {
-            quote_id: quote.quote_id,
-            input: { text: 'x402 paid demo test' },
-        });
-
-        if (executeRes.status === 402) {
-            log('✅', '402 Payment Required received — this is the correct first step!', {
-                payment_header: executeRes.headers['payment-required'] ? 'present' : 'missing',
-                price: executeRes.body?.price_usdc,
-                how_to_pay: executeRes.body?.how_to_pay ? 'included' : 'missing',
-            });
-            log('💡', 'To complete payment, use the @x402/client SDK which handles signing automatically.');
-        } else if (executeRes.status === 200 && executeRes.body?.success) {
-            log('✅', 'Paid execution succeeded!', {
-                cost: executeRes.body.cost,
-                method: executeRes.body.payment_method,
-            });
-        } else {
-            log('❌', `Unexpected response: ${executeRes.status}`, executeRes.body);
+    if (executeRes.status === 402) {
+        const challenge = executeRes.headers['payment-required'];
+        if (!challenge) {
+            throw new Error('Received HTTP 402 without PAYMENT-REQUIRED; refusing to report a successful paid-route preflight');
         }
-
-        return executeRes.body;
-
-    } catch (err) {
-        log('⚠️', `Paid execution error: ${err.message}`);
-        log('💡', 'Install x402 packages: npm install @x402/client @x402/core @x402/evm ethers');
-        return null;
+        log('✅', '402 Payment Required received (challenge header present); preflight stops here without signing or retrying.', {
+            price: executeRes.body?.price_usdc,
+            how_to_pay: executeRes.body?.how_to_pay ? 'included' : 'missing',
+        });
+    } else if (executeRes.status === 200 && executeRes.body?.success) {
+        log('ℹ️', 'The matched route completed without a paid challenge; no payment was signed.');
+    } else {
+        log('⚠️', `Unexpected preflight response: ${executeRes.status}`, executeRes.body);
     }
+
+    return executeRes.body;
 }
 
 // ─── Step 6: Verify Invocation Proof ────────────────────
@@ -317,7 +356,7 @@ async function main() {
     console.log('║     Agent-to-Agent Commerce on Base L2           ║');
     console.log('╚══════════════════════════════════════════════════╝\n');
     console.log(`  Target: ${BASE_URL}`);
-    console.log(`  Mode:   ${isPaid ? '💰 Paid (with wallet)' : '🆓 Free (no wallet needed)'}\n`);
+    console.log(`  Mode:   ${isPaidPreflight ? '🧾 Paid-route preflight (no signing)' : '🆓 Free (no wallet needed)'}\n`);
 
     try {
         // 1. Gateway info
@@ -340,9 +379,9 @@ async function main() {
         const execResult = await step4a_freeExecution(match);
         console.log();
 
-        // 5. Paid execution (if --paid flag)
-        if (isPaid) {
-            await step5_paidExecution();
+        // 5. Paid-route preflight (if explicitly requested)
+        if (isPaidPreflight) {
+            await step5_paidPreflight();
             console.log();
         }
 
@@ -361,7 +400,7 @@ async function main() {
         log('   ', '1. Browse services:   GET  /api/x402/listings');
         log('   ', '2. Match a service:   GET  /api/x402/execute/match?task=<query>');
         log('   ', '3. Execute (free):    POST /api/x402/execute { quote_id, input }');
-        log('   ', '4. Execute (paid):    Use @x402/client for automatic 402→sign→retry');
+        log('   ', '4. Paid preflight:    Run --paid-preflight; it stops at 402 without signing');
         log('   ', '5. Verify proof:      GET  /api/x402/invocations/:id/proof');
         console.log();
         log('🔗', `API Reference: ${BASE_URL}/api/x402/info`);


### PR DESCRIPTION
## What changed

- Harden authenticated execute and x402 buyer examples around explicit positive ceilings, caller-controlled authorization, quote/challenge binding, one-attempt guards, and receipt evidence.
- Replace the legacy paid buyer demo with an unsigned paid-route preflight using the canonical Router match envelope.
- Resolve any advertised execute URL against the configured Router origin and fall back to the canonical route on an origin change.
- Fail closed when a 402 omits `PAYMENT-REQUIRED`, and add behavioral coverage for canonical, malformed, protocol-relative, and slash-backslash envelopes.
- Add the payment-contract and buyer-preflight suites to CI.

## Why

The previous examples and static tests did not adequately prove zero-ceiling, authorization, repeated-payment, ambiguous-outcome, or live response-envelope behavior. This change makes the examples conservative by default: malformed or uncertain payment state stops before signing, retrying, or spending.

## Validation

- `node --experimental-strip-types --test test/*.test.mjs` — 24 passed
- `node --test test/x402-buyer-demo-preflight.test.mjs` — 8 passed
- Integrations machine-surface, ACP, Hermes, Rust-sync, growth-validator, syntax, signature, and diff checks passed

## Sequencing

Land this hardening before continuing PR #181. PR #181 remains open and still needs its ambiguous signed-request retry doctrine corrected and revalidated.