### PR TITLE
Harden Solana payment demos and payout boundaries

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,6 +12,7 @@ on:
       - 'harness-core/**'
       - 'coinbase-agentic-wallets/**'
       - 'x402/**'
+      - 'zoneless/**'
       - 'scripts/**'
       - 'examples/agoragentic-growth/**'
       - 'test/**'
@@ -187,5 +188,9 @@ jobs:
           node-version: '24'
       - name: Test payment safety contracts
         run: node --experimental-strip-types --test test/payment-safety-contracts.test.mjs
+      - name: Test Solana payment safety contracts
+        run: node --experimental-strip-types --test test/solana-payment-safety.test.mjs
+      - name: Run Solana no-funds demo
+        run: node examples/agoragentic-growth/2026-06-21-solana-x402-paid-call-adapter-demo-mjs-c10944a6cc/solana_x402_paid_call_adapter_demo.mjs
       - name: Test x402 buyer demo preflight behavior
         run: node --test test/x402-buyer-demo-preflight.test.mjs

--- a/examples/agoragentic-growth/2026-06-21-solana-x402-paid-call-adapter-demo-mjs-c10944a6cc/solana_x402_paid_call_adapter_demo.mjs
+++ b/examples/agoragentic-growth/2026-06-21-solana-x402-paid-call-adapter-demo-mjs-c10944a6cc/solana_x402_paid_call_adapter_demo.mjs
@@ -1,108 +1,46 @@
 // demo — moves no real funds.
+// Terminology: gpt-5.6-sol is a model identifier; Solana is the network; SOL is its native token; lamports are SOL's smallest unit.
 
-import http from 'node:http';
 import assert from 'node:assert/strict';
 import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
 import { pathToFileURL } from 'node:url';
 
-const RETRYABLE_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
 const DEMO_SECRET = 'demo-x402-secret';
-const DEMO_VERSION = '0.2';
-
-function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function isRetryableNetworkError(error) {
-  if (!error) return false;
-  const code = error.code || error.cause?.code;
-  return ['ECONNRESET', 'ECONNREFUSED', 'EAI_AGAIN', 'ETIMEDOUT', 'UND_ERR_CONNECT_TIMEOUT'].includes(code);
-}
+const DEMO_VERSION = '0.3';
 
 function normalizeHeaders(headersLike = {}) {
-  const out = {};
   if (headersLike instanceof Headers) {
-    for (const [key, value] of headersLike.entries()) out[key.toLowerCase()] = value;
-    return out;
+    return Object.fromEntries([...headersLike.entries()].map(([k, v]) => [k.toLowerCase(), String(v)]));
   }
-  for (const [key, value] of Object.entries(headersLike)) {
-    out[String(key).toLowerCase()] = String(value);
+  if (Array.isArray(headersLike)) {
+    return Object.fromEntries(headersLike.map(([k, v]) => [String(k).toLowerCase(), String(v)]));
   }
-  return out;
+  return Object.fromEntries(Object.entries(headersLike).map(([k, v]) => [String(k).toLowerCase(), String(v)]));
 }
 
-function stableJson(value) {
-  if (value === null || typeof value !== 'object') return JSON.stringify(value);
-  if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
-  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`).join(',')}}`;
-}
-
-function parseMaybeJson(raw) {
-  if (!raw) return null;
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return raw;
-  }
-}
-
-async function readRequestBody(req) {
-  const chunks = [];
-  for await (const chunk of req) chunks.push(chunk);
-  return Buffer.concat(chunks).toString('utf8');
-}
-
-async function parseResponseBody(response) {
-  const contentType = response.headers.get('content-type') || '';
-  const text = await response.text();
-  if (!text) return null;
-  if (contentType.includes('application/json')) {
-    try {
-      return JSON.parse(text);
-    } catch (error) {
-      return {
-        rawBody: text,
-        parseError: error.message,
-      };
-    }
-  }
-  return text;
-}
-
-function createIdempotencyKey(prefix = 'x402-demo') {
-  return `${prefix}-${randomUUID()}`;
-}
-
-function serializeBody(body, headers) {
-  if (body === undefined || body === null) return undefined;
-  if (typeof body === 'string' || body instanceof Uint8Array || body instanceof ArrayBuffer) return body;
-  const contentType = headers.get('content-type') || '';
-  if (!contentType) headers.set('content-type', 'application/json');
-  if ((headers.get('content-type') || '').includes('application/json')) return stableJson(body);
-  return String(body);
-}
-
-function normalizeChallenge(response, body) {
-  const payload = typeof body === 'object' && body !== null ? body : {};
-  return {
-    version: response.headers.get('x402-version') || payload.version || DEMO_VERSION,
-    scheme: response.headers.get('x402-scheme') || payload.scheme || 'demo-hmac',
-    challengeId: response.headers.get('x402-challenge-id') || payload.challengeId || 'unknown-challenge',
-    payTo: response.headers.get('x402-pay-to') || payload.payTo || 'demo://sink',
-    amount: response.headers.get('x402-amount') || payload.amount || '0',
-    asset: response.headers.get('x402-asset') || payload.asset || 'SOL',
-    memo: response.headers.get('x402-memo') || payload.memo || '',
-  };
+function createAmbiguousPaidOutcome(message, details = {}) {
+  const error = new Error(message);
+  error.name = 'AmbiguousPaidOutcomeError';
+  Object.assign(error, {
+    ambiguousOutcome: true,
+    outcomeUnknown: true,
+    retryable: false,
+    paymentAuthorizationMayHaveBeenConsumed: true,
+    nextAction: 'reconcile_receipt_or_settlement',
+    ...details,
+  });
+  return error;
 }
 
 function challengeSignatureInput(challenge, idempotencyKey) {
   return [
     challenge.challengeId,
     idempotencyKey,
-    challenge.amount,
+    challenge.amount_lamports,
     challenge.asset,
+    challenge.unit,
+    challenge.network,
     challenge.payTo,
-    challenge.memo,
   ].join('|');
 }
 
@@ -115,516 +53,275 @@ export function createDemoPaymentAuthorization({ challenge, idempotencyKey, secr
 
 export function verifyDemoPaymentAuthorization({ token, challenge, idempotencyKey, secret = DEMO_SECRET }) {
   if (typeof token !== 'string' || !token.startsWith('demo-hmac:')) return false;
-  const expected = Buffer.from(createDemoPaymentAuthorization({ challenge, idempotencyKey, secret }), 'utf8');
-  const actual = Buffer.from(token, 'utf8');
+  const expected = Buffer.from(createDemoPaymentAuthorization({ challenge, idempotencyKey, secret }));
+  const actual = Buffer.from(token);
   return expected.length === actual.length && timingSafeEqual(expected, actual);
 }
 
-function createCheck(name, ok, evidence, uncertainty = null) {
-  return uncertainty ? { name, ok, evidence, uncertainty } : { name, ok, evidence };
+function normalizeChallenge(response, payload = {}) {
+  return {
+    version: response.headers.get('x402-version') || payload.version || DEMO_VERSION,
+    scheme: response.headers.get('x402-scheme') || payload.scheme || 'demo-hmac',
+    challengeId: response.headers.get('x402-challenge-id') || payload.challengeId,
+    network: response.headers.get('x402-network') || payload.network || 'solana',
+    asset: response.headers.get('x402-asset') || payload.asset || 'SOL',
+    unit: response.headers.get('x402-unit') || payload.unit || 'lamports',
+    amount_lamports: response.headers.get('x402-amount-lamports') || payload.amount_lamports,
+    payTo: response.headers.get('x402-pay-to') || payload.payTo,
+  };
 }
 
-export class X402PayKitAdapter {
-  constructor({
-    fetchImpl = globalThis.fetch,
-    baseDelayMs = 40,
-    maxDelayMs = 400,
-    userAgent = 'agoragentic-solana-pay-kit-x402-demo/1.0',
-  } = {}) {
-    if (typeof fetchImpl !== 'function') {
-      throw new Error('A fetch implementation is required (Node 18+ provides global fetch).');
-    }
+async function readJson(response) {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch (cause) {
+    const error = new Error('response body is not valid JSON');
+    error.cause = cause;
+    throw error;
+  }
+}
+
+function isRedirect(status) {
+  return status >= 300 && status < 400;
+}
+
+export class SolanaX402DemoClient {
+  constructor({ fetchImpl = globalThis.fetch } = {}) {
+    if (typeof fetchImpl !== 'function') throw new Error('fetchImpl is required');
     this.fetchImpl = fetchImpl;
-    this.baseDelayMs = baseDelayMs;
-    this.maxDelayMs = maxDelayMs;
-    this.userAgent = userAgent;
+    this.ambiguousPaymentOutcome = null;
   }
 
-  async authorizePayment({ pay, challenge, idempotencyKey, request, signal }) {
-    if (typeof pay !== 'function') {
-      throw new Error(
-        'A caller-supplied pay callback is required before any payment authorization is created.'
-      );
+  reconcile({ receiptId = null, settlementStatus = 'unknown' } = {}) {
+    if (!this.ambiguousPaymentOutcome) return false;
+    if (!receiptId && settlementStatus === 'unknown') {
+      throw new Error('reconciliation requires a receipt id or explicit settlement status');
     }
-    const result = await pay({ challenge, idempotencyKey, request, signal });
-    if (!result || typeof result.token !== 'string' || !result.token) {
-      throw new Error('pay() must resolve to an object with a non-empty token string.');
+    this.ambiguousPaymentOutcome = null;
+    return true;
+  }
+
+  async execute({ url, body = {}, pay, idempotencyKey = randomUUID(), signal } = {}) {
+    if (!url) throw new Error('url is required');
+    if (this.ambiguousPaymentOutcome) {
+      throw createAmbiguousPaidOutcome('client is locked after an ambiguous paid outcome', {
+        ...this.ambiguousPaymentOutcome,
+        blockedByPriorAmbiguousOutcome: true,
+      });
     }
+    if (typeof pay !== 'function') throw new Error('a caller-supplied pay callback is required');
+
+    const baseHeaders = new Headers({
+      accept: 'application/json',
+      'content-type': 'application/json',
+      'x-idempotency-key': idempotencyKey,
+    });
+    const requestBody = JSON.stringify(body);
+
+    let challengeResponse;
+    try {
+      challengeResponse = await this.fetchImpl(url, {
+        method: 'POST',
+        headers: baseHeaders,
+        body: requestBody,
+        signal,
+        redirect: 'manual',
+      });
+    } catch (error) {
+      throw error;
+    }
+
+    if (challengeResponse.status !== 402) {
+      return {
+        ok: challengeResponse.ok,
+        status: challengeResponse.status,
+        payload: await readJson(challengeResponse),
+        paymentAttempted: false,
+        idempotencyKey,
+      };
+    }
+
+    const challengePayload = await readJson(challengeResponse);
+    const challenge = normalizeChallenge(challengeResponse, challengePayload);
+    if (!challenge.challengeId || !challenge.amount_lamports || !challenge.payTo) {
+      throw new Error('incomplete Solana x402 challenge');
+    }
+    if (challenge.network !== 'solana' || challenge.asset !== 'SOL' || challenge.unit !== 'lamports') {
+      throw new Error('unsupported or ambiguous Solana asset/unit tuple');
+    }
+
+    const authorization = await pay({ challenge, idempotencyKey, signal });
+    if (!authorization || typeof authorization.token !== 'string' || !authorization.token) {
+      throw new Error('pay() must return a non-empty token');
+    }
+
+    const signedHeaders = new Headers(baseHeaders);
+    signedHeaders.set('authorization', `${authorization.scheme || 'X402'} ${authorization.token}`);
+    signedHeaders.set('payment-signature', authorization.token);
+
+    let paidResponse;
+    try {
+      paidResponse = await this.fetchImpl(url, {
+        method: 'POST',
+        headers: signedHeaders,
+        body: requestBody,
+        signal,
+        redirect: 'manual',
+      });
+    } catch (cause) {
+      const error = createAmbiguousPaidOutcome('paid execute outcome is unknown after network loss', {
+        cause,
+        idempotencyKey,
+        challengeId: challenge.challengeId,
+        signedRequestAttempts: 1,
+      });
+      this.ambiguousPaymentOutcome = { idempotencyKey, challengeId: challenge.challengeId, signedRequestAttempts: 1 };
+      throw error;
+    }
+
+    if (paidResponse.status === 402 || isRedirect(paidResponse.status) || !paidResponse.ok) {
+      const error = createAmbiguousPaidOutcome(`paid execute returned HTTP ${paidResponse.status}`, {
+        status: paidResponse.status,
+        idempotencyKey,
+        challengeId: challenge.challengeId,
+        signedRequestAttempts: 1,
+      });
+      this.ambiguousPaymentOutcome = { idempotencyKey, challengeId: challenge.challengeId, status: paidResponse.status, signedRequestAttempts: 1 };
+      throw error;
+    }
+
+    let payload;
+    try {
+      payload = await readJson(paidResponse);
+    } catch (cause) {
+      const error = createAmbiguousPaidOutcome('paid execute response was unreadable', {
+        cause,
+        idempotencyKey,
+        challengeId: challenge.challengeId,
+        signedRequestAttempts: 1,
+      });
+      this.ambiguousPaymentOutcome = { idempotencyKey, challengeId: challenge.challengeId, signedRequestAttempts: 1 };
+      throw error;
+    }
+
+    const headers = normalizeHeaders(paidResponse.headers);
+    const receiptId = headers['x402-receipt-id'] || payload?.receipt_id || null;
+    const echoedChallenge = headers['x402-challenge-id'] || payload?.challenge_id || null;
+    const echoedIdempotency = headers['x-idempotency-key'] || payload?.idempotency_key || null;
+    const receiptVerified = Boolean(
+      receiptId
+      && echoedChallenge === challenge.challengeId
+      && echoedIdempotency === idempotencyKey
+    );
+
     return {
-      scheme: result.scheme || 'X402',
-      token: result.token,
-      meta: result.meta || null,
-      createdAt: new Date().toISOString(),
+      ok: true,
+      status: paidResponse.status,
+      payload,
+      paymentAttempted: true,
+      paymentAuthorizationsCreated: 1,
+      signedRequestAttempts: 1,
+      idempotencyKey,
+      receipt: {
+        id: receiptId,
+        verifiedAgainstChallenge: receiptVerified,
+        settlementVerified: false,
+      },
     };
-  }
-
-  buildReceiptChecklist({
-    initialChallenge,
-    finalResponse,
-    finalBody,
-    authorization,
-    idempotencyKey,
-    attempts,
-  }) {
-    const headers = finalResponse ? normalizeHeaders(finalResponse.headers) : {};
-    const body = typeof finalBody === 'object' && finalBody !== null ? finalBody : {};
-    const authorizedAttempts = attempts.filter((item) => item.sentAuthorization);
-    const authorizationFingerprints = new Set(authorizedAttempts.map((item) => item.authorizationFingerprint));
-    const challengeIdEcho = headers['x402-challenge-id'];
-    const challengeIdMatches = !initialChallenge || challengeIdEcho === initialChallenge.challengeId;
-    const checks = [
-      createCheck(
-        'initial 402 challenge observed',
-        Boolean(initialChallenge),
-        initialChallenge
-          ? `challengeId=${initialChallenge.challengeId} amount=${initialChallenge.amount} asset=${initialChallenge.asset}`
-          : 'no 402 challenge captured'
-      ),
-      createCheck(
-        'caller-supplied authorization used',
-        Boolean(authorization?.token),
-        authorization ? `scheme=${authorization.scheme} token_prefix=${authorization.token.slice(0, 18)}` : 'missing authorization'
-      ),
-      createCheck(
-        'same idempotency key sent across attempts',
-        attempts.length > 0 && attempts.every((item) => item.idempotencyKey === idempotencyKey),
-        attempts.map((item) => item.idempotencyKey).join(', ') || 'no attempts logged'
-      ),
-      createCheck(
-        'authorization reused after transient failure instead of repaying',
-        authorizedAttempts.length <= 1 || authorizationFingerprints.size === 1,
-        authorizedAttempts
-          .map((item) => `${item.kind}:${item.status ?? 'network'}:${item.authorizationFingerprint}`)
-          .join(' | ') || 'no post-payment retry required',
-        authorizedAttempts.length <= 1 ? 'No transient post-payment retry occurred; reuse was not required.' : null
-      ),
-      createCheck(
-        'final response is success',
-        Boolean(finalResponse?.ok),
-        finalResponse ? `status=${finalResponse.status}` : 'no final response'
-      ),
-      createCheck(
-        'server echoed receipt identifiers for the paid challenge',
-        Boolean(headers['x402-receipt-id'] && challengeIdEcho && challengeIdMatches),
-        `x402-receipt-id=${headers['x402-receipt-id'] || 'missing'}, x402-challenge-id=${challengeIdEcho || 'missing'}, expected=${initialChallenge?.challengeId || 'none'}`,
-        'This only checks HTTP evidence returned by the server; it does not imply on-chain settlement.'
-      ),
-      createCheck(
-        'server receipt idempotency matches request key',
-        headers['x-idempotency-key'] === idempotencyKey || body.idempotencyKey === idempotencyKey,
-        `header=${headers['x-idempotency-key'] || 'missing'}, body=${body.idempotencyKey || 'missing'}`
-      ),
-    ];
-    return {
-      passed: checks.every((check) => check.ok),
-      checks,
-    };
-  }
-
-  async execute({
-    url,
-    method = 'POST',
-    headers = {},
-    body,
-    pay,
-    idempotencyKey = createIdempotencyKey(),
-    maxAttempts = 5,
-    signal,
-  }) {
-    if (!url) throw new Error('url is required.');
-    if (maxAttempts < 2) throw new Error('maxAttempts must be at least 2.');
-
-    let authorization = null;
-    let initialChallenge = null;
-    let lastError = null;
-    const attempts = [];
-
-    for (let attemptNumber = 1; attemptNumber <= maxAttempts; attemptNumber += 1) {
-      const requestHeaders = new Headers(headers);
-      if (!requestHeaders.has('accept')) requestHeaders.set('accept', 'application/json');
-      requestHeaders.set('x-idempotency-key', idempotencyKey);
-      requestHeaders.set('x402-client', this.userAgent);
-
-      if (authorization) {
-        requestHeaders.set('authorization', `${authorization.scheme} ${authorization.token}`);
-        requestHeaders.set('PAYMENT-SIGNATURE', authorization.token);
-      }
-
-      const serializedBody = serializeBody(body, requestHeaders);
-      const authorizationFingerprint = authorization
-        ? `${authorization.scheme}:${authorization.token.slice(0, 16)}`
-        : null;
-
-      try {
-        const response = await this.fetchImpl(url, {
-          method,
-          headers: requestHeaders,
-          body: serializedBody,
-          signal,
-        });
-
-        const responseBody = await parseResponseBody(response);
-        attempts.push({
-          attempt: attemptNumber,
-          kind: 'http',
-          status: response.status,
-          idempotencyKey,
-          sentAuthorization: Boolean(authorization),
-          authorizationFingerprint,
-        });
-
-        if (response.status === 402) {
-          if (authorization) {
-            const error = new Error('server returned 402 after payment authorization was already sent');
-            error.result = {
-              ok: false,
-              status: response.status,
-              data: responseBody,
-              headers: normalizeHeaders(response.headers),
-              authorization,
-              idempotencyKey,
-              attempts,
-            };
-            throw error;
-          }
-          const challenge = normalizeChallenge(response, responseBody);
-          if (!initialChallenge) initialChallenge = challenge;
-          authorization = await this.authorizePayment({
-            pay,
-            challenge,
-            idempotencyKey,
-            request: { url, method, headers: normalizeHeaders(requestHeaders), body },
-            signal,
-          });
-          lastError = new Error(`HTTP 402 payment required for challenge ${challenge.challengeId}`);
-          continue;
-        }
-
-        if (RETRYABLE_STATUS.has(response.status) && attemptNumber < maxAttempts) {
-          lastError = new Error(`HTTP ${response.status} retryable error`);
-          await sleep(Math.min(this.baseDelayMs * 2 ** (attemptNumber - 1), this.maxDelayMs));
-          continue;
-        }
-
-        const receiptChecklist = this.buildReceiptChecklist({
-          initialChallenge,
-          finalResponse: response,
-          finalBody: responseBody,
-          authorization,
-          idempotencyKey,
-          attempts,
-        });
-
-        if (!response.ok) {
-          const error = new Error(`HTTP ${response.status}`);
-          error.result = {
-            ok: false,
-            status: response.status,
-            data: responseBody,
-            headers: normalizeHeaders(response.headers),
-            authorization,
-            idempotencyKey,
-            attempts,
-            receiptChecklist,
-          };
-          throw error;
-        }
-
-        return {
-          ok: true,
-          status: response.status,
-          data: responseBody,
-          headers: normalizeHeaders(response.headers),
-          authorization,
-          idempotencyKey,
-          attempts,
-          receiptChecklist,
-        };
-      } catch (error) {
-        if (error.result) {
-          throw error;
-        }
-        const retryable = isRetryableNetworkError(error);
-        attempts.push({
-          attempt: attemptNumber,
-          kind: 'network-error',
-          status: null,
-          error: error.message,
-          idempotencyKey,
-          sentAuthorization: Boolean(authorization),
-          authorizationFingerprint,
-        });
-        lastError = error;
-        if (!retryable || attemptNumber >= maxAttempts) throw error;
-        await sleep(Math.min(this.baseDelayMs * 2 ** (attemptNumber - 1), this.maxDelayMs));
-      }
-    }
-
-    throw lastError || new Error('x402 execute() exhausted retries.');
   }
 }
 
-export async function startDemoServer({ secret = DEMO_SECRET } = {}) {
-  const callState = new Map();
+export function createMockSolanaX402Fetch({ mode = 'success', secret = DEMO_SECRET } = {}) {
+  const state = { calls: 0, payCalls: 0, idempotencyKeys: [], signedCalls: 0 };
+  const challenge = {
+    version: DEMO_VERSION,
+    scheme: 'demo-hmac',
+    challengeId: `challenge-${randomUUID()}`,
+    network: 'solana',
+    asset: 'SOL',
+    unit: 'lamports',
+    amount_lamports: '2500',
+    payTo: 'demo://merchant/solana',
+  };
 
-  const server = http.createServer(async (req, res) => {
-    try {
-      if (req.url !== '/paid-call') {
-        res.writeHead(404, { 'content-type': 'application/json' });
-        res.end(JSON.stringify({ error: 'not_found' }));
-        return;
-      }
+  const fetchImpl = async (_url, init = {}) => {
+    state.calls += 1;
+    const headers = new Headers(init.headers);
+    const idempotencyKey = headers.get('x-idempotency-key');
+    state.idempotencyKeys.push(idempotencyKey);
+    const token = headers.get('payment-signature');
 
-      const idempotencyKey = String(req.headers['x-idempotency-key'] || '');
-      if (!idempotencyKey) {
-        res.writeHead(400, { 'content-type': 'application/json' });
-        res.end(JSON.stringify({ error: 'missing_idempotency_key' }));
-        return;
-      }
-
-      const bodyText = await readRequestBody(req);
-      const body = parseMaybeJson(bodyText) || {};
-      const state = callState.get(idempotencyKey) || {
-        challengeId: `challenge-${randomUUID()}`,
-        payTo: 'demo://merchant/solana-foundation/pay-kit',
-        amount: '2500',
-        asset: 'lamports',
-        memo: 'demo-paid-call',
-        paidAttempts: 0,
-      };
-      callState.set(idempotencyKey, state);
-
-      const challenge = {
-        version: DEMO_VERSION,
-        scheme: 'demo-hmac',
-        challengeId: state.challengeId,
-        payTo: state.payTo,
-        amount: state.amount,
-        asset: state.asset,
-        memo: state.memo,
-      };
-
-      const authHeader = String(req.headers.authorization || '');
-      const signatureHeader = String(req.headers['payment-signature'] || '');
-      const token = signatureHeader || (authHeader.startsWith('X402 ') ? authHeader.slice(5) : '');
-
-      if (!token) {
-        res.writeHead(402, {
+    if (!token) {
+      return new Response(JSON.stringify({ error: 'payment_required', ...challenge }), {
+        status: 402,
+        headers: {
           'content-type': 'application/json',
           'x402-version': challenge.version,
           'x402-scheme': challenge.scheme,
           'x402-challenge-id': challenge.challengeId,
-          'x402-pay-to': challenge.payTo,
-          'x402-amount': challenge.amount,
+          'x402-network': challenge.network,
           'x402-asset': challenge.asset,
-          'x402-memo': challenge.memo,
-        });
-        res.end(JSON.stringify({
-          error: 'payment_required',
-          ...challenge,
-        }));
-        return;
-      }
-
-      if (!verifyDemoPaymentAuthorization({ token, challenge, idempotencyKey, secret })) {
-        res.writeHead(402, {
-          'content-type': 'application/json',
-          'x402-version': challenge.version,
-          'x402-scheme': challenge.scheme,
-          'x402-challenge-id': challenge.challengeId,
+          'x402-unit': challenge.unit,
+          'x402-amount-lamports': challenge.amount_lamports,
           'x402-pay-to': challenge.payTo,
-          'x402-amount': challenge.amount,
-          'x402-asset': challenge.asset,
-          'x402-memo': challenge.memo,
-        });
-        res.end(JSON.stringify({
-          error: 'invalid_payment_authorization',
-          ...challenge,
-        }));
-        return;
-      }
+        },
+      });
+    }
 
-      state.paidAttempts += 1;
-      callState.set(idempotencyKey, state);
+    state.signedCalls += 1;
+    assert.equal(verifyDemoPaymentAuthorization({ token, challenge, idempotencyKey, secret }), true);
+    if (mode === 'network-loss') throw Object.assign(new Error('simulated network loss'), { code: 'ECONNRESET' });
+    if (mode === 'repeat-402') return new Response(JSON.stringify({ error: 'payment_required' }), { status: 402, headers: { 'content-type': 'application/json' } });
+    if (mode === 'http-500') return new Response(JSON.stringify({ error: 'upstream_failure' }), { status: 500, headers: { 'content-type': 'application/json' } });
+    if (mode === 'redirect') return new Response('', { status: 307, headers: { location: 'https://example.invalid/other' } });
+    if (mode === 'unreadable') return new Response('{not-json', { status: 200, headers: { 'content-type': 'application/json' } });
 
-      if (state.paidAttempts === 1) {
-        res.writeHead(503, {
-          'content-type': 'application/json',
-          'retry-after': '0',
-          'x-idempotency-key': idempotencyKey,
-          'x402-challenge-id': challenge.challengeId,
-        });
-        res.end(JSON.stringify({
-          error: 'transient_upstream_failure',
-          message: 'retry with the same authorization and idempotency key',
-        }));
-        return;
-      }
-
-      res.writeHead(200, {
+    return new Response(JSON.stringify({ ok: true, settled: false }), {
+      status: 200,
+      headers: {
         'content-type': 'application/json',
-        'x402-version': challenge.version,
         'x402-receipt-id': `receipt-${randomUUID()}`,
         'x402-challenge-id': challenge.challengeId,
         'x-idempotency-key': idempotencyKey,
-      });
-      res.end(JSON.stringify({
-        ok: true,
-        item: 'paid-resource',
-        settled: false,
-        idempotencyKey,
-        requestBody: body,
-        note: 'demo server accepted the payment authorization and fulfilled the request',
-      }));
-    } catch (error) {
-      res.writeHead(500, { 'content-type': 'application/json' });
-      res.end(JSON.stringify({ error: 'server_error', message: error.message }));
-    }
-  });
-
-  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
-  const address = server.address();
-  const baseUrl = `http://127.0.0.1:${address.port}`;
-  return {
-    baseUrl,
-    close: () => new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve()))),
+      },
+    });
   };
+
+  const pay = async ({ challenge: required, idempotencyKey }) => {
+    state.payCalls += 1;
+    return {
+      scheme: 'X402',
+      token: createDemoPaymentAuthorization({ challenge: required, idempotencyKey, secret }),
+    };
+  };
+
+  return { fetchImpl, pay, state, challenge };
 }
 
 export async function demo() {
-  const demoServer = await startDemoServer();
-  const adapter = new X402PayKitAdapter();
-  const payInvocations = [];
-
-  try {
-    const result = await adapter.execute({
-      url: `${demoServer.baseUrl}/paid-call`,
-      method: 'POST',
-      body: { sku: 'pro-checkout', quantity: 1 },
-      pay: async ({ challenge, idempotencyKey }) => {
-        payInvocations.push({ challengeId: challenge.challengeId, idempotencyKey });
-        return {
-          scheme: 'X402',
-          token: createDemoPaymentAuthorization({ challenge, idempotencyKey }),
-          meta: { demo: true },
-        };
-      },
-    });
-
-    assert.equal(result.ok, true);
-    assert.equal(result.status, 200);
-    assert.equal(result.data.ok, true);
-    assert.equal(payInvocations.length, 1, 'payment authorization should be created exactly once');
-    assert.deepEqual(
-      result.attempts.filter((entry) => entry.kind === 'http').map((entry) => entry.status),
-      [402, 503, 200],
-      'expected 402 challenge, transient retry, then success'
-    );
-    assert.equal(result.receiptChecklist.passed, true);
-
-    console.log(JSON.stringify({
-      demo: 'x402 execute() retry with receipt checklist',
-      payInvocations,
-      attempts: result.attempts,
-      receiptChecklist: result.receiptChecklist,
-      response: result.data,
-    }, null, 2));
-  } finally {
-    await demoServer.close();
-  }
-}
-
-async function runEdgeCaseAssertions() {
-  const challenge = {
-    challengeId: 'challenge-single-success',
-    amount: '2500',
-    asset: 'lamports',
-    payTo: 'demo://merchant/solana-foundation/pay-kit',
-    memo: 'single-success',
-  };
-
-  let call = 0;
-  const singleSuccessAdapter = new X402PayKitAdapter({
-    fetchImpl: async (url, request) => {
-      call += 1;
-      assert.equal(request.headers.get('x-idempotency-key'), 'idem-single-success');
-      if (call === 1) {
-        return new Response(JSON.stringify({ error: 'payment_required', ...challenge }), {
-          status: 402,
-          headers: { 'content-type': 'application/json', 'x402-challenge-id': challenge.challengeId },
-        });
-      }
-      assert.equal(request.headers.get('PAYMENT-SIGNATURE'), 'single-success-token');
-      return new Response(JSON.stringify({ ok: true, idempotencyKey: 'idem-single-success' }), {
-        status: 200,
-        headers: {
-          'content-type': 'application/json',
-          'x402-receipt-id': 'receipt-single-success',
-          'x402-challenge-id': challenge.challengeId,
-          'x-idempotency-key': 'idem-single-success',
-        },
-      });
-    },
-  });
-  const singleSuccess = await singleSuccessAdapter.execute({
+  const mock = createMockSolanaX402Fetch();
+  const client = new SolanaX402DemoClient({ fetchImpl: mock.fetchImpl });
+  const result = await client.execute({
     url: 'https://example.invalid/paid-call',
-    idempotencyKey: 'idem-single-success',
+    idempotencyKey: 'idem-solana-demo',
     body: { sku: 'demo' },
-    pay: async () => ({ scheme: 'X402', token: 'single-success-token' }),
+    pay: mock.pay,
   });
-  assert.equal(singleSuccess.receiptChecklist.passed, true);
-  assert.equal(singleSuccess.attempts.filter((entry) => entry.sentAuthorization).length, 1);
-
-  let repeated402Calls = 0;
-  const repeated402Adapter = new X402PayKitAdapter({
-    fetchImpl: async () => {
-      repeated402Calls += 1;
-      return new Response(JSON.stringify({ error: 'payment_required', ...challenge }), {
-        status: 402,
-        headers: { 'content-type': 'application/json', 'x402-challenge-id': challenge.challengeId },
-      });
-    },
-  });
-  await assert.rejects(
-    repeated402Adapter.execute({
-      url: 'https://example.invalid/paid-call',
-      idempotencyKey: 'idem-repeat-402',
-      body: { sku: 'demo' },
-      pay: async () => ({ scheme: 'X402', token: 'repeat-token' }),
-    }),
-    /after payment authorization/
-  );
-  assert.equal(repeated402Calls, 2);
-
-  let malformedRetryCalls = 0;
-  const malformedRetryAdapter = new X402PayKitAdapter({
-    fetchImpl: async () => {
-      malformedRetryCalls += 1;
-      if (malformedRetryCalls === 1) {
-        return new Response('{not-json', {
-          status: 503,
-          headers: { 'content-type': 'application/json' },
-        });
-      }
-      return new Response(JSON.stringify({ ok: true, idempotencyKey: 'idem-malformed-retry' }), {
-        status: 200,
-        headers: { 'content-type': 'application/json', 'x-idempotency-key': 'idem-malformed-retry' },
-      });
-    },
-  });
-  const malformedRetryResult = await malformedRetryAdapter.execute({
-    url: 'https://example.invalid/paid-call',
-    idempotencyKey: 'idem-malformed-retry',
-    body: { sku: 'demo' },
-  });
-  assert.equal(malformedRetryResult.status, 200);
-  assert.equal(malformedRetryCalls, 2);
+  assert.equal(result.ok, true);
+  assert.equal(result.paymentAuthorizationsCreated, 1);
+  assert.equal(result.signedRequestAttempts, 1);
+  assert.equal(result.receipt.verifiedAgainstChallenge, true);
+  assert.equal(result.receipt.settlementVerified, false);
+  assert.equal(mock.state.calls, 2);
+  assert.equal(mock.state.payCalls, 1);
+  assert.equal(new Set(mock.state.idempotencyKeys).size, 1);
+  console.log(JSON.stringify({ demo: 'Solana x402 fail-closed no-funds demo', result }, null, 2));
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  runEdgeCaseAssertions()
-    .then(() => demo())
-    .catch((error) => {
+  demo().catch((error) => {
     console.error(error.stack || error.message);
     process.exitCode = 1;
   });

--- a/test/solana-payment-safety.test.mjs
+++ b/test/solana-payment-safety.test.mjs
@@ -1,0 +1,136 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  SolanaX402DemoClient,
+  createMockSolanaX402Fetch,
+} from '../examples/agoragentic-growth/2026-06-21-solana-x402-paid-call-adapter-demo-mjs-c10944a6cc/solana_x402_paid_call_adapter_demo.mjs';
+import {
+  assertSolanaAddress,
+  buildPayoutReceiptDraft,
+  parseUsdcMinorUnits,
+  toZonelessPayoutRequest,
+} from '../zoneless/agoragentic_zoneless_payouts.ts';
+
+const VALID_SOLANA_ADDRESS = '11111111111111111111111111111111';
+
+async function runMode(mode) {
+  const mock = createMockSolanaX402Fetch({ mode });
+  const client = new SolanaX402DemoClient({ fetchImpl: mock.fetchImpl });
+  const execute = () => client.execute({
+    url: 'https://example.invalid/paid-call',
+    idempotencyKey: `idem-${mode}`,
+    body: { task: mode },
+    pay: mock.pay,
+  });
+  return { mock, client, execute };
+}
+
+test('Solana demo performs one challenge and one signed success', async () => {
+  const { mock, execute } = await runMode('success');
+  const result = await execute();
+  assert.equal(result.ok, true);
+  assert.equal(result.paymentAuthorizationsCreated, 1);
+  assert.equal(result.signedRequestAttempts, 1);
+  assert.equal(result.receipt.verifiedAgainstChallenge, true);
+  assert.equal(result.receipt.settlementVerified, false);
+  assert.equal(mock.state.calls, 2);
+  assert.equal(mock.state.signedCalls, 1);
+  assert.equal(mock.state.payCalls, 1);
+  assert.equal(new Set(mock.state.idempotencyKeys).size, 1);
+});
+
+for (const mode of ['repeat-402', 'http-500', 'network-loss', 'unreadable', 'redirect']) {
+  test(`Solana demo fails closed and locks after ${mode}`, async () => {
+    const { mock, client, execute } = await runMode(mode);
+    await assert.rejects(execute, (error) => {
+      assert.equal(error.ambiguousOutcome, true);
+      assert.equal(error.retryable, false);
+      assert.equal(error.signedRequestAttempts, 1);
+      return true;
+    });
+    assert.equal(mock.state.payCalls, 1);
+    assert.equal(mock.state.signedCalls, 1);
+    await assert.rejects(execute, (error) => {
+      assert.equal(error.blockedByPriorAmbiguousOutcome, true);
+      return true;
+    });
+    assert.equal(mock.state.payCalls, 1, 'locked client must not create another payment authorization');
+    assert.equal(mock.state.signedCalls, 1, 'locked client must not replay a signed request');
+    assert.equal(client.reconcile({ settlementStatus: 'not_found' }), true);
+  });
+}
+
+test('Solana demo requires a caller-supplied pay callback', async () => {
+  const mock = createMockSolanaX402Fetch();
+  const client = new SolanaX402DemoClient({ fetchImpl: mock.fetchImpl });
+  await assert.rejects(
+    client.execute({ url: 'https://example.invalid/paid-call' }),
+    /caller-supplied pay callback/,
+  );
+  assert.equal(mock.state.calls, 0);
+});
+
+test('USDC string parsing uses exact six-decimal minor units', () => {
+  assert.equal(parseUsdcMinorUnits('12.34'), 12_340_000n);
+  assert.equal(parseUsdcMinorUnits('0.000001'), 1n);
+  assert.throws(() => parseUsdcMinorUnits('0'), /greater than zero/);
+  assert.throws(() => parseUsdcMinorUnits('-1'), /positive decimal string/);
+  assert.throws(() => parseUsdcMinorUnits('1.0000001'), /at most 6/);
+  assert.throws(() => parseUsdcMinorUnits('NaN'), /positive decimal string/);
+  assert.throws(() => parseUsdcMinorUnits('Infinity'), /positive decimal string/);
+});
+
+test('Solana address validation is local and requires a 32-byte base58 address', () => {
+  assert.doesNotThrow(() => assertSolanaAddress(VALID_SOLANA_ADDRESS));
+  assert.throws(() => assertSolanaAddress('0OIl'), /non-base58/);
+  assert.throws(() => assertSolanaAddress('1111'), /32 bytes/);
+});
+
+test('Solana USDC payout request uses exact minor-unit string and source receipts', () => {
+  const request = toZonelessPayoutRequest({
+    sellerId: 'seller-1',
+    amountUsdc: '12.34',
+    solanaWallet: VALID_SOLANA_ADDRESS,
+    sourceReceipts: ['receipt-1'],
+  });
+  assert.equal(request.amount, '12340000');
+  assert.equal(request.currency, 'usdc');
+  assert.equal(request.destination, VALID_SOLANA_ADDRESS);
+  assert.throws(() => toZonelessPayoutRequest({
+    sellerId: 'seller-1',
+    amountUsdc: '1',
+    solanaWallet: VALID_SOLANA_ADDRESS,
+    sourceReceipts: [],
+  }), /source Agoragentic receipts/);
+});
+
+test('submitted is not confirmed and confirmation requires explicit settlement evidence', () => {
+  const submitted = buildPayoutReceiptDraft({
+    sellerId: 'seller-1',
+    amountUsdc: '5.00',
+    sourceReceipts: ['receipt-1'],
+    payoutTx: 'demo-signature',
+  });
+  assert.equal(submitted.status, 'submitted');
+  assert.equal(submitted.settlement_confirmed, false);
+
+  assert.throws(() => buildPayoutReceiptDraft({
+    sellerId: 'seller-1',
+    amountUsdc: '5.00',
+    sourceReceipts: ['receipt-1'],
+    payoutTx: 'demo-signature',
+    status: 'confirmed',
+  }), /explicit settlement confirmation/);
+
+  const confirmed = buildPayoutReceiptDraft({
+    sellerId: 'seller-1',
+    amountUsdc: '5.00',
+    sourceReceipts: ['receipt-1'],
+    payoutTx: 'demo-signature',
+    status: 'confirmed',
+    settlementConfirmed: true,
+  });
+  assert.equal(confirmed.status, 'confirmed');
+  assert.equal(confirmed.settlement_confirmed, true);
+});

--- a/zoneless/README.md
+++ b/zoneless/README.md
@@ -2,12 +2,22 @@
 
 Zoneless is useful to Agoragentic as a **Solana USDC seller-payout reference**, not as core payment architecture.
 
-Product boundary:
+## Terminology
+
+- `gpt-5.6-sol` is a model identifier and is unrelated to cryptocurrency.
+- **Solana** is the network.
+- **SOL** is Solana's native token.
+- **Lamports** are the smallest unit of SOL.
+- **USDC** in this folder means an SPL-token seller payout asset, not SOL.
+
+## Product boundary
 
 - Agoragentic remains the Agent OS, Router, Marketplace, x402, receipt, governance, and reconciliation system.
 - Base remains canonical internal accounting and seller settlement in V1.
-- Zoneless-style Solana payout is an optional future seller payout rail only.
+- Zoneless-style Solana USDC payout is an optional future seller payout rail only.
 - This folder is experimental and does not make Solana seller payouts live.
+- Solana seller payouts are separate from x402 buyer execution.
+- Examples and tests use local or mocked authorization and move no real funds.
 
 ## Fit
 
@@ -16,9 +26,9 @@ Use Zoneless patterns for:
 - seller payout account UX
 - Solana wallet onboarding
 - payout object/status models
-- batch payout construction
+- manually approved batch payout construction
 - payout webhooks
-- payout receipts
+- payout receipts and reconciliation
 
 Do not use Zoneless for:
 
@@ -34,11 +44,15 @@ Do not use Zoneless for:
 ```text
 Seller earns through Agoragentic
 -> Agoragentic records Base-canonical earning
--> seller payout preference chooses optional rail
--> approved batch payout is built
+-> seller payout preference chooses optional Solana USDC rail
+-> owner-approved batch payout is built
 -> operator/platform signs and broadcasts
--> Agoragentic writes seller payout receipt
+-> status becomes submitted (not confirmed)
+-> independent confirmation evidence is collected
+-> Agoragentic writes a confirmed seller payout receipt
 ```
+
+A transaction signature or broadcast response is **not** proof of settlement. `submitted` must remain distinct from `confirmed`.
 
 ## Example policy
 
@@ -56,7 +70,7 @@ Seller earns through Agoragentic
 
 ## Files
 
-- `agoragentic_zoneless_payouts.ts` provides boundary checks and receipt-shaping helpers.
+- `agoragentic_zoneless_payouts.ts` provides boundary checks, exact USDC minor-unit parsing, local Solana-address validation, and receipt-shaping helpers.
 
 ## Implementation notes
 
@@ -69,7 +83,7 @@ server/modules/solana-payout-adapter.js
 server/modules/payout-receipt-builder.js
 ```
 
-Do not import the whole Zoneless application into the Agoragentic API server.
+Do not import the whole Zoneless application into the Agoragentic API server. Production implementation must add trusted signing isolation, RPC confirmation policy, finality requirements, replay protection, webhook authentication, reconciliation, and operator approval receipts before any payout can become live.
 
 ## References
 

--- a/zoneless/agoragentic_zoneless_payouts.ts
+++ b/zoneless/agoragentic_zoneless_payouts.ts
@@ -1,10 +1,15 @@
 /**
  * Experimental Agoragentic + Zoneless payout bridge.
  *
+ * Terminology:
+ * - `gpt-5.6-sol` is a model identifier and is unrelated to crypto.
+ * - Solana is the network; SOL is its native token; lamports are SOL's smallest unit.
+ * - This helper models optional Solana USDC seller payouts only.
+ *
  * Boundary:
  * - Agoragentic remains the Agent OS / Router / Marketplace / receipt system.
  * - Base remains canonical internal accounting and seller settlement in V1.
- * - Zoneless-style Solana USDC payout is only an optional future seller payout rail.
+ * - Solana USDC payout is only an optional future seller payout rail.
  * - Do not use this helper for buyer execution, x402, runtime funding, or Solana intake normalization.
  */
 
@@ -19,6 +24,13 @@ export type AgoragenticSellerPayoutPreference = {
   requires_owner_approval: true;
 };
 
+export type AgoragenticPayoutStatus =
+  | "draft"
+  | "pending_signature"
+  | "submitted"
+  | "confirmed"
+  | "failed";
+
 export type AgoragenticPayoutReceiptDraft = {
   receipt_type: "seller_payout";
   seller_id: string;
@@ -27,13 +39,15 @@ export type AgoragenticPayoutReceiptDraft = {
   payout_network: "solana";
   payout_asset: "USDC";
   amount_usdc: string;
+  amount_minor_units: string;
   source_receipts: string[];
   payout_tx?: string;
-  status: "draft" | "pending_signature" | "paid" | "failed";
+  status: AgoragenticPayoutStatus;
+  settlement_confirmed: boolean;
 };
 
 export type ZonelessPayoutRequest = {
-  amount: number;
+  amount: string;
   currency: "usdc";
   destination: string;
   metadata: {
@@ -43,6 +57,47 @@ export type ZonelessPayoutRequest = {
   };
 };
 
+const BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+const BASE58_INDEX = new Map([...BASE58_ALPHABET].map((char, index) => [char, index]));
+
+export function parseUsdcMinorUnits(amountUsdc: string): bigint {
+  if (typeof amountUsdc !== "string") throw new Error("USDC amount must be a string");
+  const normalized = amountUsdc.trim();
+  if (!/^(?:0|[1-9]\d*)(?:\.\d{1,6})?$/.test(normalized)) {
+    throw new Error("USDC amount must be a positive decimal string with at most 6 fractional digits");
+  }
+  const [whole, fraction = ""] = normalized.split(".");
+  const minor = BigInt(whole) * 1_000_000n + BigInt(fraction.padEnd(6, "0"));
+  if (minor <= 0n) throw new Error("USDC amount must be greater than zero");
+  return minor;
+}
+
+export function decodeBase58(value: string): Uint8Array {
+  if (!value || typeof value !== "string") throw new Error("Solana address must be a non-empty string");
+  let number = 0n;
+  for (const char of value) {
+    const digit = BASE58_INDEX.get(char);
+    if (digit === undefined) throw new Error("Solana address contains non-base58 characters");
+    number = number * 58n + BigInt(digit);
+  }
+  const bytes: number[] = [];
+  while (number > 0n) {
+    bytes.push(Number(number & 255n));
+    number >>= 8n;
+  }
+  bytes.reverse();
+  const leadingZeroes = [...value].findIndex((char) => char !== "1");
+  const prefixLength = leadingZeroes === -1 ? value.length : leadingZeroes;
+  return Uint8Array.from([...new Array(prefixLength).fill(0), ...bytes]);
+}
+
+export function assertSolanaAddress(address: string): void {
+  const decoded = decodeBase58(address);
+  if (decoded.length !== 32) {
+    throw new Error(`Solana address must decode to 32 bytes; received ${decoded.length}`);
+  }
+}
+
 export function assertZonelessPayoutBoundary(preference: AgoragenticSellerPayoutPreference) {
   if (preference.canonical_balance_network !== "base") {
     throw new Error("Agoragentic seller balances must remain Base-canonical");
@@ -50,11 +105,12 @@ export function assertZonelessPayoutBoundary(preference: AgoragenticSellerPayout
   if (preference.canonical_balance_asset !== "USDC" || preference.preferred_payout_asset !== "USDC") {
     throw new Error("Only USDC payout assets are in scope");
   }
-  if (preference.preferred_payout_network === "solana" && !preference.solana_wallet) {
-    throw new Error("Solana payout preference requires a seller Solana wallet");
+  if (preference.preferred_payout_network === "solana") {
+    if (!preference.solana_wallet) throw new Error("Solana payout preference requires a seller Solana wallet");
+    assertSolanaAddress(preference.solana_wallet);
   }
   if (preference.payout_mode !== "manual_batch" || preference.requires_owner_approval !== true) {
-    throw new Error("Experimental Zoneless payout bridge requires manual batch approval");
+    throw new Error("Experimental Solana payout bridge requires manual batch approval");
   }
 }
 
@@ -64,11 +120,14 @@ export function toZonelessPayoutRequest(input: {
   solanaWallet: string;
   sourceReceipts: string[];
 }): ZonelessPayoutRequest {
-  if (!input.sourceReceipts.length) {
-    throw new Error("Seller payout must link to source Agoragentic receipts");
+  if (!input.sellerId.trim()) throw new Error("Seller id is required");
+  if (!input.sourceReceipts.length || input.sourceReceipts.some((receipt) => !receipt.trim())) {
+    throw new Error("Seller payout must link to non-empty source Agoragentic receipts");
   }
+  assertSolanaAddress(input.solanaWallet);
+  const minorUnits = parseUsdcMinorUnits(input.amountUsdc);
   return {
-    amount: Math.round(Number(input.amountUsdc) * 100),
+    amount: minorUnits.toString(),
     currency: "usdc",
     destination: input.solanaWallet,
     metadata: {
@@ -84,10 +143,27 @@ export function buildPayoutReceiptDraft(input: {
   amountUsdc: string;
   sourceReceipts: string[];
   payoutTx?: string;
-  paid?: boolean;
+  status?: AgoragenticPayoutStatus;
+  settlementConfirmed?: boolean;
 }): AgoragenticPayoutReceiptDraft {
-  if (!input.sourceReceipts.length) {
-    throw new Error("Payout receipt requires source receipts");
+  if (!input.sellerId.trim()) throw new Error("Seller id is required");
+  if (!input.sourceReceipts.length || input.sourceReceipts.some((receipt) => !receipt.trim())) {
+    throw new Error("Payout receipt requires non-empty source receipts");
+  }
+  const minorUnits = parseUsdcMinorUnits(input.amountUsdc);
+  const status = input.status ?? (input.payoutTx ? "submitted" : "draft");
+  const settlementConfirmed = input.settlementConfirmed === true;
+  if (status === "confirmed" && !input.payoutTx) {
+    throw new Error("Confirmed payout requires a transaction signature");
+  }
+  if (status === "confirmed" && !settlementConfirmed) {
+    throw new Error("Confirmed payout requires explicit settlement confirmation");
+  }
+  if (settlementConfirmed && status !== "confirmed") {
+    throw new Error("Settlement confirmation is only valid for confirmed payouts");
+  }
+  if (input.payoutTx && status === "draft") {
+    throw new Error("A payout with a transaction signature cannot remain draft");
   }
   return {
     receipt_type: "seller_payout",
@@ -97,8 +173,10 @@ export function buildPayoutReceiptDraft(input: {
     payout_network: "solana",
     payout_asset: "USDC",
     amount_usdc: input.amountUsdc,
-    source_receipts: input.sourceReceipts,
+    amount_minor_units: minorUnits.toString(),
+    source_receipts: [...input.sourceReceipts],
     payout_tx: input.payoutTx,
-    status: input.paid ? "paid" : input.payoutTx ? "pending_signature" : "draft",
+    status,
+    settlement_confirmed: settlementConfirmed,
   };
 }


### PR DESCRIPTION
## Summary
- Clarifies that `gpt-5.6-sol` is a model identifier, while Solana, SOL, lamports, and USDC are payment terms.
- Replaces the Solana x402 demo's signed-request replay behavior with a fail-closed one-challenge/one-signed-attempt flow.
- Locks the client after network loss, repeat 402, redirects, unreadable paid responses, or signed HTTP failures until receipt/settlement reconciliation.
- Replaces floating-point Solana USDC payout conversion with exact six-decimal string parsing.
- Adds local 32-byte base58 Solana address validation and separates submitted from confirmed payout state.
- Adds mocked/no-funds Solana payment and payout tests to CI.

## Validation
- [x] Validate Machine Surfaces workflow
- [x] Existing payment safety contracts
- [x] Solana payment safety contracts
- [x] Solana no-funds demo
- [x] x402 buyer preflight contracts

GitHub Actions run 529 completed successfully with both `validate` and `payment-contracts` green.

## Safety
- No real Solana RPC calls
- No real signing
- No real funds
- No production mutation
- No live payout enablement
- Draft PR only

## Terminology
`gpt-5.6-sol` remains the model name. This patch only hardens Solana/SOL/lamports/USDC surfaces.