### PR TITLE
docs: add integration navigator and adapter template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,13 +13,14 @@ Thank you for your interest in contributing! This repo maintains drop-in integra
 
 1. **Fork** this repository
 2. Create a **feature branch** (`git checkout -b feat/my-framework-adapter`)
-3. Follow the existing patterns:
+3. For a new framework adapter, start with the [adapter template kit](./templates/adapter/README.md). It includes a safe execute-first module, a copyable README outline, and the required manifest/checklist steps.
+4. Follow the existing patterns:
    - One folder per framework
    - Include a `README.md` in your folder with install, env vars, and example
    - Put `agoragentic_execute` and `agoragentic_match` first for new examples
    - Keep `agoragentic_search`, `agoragentic_invoke`, and vault/passport helpers as compatibility tools when a framework still needs them
-4. **Test** against the live API at `https://agoragentic.com`
-5. Open a **Pull Request** with:
+5. **Test** against the live API at `https://agoragentic.com`
+6. Open a **Pull Request** with:
    - What framework you're integrating
    - What tools are supported
    - A working example
@@ -31,6 +32,7 @@ Thank you for your interest in contributing! This repo maintains drop-in integra
 - **Tool names**: must match the canonical tool IDs in [`integrations.json`](./integrations.json), with execute-first examples preferred
 - **Auth**: use `AGORAGENTIC_API_KEY` env var, `amk_` prefix, `Authorization: Bearer` header
 - **Errors**: return structured error messages, never crash the agent
+- **Manifest + README**: add the integration to `integrations.json` and to the root [Available Integrations](./README.md#available-integrations) table; the template checklist covers both surfaces
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -83,17 +83,15 @@ curl "https://agoragentic.com/api/commerce/receipts/rcpt_YOUR_RECEIPT" \
 - Plug into MCP, OpenAI Agents, LangChain, CrewAI, AutoGen, smolagents, and more
 - Deploy governed agents through Agent OS with budgets, approvals, and policy
 
-## Start Here
+## Start Here — choose one path
 
-Do this before you pick a framework adapter:
+| I want to... | Start with | What happens next |
+|---|---|---|
+| **Integrate an existing agent or framework** | Pick a ready adapter from [Available Integrations](#available-integrations), then follow the [5-Minute Buyer Quickstart](#5-minute-buyer-quickstart). | Use `match()` to preview and `execute()` to route work; inspect the resulting receipt. Use the [x402 buyer example](./x402/README.md) only when a direct paid-edge flow is the right fit. |
+| **Govern an agent locally before any hosted step** | [Micro ECF](./micro-ecf/README.md) for local policy, source maps, approvals, and Harness exports. | Use [ECF Core](https://github.com/rhein1/agoragentic-ecf-core) only when the local artifact workflow is no longer enough and you need a self-hosted context-governance runtime. |
+| **Preview or deploy a governed agent** | [Agent OS control-plane examples](./agent-os/README.md). | Start with no-spend readiness and preview. A deployment request, funding, public exposure, marketplace selling, and x402 monetization are separate approval-gated steps. |
 
-1. `POST /api/quickstart`
-2. `POST /api/execute` with task `echo`
-3. optionally `GET /api/execute/match?task=...`
-4. `POST /api/execute` for real routed work
-5. `GET /api/execute/status/{invocation_id}` or `GET /api/commerce/receipts/{receipt_id}`
-
-Do **not** start with `GET /api/capabilities` or `POST /api/invoke/{listing_id}` unless you are intentionally choosing a specific provider.
+New integrations should follow the [adapter template kit](./templates/adapter/README.md), not copy a legacy adapter blindly. Do **not** start with `GET /api/capabilities` or `POST /api/invoke/{listing_id}` unless you intentionally need a specific provider.
 
 ## What Your Agent Gets
 
@@ -470,7 +468,7 @@ File: `~/.codeium/windsurf/mcp_config.json`
 
 ## Contributing
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md). New framework adapters welcome — one folder, one README, matching tool names.
+See [CONTRIBUTING.md](./CONTRIBUTING.md). New framework adapters should begin with the [adapter template kit](./templates/adapter/README.md), then add one framework folder, one README, and matching tool names.
 
 ## Security
 

--- a/templates/adapter/CHECKLIST.md
+++ b/templates/adapter/CHECKLIST.md
@@ -1,0 +1,28 @@
+# New Adapter Checklist
+
+## Before coding
+
+- [ ] Pick a root-level framework folder name that does not collide with an existing integration.
+- [ ] Read `integrations.json`, `integrations.schema.json`, and the closest current adapter for the target language.
+- [ ] Confirm the language is supported by the schema (`python`, `javascript`, `typescript`, `json`, or `rust`). Adding another language requires a schema change and validation update.
+
+## Adapter and README
+
+- [ ] Lead examples with `agoragentic_match` and `agoragentic_execute`.
+- [ ] Read authentication from `AGORAGENTIC_API_KEY`; never commit a key or a real receipt containing private data.
+- [ ] Return structured errors and preserve HTTP status/retry information where the framework permits it.
+- [ ] Add a framework README with install, configuration, match/execute example, supported tools, receipt location, and safety boundary.
+
+## Discovery surfaces
+
+- [ ] Add the framework to `integrations.json` with a valid id, language, status, path, install command, and README path.
+- [ ] Add the same framework to the root README's **Available Integrations** table.
+- [ ] Do not add the template kit itself to `integrations.json` or the integration table.
+
+## Validate and submit
+
+- [ ] Run `node scripts/verify-integrations-json.js`.
+- [ ] Run `node scripts/verify-acp.js` when changing ACP-facing files.
+- [ ] Run the framework's focused tests or a safe local example.
+- [ ] Run `git diff --check`.
+- [ ] In the pull request, state the framework, supported canonical tools, validation, and any live API test boundary.

--- a/templates/adapter/README.md
+++ b/templates/adapter/README.md
@@ -1,0 +1,46 @@
+# Adapter Template Kit
+
+Use this kit when adding a new Agoragentic integration. It is a contributor starting point, not a shipped framework adapter and must not be added to `integrations.json`.
+
+## Copy and adapt
+
+1. Create one root-level folder named for the framework, for example `my-framework/`.
+2. Copy `agoragentic_adapter.mjs` into that folder and adapt only the framework-specific registration layer.
+3. Copy the README outline below into `my-framework/README.md`.
+4. Complete [`CHECKLIST.md`](./CHECKLIST.md) before opening a pull request.
+
+New examples should lead with `agoragentic_match` and `agoragentic_execute`. Use compatibility helpers such as search or direct invoke only when the framework needs that specific behavior.
+
+## README outline
+
+```md
+# Agoragentic + <Framework>
+
+## What this adapter does
+
+One sentence describing how the framework calls `match()` and `execute()`.
+
+## Install
+
+<framework install command>
+
+## Configure
+
+Set `AGORAGENTIC_API_KEY` through the framework's normal secret/environment mechanism. Never commit a key.
+
+## Example
+
+Show a `match()` preview, then an `execute()` call with a bounded input. Explain where to inspect the returned receipt.
+
+## Supported tools
+
+List canonical `agoragentic_*` IDs and identify any compatibility-only tools.
+
+## Safety boundary
+
+State whether the example is no-spend, can route paid work, or needs separate owner approval.
+```
+
+## Template boundary
+
+The module uses Node 18+ native `fetch` and reads authentication only from `AGORAGENTIC_API_KEY`. It deliberately does not register an API key, publish a listing, activate x402, or create a deployment.

--- a/templates/adapter/agoragentic_adapter.mjs
+++ b/templates/adapter/agoragentic_adapter.mjs
@@ -1,0 +1,78 @@
+const DEFAULT_BASE_URL = 'https://agoragentic.com';
+
+export class AgoragenticAdapterError extends Error {
+  constructor({ code, message, status, retryable = false, details = null }) {
+    super(message);
+    this.name = 'AgoragenticAdapterError';
+    this.code = code;
+    this.status = status;
+    this.retryable = retryable;
+    this.details = details;
+  }
+}
+
+function getApiKey() {
+  const apiKey = process.env.AGORAGENTIC_API_KEY;
+  if (!apiKey) {
+    throw new AgoragenticAdapterError({
+      code: 'missing_api_key',
+      message: 'AGORAGENTIC_API_KEY is required for authenticated router calls.',
+      status: 401
+    });
+  }
+  return apiKey;
+}
+
+async function request(path, { method = 'GET', body } = {}) {
+  const response = await fetch(`${process.env.AGORAGENTIC_BASE_URL || DEFAULT_BASE_URL}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${getApiKey()}`,
+      ...(body ? { 'Content-Type': 'application/json' } : {})
+    },
+    ...(body ? { body: JSON.stringify(body) } : {})
+  });
+
+  const payload = await response.json().catch(() => null);
+  if (!response.ok) {
+    throw new AgoragenticAdapterError({
+      code: payload?.error?.code || payload?.code || 'router_request_failed',
+      message: payload?.error?.message || payload?.message || `Router request failed with HTTP ${response.status}.`,
+      status: response.status,
+      retryable: response.status === 429 || response.status >= 500,
+      details: payload
+    });
+  }
+  return payload;
+}
+
+/** Preview eligible providers before any routed execution. */
+export async function agoragentic_match(task) {
+  if (!task || typeof task !== 'string') {
+    throw new AgoragenticAdapterError({
+      code: 'invalid_task',
+      message: 'task must be a non-empty string.',
+      status: 400
+    });
+  }
+  return request(`/api/execute/match?task=${encodeURIComponent(task)}`);
+}
+
+/** Route work through the marketplace and return the execution result plus receipt reference. */
+export async function agoragentic_execute(task, input, { maxCost } = {}) {
+  if (!task || typeof task !== 'string') {
+    throw new AgoragenticAdapterError({
+      code: 'invalid_task',
+      message: 'task must be a non-empty string.',
+      status: 400
+    });
+  }
+  return request('/api/execute', {
+    method: 'POST',
+    body: {
+      task,
+      input,
+      ...(maxCost === undefined ? {} : { constraints: { max_cost: maxCost } })
+    }
+  });
+}


### PR DESCRIPTION
## What changed

- Reworked the existing Start Here section into three routes: framework integration, local governance, and hosted preview/deployment.
- Added a copyable adapter template module, README outline, and submission checklist.
- Linked the template from contributing and the root README.

## Why

Contributors and new users need a concise first decision plus a current execute-first adapter baseline.

## Validation

- `node scripts/verify-integrations-json.js`
- `node scripts/verify-acp.js`
- `node --check templates/adapter/agoragentic_adapter.mjs`
- `git diff --check`