### PR TITLE
feat(integrations): add Griptape, LiveKit, and Pipecat adapters

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -210,6 +210,8 @@ jobs:
           python-version: '3.x'
       - name: Test forked conformance agent
         run: node --test test/adapter-conformance-agent.test.mjs
+      - name: Test framework adapter contracts
+        run: node --test test/framework-adapter-contracts.test.mjs
       - name: Validate every integration offline
         run: node scripts/adapter-conformance-agent.mjs --jobs 4 --report "${RUNNER_TEMP}/adapter-conformance-report.json"
       - name: Upload conformance evidence

--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ The hosted Triptych OS (Agent OS) control plane is not a downloadable npm packag
 | [**pydantic-ai**](pydantic-ai/) | Python | ✅ Ready | `pydantic-ai/agoragentic_pydantic.py` | [README](pydantic-ai/README.md) |
 | [**smolagents (HuggingFace)**](smolagents/) | Python | ✅ Ready | `smolagents/agoragentic_smolagents.py` | [README](smolagents/README.md) |
 | [**Agno (Phidata)**](agno/) | Python | ✅ Ready | `agno/agoragentic_agno.py` | [README](agno/README.md) |
+| [**Griptape**](griptape/) | Python | Beta | `griptape/agoragentic_griptape.py` | [README](griptape/README.md) |
+| [**LiveKit Agents**](livekit-agents/) | Python | Beta | `livekit-agents/agoragentic_livekit.py` | [README](livekit-agents/README.md) |
+| [**Pipecat**](pipecat/) | Python | Beta | `pipecat/agoragentic_pipecat.py` | [README](pipecat/README.md) |
 | [**MetaGPT**](metagpt/) | Python | ✅ Ready | `metagpt/agoragentic_metagpt.py` | [README](metagpt/README.md) |
 | [**LlamaIndex**](llamaindex/) | Python | ✅ Ready | `llamaindex/agoragentic_llamaindex.py` | [README](llamaindex/README.md) |
 | [**AutoGPT**](autogpt/) | Python | ✅ Ready | `autogpt/agoragentic_autogpt.py` | [README](autogpt/README.md) |

--- a/griptape/README.md
+++ b/griptape/README.md
@@ -1,0 +1,46 @@
+# Agoragentic + Griptape
+
+Use native Griptape tool activities to preview Agent OS providers and route receipt-backed work through `execute()`.
+
+## Status
+
+`beta` - the adapter is covered by hermetic activity-shape and request-mapping tests. CI does not call a Griptape model driver or the live Agoragentic API.
+
+## Install
+
+```bash
+pip install griptape requests
+```
+
+## Configure
+
+Set `AGORAGENTIC_API_KEY` in the process environment. `AGORAGENTIC_BASE_URL` is optional and defaults to `https://agoragentic.com`.
+
+## Example
+
+```python
+from griptape.structures import Agent
+
+from agoragentic_griptape import AgoragenticTool
+
+agent = Agent(
+    tools=[AgoragenticTool()],
+    input="Preview providers before execution and keep the cost at or below {{ args[0] }} USDC.",
+)
+agent.run(0.10)
+```
+
+For deterministic application control, invoke `agoragentic_match` before `agoragentic_execute` and require the latter to carry a bounded `max_cost`.
+
+## Supported activities
+
+- `agoragentic_execute`: routed execution with optional `max_cost`; may spend up to the accepted listing price.
+- `agoragentic_match`: no-spend provider and price preview.
+
+Successful execution responses contain the platform result and receipt fields. HTTP failures preserve status, retryability, and `Retry-After` when present.
+
+## Safety boundary
+
+Importing or constructing `AgoragenticTool` performs no network call. `agoragentic_match` is no-spend. `agoragentic_execute` can route paid work when an agent invokes it with an authenticated key, so use `max_cost` plus your Agent OS budget and approval policy.
+
+Official framework references: [Griptape agents](https://docs.griptape.ai/stable/griptape-framework/structures/agents/) and [custom tools](https://docs.griptape.ai/stable/griptape-framework/tools/custom-tools/).

--- a/griptape/adapter.test.py
+++ b/griptape/adapter.test.py
@@ -1,0 +1,118 @@
+import functools
+import importlib.util
+import pathlib
+import sys
+import types
+import unittest
+
+
+class BaseTool:
+    def __init__(self, **kwargs):
+        self.name = kwargs.get("name", self.__class__.__name__)
+
+
+def activity(*, config):
+    def decorate(function):
+        @functools.wraps(function)
+        def wrapped(self, *, params):
+            return function(self, values=params["values"])
+        wrapped.activity_config = config
+        return wrapped
+    return decorate
+
+
+class Schema:
+    def __init__(self, value):
+        self.value = value
+
+
+class SchemaOptional:
+    def __init__(self, key, default=None):
+        self.key = key
+        self.default = default
+
+
+class Or:
+    def __init__(self, *values):
+        self.values = values
+
+
+griptape = types.ModuleType("griptape")
+griptape_tools = types.ModuleType("griptape.tools")
+griptape_tools.BaseTool = BaseTool
+griptape_utils = types.ModuleType("griptape.utils")
+griptape_decorators = types.ModuleType("griptape.utils.decorators")
+griptape_decorators.activity = activity
+schema_module = types.ModuleType("schema")
+schema_module.Optional = SchemaOptional
+schema_module.Or = Or
+schema_module.Schema = Schema
+sys.modules["griptape"] = griptape
+sys.modules["griptape.tools"] = griptape_tools
+sys.modules["griptape.utils"] = griptape_utils
+sys.modules["griptape.utils.decorators"] = griptape_decorators
+sys.modules["schema"] = schema_module
+
+spec = importlib.util.spec_from_file_location(
+    "agoragentic_griptape",
+    pathlib.Path(__file__).with_name("agoragentic_griptape.py"),
+)
+adapter = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(adapter)
+
+
+class FakeResponse:
+    def __init__(self, payload=None):
+        self.status_code = 200
+        self._payload = payload or {"ok": True}
+        self.headers = {}
+        self.text = ""
+
+    def json(self):
+        return self._payload
+
+
+class FakeSession:
+    def __init__(self):
+        self.calls = []
+
+    def request(self, method, url, **kwargs):
+        self.calls.append((method, url, kwargs))
+        if url.endswith("/api/execute"):
+            return FakeResponse({"receipt_id": "receipt-griptape-test"})
+        return FakeResponse({"providers": []})
+
+
+class GriptapeAdapterTest(unittest.TestCase):
+    def test_activity_shape_request_mapping_and_cost_ceiling(self):
+        session = FakeSession()
+        tool = adapter.AgoragenticTool(api_key="test-key", session=session)
+        self.assertEqual(session.calls, [])
+        self.assertTrue(hasattr(tool.agoragentic_execute, "activity_config"))
+        self.assertTrue(hasattr(tool.agoragentic_match, "activity_config"))
+
+        result = tool.agoragentic_execute(
+            params={"values": {"task": "review code", "input_data": {"repo": "demo"}, "max_cost": 0.1}}
+        )
+        preview = tool.agoragentic_match(params={"values": {"task": "review code", "max_cost": 0.1}})
+
+        self.assertEqual(result["receipt_id"], "receipt-griptape-test")
+        self.assertEqual(preview, {"providers": []})
+        execute_call = session.calls[0]
+        self.assertEqual(execute_call[0:2], ("POST", "https://agoragentic.com/api/execute"))
+        self.assertEqual(execute_call[2]["json"]["constraints"], {"max_cost": 0.1})
+        self.assertNotIn("provider_id", execute_call[2]["json"])
+        self.assertEqual(session.calls[1][0:2], ("GET", "https://agoragentic.com/api/execute/match"))
+
+    def test_invalid_ceiling_fails_before_network(self):
+        session = FakeSession()
+        tool = adapter.AgoragenticTool(session=session)
+        negative = tool.agoragentic_execute(params={"values": {"task": "review", "max_cost": -1}})
+        non_finite = tool.agoragentic_match(params={"values": {"task": "review", "max_cost": float("nan")}})
+        self.assertEqual(negative["error"]["code"], "invalid_input")
+        self.assertEqual(non_finite["error"]["code"], "invalid_input")
+        self.assertEqual(session.calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/griptape/agoragentic_griptape.py
+++ b/griptape/agoragentic_griptape.py
@@ -1,0 +1,189 @@
+"""Execute-first Agoragentic activities for Griptape agents and workflows."""
+
+import math
+import os
+from typing import Any, Dict, Optional
+
+from griptape.tools import BaseTool
+from griptape.utils.decorators import activity
+from schema import Optional as SchemaOptional
+from schema import Or, Schema
+
+
+DEFAULT_BASE_URL = "https://agoragentic.com"
+RETRYABLE_STATUSES = {408, 425, 429, 500, 502, 503, 504}
+
+
+def _validation_error(message: str) -> Dict[str, Any]:
+    return {
+        "ok": False,
+        "error": {"code": "invalid_input", "message": message},
+        "retryable": False,
+    }
+
+
+def _valid_max_cost(value: Optional[float]) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        return value >= 0
+    return isinstance(value, float) and math.isfinite(value) and value >= 0
+
+
+class AgoragenticClient:
+    """HTTP client shared by the Griptape activity methods."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        session: Any = None,
+    ) -> None:
+        self.api_key = os.getenv("AGORAGENTIC_API_KEY", "") if api_key is None else api_key
+        self.base_url = (base_url or os.getenv("AGORAGENTIC_BASE_URL") or DEFAULT_BASE_URL).rstrip("/")
+        if session is None:
+            try:
+                import requests
+            except ImportError as exc:
+                raise RuntimeError("Install requests to use the Griptape adapter") from exc
+            session = requests.Session()
+        self.session = session
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {"Accept": "application/json", "Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    def _request(self, method: str, path: str, timeout: int, **kwargs: Any) -> Dict[str, Any]:
+        try:
+            response = self.session.request(
+                method,
+                f"{self.base_url}{path}",
+                headers=self._headers(),
+                timeout=timeout,
+                **kwargs,
+            )
+        except Exception as exc:
+            return {
+                "ok": False,
+                "error": {"code": "network_error", "message": str(exc)[:500]},
+                "retryable": True,
+            }
+
+        status_code = int(getattr(response, "status_code", 0))
+        try:
+            payload = response.json()
+        except (TypeError, ValueError):
+            text = str(getattr(response, "text", ""))[:500]
+            payload = {"message": text or "Non-JSON response"}
+
+        if 200 <= status_code < 300:
+            return payload if isinstance(payload, dict) else {"result": payload}
+
+        if isinstance(payload, dict):
+            raw_error = payload.get("error")
+            if isinstance(raw_error, dict):
+                message = raw_error.get("message") or raw_error.get("code")
+            else:
+                message = raw_error or payload.get("message")
+        else:
+            message = None
+        result: Dict[str, Any] = {
+            "ok": False,
+            "error": {"code": "http_error", "message": str(message or f"HTTP {status_code}")[:500]},
+            "status_code": status_code,
+            "retryable": status_code in RETRYABLE_STATUSES,
+        }
+        retry_after = getattr(response, "headers", {}).get("Retry-After")
+        if retry_after:
+            result["retry_after"] = retry_after
+        return result
+
+    def execute(
+        self,
+        task: str,
+        input_data: Optional[Dict[str, Any]] = None,
+        max_cost: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        if not isinstance(task, str) or not task.strip():
+            return _validation_error("task must be a non-empty string")
+        if input_data is not None and not isinstance(input_data, dict):
+            return _validation_error("input_data must be an object")
+        if not _valid_max_cost(max_cost):
+            return _validation_error("max_cost must be a non-negative number")
+
+        constraints: Dict[str, Any] = {}
+        if max_cost is not None:
+            constraints["max_cost"] = max_cost
+        return self._request(
+            "POST",
+            "/api/execute",
+            timeout=90,
+            json={"task": task.strip(), "input": input_data or {}, "constraints": constraints},
+        )
+
+    def match(self, task: str, max_cost: Optional[float] = None) -> Dict[str, Any]:
+        if not isinstance(task, str) or not task.strip():
+            return _validation_error("task must be a non-empty string")
+        if not _valid_max_cost(max_cost):
+            return _validation_error("max_cost must be a non-negative number")
+
+        params: Dict[str, Any] = {"task": task.strip()}
+        if max_cost is not None:
+            params["max_cost"] = max_cost
+        return self._request("GET", "/api/execute/match", timeout=30, params=params)
+
+
+class AgoragenticTool(BaseTool):
+    """Griptape tool with execute-first Agent OS activities."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        session: Any = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._client = AgoragenticClient(api_key=api_key, base_url=base_url, session=session)
+
+    @activity(
+        config={
+            "description": "Route a task through Agent OS. May call a paid listing; max_cost sets the USDC ceiling.",
+            "schema": Schema(
+                {
+                    "task": str,
+                    SchemaOptional("input_data", default={}): dict,
+                    SchemaOptional("max_cost"): Or(int, float),
+                }
+            ),
+        }
+    )
+    def agoragentic_execute(self, *, values: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute a routed capability call and return receipt-backed evidence."""
+        return self._client.execute(
+            values.get("task", ""),
+            values.get("input_data"),
+            values.get("max_cost"),
+        )
+
+    @activity(
+        config={
+            "description": "Preview Agent OS providers, prices, and trust signals without executing or spending.",
+            "schema": Schema(
+                {
+                    "task": str,
+                    SchemaOptional("max_cost"): Or(int, float),
+                }
+            ),
+        }
+    )
+    def agoragentic_match(self, *, values: Dict[str, Any]) -> Dict[str, Any]:
+        """Preview routed providers without spending."""
+        return self._client.match(values.get("task", ""), values.get("max_cost"))
+
+
+__all__ = ["AgoragenticClient", "AgoragenticTool"]

--- a/integrations.json
+++ b/integrations.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.25.0",
-  "updated_at": "2026-07-04",
+  "version": "2.26.0",
+  "updated_at": "2026-07-18",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
   "packages": {
@@ -556,6 +556,33 @@
       "docs": "agno/README.md"
     },
     {
+      "id": "griptape",
+      "name": "Griptape",
+      "language": "python",
+      "status": "beta",
+      "path": "griptape/agoragentic_griptape.py",
+      "install": "pip install griptape requests",
+      "docs": "griptape/README.md"
+    },
+    {
+      "id": "livekit-agents",
+      "name": "LiveKit Agents",
+      "language": "python",
+      "status": "beta",
+      "path": "livekit-agents/agoragentic_livekit.py",
+      "install": "pip install livekit-agents requests",
+      "docs": "livekit-agents/README.md"
+    },
+    {
+      "id": "pipecat",
+      "name": "Pipecat",
+      "language": "python",
+      "status": "beta",
+      "path": "pipecat/agoragentic_pipecat.py",
+      "install": "pip install pipecat-ai requests",
+      "docs": "pipecat/README.md"
+    },
+    {
       "id": "metagpt",
       "name": "MetaGPT",
       "language": "python",
@@ -1061,6 +1088,12 @@
     "pdf_mcp": "pdf-mcp/README.md",
     "pdf_mcp_adapter": "pdf-mcp/agoragentic_pdf_mcp.mjs",
     "coinbase_agentic_wallets": "coinbase-agentic-wallets/README.md",
-    "coinbase_agentic_wallets_adapter": "coinbase-agentic-wallets/agoragentic_agentic_wallet.ts"
+    "coinbase_agentic_wallets_adapter": "coinbase-agentic-wallets/agoragentic_agentic_wallet.ts",
+    "griptape": "griptape/README.md",
+    "griptape_adapter": "griptape/agoragentic_griptape.py",
+    "livekit_agents": "livekit-agents/README.md",
+    "livekit_agents_adapter": "livekit-agents/agoragentic_livekit.py",
+    "pipecat": "pipecat/README.md",
+    "pipecat_adapter": "pipecat/agoragentic_pipecat.py"
   }
 }

--- a/livekit-agents/README.md
+++ b/livekit-agents/README.md
@@ -1,0 +1,48 @@
+# Agoragentic + LiveKit Agents
+
+Add receipt-backed Agent OS routing to realtime voice, video, and physical AI agents through native LiveKit function tools.
+
+## Status
+
+`beta` - the adapter is covered by hermetic async tool-shape and request-mapping tests. CI does not start a LiveKit room, call a model provider, or contact the live Agoragentic API.
+
+## Install
+
+```bash
+pip install livekit-agents requests
+```
+
+## Configure
+
+Set `AGORAGENTIC_API_KEY` in the agent worker environment. `AGORAGENTIC_BASE_URL` is optional and defaults to `https://agoragentic.com`.
+
+## Example
+
+```python
+from livekit.agents import Agent
+
+from agoragentic_livekit import build_agoragentic_tools
+
+
+class MarketplaceVoiceAgent(Agent):
+    def __init__(self):
+        super().__init__(
+            instructions="Preview providers before execution and state the accepted cost ceiling.",
+            tools=build_agoragentic_tools(),
+        )
+```
+
+The HTTP work is moved off LiveKit's realtime event loop. The returned tools can also be shared across agents or passed to an `AgentSession` using LiveKit's normal tool configuration.
+
+## Supported tools
+
+- `agoragentic_execute`: routed execution with optional `max_cost`; may spend up to the accepted listing price.
+- `agoragentic_match`: no-spend provider and price preview.
+
+Successful execution responses contain the platform result and receipt fields. HTTP failures preserve status, retryability, and `Retry-After` when present.
+
+## Safety boundary
+
+Importing or building the tools starts no room and performs no network call. `agoragentic_match` is no-spend. `agoragentic_execute` can route paid work when the LLM invokes it with an authenticated key, so keep voice-agent confirmation, `max_cost`, and Agent OS approval policy in the loop.
+
+Official framework references: [LiveKit Agents](https://docs.livekit.io/agents/) and [function tools](https://docs.livekit.io/agents/logic/tools/definition/).

--- a/livekit-agents/adapter.test.py
+++ b/livekit-agents/adapter.test.py
@@ -1,0 +1,85 @@
+import asyncio
+import importlib.util
+import pathlib
+import sys
+import types
+import unittest
+
+
+class FakeFunctionTool:
+    def __init__(self, function, name, description):
+        self.function = function
+        self.id = name
+        self.description = description
+
+
+def function_tool(function, *, name=None, description=None):
+    return FakeFunctionTool(function, name or function.__name__, description or function.__doc__)
+
+
+livekit = types.ModuleType("livekit")
+livekit_agents = types.ModuleType("livekit.agents")
+livekit_agents.function_tool = function_tool
+sys.modules["livekit"] = livekit
+sys.modules["livekit.agents"] = livekit_agents
+
+spec = importlib.util.spec_from_file_location(
+    "agoragentic_livekit",
+    pathlib.Path(__file__).with_name("agoragentic_livekit.py"),
+)
+adapter = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(adapter)
+
+
+class FakeResponse:
+    def __init__(self, payload=None):
+        self.status_code = 200
+        self._payload = payload or {"ok": True}
+        self.headers = {}
+        self.text = ""
+
+    def json(self):
+        return self._payload
+
+
+class FakeSession:
+    def __init__(self):
+        self.calls = []
+
+    def request(self, method, url, **kwargs):
+        self.calls.append((method, url, kwargs))
+        if url.endswith("/api/execute"):
+            return FakeResponse({"receipt_id": "receipt-livekit-test"})
+        return FakeResponse({"providers": []})
+
+
+class LiveKitAdapterTest(unittest.TestCase):
+    def test_async_tools_do_not_block_registration_or_hardcode_provider(self):
+        session = FakeSession()
+        tools = adapter.build_agoragentic_tools(api_key="test-key", session=session)
+        self.assertEqual([tool.id for tool in tools], ["agoragentic_execute", "agoragentic_match"])
+        self.assertEqual(session.calls, [])
+
+        result = asyncio.run(tools[0].function("summarize a document", {"text": "demo"}, 0.05))
+        preview = asyncio.run(tools[1].function("summarize a document", 0.05))
+
+        self.assertEqual(result["receipt_id"], "receipt-livekit-test")
+        self.assertEqual(preview, {"providers": []})
+        execute_call = session.calls[0]
+        self.assertEqual(execute_call[0:2], ("POST", "https://agoragentic.com/api/execute"))
+        self.assertEqual(execute_call[2]["json"]["constraints"], {"max_cost": 0.05})
+        self.assertNotIn("provider_id", execute_call[2]["json"])
+        self.assertEqual(session.calls[1][0:2], ("GET", "https://agoragentic.com/api/execute/match"))
+
+    def test_invalid_ceiling_fails_before_network(self):
+        session = FakeSession()
+        tools = adapter.build_agoragentic_tools(session=session)
+        negative = asyncio.run(tools[0].function("summarize", {}, -1))
+        non_finite = asyncio.run(tools[1].function("summarize", float("inf")))
+        self.assertEqual(negative["error"]["code"], "invalid_input")
+        self.assertEqual(non_finite["error"]["code"], "invalid_input")
+        self.assertEqual(session.calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/livekit-agents/agoragentic_livekit.py
+++ b/livekit-agents/agoragentic_livekit.py
@@ -1,0 +1,182 @@
+"""Execute-first Agoragentic function tools for LiveKit Agents."""
+
+import asyncio
+import functools
+import math
+import os
+from typing import Any, Dict, List, Optional
+
+
+DEFAULT_BASE_URL = "https://agoragentic.com"
+RETRYABLE_STATUSES = {408, 425, 429, 500, 502, 503, 504}
+
+
+def _validation_error(message: str) -> Dict[str, Any]:
+    return {
+        "ok": False,
+        "error": {"code": "invalid_input", "message": message},
+        "retryable": False,
+    }
+
+
+def _valid_max_cost(value: Optional[float]) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        return value >= 0
+    return isinstance(value, float) and math.isfinite(value) and value >= 0
+
+
+class AgoragenticClient:
+    """Blocking HTTP client called off the realtime event loop."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        session: Any = None,
+    ) -> None:
+        self.api_key = os.getenv("AGORAGENTIC_API_KEY", "") if api_key is None else api_key
+        self.base_url = (base_url or os.getenv("AGORAGENTIC_BASE_URL") or DEFAULT_BASE_URL).rstrip("/")
+        if session is None:
+            try:
+                import requests
+            except ImportError as exc:
+                raise RuntimeError("Install requests to use the LiveKit Agents adapter") from exc
+            session = requests.Session()
+        self.session = session
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {"Accept": "application/json", "Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    def _request(self, method: str, path: str, timeout: int, **kwargs: Any) -> Dict[str, Any]:
+        try:
+            response = self.session.request(
+                method,
+                f"{self.base_url}{path}",
+                headers=self._headers(),
+                timeout=timeout,
+                **kwargs,
+            )
+        except Exception as exc:
+            return {
+                "ok": False,
+                "error": {"code": "network_error", "message": str(exc)[:500]},
+                "retryable": True,
+            }
+
+        status_code = int(getattr(response, "status_code", 0))
+        try:
+            payload = response.json()
+        except (TypeError, ValueError):
+            text = str(getattr(response, "text", ""))[:500]
+            payload = {"message": text or "Non-JSON response"}
+
+        if 200 <= status_code < 300:
+            return payload if isinstance(payload, dict) else {"result": payload}
+
+        if isinstance(payload, dict):
+            raw_error = payload.get("error")
+            if isinstance(raw_error, dict):
+                message = raw_error.get("message") or raw_error.get("code")
+            else:
+                message = raw_error or payload.get("message")
+        else:
+            message = None
+        result: Dict[str, Any] = {
+            "ok": False,
+            "error": {"code": "http_error", "message": str(message or f"HTTP {status_code}")[:500]},
+            "status_code": status_code,
+            "retryable": status_code in RETRYABLE_STATUSES,
+        }
+        retry_after = getattr(response, "headers", {}).get("Retry-After")
+        if retry_after:
+            result["retry_after"] = retry_after
+        return result
+
+    def execute(
+        self,
+        task: str,
+        input_data: Optional[Dict[str, Any]] = None,
+        max_cost: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        if not isinstance(task, str) or not task.strip():
+            return _validation_error("task must be a non-empty string")
+        if input_data is not None and not isinstance(input_data, dict):
+            return _validation_error("input_data must be an object")
+        if not _valid_max_cost(max_cost):
+            return _validation_error("max_cost must be a non-negative number")
+
+        constraints: Dict[str, Any] = {}
+        if max_cost is not None:
+            constraints["max_cost"] = max_cost
+        return self._request(
+            "POST",
+            "/api/execute",
+            timeout=90,
+            json={"task": task.strip(), "input": input_data or {}, "constraints": constraints},
+        )
+
+    def match(self, task: str, max_cost: Optional[float] = None) -> Dict[str, Any]:
+        if not isinstance(task, str) or not task.strip():
+            return _validation_error("task must be a non-empty string")
+        if not _valid_max_cost(max_cost):
+            return _validation_error("max_cost must be a non-negative number")
+
+        params: Dict[str, Any] = {"task": task.strip()}
+        if max_cost is not None:
+            params["max_cost"] = max_cost
+        return self._request("GET", "/api/execute/match", timeout=30, params=params)
+
+
+async def _offload(function: Any, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+    loop = asyncio.get_running_loop()
+    call = functools.partial(function, *args, **kwargs)
+    return await loop.run_in_executor(None, call)
+
+
+def build_agoragentic_tools(
+    api_key: Optional[str] = None,
+    base_url: Optional[str] = None,
+    session: Any = None,
+) -> List[Any]:
+    """Return LiveKit FunctionTool objects without starting an AgentSession."""
+    try:
+        from livekit.agents import function_tool
+    except ImportError as exc:
+        raise RuntimeError("Install livekit-agents to build LiveKit function tools") from exc
+
+    client = AgoragenticClient(api_key=api_key, base_url=base_url, session=session)
+
+    async def agoragentic_execute(
+        task: str,
+        input_data: Optional[Dict[str, Any]] = None,
+        max_cost: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Route a task through Agent OS; max_cost is the permitted USDC ceiling."""
+        return await _offload(client.execute, task, input_data, max_cost)
+
+    async def agoragentic_match(task: str, max_cost: Optional[float] = None) -> Dict[str, Any]:
+        """Preview eligible Agent OS providers without executing or spending."""
+        return await _offload(client.match, task, max_cost)
+
+    return [
+        function_tool(
+            agoragentic_execute,
+            name="agoragentic_execute",
+            description="Route a task through Agent OS. May call a paid listing; max_cost sets the USDC ceiling.",
+        ),
+        function_tool(
+            agoragentic_match,
+            name="agoragentic_match",
+            description="Preview Agent OS providers, prices, and trust signals without executing or spending.",
+        ),
+    ]
+
+
+__all__ = ["AgoragenticClient", "build_agoragentic_tools"]

--- a/pipecat/README.md
+++ b/pipecat/README.md
@@ -1,0 +1,44 @@
+# Agoragentic + Pipecat
+
+Expose Agent OS provider matching and receipt-backed execution as Pipecat direct functions for realtime voice and multimodal agents.
+
+## Status
+
+`beta` - the adapter is covered by hermetic callback and request-mapping tests. CI does not start a media pipeline, call an LLM provider, or contact the live Agoragentic API.
+
+## Install
+
+```bash
+pip install pipecat-ai requests
+```
+
+## Configure
+
+Set `AGORAGENTIC_API_KEY` in the Pipecat worker environment. `AGORAGENTIC_BASE_URL` is optional and defaults to `https://agoragentic.com`.
+
+## Example
+
+```python
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.aggregators.llm_response_universal import LLMContextAggregatorPair
+
+from agoragentic_pipecat import build_agoragentic_tools
+
+context = LLMContext(tools=build_agoragentic_tools())
+user_aggregator, assistant_aggregator = LLMContextAggregatorPair(context)
+```
+
+Add the aggregators and your LLM service to the normal Pipecat pipeline. Tool results are returned through `FunctionCallParams.result_callback`, and blocking HTTP work is moved off the realtime event loop.
+
+## Supported tools
+
+- `agoragentic_execute`: routed execution with optional `max_cost`; may spend up to the accepted listing price.
+- `agoragentic_match`: no-spend provider and price preview.
+
+Successful execution responses contain the platform result and receipt fields. HTTP failures preserve status, retryability, and `Retry-After` when present.
+
+## Safety boundary
+
+Importing or building the direct functions starts no pipeline and performs no network call. `agoragentic_match` is no-spend. `agoragentic_execute` can route paid work when an LLM calls it with an authenticated key, so set `max_cost` and retain application-level confirmation and Agent OS approval policy.
+
+Official framework references: [Pipecat](https://docs.pipecat.ai/) and [function calling](https://docs.pipecat.ai/pipecat/learn/function-calling).

--- a/pipecat/adapter.test.py
+++ b/pipecat/adapter.test.py
@@ -1,0 +1,88 @@
+import asyncio
+import importlib.util
+import pathlib
+import sys
+import types
+import unittest
+
+
+class FunctionCallParams:
+    def __init__(self):
+        self.results = []
+
+    async def result_callback(self, result):
+        self.results.append(result)
+
+
+pipecat = types.ModuleType("pipecat")
+pipecat_services = types.ModuleType("pipecat.services")
+pipecat_llm_service = types.ModuleType("pipecat.services.llm_service")
+pipecat_llm_service.FunctionCallParams = FunctionCallParams
+sys.modules["pipecat"] = pipecat
+sys.modules["pipecat.services"] = pipecat_services
+sys.modules["pipecat.services.llm_service"] = pipecat_llm_service
+
+spec = importlib.util.spec_from_file_location(
+    "agoragentic_pipecat",
+    pathlib.Path(__file__).with_name("agoragentic_pipecat.py"),
+)
+adapter = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(adapter)
+
+
+class FakeResponse:
+    def __init__(self, payload=None):
+        self.status_code = 200
+        self._payload = payload or {"ok": True}
+        self.headers = {}
+        self.text = ""
+
+    def json(self):
+        return self._payload
+
+
+class FakeSession:
+    def __init__(self):
+        self.calls = []
+
+    def request(self, method, url, **kwargs):
+        self.calls.append((method, url, kwargs))
+        if url.endswith("/api/execute"):
+            return FakeResponse({"receipt_id": "receipt-pipecat-test"})
+        return FakeResponse({"providers": []})
+
+
+class PipecatAdapterTest(unittest.TestCase):
+    def test_direct_function_shape_callbacks_and_request_mapping(self):
+        session = FakeSession()
+        tools = adapter.build_agoragentic_tools(api_key="test-key", session=session)
+        self.assertEqual([tool.__name__ for tool in tools], ["agoragentic_execute", "agoragentic_match"])
+        self.assertEqual(session.calls, [])
+
+        execute_params = FunctionCallParams()
+        match_params = FunctionCallParams()
+        asyncio.run(tools[0](execute_params, "classify text", {"text": "demo"}, 0.02))
+        asyncio.run(tools[1](match_params, "classify text", 0.02))
+
+        self.assertEqual(execute_params.results, [{"receipt_id": "receipt-pipecat-test"}])
+        self.assertEqual(match_params.results, [{"providers": []}])
+        execute_call = session.calls[0]
+        self.assertEqual(execute_call[0:2], ("POST", "https://agoragentic.com/api/execute"))
+        self.assertEqual(execute_call[2]["json"]["constraints"], {"max_cost": 0.02})
+        self.assertNotIn("provider_id", execute_call[2]["json"])
+        self.assertEqual(session.calls[1][0:2], ("GET", "https://agoragentic.com/api/execute/match"))
+
+    def test_invalid_input_is_returned_through_callback_without_network(self):
+        session = FakeSession()
+        tools = adapter.build_agoragentic_tools(session=session)
+        missing_task = FunctionCallParams()
+        non_finite = FunctionCallParams()
+        asyncio.run(tools[0](missing_task, "", {}, 0.02))
+        asyncio.run(tools[1](non_finite, "classify text", float("-inf")))
+        self.assertEqual(missing_task.results[0]["error"]["code"], "invalid_input")
+        self.assertEqual(non_finite.results[0]["error"]["code"], "invalid_input")
+        self.assertEqual(session.calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pipecat/agoragentic_pipecat.py
+++ b/pipecat/agoragentic_pipecat.py
@@ -1,0 +1,189 @@
+"""Execute-first Agoragentic direct functions for Pipecat."""
+
+import asyncio
+import functools
+import math
+import os
+from typing import Any, Dict, List, Optional
+
+
+DEFAULT_BASE_URL = "https://agoragentic.com"
+RETRYABLE_STATUSES = {408, 425, 429, 500, 502, 503, 504}
+
+
+def _validation_error(message: str) -> Dict[str, Any]:
+    return {
+        "ok": False,
+        "error": {"code": "invalid_input", "message": message},
+        "retryable": False,
+    }
+
+
+def _valid_max_cost(value: Optional[float]) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        return value >= 0
+    return isinstance(value, float) and math.isfinite(value) and value >= 0
+
+
+class AgoragenticClient:
+    """Blocking HTTP client called outside Pipecat's realtime event loop."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        session: Any = None,
+    ) -> None:
+        self.api_key = os.getenv("AGORAGENTIC_API_KEY", "") if api_key is None else api_key
+        self.base_url = (base_url or os.getenv("AGORAGENTIC_BASE_URL") or DEFAULT_BASE_URL).rstrip("/")
+        if session is None:
+            try:
+                import requests
+            except ImportError as exc:
+                raise RuntimeError("Install requests to use the Pipecat adapter") from exc
+            session = requests.Session()
+        self.session = session
+
+    def _headers(self) -> Dict[str, str]:
+        headers = {"Accept": "application/json", "Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    def _request(self, method: str, path: str, timeout: int, **kwargs: Any) -> Dict[str, Any]:
+        try:
+            response = self.session.request(
+                method,
+                f"{self.base_url}{path}",
+                headers=self._headers(),
+                timeout=timeout,
+                **kwargs,
+            )
+        except Exception as exc:
+            return {
+                "ok": False,
+                "error": {"code": "network_error", "message": str(exc)[:500]},
+                "retryable": True,
+            }
+
+        status_code = int(getattr(response, "status_code", 0))
+        try:
+            payload = response.json()
+        except (TypeError, ValueError):
+            text = str(getattr(response, "text", ""))[:500]
+            payload = {"message": text or "Non-JSON response"}
+
+        if 200 <= status_code < 300:
+            return payload if isinstance(payload, dict) else {"result": payload}
+
+        if isinstance(payload, dict):
+            raw_error = payload.get("error")
+            if isinstance(raw_error, dict):
+                message = raw_error.get("message") or raw_error.get("code")
+            else:
+                message = raw_error or payload.get("message")
+        else:
+            message = None
+        result: Dict[str, Any] = {
+            "ok": False,
+            "error": {"code": "http_error", "message": str(message or f"HTTP {status_code}")[:500]},
+            "status_code": status_code,
+            "retryable": status_code in RETRYABLE_STATUSES,
+        }
+        retry_after = getattr(response, "headers", {}).get("Retry-After")
+        if retry_after:
+            result["retry_after"] = retry_after
+        return result
+
+    def execute(
+        self,
+        task: str,
+        input_data: Optional[Dict[str, Any]] = None,
+        max_cost: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        if not isinstance(task, str) or not task.strip():
+            return _validation_error("task must be a non-empty string")
+        if input_data is not None and not isinstance(input_data, dict):
+            return _validation_error("input_data must be an object")
+        if not _valid_max_cost(max_cost):
+            return _validation_error("max_cost must be a non-negative number")
+
+        constraints: Dict[str, Any] = {}
+        if max_cost is not None:
+            constraints["max_cost"] = max_cost
+        return self._request(
+            "POST",
+            "/api/execute",
+            timeout=90,
+            json={"task": task.strip(), "input": input_data or {}, "constraints": constraints},
+        )
+
+    def match(self, task: str, max_cost: Optional[float] = None) -> Dict[str, Any]:
+        if not isinstance(task, str) or not task.strip():
+            return _validation_error("task must be a non-empty string")
+        if not _valid_max_cost(max_cost):
+            return _validation_error("max_cost must be a non-negative number")
+
+        params: Dict[str, Any] = {"task": task.strip()}
+        if max_cost is not None:
+            params["max_cost"] = max_cost
+        return self._request("GET", "/api/execute/match", timeout=30, params=params)
+
+
+async def _offload(function: Any, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+    loop = asyncio.get_running_loop()
+    call = functools.partial(function, *args, **kwargs)
+    return await loop.run_in_executor(None, call)
+
+
+def build_agoragentic_tools(
+    api_key: Optional[str] = None,
+    base_url: Optional[str] = None,
+    session: Any = None,
+) -> List[Any]:
+    """Return Pipecat direct functions for use in LLMContext(tools=[...])."""
+    try:
+        from pipecat.services.llm_service import FunctionCallParams
+    except ImportError as exc:
+        raise RuntimeError("Install pipecat-ai to build Pipecat direct functions") from exc
+
+    client = AgoragenticClient(api_key=api_key, base_url=base_url, session=session)
+
+    async def agoragentic_execute(
+        params: FunctionCallParams,
+        task: str,
+        input_data: Optional[Dict[str, Any]] = None,
+        max_cost: Optional[float] = None,
+    ) -> None:
+        """Route a task through Agent OS.
+
+        Args:
+            task: Task intent for provider routing.
+            input_data: Structured task input.
+            max_cost: Maximum permitted USDC cost.
+        """
+        result = await _offload(client.execute, task, input_data, max_cost)
+        await params.result_callback(result)
+
+    async def agoragentic_match(
+        params: FunctionCallParams,
+        task: str,
+        max_cost: Optional[float] = None,
+    ) -> None:
+        """Preview Agent OS providers without executing or spending.
+
+        Args:
+            task: Task intent to match.
+            max_cost: Maximum quoted USDC cost.
+        """
+        result = await _offload(client.match, task, max_cost)
+        await params.result_callback(result)
+
+    return [agoragentic_execute, agoragentic_match]
+
+
+__all__ = ["AgoragenticClient", "build_agoragentic_tools"]

--- a/test/framework-adapter-contracts.test.mjs
+++ b/test/framework-adapter-contracts.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+
+const repoRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const adapters = [
+  ["Griptape", "griptape/adapter.test.py"],
+  ["LiveKit Agents", "livekit-agents/adapter.test.py"],
+  ["Pipecat", "pipecat/adapter.test.py"],
+];
+
+for (const [name, relativePath] of adapters) {
+  test(`${name} adapter passes its hermetic framework contract`, () => {
+    const result = spawnSync(
+      process.env.ADAPTER_CONFORMANCE_PYTHON || "python",
+      [path.join(repoRoot, relativePath)],
+      { cwd: repoRoot, encoding: "utf8", timeout: 30_000 },
+    );
+
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    assert.match(result.stderr, /OK/);
+  });
+}


### PR DESCRIPTION
## Summary
- add beta adapters for Griptape, LiveKit Agents, and Pipecat
- expose router-first `agoragentic_execute` and no-spend `agoragentic_match` through each framework's native tool shape
- add hermetic contract tests to CI and register all three adapters in the public manifest and root README

## Framework fit
- Griptape uses a `BaseTool` with native `@activity` methods
- LiveKit Agents uses native `FunctionTool` objects and offloads blocking HTTP from the realtime loop
- Pipecat uses direct functions for `LLMContext(tools=[...])` and returns results through `FunctionCallParams.result_callback`

## Safety boundary
- import and tool construction perform no network call
- provider selection remains router-first; no provider IDs are hardcoded
- `agoragentic_match` does not execute or spend
- `agoragentic_execute` may route paid work only when invoked with credentials
- invalid, negative, boolean, NaN, and infinite `max_cost` values fail before HTTP
- tests are hermetic and perform no live, wallet, or paid calls

## Validation
- `node --test`: 88 passed
- framework contract wrapper: 3 passed
- forked conformance agent: 74/74 catalog entries passed; 0 failures
- manifest schema and machine-surface verification passed
- Hermes, ACP, Rust public-sync, and growth-example guards passed
- Micro ECF: 6 tests + syntax check passed
- Harness Core: 7 tests passed
- Premortem Golden Loop: 8 tests passed
- real framework construction checks passed with Griptape 1.11.0, LiveKit Agents 1.6.6, and Pipecat 1.5.0

## Coordination
This is based on current `main` after #189. It deliberately excludes the six documentation-only framework entries in draft #188. Because both PRs touch `README.md` and `integrations.json`, #188 will need to rebase and retain these three entries if it lands later.