### PR TITLE
docs: add ecosystem onboarding guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,13 @@ Agent workflow contracts: [governed agent runs](./docs/agent-workflow-contracts.
 
 | I want to... | Start with | What happens next |
 |---|---|---|
-| **Integrate an existing agent or framework** | Pick a ready adapter from [Available Integrations](#available-integrations), then follow the [5-Minute Buyer Quickstart](#5-minute-buyer-quickstart). | Use `match()` to preview and `execute()` to route work; inspect the resulting receipt. Use the [x402 buyer example](./x402/README.md) only when a direct paid-edge flow is the right fit. |
+| **Integrate an existing agent or framework** | Pick a ready adapter from [Featured Integration Paths](#featured-integration-paths), then follow the [5-Minute Buyer Quickstart](#5-minute-buyer-quickstart). | Use `match()` to preview and `execute()` to route work; inspect the resulting receipt. Use the [x402 buyer example](./x402/README.md) only when a direct paid-edge flow is the right fit. |
 | **Govern an agent locally before any hosted step** | [Micro ECF](https://github.com/rhein1/agoragentic-micro-ecf) for local policy, source maps, approvals, and Harness exports. | Use [ECF Core](https://github.com/rhein1/agoragentic-ecf-core) only when the local artifact workflow is no longer enough and you need a self-hosted context-governance runtime. |
 | **Preview or deploy a governed agent** | [Agent OS control-plane examples](./agent-os/README.md). | Start with no-spend readiness and preview. A deployment request, funding, public exposure, marketplace selling, and x402 monetization are separate approval-gated steps. |
 
 New integrations should follow the [adapter template kit](./templates/adapter/README.md), not copy a legacy adapter blindly. Do **not** start with `GET /api/capabilities` or `POST /api/invoke/{listing_id}` unless you intentionally need a specific provider.
+
+Continue with the [ecosystem walkthroughs](./docs/ECOSYSTEM_WALKTHROUGHS.md), [glossary](./docs/GLOSSARY.md), or [troubleshooting guide](./docs/TROUBLESHOOTING.md).
 
 ## Offline Adapter Conformance
 
@@ -402,6 +404,9 @@ Your Agent  →  Integration (tools/MCP)  →  Agent OS + Agoragentic API
 |-------|------|
 | Machine-readable index | [`integrations.json`](./integrations.json) |
 | JSON Schema | [`integrations.schema.json`](./integrations.schema.json) |
+| Ecosystem walkthroughs | [`docs/ECOSYSTEM_WALKTHROUGHS.md`](./docs/ECOSYSTEM_WALKTHROUGHS.md) |
+| Glossary and maturity labels | [`docs/GLOSSARY.md`](./docs/GLOSSARY.md) |
+| Troubleshooting | [`docs/TROUBLESHOOTING.md`](./docs/TROUBLESHOOTING.md) |
 | Agent instructions | [`AGENTS.md`](./AGENTS.md) |
 | ACP registry positioning | [`ACP_REGISTRY.md`](./ACP_REGISTRY.md) |
 | Agent Client Protocol adapter | [`acp/agent.json`](./acp/agent.json) |

--- a/docs/ECOSYSTEM_WALKTHROUGHS.md
+++ b/docs/ECOSYSTEM_WALKTHROUGHS.md
@@ -1,0 +1,57 @@
+# Ecosystem Walkthroughs
+
+Use this page to choose a problem-first path through the repository. It indexes the canonical examples instead of duplicating their commands, so follow the linked README for the current contract and safety boundary.
+
+## Choose a path
+
+| I want to... | Start here | Expected evidence | Spend boundary |
+|---|---|---|---|
+| Add routed work to an existing agent or framework | [Existing agent to Router receipt](#existing-agent-to-router-receipt) | Match response, execution result, receipt reference | `match()` is a preview; `execute()` can cost the selected listing price |
+| Govern a local agent before hosted deployment | [Local policy to Agent OS preview](#local-policy-to-agent-os-preview) | Source map, policy summary, context packet, Harness export, preview | Local build, readiness, and preview are no-spend; later hosted actions remain gated |
+| Inspect a direct x402 payment path safely | [x402 preflight to receipt verification](#x402-preflight-to-receipt-verification) | Validated quote/challenge and receipt or proof state | The provided preflights stop before signing or spending |
+| Prototype a wrapper around an existing API | [Mock-first public API wrapper](#mock-first-public-api-wrapper) | Local mock result with an explicit boundary object | No provider call, listing publication, wallet action, or x402 route |
+
+## Existing agent to Router receipt
+
+1. Choose an entry from [`integrations.json`](../integrations.json). Prefer a `ready` entry whose README matches your framework and runtime; check the [maturity definitions](./GLOSSARY.md#integration-maturity).
+2. Follow that integration's README to expose `agoragentic_match` and `agoragentic_execute`. Keep provider selection in the Router instead of hardcoding a listing ID.
+3. Use the root [5-Minute Buyer Quickstart](../README.md#5-minute-buyer-quickstart) to register, preview providers, execute a bounded task, and fetch its receipt.
+4. If no adapter fits, start from the [adapter template kit](../templates/adapter/README.md) and run the [offline conformance agent](./ADAPTER_CONFORMANCE_AGENT.md).
+5. For a local governance example around an existing workflow, run the [LangGraph PII Pipeline Guard](../examples/langgraph_pii_pipeline_guard/README.md). It is a local simulation, not a hosted Router call.
+
+Success means the framework can preview or route a task and preserve the returned receipt reference. It does not by itself prove a live framework runtime, paid settlement, or on-chain finality; use the integration README and receipt fields for those narrower claims.
+
+## Local policy to Agent OS preview
+
+1. Use the canonical [Micro ECF repository](https://github.com/rhein1/agoragentic-micro-ecf) to plan and install local policy artifacts. The `micro-ecf/` folder here is a compatibility snapshot.
+2. Follow the snapshot's [post-install workflow](../micro-ecf/POST_INSTALL.md) to run `doctor`, inspect `ECF.md`, refresh bounded artifacts, and keep blocked sources out of exported context.
+3. Review the [secret-block proof](../micro-ecf/examples/secret-block-proof.md) to see how an allowed source and a blocked `.env` can coexist without exporting the secret file.
+4. Use [Harness Core](../harness-core/README.md) when you want a smaller local-only proof, local receipt, listing-readiness check, and Agent OS Harness export without installing Micro ECF.
+5. Send a Harness export through the no-spend readiness and preview steps in the [Agent OS control-plane example](../agent-os/README.md).
+
+Micro ECF and Harness Core prepare local evidence; they do not deploy, fund, publish, settle x402, or provision hosted runtime. An Agent OS deployment request, funding, public API exposure, marketplace selling, and monetization are separate approval-gated steps.
+
+## x402 preflight to receipt verification
+
+1. Read the [x402 buyer integration](../x402/README.md) and run its free demo or `--paid-preflight` mode. The paid preflight obtains a 402 challenge and stops before reading a wallet key, signing, retrying, or spending.
+2. For the public receipt-reconciliation resource, run the [Interchange x402 preflight](../interchange/examples/x402-receipt-reconciliation/README.md). Validate the version, scheme, resource, amount, Base network, USDC asset, and independently approved recipient before any signer is invoked.
+3. Verify an existing receipt with the [read-only receipt verifier example](../interchange/examples/verify-receipt/README.md). The safe missing-receipt probe is useful before supplying real receipt material.
+4. Use the [15-minute Interchange sandbox](../interchange/SANDBOX_WALKTHROUGH.md) when implementing the public federation wire contract. It is a local/no-spend conformance path, not evidence of a live partner relationship.
+
+Keep payment authority in the caller's wallet, HSM, or managed-wallet runtime. A payment challenge is not an authorization to sign, a payment submission is not terminal settlement, and only the documented verified proof state supports an on-chain verification claim.
+
+## Mock-first public API wrapper
+
+1. Open the [public API wrapper examples](../examples/public-api-wrappers/README.md).
+2. Choose the Node.js, Python, or MCP-shaped example and replace only the mock boundary when you are ready to integrate a provider under your own authorization and secret policy.
+3. Preserve explicit evidence such as `provider_called`, `live_execute_called`, and `spend_authorized` so a mock run cannot be presented as a live provider result.
+4. Before proposing a marketplace adapter, use the [template checklist](../templates/adapter/CHECKLIST.md) and run the [offline conformance agent](./ADAPTER_CONFORMANCE_AGENT.md).
+
+The checked-in wrapper examples are deliberately mock-first: they make no provider calls, publish no listing, store no raw secret, and create no x402 route.
+
+## Related reference pages
+
+- [Glossary](./GLOSSARY.md)
+- [Troubleshooting](./TROUBLESHOOTING.md)
+- [Agent Commerce Interchange status and examples](../interchange/README.md)
+- [Machine-readable integration inventory](../integrations.json)

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,131 @@
+# Glossary
+
+These definitions describe the public integration surfaces in this repository. They do not expand authority to deploy, spend, publish, handle credentials, or expose private runtime internals.
+
+## Product and routing terms
+
+**Triptych OS (Agent OS)**
+
+The hosted runtime and control-plane product for deployed agents and swarms. `Agent OS` remains the stable API and discovery name. The examples in this repository are client integrations and public contracts, not a downloadable copy of the hosted control plane.
+
+**Router / Marketplace**
+
+The transaction rail that matches a task to an eligible provider, executes work, meters cost, and returns receipt and reconciliation data. New integrations should use `execute(task, input)` rather than hardcode a provider ID.
+
+**Provider or listing**
+
+A capability that the Router may select. A listing describes the callable service and its current price and policy; a provider is the agent or service that fulfills it.
+
+**Match**
+
+A provider and price preview performed before execution. `agoragentic_match` is the preferred no-spend way to inspect eligible routes. A missing or malformed x402 quote must not be interpreted as a free route.
+
+**Execute**
+
+A routed capability call through `POST /api/execute` or the corresponding adapter tool. Execution can cost the selected listing price and should carry an explicit cost ceiling and approval policy when spend is possible.
+
+**Direct invoke**
+
+A call to a specific known listing. It is a compatibility path for cases where the caller intentionally needs that provider; it is not the default integration path.
+
+**Quote**
+
+A bounded, durable description of the selected listing, price, execution rail, and related conditions before spend. Paid flows should reject incomplete, malformed, stale, over-limit, or network/asset-mismatched quotes.
+
+**Quote-locked execution**
+
+Execution that references a reviewed quote so provider, price, input, procurement state, and approval can be reconciled against the same intent.
+
+## Payment and evidence terms
+
+**Receipt**
+
+A normalized record or reference for an execution, including fields such as the receipt ID, provider, cost, and settlement or proof state. A receipt is evidence to inspect; its presence alone is not proof of terminal on-chain settlement.
+
+**Receipt-backed**
+
+An output that preserves a receipt reference or verifiable receipt data alongside the result. It does not mean the receipt has been independently verified or that settlement is final unless the relevant fields say so.
+
+**Settlement**
+
+The payment lifecycle after a paid execution. Payment creation, submission, and terminal verification are different states. For the x402 proof endpoint documented here, only `on_chain.status === "verified"` confirms the proof on-chain.
+
+**Reconciliation**
+
+Comparing the approved intent, quote, execution, receipt, spend, and outcome so discrepancies can be reviewed after a run.
+
+**x402**
+
+An HTTP 402 payment flow used by supported pay-per-request services. The client receives a challenge, validates every payment requirement against independent operator policy, signs outside Agoragentic, and retries under a bounded payment contract.
+
+**Idempotency key**
+
+A caller-supplied identifier for one execution intent. The manual x402 example uses it as a local guard; `/api/x402/execute` does not promise server-side route deduplication from that key. Do not use a second 402 response as permission to sign again.
+
+## Governance and context terms
+
+**Policy boundary**
+
+The explicit limits on sources, tools, budgets, approvals, memory, exports, and actions. A policy boundary should fail closed when required evidence or authority is missing.
+
+**Micro ECF**
+
+The open, lightweight local context and policy wedge. It builds source maps, policy summaries, citation-ready context packets, and Agent OS Harness exports. It does not deploy, spend, publish, provision hosted runtime, or settle x402.
+
+**ECF Core**
+
+The separate open-source, self-hosted context-governance runtime for projects that outgrow static Micro ECF artifacts but do not need hosted Agent OS deployment.
+
+**Full ECF**
+
+The private enterprise runtime layer underneath Agent OS Enterprise. Its internals, private connectors, customer evidence, operator material, and resident context are not part of this public repository.
+
+**Source map**
+
+A bounded inventory of allowed and blocked local sources, including paths, provenance, hashes or summaries, and reasons for exclusions. It may record that a secret-like file exists without exporting its raw contents.
+
+**Context packet**
+
+A citation-ready governance artifact built from allowed source summaries and provenance. It is not a raw source dump, semantic retrieval result, or generated answer bundle.
+
+**Evidence unit**
+
+An ECF Core term for a structured, source-linked unit used in self-hosted grounding and evaluation workflows. It is context evidence, not an execution receipt or payment proof.
+
+**Agent OS Harness export**
+
+A public-safe packet that carries bounded agent, policy, context, and preview intent into Agent OS readiness or deployment-preview checks. Producing the export does not provision runtime or authorize later hosted actions.
+
+**Local receipt**
+
+A no-spend proof artifact produced by local tooling such as Harness Core. Its settlement network is `none` and settlement is not applicable; do not present it as a hosted commerce receipt.
+
+## Integration maturity
+
+The `status` field in [`integrations.json`](../integrations.json) uses the four values allowed by [`integrations.schema.json`](../integrations.schema.json). The label describes repository integration maturity, not a blanket claim about external framework installation, live API reachability, paid execution, receipt verification, or settlement. Read each integration README for its exact evidence boundary.
+
+**Ready**
+
+The recommended repository path when its documented prerequisites fit. The integration has a concrete public surface and documentation and is expected to pass the repository's applicable offline checks. Live or paid coverage must still be claimed separately.
+
+**Beta**
+
+A usable implementation or contract with a narrower evidence boundary, commonly hermetic request-mapping tests or incomplete live framework/API coverage. Review the integration's Status and Safety Boundary sections before relying on it.
+
+**Experimental**
+
+An early reference, scaffold, protocol, or documentation integration that is still being validated. Do not assume it is a version-pinned, tested drop-in component unless its README proves that narrower claim.
+
+**Deprecated**
+
+A historical or compatibility entry retained for reference. Do not choose it for a new integration unless its README gives a current replacement or migration reason.
+
+## Conformance terms
+
+**Offline conformance pass**
+
+Evidence that manifest fields, repository-contained paths, bounded syntax parsing, credential-shaped literal checks, and other static checks passed. Adapter code is not imported or executed, and no network, wallet, paid, or production action occurs.
+
+**Advisory**
+
+A non-failing conformance observation, such as a missing execute-first signal or no colocated test. Advisories narrow what the evidence proves even when the overall static run passes.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,94 @@
+# Troubleshooting
+
+Start with the exact integration README and [`integrations.json`](../integrations.json). The entries below reflect errors and safety boundaries implemented or documented in this repository; hosted behavior can still change, so preserve the returned HTTP status and response body when diagnosing a live call.
+
+## `missing_api_key` or HTTP 401
+
+Authenticated Router calls require `AGORAGENTIC_API_KEY`. Set it in the process environment and send it as `Authorization: Bearer amk_...`; do not commit it in source, README examples, exported flow JSON, or reports.
+
+The four direct public tool endpoints in the root README do not require a key, but `POST /api/execute` and adapter calls through the authenticated Router do. The adapter template reports `missing_api_key` with status 401 when the environment variable is absent.
+
+## `invalid_task`
+
+The adapter template requires `task` to be a non-empty string for both match and execute. Pass the routing intent as the task and put structured arguments in `input`:
+
+```javascript
+await agoragentic_execute('weather', { latitude: 40.71, longitude: -74.01 });
+```
+
+Do not substitute a provider ID for the task unless you intentionally switch to a direct-invoke API.
+
+## `router_request_failed`, HTTP 429, or a 5xx response
+
+The template preserves the Router's error code and message when available and uses `router_request_failed` only as a fallback. It marks HTTP 429 and 5xx responses retryable; other statuses are not retryable by default.
+
+Log the status, structured code, and redacted response details. Back off for 429/5xx responses. Do not blindly retry a validation/auth error, and never turn a 402 response into an automatic signing loop.
+
+## No x402 provider matched
+
+For `GET /api/x402/execute/match`, no match is represented by both `quote: null` and `selected_provider: null`. Stop or change the task/ceiling; do not infer that a missing quote means the route is free.
+
+If a quote is present, require a boolean `payment_required`, a finite non-negative price within the reviewed ceiling, a quote ID, `execution_ready === true`, and the approved settlement network before proceeding. See the [x402 buyer integration](../x402/README.md).
+
+## Execution returned `pending_approval`
+
+This is an approval state, not a completed execution. Use the buyer/supervisor flow in the [Agent OS control-plane example](../agent-os/README.md). After the supervisor approves the one-time request, retry the same `quote_id` and input so the approval remains bound to the reviewed intent.
+
+Do not auto-approve unless the owner has explicitly configured a controlled supervisor account for that behavior.
+
+## A paid preflight returned HTTP 402
+
+That is the expected first response for a paid x402 resource. Decode the `PAYMENT-REQUIRED` challenge, validate the protocol version, exact-transfer scheme, resource, amount, Base network, USDC asset, and independently configured recipient, then stop unless a wallet owner has authorized signing.
+
+The repository's [buyer paid-preflight](../x402/README.md) and [receipt-reconciliation preflight](../interchange/examples/x402-receipt-reconciliation/README.md) deliberately do not read a private key, sign, retry, or spend.
+
+## A paid retry returned a second 402
+
+Fail closed. Do not create another signature or payment attempt. The hardened wallet wrapper and repository payment-safety contracts treat a second 402 after authorization as a failure, and locally block reused intent keys within one client instance.
+
+Also remember that the manual example's idempotency key is a caller-side guard; the endpoint does not promise server-side route deduplication from that key.
+
+## I have a receipt, but is it settled?
+
+Do not collapse receipt presence, payment submission, and terminal settlement into one state. Fetch or verify the receipt, inspect its settlement/proof fields, and preserve any pending state. For the documented x402 invocation proof, only `on_chain.status === "verified"` confirms the proof on-chain.
+
+Use the [read-only public verifier example](../interchange/examples/verify-receipt/README.md) for receipt IDs or receipt JSON. Its `--demo-missing` mode is a safe way to verify the client path without supplying a real receipt.
+
+## Adapter conformance says `Unknown integration id(s)`
+
+`--adapter` accepts manifest IDs, not display names or directory guesses. Copy the exact `id` from [`integrations.json`](../integrations.json):
+
+```bash
+node scripts/adapter-conformance-agent.mjs --adapter langchain,crewai
+```
+
+If the ID is new, add a complete manifest entry before running the targeted check.
+
+## Adapter conformance fails or reports advisories
+
+Use the failing check ID in the text output or JSON report:
+
+| Check | What to inspect |
+|---|---|
+| `manifest_fields` | `id`, `name`, `language`, `status`, `path`, and `docs` must be non-empty strings |
+| `primary_path` / `docs_path` | Paths must exist, remain repository-relative, and not escape through traversal or symlinks |
+| `primary_syntax` | Parse the declared JavaScript, TypeScript, Python, or JSON artifact without executing it |
+| `credential_literals` | Remove the credential-shaped value; the report intentionally records only its rule and path |
+| `execute_first_signal` | Advisory: add the current execute-first path to the artifact or docs |
+| `colocated_tests` | Advisory: add a hermetic adapter-local test if runtime behavior needs proof |
+
+A pass is offline static and syntax evidence only. It does not prove dependency installation, framework runtime behavior, a live endpoint, a verified receipt, or settlement. See the [conformance contract](./ADAPTER_CONFORMANCE_AGENT.md).
+
+## Micro ECF reports `.env` or another source as blocked
+
+For secret-like files, this is the expected safety behavior. Micro ECF may record the path and reason while keeping raw contents out of context packets, Harness exports, Agent OS previews, and MCP responses. Do not unblock or copy the file merely to reduce the blocked count.
+
+Keep safe project knowledge in an allowed documentation source, then rerun the read-only scan and inspect the source map. The [secret-block proof](../micro-ecf/examples/secret-block-proof.md) shows an allowed README and blocked `.env` coexisting correctly.
+
+## The integration is marked Ready, Beta, Experimental, or Deprecated
+
+Treat the label as repository maturity, not proof of every external or live behavior. Read the integration README's status, test coverage, and safety boundary, then consult the [maturity definitions](./GLOSSARY.md#integration-maturity). The offline conformance agent cannot upgrade a live-evidence claim by itself.
+
+## Still stuck?
+
+Collect the integration ID, command, runtime versions, HTTP status, redacted response body, and the smallest offline reproduction. Never include API keys, wallet material, payment signatures, raw private receipts, or customer data in an issue or conformance report.


### PR DESCRIPTION
## What changed

- add a problem-first ecosystem walkthrough index over existing canonical examples
- add a glossary for routing, payment, governance, evidence, and integration-maturity terms
- add evidence-backed troubleshooting for adapter, approval, x402, receipt, conformance, and Micro ECF cases
- link all three pages directly from Start Here and Specs & Discovery
- repair the stale Available Integrations anchor to point at Featured Integration Paths

## Why

The repository had strong framework-specific and product-layer documentation, but builders still had to infer the cross-ecosystem route and maturity vocabulary. These pages improve discovery without duplicating canonical commands or overstating live, paid, or settlement evidence.

## Impact

Documentation only. No API, adapter, runtime, payment, deployment, credential, or production behavior changes.

## Validation

- `node scripts/verify-integrations-json.js`
- `node --test test/adapter-conformance-agent.test.mjs test/payment-safety-contracts.test.mjs micro-ecf/test/cli.test.mjs harness-core/test/cli.test.cjs` (34 passed)
- representative Ready/Beta/Experimental adapter conformance (3 passed, 0 failed)
- relative Markdown link resolution check
- `git diff origin/main..HEAD --check`