### PR TITLE
fix(mcp): patch body-parser denial of service advisory

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -118,21 +118,34 @@
             }
         },
         "node_modules/body-parser": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-            "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+            "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
             "license": "MIT",
             "dependencies": {
                 "bytes": "^3.1.2",
-                "content-type": "^1.0.5",
+                "content-type": "^2.0.0",
                 "debug": "^4.4.3",
-                "http-errors": "^2.0.0",
-                "iconv-lite": "^0.7.0",
+                "http-errors": "^2.0.1",
+                "iconv-lite": "^0.7.2",
                 "on-finished": "^2.4.1",
-                "qs": "^6.14.1",
-                "raw-body": "^3.0.1",
-                "type-is": "^2.0.1"
+                "qs": "^6.15.2",
+                "raw-body": "^3.0.2",
+                "type-is": "^2.1.0"
             },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/body-parser/node_modules/content-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+            "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=18"
             },
@@ -440,9 +453,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
             "funding": [
                 {
                     "type": "github",
@@ -577,9 +590,9 @@
             }
         },
         "node_modules/hono": {
-            "version": "4.12.26",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
-            "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
+            "version": "4.12.31",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+            "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
             "license": "MIT",
             "peer": true,
             "engines": {


### PR DESCRIPTION
## Summary
- update transitive `body-parser` from 2.2.2 to patched 2.3.0 for Dependabot alert #6 / CVE-2026-12590
- refresh the already-allowed `fast-uri` and `hono` patch releases, clearing their current npm advisories
- keep the change lockfile-only; no MCP runtime or public API behavior changes

## Validation
- `npm ci --omit=dev`
- `node --check mcp-server.js`
- `npm pack --dry-run`
- `npm ls body-parser fast-uri hono --all`
- `node scripts/verify-integrations-json.js`
- `node scripts/verify-acp.js`
- `ajv validate -s integrations.schema.json -d integrations.json --all-errors --spec=draft2020 -c ajv-formats`
- `git diff --check`

## Security result
`body-parser` resolves to 2.3.0, `fast-uri` to 3.1.4, and `hono` to 4.12.31. The alert #6 dependency is no longer present in the installed tree.

An unrelated moderate `@hono/node-server` advisory remains upstream in `@modelcontextprotocol/sdk`; resolving it currently requires an unsupported major transitive override or SDK downgrade and is intentionally outside this patch.