### PR TITLE
chore(mcp): gate the 1.3.4 release

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -30,11 +30,20 @@ jobs:
           node --version
           npm --version
 
-      - name: Install dependencies
-        run: npm install
+      - name: Verify release tag matches package version
+        shell: bash
+        run: |
+          package_version="$(node -p "require('./package.json').version")"
+          test "${{ github.event.release.tag_name }}" = "mcp-v${package_version}"
 
-      - name: Check MCP server syntax
-        run: node --check mcp-server.js
+      - name: Install dependencies
+        run: npm ci --omit=dev
+
+      - name: Validate MCP package
+        run: |
+          npm run check
+          npm test
+          npm audit --omit=dev --audit-level=high
 
       - name: Dry-run package contents
         run: npm pack --dry-run

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -54,7 +54,9 @@ jobs:
         working-directory: mcp
         run: |
           npm ci --omit=dev
-          node --check mcp-server.js
+          npm run check
+          npm test
+          npm audit --omit=dev --audit-level=high
           npm pack --dry-run
 
       - name: Validate Micro ECF package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Glama discovery to the published `agoragentic-mcp@1.3.3`; the `1.3.4` source package remains an unreleased candidate.
 - Corrected Harness Core publication, Micro ECF canonical-repository, skill URL, paid-price-floor, and live-availability wording across machine-readable discovery.
 - Renamed the README table to `Featured Integration Paths`; `integrations.json` is the complete inventory.
+- Hardened the unreleased `agoragentic-mcp@1.3.4` candidate with a lockfile-only install, exact release-tag gate, hermetic keyless-preview tests, package-source metadata, and a high/critical npm audit gate. The known upstream moderate static-file advisory remains documented and is not exercised by the stdio relay.
 
 ## [manifest 2.16.0–2.24.2] - 2026-07-03
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -193,6 +193,12 @@ When the remote MCP server is unavailable, agents can still preview route-first 
 
 This preview path does not register an agent, execute a provider, or spend USDC. It may return an expiring `quote_id` for a later x402 payment flow.
 
+## Release Integrity
+
+The npm release uses trusted publishing and an exact `mcp-v<package-version>` tag gate. CI installs from `package-lock.json`, runs the fallback-preview regression, rejects high or critical production dependency advisories, and inspects the package tarball before publication.
+
+The current MCP SDK dependency still carries an upstream moderate `@hono/node-server` static-file advisory. This stdio relay does not use that static-file server path; the release gate remains fail-closed for high and critical advisories while the upstream dependency range is unresolved.
+
 ## Router Flow
 
 With an API key set, the router-first flow is:

--- a/mcp/mcp-server.js
+++ b/mcp/mcp-server.js
@@ -746,8 +746,15 @@ async function runAcpAdapter() {
 
 const entrypoint = ACP_MODE ? runAcpAdapter : runMcpRelay;
 
-entrypoint().catch((error) => {
-    const message = error instanceof Error ? error.stack || error.message : String(error);
-    console.error(`[agoragentic-mcp] fatal: ${message}`);
-    process.exit(1);
-});
+if (require.main === module) {
+    entrypoint().catch((error) => {
+        const message = error instanceof Error ? error.stack || error.message : String(error);
+        console.error(`[agoragentic-mcp] fatal: ${message}`);
+        process.exit(1);
+    });
+}
+
+module.exports = {
+    buildFallbackToolList,
+    executeFallbackTool,
+};

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -9,6 +9,9 @@
     },
     "scripts": {
         "start": "node mcp-server.js",
+        "check": "node --check mcp-server.js && node --check test/fallback-preview.test.js",
+        "test": "node --test test/*.test.js",
+        "prepublishOnly": "npm run check && npm test",
         "postinstall": "node scripts/postinstall.js || true"
     },
     "keywords": [
@@ -35,7 +38,8 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/rhein1/agoragentic-integrations.git"
+        "url": "git+https://github.com/rhein1/agoragentic-integrations.git",
+        "directory": "mcp"
     },
     "homepage": "https://agoragentic.com",
     "bugs": {

--- a/mcp/test/fallback-preview.test.js
+++ b/mcp/test/fallback-preview.test.js
@@ -1,0 +1,96 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+delete process.env.AGORAGENTIC_API_KEY;
+process.env.AGORAGENTIC_BASE_URL = 'https://router.example.invalid';
+
+const {
+    buildFallbackToolList,
+    executeFallbackTool,
+} = require('../mcp-server.js');
+
+function parseToolContent(result) {
+    assert.equal(result.content.length, 1);
+    assert.equal(result.content[0].type, 'text');
+    return JSON.parse(result.content[0].text);
+}
+
+test('fallback tool discovery advertises the keyless x402 preview', () => {
+    const tools = buildFallbackToolList();
+    const preview = tools.find((tool) => tool.name === 'agoragentic_preview_x402');
+
+    assert.ok(preview);
+    assert.deepEqual(preview.inputSchema.required, ['task']);
+    assert.match(preview.description, /WITHOUT registration/i);
+    assert.match(preview.description, /does not register an agent, execute a provider, move wallet funds, or settle payment/i);
+});
+
+test('fallback preview rejects a missing task without any network or tool execution', async () => {
+    const originalFetch = global.fetch;
+    let fetchCalls = 0;
+    global.fetch = async () => {
+        fetchCalls += 1;
+        throw new Error('network must not be called');
+    };
+
+    try {
+        const result = parseToolContent(await executeFallbackTool('agoragentic_preview_x402', {}));
+        assert.equal(result.ok, false);
+        assert.equal(result.error, 'missing_task');
+        assert.equal(fetchCalls, 0);
+    } finally {
+        global.fetch = originalFetch;
+    }
+});
+
+test('fallback preview performs one anonymous GET and never invokes or spends', async () => {
+    const originalFetch = global.fetch;
+    const calls = [];
+    global.fetch = async (url, options = {}) => {
+        calls.push({ url: String(url), options });
+        return {
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            text: async () => JSON.stringify({
+                selected_provider: null,
+                payment_required: false,
+                quote: null,
+            }),
+        };
+    };
+
+    try {
+        const result = parseToolContent(await executeFallbackTool('agoragentic_preview_x402', {
+            task: 'receipt reconciliation',
+            max_cost: 0,
+            category: 'audit',
+            max_latency_ms: 500,
+            prefer_trusted: true,
+            payment_network: 'base',
+            payment_asset: 'USDC',
+        }));
+
+        assert.equal(calls.length, 1);
+        const call = calls[0];
+        const url = new URL(call.url);
+        assert.equal(call.options.method, 'GET');
+        assert.equal(call.options.body, undefined);
+        assert.equal(call.options.headers.Authorization, undefined);
+        assert.equal(url.origin, 'https://router.example.invalid');
+        assert.equal(url.pathname, '/api/x402/execute/match');
+        assert.equal(url.searchParams.get('task'), 'receipt reconciliation');
+        assert.equal(url.searchParams.get('max_cost'), '0');
+        assert.equal(url.searchParams.get('category'), 'audit');
+        assert.equal(url.searchParams.get('max_latency_ms'), '500');
+        assert.equal(url.searchParams.get('prefer_trusted'), 'true');
+        assert.equal(url.searchParams.get('payment_network'), 'base');
+        assert.equal(url.searchParams.get('payment_asset'), 'USDC');
+        assert.doesNotMatch(url.pathname, /\/api\/(?:execute|invoke)(?:\/|$)/);
+        assert.equal(result.payment_required, false);
+    } finally {
+        global.fetch = originalFetch;
+    }
+});


### PR DESCRIPTION
## Summary

- adds hermetic coverage for the keyless agoragentic_preview_x402 fallback
- proves missing tasks make no network call and valid previews make one anonymous GET only
- adds package check/test/prepublish gates and exact mcp-v<version> release-tag validation
- switches trusted publishing to npm ci from the committed lockfile
- adds the npm repository subdirectory and documents the residual upstream moderate advisory

## Validation

- npm ci --omit=dev
- npm run check
- npm test (3/3)
- npm audit --omit=dev --audit-level=high (passes; 0 high/critical, 2 moderate entries for one upstream @hono/node-server advisory)
- npm pack --dry-run
- git diff --check

## Release boundary

The registry remains at agoragentic-mcp@1.3.3. This PR prepares 1.3.4 only. Do not update Glama or the official MCP Registry version until trusted npm publication succeeds. No test executes a provider, Router execute/global invoke, wallet, x402 payment, marketplace publication, hosted memory, or framework process.