### PR TITLE
fix(release): harden trusted publisher tag handling

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -32,9 +32,11 @@ jobs:
 
       - name: Verify release tag matches package version
         shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           package_version="$(node -p "require('./package.json').version")"
-          test "${{ github.event.release.tag_name }}" = "mcp-v${package_version}"
+          test "${RELEASE_TAG}" = "mcp-v${package_version}"
 
       - name: Install dependencies
         run: npm ci --omit=dev

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -34,9 +34,11 @@ jobs:
 
       - name: Verify release tag matches package version
         shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           package_version="$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml', 'rb'))['project']['version'])")"
-          test "${{ github.event.release.tag_name }}" = "py-v${package_version}"
+          test "${RELEASE_TAG}" = "py-v${package_version}"
 
       - name: Install build tooling
         run: python -m pip install --upgrade build

--- a/test/sdk-public-source.test.mjs
+++ b/test/sdk-public-source.test.mjs
@@ -64,3 +64,12 @@ test('PyPI trusted publishing builds from the public sdk/python source', () => {
   assert.match(workflow, /packages-dir: sdk\/python\/dist\//);
   assert.doesNotMatch(workflow, /password:|api-token:|PYPI_API_TOKEN/);
 });
+
+test('trusted publishers bind release tags through environment variables', () => {
+  for (const relativePath of ['.github/workflows/publish-mcp.yml', '.github/workflows/publish-pypi.yml']) {
+    const workflow = read(relativePath);
+    assert.match(workflow, /RELEASE_TAG: \$\{\{ github\.event\.release\.tag_name \}\}/);
+    assert.match(workflow, /test "\$\{RELEASE_TAG\}"/);
+    assert.doesNotMatch(workflow, /test "\$\{\{ github\.event\.release\.tag_name \}\}"/);
+  }
+});


### PR DESCRIPTION
## Summary
- bind MCP and PyPI release tags through quoted environment variables before shell comparison
- prevent Git-valid tag names from injecting shell substitution into OIDC publisher jobs
- add a CI regression for both workflows

## Validation
- public SDK source tests: 5/5
- MCP tests: 3/3
- Python SDK compile check
- git diff --check

No package is published by this PR.