### PR TITLE
chore(mcp): sync 1.3.4 registry metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped the canonical manifest to `2.27.0` with 93 indexed integration surfaces.
 - Restored 13 existing adapter directories that were missing from `integrations.json`: Dfns, fast-agent, Goose, Haystack, Kibble, LI.FI, MPPScan, Olas, Reown, Safe, Superfluid, Tempo MPP, and u402.
 - Updated Agent OS CLI discovery from the stale `1.6.8` pin to `@latest` (currently published as `1.6.9`).
-- Updated Glama discovery to the published `agoragentic-mcp@1.3.3`; the `1.3.4` source package remains an unreleased candidate.
+- Published `agoragentic-mcp@1.3.4` and synchronized its Glama and official MCP Registry manifests with the npm package version.
 - Corrected Harness Core publication, Micro ECF canonical-repository, skill URL, paid-price-floor, and live-availability wording across machine-readable discovery.
 - Renamed the README table to `Featured Integration Paths`; `integrations.json` is the complete inventory.
-- Hardened the unreleased `agoragentic-mcp@1.3.4` candidate with a lockfile-only install, exact release-tag gate, hermetic keyless-preview tests, package-source metadata, and a high/critical npm audit gate. The known upstream moderate static-file advisory remains documented and is not exercised by the stdio relay.
+- Hardened `agoragentic-mcp@1.3.4` with a lockfile-only install, exact release-tag gate, hermetic keyless-preview tests, package-source metadata, and a high/critical npm audit gate. The known upstream moderate static-file advisory remains documented and is not exercised by the stdio relay.
 
 ## [manifest 2.16.0–2.24.2] - 2026-07-03
 

--- a/glama.json
+++ b/glama.json
@@ -8,12 +8,12 @@
     "source": "github"
   },
   "maintainers": ["rhein1"],
-  "version": "1.3.3",
+  "version": "1.3.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "agoragentic-mcp",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "transport": {
         "type": "stdio"
       },

--- a/scripts/verify-integrations-json.js
+++ b/scripts/verify-integrations-json.js
@@ -199,9 +199,20 @@ function assertA2aRouterFirst() {
 
 function assertRegistryMetadata() {
   const glama = JSON.parse(fs.readFileSync(path.join(root, 'glama.json'), 'utf8'));
-  const packageVersion = glama.packages?.[0]?.version;
-  if (!glama.version || glama.version !== packageVersion) {
+  const server = JSON.parse(fs.readFileSync(path.join(root, 'mcp', 'server.json'), 'utf8'));
+  const mcpPackage = JSON.parse(fs.readFileSync(path.join(root, 'mcp', 'package.json'), 'utf8'));
+  const packageVersion = mcpPackage.version;
+  if (!glama.version || glama.version !== glama.packages?.[0]?.version) {
     fail('glama.json top-level and npm package versions must match');
+  }
+  if (glama.version !== packageVersion) {
+    fail(`glama.json version must match mcp/package.json (${packageVersion})`);
+  }
+  if (server.version !== packageVersion || server.packages?.[0]?.version !== packageVersion) {
+    fail(`mcp/server.json versions must match mcp/package.json (${packageVersion})`);
+  }
+  if (mcpPackage.mcpName !== server.name || server.name !== glama.name) {
+    fail('MCP package and registry names must match');
   }
   if (/execute paid work/i.test(glama.description || '')) {
     fail('glama.json must not present paid execution as unconditionally available');


### PR DESCRIPTION
## Summary

- sync Glama metadata to the published `agoragentic-mcp@1.3.4`
- record the 1.3.4 publication in the changelog
- fail CI when Glama or official MCP Registry metadata drifts from `mcp/package.json`

## Validation

- `node scripts/verify-integrations-json.js`
- `node --test test/sdk-public-source.test.mjs`
- `npm test` in `mcp/` (3/3)
- `npm run check` in `mcp/`
- `npm pack --dry-run --json` in `mcp/`
- npm registry verified `agoragentic-mcp@1.3.4`
- `git diff --check`

## Boundary

Discovery metadata and drift protection only. No runtime behavior, paid execution, settlement, wallet, trust, deployment, or provider-dispatch changes.