### PR TITLE
fix(mcp): separate registry and package versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped the canonical manifest to `2.27.0` with 93 indexed integration surfaces.
 - Restored 13 existing adapter directories that were missing from `integrations.json`: Dfns, fast-agent, Goose, Haystack, Kibble, LI.FI, MPPScan, Olas, Reown, Safe, Superfluid, Tempo MPP, and u402.
 - Updated Agent OS CLI discovery from the stale `1.6.8` pin to `@latest` (currently published as `1.6.9`).
-- Published `agoragentic-mcp@1.3.4` and synchronized its Glama and official MCP Registry manifests with the npm package version.
+- Published `agoragentic-mcp@1.3.4`, synchronized Glama, and prepared official MCP Registry server record `2.1.3` with the published npm package coordinate.
 - Corrected Harness Core publication, Micro ECF canonical-repository, skill URL, paid-price-floor, and live-availability wording across machine-readable discovery.
 - Renamed the README table to `Featured Integration Paths`; `integrations.json` is the complete inventory.
 - Hardened `agoragentic-mcp@1.3.4` with a lockfile-only install, exact release-tag gate, hermetic keyless-preview tests, package-source metadata, and a high/critical npm audit gate. The known upstream moderate static-file advisory remains documented and is not exercised by the stdio relay.

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -1,12 +1,14 @@
 {
     "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
     "name": "io.github.rhein1/agoragentic",
-    "description": "MCP server for Agoragentic's hosted Triptych OS (Agent OS) Router / Marketplace. Agents can register, search, preview routed providers, execute paid work, call known capabilities, and read receipt-backed execution status.",
+    "title": "Agoragentic Agent OS MCP",
+    "description": "Triptych OS (Agent OS) MCP for governed routing, receipts, and USDC settlement on Base.",
+    "websiteUrl": "https://agoragentic.com",
     "repository": {
         "url": "https://github.com/rhein1/agoragentic-integrations",
         "source": "github"
     },
-    "version": "1.3.4",
+    "version": "2.1.3",
     "packages": [
         {
             "registryType": "npm",
@@ -26,16 +28,37 @@
                 {
                     "description": "Optional remote MCP URL. Defaults to https://agoragentic.com/api/mcp.",
                     "isRequired": false,
-                    "format": "uri",
+                    "format": "string",
                     "isSecret": false,
                     "name": "AGORAGENTIC_MCP_URL"
                 },
                 {
                     "description": "Optional API base URL for fallback tools. Defaults to https://agoragentic.com.",
                     "isRequired": false,
-                    "format": "uri",
+                    "format": "string",
                     "isSecret": false,
                     "name": "AGORAGENTIC_BASE_URL"
+                }
+            ]
+        }
+    ],
+    "remotes": [
+        {
+            "type": "streamable-http",
+            "url": "https://agoragentic.com/api/mcp",
+            "headers": [
+                {
+                    "description": "Optional Bearer token for authenticated Router / Marketplace tools.",
+                    "value": "Bearer {api_key}",
+                    "variables": {
+                        "api_key": {
+                            "description": "Agoragentic API key from POST /api/quickstart.",
+                            "format": "string",
+                            "isSecret": true,
+                            "placeholder": "api_key_from_quickstart"
+                        }
+                    },
+                    "name": "Authorization"
                 }
             ]
         }

--- a/scripts/verify-integrations-json.js
+++ b/scripts/verify-integrations-json.js
@@ -208,8 +208,11 @@ function assertRegistryMetadata() {
   if (glama.version !== packageVersion) {
     fail(`glama.json version must match mcp/package.json (${packageVersion})`);
   }
-  if (server.version !== packageVersion || server.packages?.[0]?.version !== packageVersion) {
-    fail(`mcp/server.json versions must match mcp/package.json (${packageVersion})`);
+  if (server.packages?.[0]?.version !== packageVersion) {
+    fail(`mcp/server.json npm package version must match mcp/package.json (${packageVersion})`);
+  }
+  if (typeof server.version !== 'string' || !/^\d+\.\d+\.\d+$/.test(server.version)) {
+    fail('mcp/server.json registry version must be a semantic version');
   }
   if (mcpPackage.mcpName !== server.name || server.name !== glama.name) {
     fail('MCP package and registry names must match');


### PR DESCRIPTION
## Summary

Corrects the registry-version assumption introduced in #201 after checking the live official MCP Registry.

- use independent official server version `2.1.3`
- keep the published npm package coordinate at `agoragentic-mcp@1.3.4`
- restore the current remote MCP endpoint and bounded auth metadata
- keep CI checking the embedded npm package version without equating it to the server record version

## Evidence

The live registry currently marks server `2.1.2` as latest and points it to npm package `1.3.3`; those are intentionally separate version lines.

## Validation

- official `mcp-publisher 1.7.9 validate mcp/server.json`: valid
- `node scripts/verify-integrations-json.js`
- `node scripts/adapter-conformance-agent.mjs --jobs 4`: 93/93
- `npm test --prefix mcp`: 3/3
- `npm run check --prefix mcp`
- `git diff --check`

## Boundary

Registry metadata correction only. No package code, runtime behavior, paid execution, settlement, wallet, trust, deployment, or provider-dispatch changes.