### PR TITLE
fix(mcp): clear SDK dependency audit findings

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -33,7 +33,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "agoragentic-mcp@1.3.4"
+        "agoragentic-mcp@1.3.5"
       ]
     }
   }

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           npm run check
           npm test
-          npm audit --omit=dev --audit-level=high
+          npm audit --omit=dev --audit-level=moderate
 
       - name: Dry-run package contents
         run: npm pack --dry-run

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -79,7 +79,7 @@ jobs:
           npm ci --omit=dev
           npm run check
           npm test
-          npm audit --omit=dev --audit-level=high
+          npm audit --omit=dev --audit-level=moderate
           npm pack --dry-run
 
       - name: Validate Micro ECF package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a status-safe 1280x640 integrations banner and first-viewport discovery copy.
 
 ### Changed
+- Prepared `agoragentic-mcp@1.3.5` with `@modelcontextprotocol/sdk` 1.29.0, patched `@hono/node-server` 2.0.11, a Node.js 20 minimum, a zero-vulnerability production dependency audit, and moderate-or-higher CI/release audit gates; synchronized all client-native manifests and MCP registry metadata to the release candidate.
 - Bumped the canonical manifest to `2.29.0` with 97 indexed surfaces and added machine discovery pointers for the native client packages.
 - Replaced the stale quickstart free-balance example with the bounded API-key response shape and synchronized the social banner count.
 - Recorded the current OpenAI public-plugin policy blocker instead of presenting the commerce MCP surface as submission-ready.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-slim
+FROM node:20-slim
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ These packages reuse the published MCP relay and default to no embedded API key.
 | [Cursor](./cursor/README.md) | Clone into `~/.cursor/plugins/local/agoragentic` | Local package ready; publisher submission pending |
 | [Gemini CLI](./gemini-cli/README.md) | `gemini extensions install https://github.com/rhein1/agoragentic-integrations` | Direct install ready; gallery discovery follows the GitHub topic |
 | [Claude Code](./claude-code/README.md) | `/plugin marketplace add rhein1/agoragentic-integrations` | Self-hosted community marketplace ready |
-| [Cline](./cline/README.md) | Add `npx -y agoragentic-mcp@1.3.4` as an MCP server | Submission packet ready; Cline review pending |
+| [Cline](./cline/README.md) | Add `npx -y agoragentic-mcp@1.3.5` as an MCP server | Submission packet ready; Cline review pending |
 
 The canonical descriptions, assets, package coordinate, authority boundary, and per-channel statuses live in [`docs/catalog-profile.json`](./docs/catalog-profile.json). Tool inventory is live and authentication-dependent; directory copy must not publish a static tool count.
 

--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -12,7 +12,7 @@ Run these commands inside Claude Code:
 /reload-plugins
 ```
 
-The plugin starts `agoragentic-mcp@1.3.4` without embedding an API key and adds an Agoragentic skill with preview-first operating rules.
+The plugin starts `agoragentic-mcp@1.3.5` without embedding an API key and adds an Agoragentic skill with preview-first operating rules.
 
 ## Status
 

--- a/claude-code/plugin/.mcp.json
+++ b/claude-code/plugin/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "agoragentic-mcp@1.3.4"
+        "agoragentic-mcp@1.3.5"
       ]
     }
   }

--- a/cline/README.md
+++ b/cline/README.md
@@ -18,7 +18,7 @@ Add an MCP server in Cline:
   "mcpServers": {
     "agoragentic": {
       "command": "npx",
-      "args": ["-y", "agoragentic-mcp@1.3.4"]
+      "args": ["-y", "agoragentic-mcp@1.3.5"]
     }
   }
 }

--- a/cursor/README.md
+++ b/cursor/README.md
@@ -1,6 +1,6 @@
 # Agoragentic for Cursor
 
-The repository includes a Cursor plugin manifest at [`.cursor-plugin/plugin.json`](../.cursor-plugin/plugin.json). It installs the public Agoragentic skill and starts `agoragentic-mcp@1.3.4` over stdio.
+The repository includes a Cursor plugin manifest at [`.cursor-plugin/plugin.json`](../.cursor-plugin/plugin.json). It installs the public Agoragentic skill and starts `agoragentic-mcp@1.3.5` over stdio.
 
 ## Status
 

--- a/docs/catalog-profile.json
+++ b/docs/catalog-profile.json
@@ -20,8 +20,8 @@
   "mcp": {
     "registry_name": "io.github.rhein1/agoragentic",
     "npm_package": "agoragentic-mcp",
-    "package_version": "1.3.4",
-    "command": "npx -y agoragentic-mcp@1.3.4",
+    "package_version": "1.3.5",
+    "command": "npx -y agoragentic-mcp@1.3.5",
     "transport": "stdio-relay",
     "remote_endpoint": "https://agoragentic.com/api/mcp",
     "tool_inventory": "dynamic_and_auth_dependent",

--- a/gemini-cli/README.md
+++ b/gemini-cli/README.md
@@ -1,6 +1,6 @@
 # Agoragentic for Gemini CLI
 
-The root [`gemini-extension.json`](../gemini-extension.json) makes this repository installable as a Gemini CLI extension. It launches `agoragentic-mcp@1.3.4` and loads the no-spend defaults in [`GEMINI.md`](../GEMINI.md).
+The root [`gemini-extension.json`](../gemini-extension.json) makes this repository installable as a Gemini CLI extension. It launches `agoragentic-mcp@1.3.5` and loads the no-spend defaults in [`GEMINI.md`](../GEMINI.md).
 
 ## Install
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -7,7 +7,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "agoragentic-mcp@1.3.4"
+        "agoragentic-mcp@1.3.5"
       ]
     }
   },

--- a/glama.json
+++ b/glama.json
@@ -8,12 +8,12 @@
     "source": "github"
   },
   "maintainers": ["rhein1"],
-  "version": "1.3.4",
+  "version": "1.3.5",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "agoragentic-mcp",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "transport": {
         "type": "stdio"
       },

--- a/integrations.json
+++ b/integrations.json
@@ -1179,7 +1179,7 @@
       "language": "json",
       "status": "beta",
       "path": "cline/README.md",
-      "install": "npx -y agoragentic-mcp@1.3.4",
+      "install": "npx -y agoragentic-mcp@1.3.5",
       "docs": "cline/README.md"
     }
   ],

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -103,7 +103,7 @@ The canonical inventory is `integrations.json` and contains 97 integration surfa
 | Cursor Plugin | .cursor-plugin/plugin.json | clone the repository into Cursor's local plugin directory |
 | Gemini CLI Extension | gemini-extension.json | gemini extensions install https://github.com/rhein1/agoragentic-integrations |
 | Claude Code Plugin | .claude-plugin/marketplace.json | /plugin marketplace add rhein1/agoragentic-integrations |
-| Cline MCP Package | llms-install.md | add npx -y agoragentic-mcp@1.3.4 as an MCP server |
+| Cline MCP Package | llms-install.md | add npx -y agoragentic-mcp@1.3.5 as an MCP server |
 | Vercel AI SDK | vercel-ai/agoragentic_vercel.js | npm install ai @ai-sdk/openai |
 | Cloudflare Agents | cloudflare-agents/agoragentic_cloudflare_agent.ts | copy into a Cloudflare Agent or Worker project |
 | Mastra | mastra/agoragentic_mastra.js | npm install |

--- a/llms-install.md
+++ b/llms-install.md
@@ -4,7 +4,7 @@ Use this procedure to install the public `agoragentic-mcp` stdio relay in Cline.
 
 ## Prerequisites
 
-- Node.js 18 or newer
+- Node.js 20 or newer
 - Cline with MCP server support
 - Network access to `https://agoragentic.com`
 
@@ -22,7 +22,7 @@ An Agoragentic API key is optional and must not be requested for the first-run p
   "mcpServers": {
     "agoragentic": {
       "command": "npx",
-      "args": ["-y", "agoragentic-mcp@1.3.4"]
+      "args": ["-y", "agoragentic-mcp@1.3.5"]
     }
   }
 }

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,31 +1,31 @@
 {
     "name": "agoragentic-mcp",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "agoragentic-mcp",
-            "version": "1.3.4",
+            "version": "1.3.5",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "@modelcontextprotocol/sdk": "^1.27.1"
+                "@modelcontextprotocol/sdk": "1.29.0"
             },
             "bin": {
                 "agoragentic-mcp": "mcp-server.js"
             },
             "engines": {
-                "node": ">=18.0.0"
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@hono/node-server": {
-            "version": "1.19.14",
-            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-            "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+            "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
             "license": "MIT",
             "engines": {
-                "node": ">=18.14.1"
+                "node": ">=20"
             },
             "peerDependencies": {
                 "hono": "^4"
@@ -337,9 +337,9 @@
             }
         },
         "node_modules/es-object-atoms": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-            "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+            "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
@@ -429,11 +429,12 @@
             }
         },
         "node_modules/express-rate-limit": {
-            "version": "8.5.2",
-            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-            "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+            "version": "8.6.0",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+            "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
             "license": "MIT",
             "dependencies": {
+                "debug": "^4.4.3",
                 "ip-address": "^10.2.0"
             },
             "engines": {
@@ -578,9 +579,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-            "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -620,9 +621,9 @@
             }
         },
         "node_modules/iconv-lite": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-            "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+            "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -855,12 +856,13 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.15.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-            "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+            "version": "6.15.3",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "side-channel": "^1.1.0"
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
             },
             "engines": {
                 "node": ">=0.6"
@@ -870,12 +872,16 @@
             }
         },
         "node_modules/range-parser": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+            "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/raw-body": {
@@ -997,14 +1003,14 @@
             }
         },
         "node_modules/side-channel": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
                 "side-channel-map": "^1.0.1",
                 "side-channel-weakmap": "^1.0.2"
             },

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "agoragentic-mcp",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "mcpName": "io.github.rhein1/agoragentic",
     "description": "Stdio relay and fallback MCP server for Agoragentic's hosted Triptych OS (Agent OS) Router / Marketplace. Exposes registration, search, provider preview, paid execution, and receipt-backed status tools.",
     "main": "mcp-server.js",
@@ -46,10 +46,13 @@
         "url": "https://github.com/rhein1/agoragentic-integrations/issues"
     },
     "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.27.1"
+        "@modelcontextprotocol/sdk": "1.29.0"
+    },
+    "overrides": {
+        "@hono/node-server": "2.0.11"
     },
     "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
     },
     "files": [
         "mcp-server.js",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
         "url": "https://github.com/rhein1/agoragentic-integrations",
         "source": "github"
     },
-    "version": "2.1.3",
+    "version": "2.1.4",
     "packages": [
         {
             "registryType": "npm",
             "identifier": "agoragentic-mcp",
-            "version": "1.3.4",
+            "version": "1.3.5",
             "transport": {
                 "type": "stdio"
             },


### PR DESCRIPTION
## Summary

Clears the production dependency findings discovered while validating the Docker MCP Registry submission and prepares `agoragentic-mcp@1.3.5`.

- keeps current `@modelcontextprotocol/sdk` 1.29.0
- overrides its vulnerable Hono adapter with audited `@hono/node-server` 2.0.11
- raises the package minimum from EOL Node 18 to Node 20
- updates the Docker base image to `node:20-slim`
- raises CI and trusted-publish audit gates from high to moderate
- synchronizes Cursor, Gemini CLI, Claude Code, Cline, Glama, catalog, and MCP Registry metadata to 1.3.5
- bumps the MCP Registry record to 2.1.4

The npm-recommended SDK downgrade was tested and rejected because it introduced a direct high-severity SDK advisory.

## Validation

Passed locally:

- `npm ci --omit=dev`
- `npm run check`
- `npm test` (3/3)
- `npm audit --omit=dev` (0 vulnerabilities)
- `npm pack --dry-run`
- MCP Inspector initialization and `tools/list` against the local relay
- clean Node 20 Docker build
- MCP tests inside the built container (3/3)
- production dependency audit inside the built container (0 vulnerabilities)
- MCP Inspector `tools/list` through the built container
- `node scripts/verify-client-distribution.mjs`
- `node scripts/verify-integrations-json.js`
- `node scripts/verify-doc-links.mjs`
- `gemini extensions validate .`
- `claude plugin validate .`
- `claude plugin validate claude-code/plugin`
- `git diff --check`

## Boundary

No MCP tool was invoked during compatibility validation. No API key, wallet, x402 payment, marketplace execution, provider dispatch, deployment, or USDC spend was used. This PR prepares the package and release gates; npm publication remains tied to the exact `mcp-v1.3.5` GitHub release and trusted publishing workflow.