### PR TITLE
fix(mcp): bundle audited runtime dependencies

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -33,7 +33,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "agoragentic-mcp@1.3.5"
+        "agoragentic-mcp@1.3.6"
       ]
     }
   }

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -39,13 +39,14 @@ jobs:
           test "${RELEASE_TAG}" = "mcp-v${package_version}"
 
       - name: Install dependencies
-        run: npm ci --omit=dev
+        run: npm ci
 
       - name: Validate MCP package
         run: |
           npm run check
           npm test
-          npm audit --omit=dev --audit-level=moderate
+          npm audit --audit-level=moderate
+          npm run verify:packed-install
 
       - name: Dry-run package contents
         run: npm pack --dry-run

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -76,10 +76,11 @@ jobs:
       - name: Validate MCP package
         working-directory: mcp
         run: |
-          npm ci --omit=dev
+          npm ci
           npm run check
           npm test
-          npm audit --omit=dev --audit-level=moderate
+          npm audit --audit-level=moderate
+          npm run verify:packed-install
           npm pack --dry-run
 
       - name: Validate Micro ECF package

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 mcp/node_modules/
 mcp/build/
+mcp/dist/
 mcp/.mcpregistry_*
 n8n/node_modules/
 n8n/dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a status-safe 1280x640 integrations banner and first-viewport discovery copy.
 
 ### Changed
-- Prepared `agoragentic-mcp@1.3.5` with `@modelcontextprotocol/sdk` 1.29.0, patched `@hono/node-server` 2.0.11, a Node.js 20 minimum, a zero-vulnerability production dependency audit, and moderate-or-higher CI/release audit gates; synchronized all client-native manifests and MCP registry metadata to the release candidate.
+- Superseded `agoragentic-mcp@1.3.5` with `1.3.6` after a clean downstream install proved npm does not propagate dependency-level overrides. The 1.3.6 package bundles the audited MCP SDK/Hono tree into a Node.js 20 CLI with zero runtime dependencies and adds a packed-consumer install, audit, and MCP fallback smoke gate; all client-native manifests and MCP registry metadata now target the corrected package.
 - Bumped the canonical manifest to `2.29.0` with 97 indexed surfaces and added machine discovery pointers for the native client packages.
 - Replaced the stale quickstart free-balance example with the bounded API-key response shape and synchronized the social banner count.
 - Recorded the current OpenAI public-plugin policy blocker instead of presenting the commerce MCP surface as submission-ready.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,22 @@
+FROM node:20-slim AS build
+
+WORKDIR /app
+
+# Install the audited build toolchain before copying the relay source.
+COPY mcp/package.json mcp/package-lock.json* ./mcp/
+COPY mcp/scripts/postinstall.js ./mcp/scripts/postinstall.js
+RUN cd mcp && npm ci
+
+COPY mcp/mcp-server.js ./mcp/mcp-server.js
+COPY mcp/scripts/build.js ./mcp/scripts/build.js
+RUN cd mcp && npm run build
+
 FROM node:20-slim
 
 WORKDIR /app
 
-# Copy package metadata and the lifecycle script before the locked install.
-COPY mcp/package.json mcp/package-lock.json* ./mcp/
-COPY mcp/scripts/postinstall.js ./mcp/scripts/postinstall.js
-RUN cd mcp && npm ci --omit=dev
+COPY --from=build /app/mcp/dist/mcp-server.cjs ./mcp/dist/mcp-server.cjs
+COPY mcp/package.json ./mcp/package.json
 
-COPY mcp/ ./mcp/
-
-# Glama inspects the server by running it via stdio
-ENTRYPOINT ["node", "mcp/mcp-server.js"]
+# Glama and Docker MCP inspect the bundled server through stdio.
+ENTRYPOINT ["node", "mcp/dist/mcp-server.cjs"]

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ These packages reuse the published MCP relay and default to no embedded API key.
 | [Cursor](./cursor/README.md) | Clone into `~/.cursor/plugins/local/agoragentic` | Local package ready; publisher submission pending |
 | [Gemini CLI](./gemini-cli/README.md) | `gemini extensions install https://github.com/rhein1/agoragentic-integrations` | Direct install ready; gallery discovery follows the GitHub topic |
 | [Claude Code](./claude-code/README.md) | `/plugin marketplace add rhein1/agoragentic-integrations` | Self-hosted community marketplace ready |
-| [Cline](./cline/README.md) | Add `npx -y agoragentic-mcp@1.3.5` as an MCP server | Submission packet ready; Cline review pending |
+| [Cline](./cline/README.md) | Add `npx -y agoragentic-mcp@1.3.6` as an MCP server | Submission packet ready; Cline review pending |
 
 The canonical descriptions, assets, package coordinate, authority boundary, and per-channel statuses live in [`docs/catalog-profile.json`](./docs/catalog-profile.json). Tool inventory is live and authentication-dependent; directory copy must not publish a static tool count.
 

--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -12,7 +12,7 @@ Run these commands inside Claude Code:
 /reload-plugins
 ```
 
-The plugin starts `agoragentic-mcp@1.3.5` without embedding an API key and adds an Agoragentic skill with preview-first operating rules.
+The plugin starts `agoragentic-mcp@1.3.6` without embedding an API key and adds an Agoragentic skill with preview-first operating rules.
 
 ## Status
 

--- a/claude-code/plugin/.mcp.json
+++ b/claude-code/plugin/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "agoragentic-mcp@1.3.5"
+        "agoragentic-mcp@1.3.6"
       ]
     }
   }

--- a/cline/README.md
+++ b/cline/README.md
@@ -18,7 +18,7 @@ Add an MCP server in Cline:
   "mcpServers": {
     "agoragentic": {
       "command": "npx",
-      "args": ["-y", "agoragentic-mcp@1.3.5"]
+      "args": ["-y", "agoragentic-mcp@1.3.6"]
     }
   }
 }

--- a/cursor/README.md
+++ b/cursor/README.md
@@ -1,6 +1,6 @@
 # Agoragentic for Cursor
 
-The repository includes a Cursor plugin manifest at [`.cursor-plugin/plugin.json`](../.cursor-plugin/plugin.json). It installs the public Agoragentic skill and starts `agoragentic-mcp@1.3.5` over stdio.
+The repository includes a Cursor plugin manifest at [`.cursor-plugin/plugin.json`](../.cursor-plugin/plugin.json). It installs the public Agoragentic skill and starts `agoragentic-mcp@1.3.6` over stdio.
 
 ## Status
 

--- a/docs/catalog-profile.json
+++ b/docs/catalog-profile.json
@@ -20,8 +20,8 @@
   "mcp": {
     "registry_name": "io.github.rhein1/agoragentic",
     "npm_package": "agoragentic-mcp",
-    "package_version": "1.3.5",
-    "command": "npx -y agoragentic-mcp@1.3.5",
+    "package_version": "1.3.6",
+    "command": "npx -y agoragentic-mcp@1.3.6",
     "transport": "stdio-relay",
     "remote_endpoint": "https://agoragentic.com/api/mcp",
     "tool_inventory": "dynamic_and_auth_dependent",

--- a/gemini-cli/README.md
+++ b/gemini-cli/README.md
@@ -1,6 +1,6 @@
 # Agoragentic for Gemini CLI
 
-The root [`gemini-extension.json`](../gemini-extension.json) makes this repository installable as a Gemini CLI extension. It launches `agoragentic-mcp@1.3.5` and loads the no-spend defaults in [`GEMINI.md`](../GEMINI.md).
+The root [`gemini-extension.json`](../gemini-extension.json) makes this repository installable as a Gemini CLI extension. It launches `agoragentic-mcp@1.3.6` and loads the no-spend defaults in [`GEMINI.md`](../GEMINI.md).
 
 ## Install
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -7,7 +7,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "agoragentic-mcp@1.3.5"
+        "agoragentic-mcp@1.3.6"
       ]
     }
   },

--- a/glama.json
+++ b/glama.json
@@ -8,12 +8,12 @@
     "source": "github"
   },
   "maintainers": ["rhein1"],
-  "version": "1.3.5",
+  "version": "1.3.6",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "agoragentic-mcp",
-      "version": "1.3.5",
+      "version": "1.3.6",
       "transport": {
         "type": "stdio"
       },

--- a/integrations.json
+++ b/integrations.json
@@ -1179,7 +1179,7 @@
       "language": "json",
       "status": "beta",
       "path": "cline/README.md",
-      "install": "npx -y agoragentic-mcp@1.3.5",
+      "install": "npx -y agoragentic-mcp@1.3.6",
       "docs": "cline/README.md"
     }
   ],

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -103,7 +103,7 @@ The canonical inventory is `integrations.json` and contains 97 integration surfa
 | Cursor Plugin | .cursor-plugin/plugin.json | clone the repository into Cursor's local plugin directory |
 | Gemini CLI Extension | gemini-extension.json | gemini extensions install https://github.com/rhein1/agoragentic-integrations |
 | Claude Code Plugin | .claude-plugin/marketplace.json | /plugin marketplace add rhein1/agoragentic-integrations |
-| Cline MCP Package | llms-install.md | add npx -y agoragentic-mcp@1.3.5 as an MCP server |
+| Cline MCP Package | llms-install.md | add npx -y agoragentic-mcp@1.3.6 as an MCP server |
 | Vercel AI SDK | vercel-ai/agoragentic_vercel.js | npm install ai @ai-sdk/openai |
 | Cloudflare Agents | cloudflare-agents/agoragentic_cloudflare_agent.ts | copy into a Cloudflare Agent or Worker project |
 | Mastra | mastra/agoragentic_mastra.js | npm install |

--- a/llms-install.md
+++ b/llms-install.md
@@ -22,7 +22,7 @@ An Agoragentic API key is optional and must not be requested for the first-run p
   "mcpServers": {
     "agoragentic": {
       "command": "npx",
-      "args": ["-y", "agoragentic-mcp@1.3.5"]
+      "args": ["-y", "agoragentic-mcp@1.3.6"]
     }
   }
 }

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,28 +1,472 @@
 {
     "name": "agoragentic-mcp",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "agoragentic-mcp",
-            "version": "1.3.5",
+            "version": "1.3.6",
             "hasInstallScript": true,
             "license": "MIT",
-            "dependencies": {
-                "@modelcontextprotocol/sdk": "1.29.0"
-            },
             "bin": {
-                "agoragentic-mcp": "mcp-server.js"
+                "agoragentic-mcp": "dist/mcp-server.cjs"
+            },
+            "devDependencies": {
+                "@modelcontextprotocol/sdk": "1.29.0",
+                "esbuild": "0.25.12"
             },
             "engines": {
                 "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+            "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+            "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+            "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+            "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+            "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+            "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+            "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+            "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+            "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+            "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+            "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+            "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+            "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+            "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+            "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+            "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+            "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+            "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+            "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+            "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+            "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+            "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+            "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+            "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@hono/node-server": {
             "version": "2.0.11",
             "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
             "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=20"
@@ -35,6 +479,7 @@
             "version": "1.29.0",
             "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
             "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@hono/node-server": "^1.19.9",
@@ -75,6 +520,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
             "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "mime-types": "^3.0.0",
@@ -88,6 +534,7 @@
             "version": "8.20.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
             "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -104,6 +551,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
             "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ajv": "^8.0.0"
@@ -121,6 +569,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
             "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "bytes": "^3.1.2",
@@ -145,6 +594,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
             "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -158,6 +608,7 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
             "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
@@ -167,6 +618,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
             "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -180,6 +632,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
             "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
@@ -196,6 +649,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
             "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -209,6 +663,7 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
             "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -218,6 +673,7 @@
             "version": "0.7.2",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
             "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -227,6 +683,7 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
             "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.6.0"
@@ -236,6 +693,7 @@
             "version": "2.8.6",
             "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
             "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "object-assign": "^4",
@@ -253,6 +711,7 @@
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
@@ -267,6 +726,7 @@
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
             "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -284,6 +744,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
             "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
@@ -293,6 +754,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
             "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.1",
@@ -307,12 +769,14 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/encodeurl": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
             "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
@@ -322,6 +786,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
             "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -331,6 +796,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -340,6 +806,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
             "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
@@ -348,16 +815,60 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/esbuild": {
+            "version": "0.25.12",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+            "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.25.12",
+                "@esbuild/android-arm": "0.25.12",
+                "@esbuild/android-arm64": "0.25.12",
+                "@esbuild/android-x64": "0.25.12",
+                "@esbuild/darwin-arm64": "0.25.12",
+                "@esbuild/darwin-x64": "0.25.12",
+                "@esbuild/freebsd-arm64": "0.25.12",
+                "@esbuild/freebsd-x64": "0.25.12",
+                "@esbuild/linux-arm": "0.25.12",
+                "@esbuild/linux-arm64": "0.25.12",
+                "@esbuild/linux-ia32": "0.25.12",
+                "@esbuild/linux-loong64": "0.25.12",
+                "@esbuild/linux-mips64el": "0.25.12",
+                "@esbuild/linux-ppc64": "0.25.12",
+                "@esbuild/linux-riscv64": "0.25.12",
+                "@esbuild/linux-s390x": "0.25.12",
+                "@esbuild/linux-x64": "0.25.12",
+                "@esbuild/netbsd-arm64": "0.25.12",
+                "@esbuild/netbsd-x64": "0.25.12",
+                "@esbuild/openbsd-arm64": "0.25.12",
+                "@esbuild/openbsd-x64": "0.25.12",
+                "@esbuild/openharmony-arm64": "0.25.12",
+                "@esbuild/sunos-x64": "0.25.12",
+                "@esbuild/win32-arm64": "0.25.12",
+                "@esbuild/win32-ia32": "0.25.12",
+                "@esbuild/win32-x64": "0.25.12"
+            }
+        },
         "node_modules/escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
             "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/etag": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
             "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -367,6 +878,7 @@
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
             "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "eventsource-parser": "^3.0.1"
@@ -379,6 +891,7 @@
             "version": "3.0.8",
             "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
             "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=18.0.0"
@@ -388,6 +901,7 @@
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
             "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+            "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -432,6 +946,7 @@
             "version": "8.6.0",
             "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
             "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "debug": "^4.4.3",
@@ -451,12 +966,14 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-uri": {
             "version": "3.1.4",
             "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
             "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -473,6 +990,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
             "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "debug": "^4.4.0",
@@ -494,6 +1012,7 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
             "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -503,6 +1022,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
             "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
@@ -512,6 +1032,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -521,6 +1042,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
             "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
@@ -545,6 +1067,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
             "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "dunder-proto": "^1.0.1",
@@ -558,6 +1081,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
             "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -570,6 +1094,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -582,6 +1107,7 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
             "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -594,6 +1120,7 @@
             "version": "4.12.31",
             "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
             "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+            "dev": true,
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -604,6 +1131,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
             "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "depd": "~2.0.0",
@@ -624,6 +1152,7 @@
             "version": "0.7.3",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
             "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -640,12 +1169,14 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/ip-address": {
             "version": "10.2.0",
             "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
             "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 12"
@@ -655,6 +1186,7 @@
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
             "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.10"
@@ -664,18 +1196,21 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
             "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/jose": {
             "version": "6.2.3",
             "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
             "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/panva"
@@ -685,18 +1220,21 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/json-schema-typed": {
             "version": "8.0.2",
             "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
             "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+            "dev": true,
             "license": "BSD-2-Clause"
         },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -706,6 +1244,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
             "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
@@ -715,6 +1254,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
             "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -727,6 +1267,7 @@
             "version": "1.54.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
             "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -736,6 +1277,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
             "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "mime-db": "^1.54.0"
@@ -752,12 +1294,14 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/negotiator": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
             "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -767,6 +1311,7 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -776,6 +1321,7 @@
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
             "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -788,6 +1334,7 @@
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
             "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ee-first": "1.1.1"
@@ -800,6 +1347,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
@@ -809,6 +1357,7 @@
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
             "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
@@ -818,6 +1367,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -827,6 +1377,7 @@
             "version": "8.4.2",
             "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
             "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "type": "opencollective",
@@ -837,6 +1388,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
             "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=16.20.0"
@@ -846,6 +1398,7 @@
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
             "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "forwarded": "0.2.0",
@@ -859,6 +1412,7 @@
             "version": "6.15.3",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
             "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+            "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "es-define-property": "^1.0.1",
@@ -875,6 +1429,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
             "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -888,6 +1443,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
             "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "bytes": "~3.1.2",
@@ -903,6 +1459,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -912,6 +1469,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
             "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "debug": "^4.4.0",
@@ -928,12 +1486,14 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/send": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
             "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "debug": "^4.4.3",
@@ -960,6 +1520,7 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
             "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "encodeurl": "^2.0.0",
@@ -979,12 +1540,14 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
             "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "shebang-regex": "^3.0.0"
@@ -997,6 +1560,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -1006,6 +1570,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
             "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -1025,6 +1590,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
             "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -1041,6 +1607,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
             "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -1059,6 +1626,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
             "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -1078,6 +1646,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
             "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
@@ -1087,6 +1656,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
             "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.6"
@@ -1096,6 +1666,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
             "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "content-type": "^2.0.0",
@@ -1114,6 +1685,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
             "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=18"
@@ -1127,6 +1699,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
             "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
@@ -1136,6 +1709,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
             "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
@@ -1145,6 +1719,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "isexe": "^2.0.0"
@@ -1160,12 +1735,14 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/zod": {
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
             "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+            "dev": true,
             "license": "MIT",
             "peer": true,
             "funding": {
@@ -1176,6 +1753,7 @@
             "version": "3.25.2",
             "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
             "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+            "dev": true,
             "license": "ISC",
             "peerDependencies": {
                 "zod": "^3.25.28 || ^4"

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,17 +1,21 @@
 {
     "name": "agoragentic-mcp",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "mcpName": "io.github.rhein1/agoragentic",
     "description": "Stdio relay and fallback MCP server for Agoragentic's hosted Triptych OS (Agent OS) Router / Marketplace. Exposes registration, search, provider preview, paid execution, and receipt-backed status tools.",
-    "main": "mcp-server.js",
+    "main": "dist/mcp-server.cjs",
     "bin": {
-        "agoragentic-mcp": "mcp-server.js"
+        "agoragentic-mcp": "dist/mcp-server.cjs"
     },
     "scripts": {
-        "start": "node mcp-server.js",
-        "check": "node --check mcp-server.js && node --check test/fallback-preview.test.js",
+        "start": "node dist/mcp-server.cjs",
+        "dev": "node mcp-server.js",
+        "build": "node scripts/build.js",
+        "check": "node --check mcp-server.js && node --check scripts/build.js && node --check scripts/verify-packed-install.js && node --check test/fallback-preview.test.js",
         "test": "node --test test/*.test.js",
-        "prepublishOnly": "npm run check && npm test",
+        "verify:packed-install": "node scripts/verify-packed-install.js",
+        "prepack": "npm run build",
+        "prepublishOnly": "npm run check && npm test && npm run verify:packed-install",
         "postinstall": "node scripts/postinstall.js || true"
     },
     "keywords": [
@@ -45,8 +49,9 @@
     "bugs": {
         "url": "https://github.com/rhein1/agoragentic-integrations/issues"
     },
-    "dependencies": {
-        "@modelcontextprotocol/sdk": "1.29.0"
+    "devDependencies": {
+        "@modelcontextprotocol/sdk": "1.29.0",
+        "esbuild": "0.25.12"
     },
     "overrides": {
         "@hono/node-server": "2.0.11"
@@ -55,7 +60,7 @@
         "node": ">=20.0.0"
     },
     "files": [
-        "mcp-server.js",
+        "dist/mcp-server.cjs",
         "scripts/postinstall.js",
         "README.md",
         "LICENSE"

--- a/mcp/scripts/build.js
+++ b/mcp/scripts/build.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const path = require('path');
+const { build } = require('esbuild');
+
+const packageRoot = path.resolve(__dirname, '..');
+
+build({
+    entryPoints: [path.join(packageRoot, 'mcp-server.js')],
+    outfile: path.join(packageRoot, 'dist', 'mcp-server.cjs'),
+    bundle: true,
+    platform: 'node',
+    target: 'node20',
+    format: 'cjs',
+    legalComments: 'none',
+}).catch((error) => {
+    console.error(error);
+    process.exit(1);
+});

--- a/mcp/scripts/verify-packed-install.js
+++ b/mcp/scripts/verify-packed-install.js
@@ -1,0 +1,152 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const readline = require('readline');
+const { execFileSync, spawn } = require('child_process');
+
+const npmCli = process.env.npm_execpath;
+const npmCommand = npmCli ? process.execPath : process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+function runNpm(args, options = {}) {
+    const commandArgs = npmCli ? [npmCli, ...args] : args;
+    return execFileSync(npmCommand, commandArgs, {
+        encoding: 'utf8',
+        stdio: options.capture ? ['ignore', 'pipe', 'inherit'] : 'inherit',
+        ...options,
+    });
+}
+
+function verifyMcpFallback(entrypoint) {
+    return new Promise((resolve, reject) => {
+        const child = spawn(process.execPath, [entrypoint], {
+            env: {
+                ...process.env,
+                AGORAGENTIC_MCP_URL: 'http://127.0.0.1:9/mcp',
+                AGORAGENTIC_API_KEY: '',
+            },
+            stdio: ['pipe', 'pipe', 'pipe'],
+        });
+
+        let stderr = '';
+        let settled = false;
+        const output = readline.createInterface({ input: child.stdout });
+        const timeout = setTimeout(() => {
+            finish(new Error(`packed MCP smoke timed out\n${stderr}`));
+        }, 15000);
+
+        function finish(error) {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            output.close();
+            child.kill();
+            if (error) reject(error);
+            else resolve();
+        }
+
+        child.stderr.on('data', (chunk) => {
+            stderr += chunk.toString();
+        });
+
+        child.on('error', finish);
+        child.on('exit', (code) => {
+            if (!settled) {
+                finish(new Error(`packed MCP exited before tools/list (code ${code})\n${stderr}`));
+            }
+        });
+
+        output.on('line', (line) => {
+            let message;
+            try {
+                message = JSON.parse(line);
+            } catch {
+                return;
+            }
+
+            if (message.id === 1 && message.result) {
+                child.stdin.write(`${JSON.stringify({
+                    jsonrpc: '2.0',
+                    method: 'notifications/initialized',
+                    params: {},
+                })}\n`);
+                child.stdin.write(`${JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: 2,
+                    method: 'tools/list',
+                    params: {},
+                })}\n`);
+                return;
+            }
+
+            if (message.id === 2) {
+                try {
+                    const tools = message.result?.tools || [];
+                    assert(tools.some((tool) => tool.name === 'agoragentic_preview_x402'));
+                    assert(tools.some((tool) => tool.name === 'agoragentic_execute'));
+                    finish();
+                } catch (error) {
+                    finish(error);
+                }
+            }
+        });
+
+        child.stdin.write(`${JSON.stringify({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+                protocolVersion: '2025-06-18',
+                capabilities: {},
+                clientInfo: {
+                    name: 'agoragentic-packed-install-smoke',
+                    version: '1.0.0',
+                },
+            },
+        })}\n`);
+    });
+}
+
+async function main() {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agoragentic-mcp-packed-'));
+    const packDir = path.join(tempRoot, 'pack');
+    const consumerDir = path.join(tempRoot, 'consumer');
+    fs.mkdirSync(packDir);
+    fs.mkdirSync(consumerDir);
+
+    try {
+        const packed = JSON.parse(
+            runNpm(['pack', '--pack-destination', packDir, '--json'], { capture: true })
+        );
+        assert(Array.isArray(packed) && packed.length === 1, 'npm pack must produce one tarball');
+
+        const tarball = path.join(packDir, packed[0].filename);
+        runNpm(['install', '--prefix', consumerDir, '--ignore-scripts', tarball]);
+        runNpm(['audit', '--prefix', consumerDir, '--omit=dev', '--audit-level=moderate']);
+
+        const installedRoot = path.join(consumerDir, 'node_modules', 'agoragentic-mcp');
+        const installedPackage = JSON.parse(
+            fs.readFileSync(path.join(installedRoot, 'package.json'), 'utf8')
+        );
+        assert.deepStrictEqual(
+            installedPackage.dependencies || {},
+            {},
+            'packed consumers must not install runtime dependencies'
+        );
+
+        const entrypoint = path.join(installedRoot, 'dist', 'mcp-server.cjs');
+        assert(fs.existsSync(entrypoint), 'packed MCP bundle is missing');
+        await verifyMcpFallback(entrypoint);
+
+        console.log('packed consumer install verified: zero runtime dependencies, audit clean, MCP fallback ready');
+    } finally {
+        fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
         "url": "https://github.com/rhein1/agoragentic-integrations",
         "source": "github"
     },
-    "version": "2.1.4",
+    "version": "2.1.5",
     "packages": [
         {
             "registryType": "npm",
             "identifier": "agoragentic-mcp",
-            "version": "1.3.5",
+            "version": "1.3.6",
             "transport": {
                 "type": "stdio"
             },


### PR DESCRIPTION
## Summary

Corrects the consumer-install gap in `agoragentic-mcp@1.3.5` and prepares 1.3.6.

A clean downstream install proved that npm does not propagate a dependency package's `overrides` (or shrinkwrap resolution) into the consumer tree. Although the 1.3.5 repository and container audits were green, consumers still resolved `@hono/node-server@1.19.14` through the MCP SDK.

This PR provides a durable package boundary:

- bundles the official MCP SDK 1.29.0 and patched Hono 2.0.11 into the CLI with esbuild
- publishes zero runtime dependencies
- keeps the audited SDK/Hono/esbuild tree as development/build dependencies
- adds a multi-stage Node 20 Docker image with no runtime `node_modules`
- adds a packed-consumer gate that installs the tarball into a fresh project, audits it, asserts zero runtime dependencies, and performs MCP initialize + fallback `tools/list`
- runs that consumer gate in CI, `prepublishOnly`, and trusted publishing
- synchronizes Cursor, Gemini CLI, Claude Code, Cline, Glama, catalog, and MCP Registry metadata to 1.3.6
- bumps the MCP Registry record to 2.1.5

## Validation

Passed locally:

- `npm ci`
- `npm run check`
- `npm test` (3/3)
- `npm audit --audit-level=moderate` (0 vulnerabilities)
- `npm run verify:packed-install`
  - fresh consumer installed one package
  - zero runtime dependencies
  - consumer audit clean
  - MCP initialize and fallback `tools/list` passed
- `npm pack --dry-run`
- clean multi-stage Node 20 Docker build
- runtime image has no `node_modules`
- MCP Inspector `tools/list` through the runtime image
- `node scripts/verify-client-distribution.mjs`
- `node scripts/verify-integrations-json.js`
- `node scripts/verify-doc-links.mjs`
- Gemini CLI and both Claude plugin validations
- `git diff --check`

## Boundary

No MCP tool was called. The packed runtime smoke forces a loopback connection failure and verifies local fallback discovery only. No API key, wallet, x402 payment, marketplace execution, provider dispatch, deployment, or USDC spend was used.

After merge, the exact `mcp-v1.3.6` release will supersede 1.3.5 through the existing trusted-publishing workflow.