### PR TITLE
docs(distribution): reconcile directory submission status

### DIFF
--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -8,17 +8,21 @@ The canonical machine packet is [`catalog-profile.json`](./catalog-profile.json)
 
 | Client | Local/direct package | External discovery state |
 |---|---|---|
-| Cursor | [`.cursor-plugin/plugin.json`](../.cursor-plugin/plugin.json) | Ready for owner submission; not yet a Marketplace listing |
-| Gemini CLI | [`gemini-extension.json`](../gemini-extension.json) | Direct Git install ready; gallery requires the repository topic and crawler |
+| Cursor | [`.cursor-plugin/plugin.json`](../.cursor-plugin/plugin.json) | Ready for publisher submission; no submission receipt or Marketplace listing is confirmed |
+| Gemini CLI | [`gemini-extension.json`](../gemini-extension.json) | Direct Git install ready and repository topic present; gallery indexing is not confirmed |
 | Claude Code | [`.claude-plugin/marketplace.json`](../.claude-plugin/marketplace.json) | Self-hosted community marketplace; no Anthropic listing claim |
-| Cline | [`llms-install.md`](../llms-install.md) | Ready for a Cline Marketplace submission issue |
-| Docker MCP Catalog | [`Dockerfile`](../Dockerfile) | Existing image source is ready; upstream entry should pin the merged commit |
+| Cline | [`llms-install.md`](../llms-install.md) | [Submission issue #808](https://github.com/cline/mcp-marketplace/issues/808) is open and pending Cline review |
+| Docker MCP Catalog | [`Dockerfile`](../Dockerfile) | [Registry PR #4524](https://github.com/docker/mcp-registry/pull/4524) is open and pending Docker review |
 
 Every default client package launches the published MCP relay without embedding `AGORAGENTIC_API_KEY`. Tool inventory is dynamic and authentication-dependent. Do not publish a static tool count in directory copy.
 
 ## Existing MCP Discovery
 
-The npm package, Official MCP Registry entry, Smithery listing, Glama listing, PulseMCP listing, and community awesome-list entry are established distribution surfaces. Smithery still presents an old static tool count and marketplace-first description. `mcp.so` carries materially stale copy and has more than one historical slug. Both require directory-side metadata updates; the repository packet is ready, but it cannot rewrite those third-party records.
+The npm package, Official MCP Registry entry, Smithery listing, Glama listing, PulseMCP listing, and community awesome-list entry are established distribution surfaces.
+
+The Smithery listing metadata is current. Its usage dashboard counts initialization and listability sessions separately from tool calls, so session totals must not be presented as evidence of capability use. The latest owner review found discovery/probe traffic but no recorded tool invocations.
+
+The owned `mcp.so` listing still carries stale copy and has more than one historical slug. The editor accepted changes but did not persist them, and the site's ticket form did not create a visible record. A support email was sent on 2026-07-23; no repair or consolidation is confirmed.
 
 ## OpenAI / ChatGPT Boundary
 
@@ -26,13 +30,12 @@ Do not submit the existing commerce MCP surface to the OpenAI public plugin dire
 
 The existing OpenAI Agents SDK adapters in this repository remain open-source framework integrations. They are not ChatGPT App Directory listings.
 
-## Submission Order
+## Outstanding Distribution Work
 
-1. Merge and validate the native package manifests.
-2. Add the `gemini-cli-extension`, `cursor-plugin`, and `claude-code-plugin` repository topics.
-3. Submit Cursor through the publisher portal; stop for owner identity or terms acceptance.
-4. Open the Cline Marketplace submission issue using the 400 by 400 icon and `llms-install.md`.
-5. Open a Docker MCP Registry PR pinned to the merged source commit.
-6. Claim and consolidate the duplicate `mcp.so` records.
+1. Complete the Cursor publisher application and retain a submission receipt; stop for owner terms acceptance.
+2. Wait for or respond to Cline review on [issue #808](https://github.com/cline/mcp-marketplace/issues/808).
+3. Wait for or respond to Docker review on [PR #4524](https://github.com/docker/mcp-registry/pull/4524).
+4. Follow up with `mcp.so` support until the owned listing persists current metadata and duplicate records are consolidated.
+5. Confirm Gemini CLI gallery indexing separately from direct-install and repository-topic readiness.
 
 External status must be updated only after the corresponding service confirms submission or listing.

--- a/docs/catalog-profile.json
+++ b/docs/catalog-profile.json
@@ -1,7 +1,7 @@
 {
   "schema": "agoragentic.integration-distribution.v1",
-  "version": "1.0.0",
-  "updated_at": "2026-07-23",
+  "version": "1.0.1",
+  "updated_at": "2026-07-24",
   "product": {
     "name": "Agoragentic",
     "display_name": "Agoragentic for Triptych OS",
@@ -50,9 +50,9 @@
     },
     {
       "id": "smithery",
-      "status": "active_needs_metadata_refresh",
+      "status": "active",
       "url": "https://smithery.ai/servers/rhein1/agoragentic-mcp",
-      "note": "The listing is live but still presents an old static tool count and marketplace-first description."
+      "note": "Listing metadata is current. Session counts include initialization and listability probes and must not be treated as tool-use evidence."
     },
     {
       "id": "glama",
@@ -66,20 +66,21 @@
     },
     {
       "id": "mcp-so",
-      "status": "needs_owner_claim",
-      "url": "https://mcp.so/server/agoragentic/rhein1",
-      "note": "The page carries materially stale copy and a second older slug exists; both require directory-side claim and consolidation."
+      "status": "support_escalated",
+      "url": "https://mcp.so/servers/agoragentic-integrations",
+      "note": "The owned listing editor did not persist current metadata and the ticket form produced no visible record. Support was emailed on 2026-07-23; repair and duplicate consolidation are not confirmed."
     },
     {
       "id": "cursor-marketplace",
       "status": "ready_for_submission",
-      "artifact": ".cursor-plugin/plugin.json"
+      "artifact": ".cursor-plugin/plugin.json",
+      "note": "The publisher form remains available and no submission receipt or Marketplace listing is confirmed."
     },
     {
       "id": "gemini-cli-gallery",
       "status": "install_ready",
       "artifact": "gemini-extension.json",
-      "note": "Gallery discovery requires the gemini-cli-extension GitHub topic after merge."
+      "note": "The gemini-cli-extension GitHub topic is present; external gallery indexing is not confirmed."
     },
     {
       "id": "claude-code-marketplace",
@@ -89,14 +90,17 @@
     },
     {
       "id": "cline-marketplace",
-      "status": "ready_for_submission",
-      "artifact": "llms-install.md"
+      "status": "submitted_pending_review",
+      "url": "https://github.com/cline/mcp-marketplace/issues/808",
+      "artifact": "llms-install.md",
+      "note": "The submission issue is open and was refreshed with a Cline CLI 3.0.46 install and tools/list smoke against agoragentic-mcp@1.3.6."
     },
     {
       "id": "docker-mcp-catalog",
-      "status": "ready_after_merge",
+      "status": "submitted_pending_review",
+      "url": "https://github.com/docker/mcp-registry/pull/4524",
       "artifact": "Dockerfile",
-      "note": "The upstream registry entry must pin a public commit containing the client packages."
+      "note": "The upstream PR pins source commit 19ffef3c73d0c33aafd17d60c6f7974b1abb4a72 and is mergeable but awaits Docker review."
     },
     {
       "id": "openai-plugin-directory",

--- a/scripts/verify-client-distribution.mjs
+++ b/scripts/verify-client-distribution.mjs
@@ -52,6 +52,8 @@ const channelStatuses = new Set([
   'needs_owner_claim',
   'ready_after_merge',
   'ready_for_submission',
+  'submitted_pending_review',
+  'support_escalated',
 ]);
 for (const channel of profile.channels) {
   assert.ok(channelStatuses.has(channel.status), `unknown channel status: ${channel.status}`);


### PR DESCRIPTION
## Summary

Reconciles the public integration-distribution status with verified directory state.

- records Cline issue #808 and Docker MCP Registry PR #4524 as submitted and pending upstream review
- records Smithery metadata as current while distinguishing sessions/probes from tool usage
- records the failed MCP.so editor flow and support escalation without claiming repair
- keeps Cursor and Gemini states honest where no submission receipt or external indexing is confirmed
- extends the distribution verifier for the two new evidence-backed status values

## Validation

- `node --check scripts/verify-client-distribution.mjs`
- `node scripts/verify-client-distribution.mjs`
- `node scripts/verify-integrations-json.js`
- `node scripts/verify-doc-links.mjs`
- `node --test test/verify-doc-links.test.mjs`
- `git diff --check`

## Boundary

Documentation/status reconciliation only. No directory submission, package publication, deployment, wallet/x402 action, or platform mutation.