### PR TITLE
ci(n8n): gate known dev advisory explicitly

### DIFF
--- a/.github/workflows/publish-n8n.yml
+++ b/.github/workflows/publish-n8n.yml
@@ -50,7 +50,7 @@ jobs:
         run: npm audit --omit=dev --audit-level=moderate
 
       - name: Reject high or critical toolchain advisories
-        run: npm audit --audit-level=high
+        run: npm run audit:dev
 
       - name: Dry-run package contents
         run: npm pack --dry-run

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -109,7 +109,7 @@ jobs:
           npm ci
           npm run check
           npm audit --omit=dev --audit-level=moderate
-          npm audit --audit-level=high
+          npm run audit:dev
           npm pack --dry-run
 
       - name: Install ajv-cli

--- a/n8n/TOOLCHAIN_AUDIT.md
+++ b/n8n/TOOLCHAIN_AUDIT.md
@@ -1,6 +1,6 @@
 # n8n Toolchain Audit
 
-Audit date: 2026-07-22
+Audit date: 2026-07-24
 
 ## Candidate
 
@@ -17,12 +17,27 @@ Audit date: 2026-07-22
 - `npm run build`
 - `npm pack --dry-run`
 - `npm audit --omit=dev --audit-level=moderate`: zero production vulnerabilities
-- `npm audit --audit-level=high`: zero high or critical vulnerabilities
+- `npm run audit:dev`: only the documented development advisory is present
 
 Both audit commands run in pull-request validation and again in the trusted-publishing workflow, so the recorded boundary is release-gated rather than advisory-only.
 
-## Residual Advisory
+## Transitive Security Policy
 
-The stable n8n node CLI currently brings six moderate development-only findings through its AI SDK, LangChain, and `uuid` dependency chain. npm offers only an invalid downgrade of the builder as an automated fix. The package does not ship those development dependencies, and the production dependency audit is clean. This candidate does not force an incompatible transitive override or move to the 0.41 beta toolchain.
+The stable n8n node CLI currently brings moderate development-only findings
+through its AI SDK, LangChain, and `uuid` dependency chain. npm offers only an
+invalid downgrade of the builder as an automated fix. The package does not ship
+those development dependencies, and the production dependency audit is clean.
 
-Recheck the advisory chain when n8n promotes a stable CLI release with an updated AI SDK dependency tree.
+The graph also contains GHSA-mh99-v99m-4gvg through older minimatch consumers.
+The only patched `brace-expansion` release is the API-incompatible 5.0.8 line;
+forcing it into those consumers breaks the n8n lint toolchain. This dependency
+is development-only, receives no untrusted glob input in this package, and is
+not included in the published tarball.
+
+CI and trusted publishing run a fail-closed high/critical audit policy that
+permits only GHSA-mh99-v99m-4gvg in the full development graph while rejecting
+every other high or critical advisory. Moderate development-only findings
+remain visible in npm and Dependabot rather than being hidden.
+
+Recheck this exception when n8n promotes a stable CLI release with an updated
+minimatch dependency tree.

--- a/n8n/package.json
+++ b/n8n/package.json
@@ -22,13 +22,14 @@
         "directory": "n8n"
     },
     "scripts": {
+        "audit:dev": "node scripts/audit-dev-dependencies.cjs",
         "build": "n8n-node build",
         "build:watch": "tsc --watch",
         "dev": "n8n-node dev",
         "lint": "n8n-node lint",
         "lint:fix": "n8n-node lint --fix",
         "release": "n8n-node release",
-        "test": "node --test test/release.test.cjs",
+        "test": "node --test test/*.test.cjs",
         "check": "npm test && npm run lint && npm run build",
         "prepublishOnly": "npm run check"
     },

--- a/n8n/scripts/audit-dev-dependencies.cjs
+++ b/n8n/scripts/audit-dev-dependencies.cjs
@@ -1,0 +1,131 @@
+'use strict';
+
+const { spawnSync } = require('node:child_process');
+
+const ALLOWED_ADVISORY = 'https://github.com/advisories/GHSA-mh99-v99m-4gvg';
+const ALLOWED_PACKAGES = new Set([
+	'@eslint/config-array',
+	'@eslint/eslintrc',
+	'@n8n/eslint-plugin-community-nodes',
+	'@n8n/node-cli',
+	'@oclif/core',
+	'brace-expansion',
+	'ejs',
+	'eslint',
+	'filelist',
+	'jake',
+	'minimatch',
+]);
+
+function validateAuditReport(report) {
+	if (report?.auditReportVersion !== 2 || !report.vulnerabilities) {
+		throw new Error('npm audit returned an unsupported report shape');
+	}
+
+	const allVulnerabilities = report.vulnerabilities;
+	const allNames = new Set(Object.keys(allVulnerabilities));
+	const vulnerabilities = Object.fromEntries(
+		Object.entries(allVulnerabilities).filter(([, vulnerability]) =>
+			['high', 'critical'].includes(vulnerability.severity),
+		),
+	);
+	const names = Object.keys(vulnerabilities);
+	if (names.length === 0) {
+		return { clean: true, allowed: [] };
+	}
+
+	const unexpectedPackages = names.filter((name) => !ALLOWED_PACKAGES.has(name));
+	const missingPackages = [...ALLOWED_PACKAGES].filter(
+		(name) => !Object.hasOwn(vulnerabilities, name),
+	);
+	if (unexpectedPackages.length || missingPackages.length) {
+		throw new Error(
+			`unexpected audit package set; extra=${unexpectedPackages.join(',') || 'none'} ` +
+				`missing=${missingPackages.join(',') || 'none'}`,
+		);
+	}
+
+	const advisoryUrls = new Set();
+	for (const [name, vulnerability] of Object.entries(vulnerabilities)) {
+		if (vulnerability.severity !== 'high') {
+			throw new Error(`${name} changed severity to ${vulnerability.severity}`);
+		}
+		for (const via of vulnerability.via) {
+			if (typeof via === 'string') {
+				if (!allNames.has(via)) {
+					throw new Error(`${name} depends on unexpected vulnerable package ${via}`);
+				}
+				continue;
+			}
+			if (!via?.url) {
+				throw new Error(`${name} contains an advisory without a URL`);
+			}
+			if (['high', 'critical'].includes(via.severity)) {
+				advisoryUrls.add(via.url);
+			}
+		}
+	}
+
+	if (
+		advisoryUrls.size !== 1 ||
+		!advisoryUrls.has(ALLOWED_ADVISORY)
+	) {
+		throw new Error(
+			`unexpected advisory set: ${[...advisoryUrls].sort().join(',') || 'none'}`,
+		);
+	}
+
+	const counts = report.metadata?.vulnerabilities;
+	if (!counts || counts.critical !== 0 || counts.high !== ALLOWED_PACKAGES.size) {
+		throw new Error(
+			`unexpected vulnerability counts: ${JSON.stringify(counts ?? null)}`,
+		);
+	}
+
+	return { clean: false, allowed: names.sort() };
+}
+
+function main() {
+	const npmCli = process.env.npm_execpath;
+	const command = npmCli ? process.execPath : 'npm';
+	const args = npmCli
+		? [npmCli, 'audit', '--json', '--audit-level=high']
+		: ['audit', '--json', '--audit-level=high'];
+	const result = spawnSync(command, args, {
+		encoding: 'utf8',
+	});
+	if (result.error) throw result.error;
+	if (![0, 1].includes(result.status)) {
+		throw new Error(
+			`npm audit failed with status ${result.status}: ${result.stderr.trim()}`,
+		);
+	}
+
+	let report;
+	try {
+		report = JSON.parse(result.stdout);
+	} catch (error) {
+		throw new Error(`npm audit did not return JSON: ${error.message}`);
+	}
+
+	const verdict = validateAuditReport(report);
+	if (verdict.clean) {
+		console.log('Development dependency audit is clean.');
+		return;
+	}
+	console.log(
+		`Allowed development-only advisory ${ALLOWED_ADVISORY}; ` +
+			`${verdict.allowed.length} affected dependency nodes verified.`,
+	);
+}
+
+if (require.main === module) {
+	try {
+		main();
+	} catch (error) {
+		console.error(`Development dependency audit rejected: ${error.message}`);
+		process.exitCode = 1;
+	}
+}
+
+module.exports = { validateAuditReport };

--- a/n8n/test/audit-policy.test.cjs
+++ b/n8n/test/audit-policy.test.cjs
@@ -1,0 +1,107 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+	validateAuditReport,
+} = require('../scripts/audit-dev-dependencies.cjs');
+
+const allowedPackages = [
+	'@eslint/config-array',
+	'@eslint/eslintrc',
+	'@n8n/eslint-plugin-community-nodes',
+	'@n8n/node-cli',
+	'@oclif/core',
+	'brace-expansion',
+	'ejs',
+	'eslint',
+	'filelist',
+	'jake',
+	'minimatch',
+];
+
+function allowedReport() {
+	const vulnerabilities = Object.fromEntries(
+		allowedPackages.map((name) => [
+			name,
+			{
+				severity: 'high',
+				via:
+					name === 'brace-expansion'
+						? [
+								{
+									url: 'https://github.com/advisories/GHSA-mh99-v99m-4gvg',
+									severity: 'high',
+								},
+							]
+						: ['brace-expansion'],
+			},
+		]),
+	);
+	return {
+		auditReportVersion: 2,
+		vulnerabilities,
+		metadata: {
+			vulnerabilities: {
+				info: 0,
+				low: 0,
+				moderate: 0,
+				high: allowedPackages.length,
+				critical: 0,
+				total: allowedPackages.length,
+			},
+		},
+	};
+}
+
+test('accepts only the documented development advisory graph', () => {
+	const report = allowedReport();
+	report.vulnerabilities.uuid = {
+		severity: 'moderate',
+		via: [
+			{
+				url: 'https://github.com/advisories/GHSA-w5hq-g745-h8pq',
+			},
+		],
+	};
+	report.metadata.vulnerabilities.moderate = 1;
+	report.metadata.vulnerabilities.total += 1;
+	const verdict = validateAuditReport(report);
+	assert.equal(verdict.clean, false);
+	assert.deepEqual(verdict.allowed, [...allowedPackages].sort());
+});
+
+test('accepts a fully clean development audit', () => {
+	const report = allowedReport();
+	report.vulnerabilities = {};
+	report.metadata.vulnerabilities.high = 0;
+	report.metadata.vulnerabilities.total = 0;
+	assert.deepEqual(validateAuditReport(report), { clean: true, allowed: [] });
+});
+
+test('rejects a new advisory even when it affects an allowed package', () => {
+	const report = allowedReport();
+	report.vulnerabilities['brace-expansion'].via.push({
+		url: 'https://github.com/advisories/GHSA-unexpected',
+		severity: 'high',
+	});
+	assert.throws(
+		() => validateAuditReport(report),
+		/unexpected advisory set/,
+	);
+});
+
+test('rejects changes to the affected package graph', () => {
+	const report = allowedReport();
+	report.vulnerabilities['new-package'] = {
+		severity: 'high',
+		via: ['brace-expansion'],
+	};
+	report.metadata.vulnerabilities.high += 1;
+	report.metadata.vulnerabilities.total += 1;
+	assert.throws(
+		() => validateAuditReport(report),
+		/unexpected audit package set/,
+	);
+});


### PR DESCRIPTION
## Summary

- replaces the now-impossible blanket development audit gate with a fail-closed policy
- permits only GHSA-mh99-v99m-4gvg in the stable n8n build-tool graph
- rejects every other high/critical advisory, advisory-URL change, affected-package change, or report-shape change
- keeps the production dependency audit at zero and applies the same policy to trusted publishing
- documents why forcing `brace-expansion@5.0.8` is unsafe for the current minimatch consumers

## Validation

- `npm ci`
- `npm run check`: 6 tests, n8n lint, TypeScript build
- `npm audit --omit=dev --audit-level=moderate`: 0 production vulnerabilities
- `npm run audit:dev`: exact documented advisory accepted; all other high/critical findings fail closed
- `npm pack --dry-run`: 16 intended files
- `node scripts/verify-doc-links.mjs`
- `node --test test/verify-doc-links.test.mjs`: 3 pass
- `node scripts/verify-integrations-json.js`
- `git diff --check`

## Boundary

No package publication, runtime dependency, Router, x402, wallet, settlement, or production API behavior changes.