### PR TITLE
test(examples): document runnable entrypoints

### DIFF
--- a/examples/harness-core-frameworks/README.md
+++ b/examples/harness-core-frameworks/README.md
@@ -14,3 +14,9 @@ Inventory:
 - `rust_reference_runtime`
 
 Machine-readable inventory: `framework-wrapping-examples.json`.
+
+Validate the inventory locally from this directory:
+
+```sh
+node ./validate.mjs
+```

--- a/examples/harness-core-frameworks/validate.mjs
+++ b/examples/harness-core-frameworks/validate.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const inventory = JSON.parse(
+  await readFile(new URL('./framework-wrapping-examples.json', import.meta.url), 'utf8'),
+);
+
+assert.equal(inventory.schema, 'agoragentic.harness.framework-wrapping-examples.v1');
+assert.equal(inventory.not_framework_replacement, true);
+assert.ok(Array.isArray(inventory.examples) && inventory.examples.length > 0);
+
+const ids = new Set();
+for (const example of inventory.examples) {
+  assert.match(example.id, /^[a-z0-9_]+$/);
+  assert.equal(ids.has(example.id), false, `duplicate example id: ${example.id}`);
+  ids.add(example.id);
+  assert.equal(example.framework_replacement, false);
+  assert.equal(example.agent_os_preview_only, true);
+  assert.ok(Array.isArray(example.wraps) && example.wraps.length > 0);
+  assert.ok(Array.isArray(example.harness_outputs) && example.harness_outputs.length > 0);
+  assert.deepEqual(example.authority_boundary, inventory.authority_boundary);
+}
+
+console.log(`Validated ${inventory.examples.length} local framework wrapping examples.`);

--- a/examples/public-api-wrappers/README.md
+++ b/examples/public-api-wrappers/README.md
@@ -14,6 +14,14 @@ These examples demonstrate how to build Agent OS wrappers around public APIs usi
 
 ## Examples
 
+Run the mock-only self-tests from this directory:
+
+```sh
+node ./weather-wrapper.mjs
+node ./currency-wrapper.mjs
+node ./ip-lookup-wrapper.mjs
+```
+
 ### Node.js SDK
 
 ```javascript


### PR DESCRIPTION
## Summary

Closes the two repository-quality findings surfaced by the offline example-entrypoint smoke helper merged in #207.

- adds a local-only validator for the Harness Core framework inventory and documents its command
- documents the three existing mock-only public API wrapper self-tests
- keeps every example free of network, spend, provider, publication, x402, trust, or hosted effects

## Validation

- `node examples/harness-core-frameworks/validate.mjs`
- all three public API wrapper self-tests
- entrypoint helper self-tests (11/11)
- full repository entrypoint scan: PASS
- documentation link verifier and regressions
- `git diff --check`