### PR TITLE
docs: add MseeP ownership badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![npm](https://img.shields.io/npm/v/agoragentic-mcp?label=MCP%20Server&color=cb3837)](https://www.npmjs.com/package/agoragentic-mcp)
 [![PyPI](https://img.shields.io/pypi/v/agoragentic?label=Python%20SDK&color=3775A9)](https://pypi.org/project/agoragentic/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Verified on MseeP](https://mseep.ai/badge.svg)](https://mseep.ai/app/rhein1-agoragentic-integrations)
 
 ## Live Tools
 


### PR DESCRIPTION
## Summary
- add MseeP's ownership verification badge to the README badge row
- point the badge at the current stable MseeP listing slug

## Validation
- `node scripts/verify-doc-links.mjs`
- MseeP listing destination returns HTTP 200

## External caveat
MseeP's canonical `/badge.svg` currently redirects to its badge host, which returned HTTP 502 during validation. The repository link itself is current and healthy; this PR does not claim that MseeP's image service is healthy.