### PR TITLE
docs: launch community integration testing campaign

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -1,0 +1,103 @@
+title: "[Integration test] "
+labels:
+  - community-test
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for testing an Agoragentic integration in your own environment. Remove API keys, wallet material, authorization headers, cookies, private repository content, and unredacted environment output before submitting.
+
+  - type: dropdown
+    id: integration
+    attributes:
+      label: Integration
+      description: Select the adapter or client path you tested.
+      options:
+        - MCP
+        - Claude Code Plugin
+        - Gemini CLI Extension
+        - LangChain
+        - CrewAI
+        - AutoGen
+        - OpenAI Agents SDK
+        - Google ADK
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: framework_version
+    attributes:
+      label: Framework or client version
+      description: Use the exact installed version where possible.
+      placeholder: "Example: langchain 0.3.27"
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Include operating system and Node.js or Python version.
+      placeholder: "Example: Ubuntu 24.04, Python 3.12.4"
+    validations:
+      required: true
+
+  - type: input
+    id: adapter_version
+    attributes:
+      label: Agoragentic version
+      description: Provide the repository commit, npm package version, or Python package version used.
+      placeholder: "Example: repository commit abc1234 or agoragentic-mcp 1.3.6"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: test_lane
+    attributes:
+      label: Test lane
+      options:
+        - Offline conformance only
+        - Free live runtime only
+        - Offline conformance and free live runtime
+    validations:
+      required: true
+
+  - type: dropdown
+    id: outcome
+    attributes:
+      label: Outcome
+      options:
+        - Pass
+        - Partial
+        - Fail
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Commands and reproduction steps
+      description: Include the smallest redacted sequence another user can repeat.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Redacted result
+      description: State what worked or failed. For a live test, say whether a receipt was returned and whether the cost was zero; do not paste a sensitive receipt.
+      placeholder: "The adapter returned a structured result and a receipt with cost 0."
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: boundaries
+    attributes:
+      label: Safety confirmation
+      options:
+        - label: I removed API keys, wallet material, authorization headers, cookies, private repository content, and unredacted environment output.
+          required: true
+        - label: I did not make a paid call or approve a wallet transaction as part of this report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Integration test report
+    url: https://github.com/rhein1/agoragentic-integrations/discussions/new?category=show-and-tell
+    about: Share independent offline or no-spend runtime evidence through the structured discussion form.
+  - name: Integration questions
+    url: https://github.com/rhein1/agoragentic-integrations/discussions/new?category=q-a
+    about: Ask installation, framework, or adapter questions in GitHub Discussions.
+  - name: Security vulnerability
+    url: https://github.com/rhein1/agoragentic-integrations/security/policy
+    about: Follow the private reporting instructions in the repository security policy.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,12 @@ Thank you for your interest in contributing! This repo maintains drop-in integra
    - The offline conformance result and any focused test result
    - A working example plus an explicit live/network/spend boundary
 
+## Test An Existing Integration
+
+Independent runtime reports are useful even when you are not changing code. Start with the [community testing guide](./docs/COMMUNITY_TESTING.md), run one adapter's offline conformance check, and optionally exercise the documented free live path only after confirming the matched provider costs `0`.
+
+Share the result through the structured [Show and tell test report](https://github.com/rhein1/agoragentic-integrations/discussions/new?category=show-and-tell). Do not post API keys, wallet material, authorization headers, cookies, or unredacted environment output. A community report is independent runtime evidence; it does not replace repository conformance, security review, or paid settlement proof.
+
 ## Standards
 
 - **Python**: target `>=3.8`, use `requests` for HTTP, follow existing naming

--- a/README.md
+++ b/README.md
@@ -114,6 +114,16 @@ The coordinator forks an isolated worker for each selected manifest entry. Worke
 
 This is honest offline evidence, not a live-runtime or settlement claim: it performs no network calls, paid calls, wallet actions, or production mutation. See the [Adapter Conformance Agent contract](./docs/ADAPTER_CONFORMANCE_AGENT.md).
 
+## Help Test An Integration
+
+We are collecting independent, no-spend runtime reports for the ready MCP, Claude Code, Gemini CLI, LangChain, CrewAI, AutoGen, OpenAI Agents SDK, and Google ADK paths.
+
+1. Run the repository-owned offline conformance check for one adapter.
+2. Optionally follow that adapter's README and exercise a free `echo` route after confirming the matched provider costs `0`.
+3. Submit a structured [integration test report](https://github.com/rhein1/agoragentic-integrations/discussions/new?category=show-and-tell).
+
+Never paste API keys, wallet material, authorization headers, cookies, or unredacted environment output. Stop before any payment challenge or nonzero quote. The [community testing guide](./docs/COMMUNITY_TESTING.md) defines the commands, evidence boundary, initial test cohort, and public compatibility matrix.
+
 ## What Your Agent Gets
 
 - The `execute(task, input)` rail for routed work with receipts
@@ -435,6 +445,7 @@ Your Agent  →  Integration (tools/MCP)  →  Agent OS + Agoragentic API
 | Ecosystem walkthroughs | [`docs/ECOSYSTEM_WALKTHROUGHS.md`](./docs/ECOSYSTEM_WALKTHROUGHS.md) |
 | Glossary and maturity labels | [`docs/GLOSSARY.md`](./docs/GLOSSARY.md) |
 | Troubleshooting | [`docs/TROUBLESHOOTING.md`](./docs/TROUBLESHOOTING.md) |
+| Community testing and independent evidence | [`docs/COMMUNITY_TESTING.md`](./docs/COMMUNITY_TESTING.md) |
 | Agent instructions | [`AGENTS.md`](./AGENTS.md) |
 | Public SDK package sources | [`sdk/README.md`](./sdk/README.md) |
 | ACP registry positioning | [`ACP_REGISTRY.md`](./ACP_REGISTRY.md) |

--- a/docs/COMMUNITY_TESTING.md
+++ b/docs/COMMUNITY_TESTING.md
@@ -1,0 +1,68 @@
+# Community Integration Testing
+
+Agoragentic maintains deterministic offline checks for every entry in `integrations.json`. This campaign collects a different kind of evidence: whether an external user can follow an adapter's documented path in their own environment.
+
+Repository conformance and community runtime evidence are separate claims. Neither one proves a paid settlement, security audit, production deployment, or general framework compatibility.
+
+## Initial Test Cohort
+
+| Integration | Manifest ID | Repository state | Independent runtime evidence | Guide |
+|---|---|---|---|---|
+| MCP | `mcp` | Ready | Awaiting first report | [MCP README](../mcp/README.md) |
+| Claude Code Plugin | `claude-code-plugin` | Ready | Awaiting first report | [Claude Code README](../claude-code/README.md) |
+| Gemini CLI Extension | `gemini-cli-extension` | Ready | Awaiting first report | [Gemini CLI README](../gemini-cli/README.md) |
+| LangChain | `langchain` | Ready | Awaiting first report | [LangChain README](../langchain/README.md) |
+| CrewAI | `crewai` | Ready | Awaiting first report | [CrewAI README](../crewai/README.md) |
+| AutoGen | `autogen` | Ready | Awaiting first report | [AutoGen README](../autogen/README.md) |
+| OpenAI Agents SDK | `openai-agents` | Ready | Awaiting first report | [OpenAI Agents README](../openai-agents/README.md) |
+| Google ADK | `google-adk` | Ready | Awaiting first report | [Google ADK README](../google-adk/README.md) |
+
+`Ready` is the repository's maintainer-declared maturity label. It is not an independent-user claim. Each accepted report will be linked from this table with its framework version, runtime, operating system, adapter/package version, and outcome.
+
+## Path A: Offline Conformance
+
+This path needs no Agoragentic account, API key, wallet, network call from adapter code, or paid invocation. Node.js 24 and Python 3 are required for the complete syntax matrix.
+
+```bash
+git clone --depth 1 https://github.com/rhein1/agoragentic-integrations.git
+cd agoragentic-integrations
+node scripts/adapter-conformance-agent.mjs --adapter mcp
+```
+
+Replace `mcp` with an ID from the table. A pass proves declared files, syntax, repository containment, static credential checks, and advisory signals. The adapter is not imported or executed. See the [conformance contract](./ADAPTER_CONFORMANCE_AGENT.md).
+
+## Path B: Optional Free Runtime Check
+
+This path checks actual adapter behavior and is still designed to spend nothing.
+
+1. Follow the selected adapter's README in a disposable test project.
+2. Use a separate test agent/API key if registration is required.
+3. Call the adapter's match path, or the documented `GET /api/execute/match` preflight, for task `echo` and confirm the selected provider price is exactly `0`.
+4. Only then call the adapter's execute path with task `echo` and benign input such as `{"message":"community integration test"}`.
+5. Confirm a structured result and receipt are returned with cost `0`.
+6. Stop if a payment challenge, wallet request, paid provider, or nonzero quote appears.
+
+The only hosted mutations in this lane are an optional disposable buyer registration and the free invocation/receipt records. It does not authorize wallet use, paid calls, seller or listing publication, trust mutation, or secret disclosure.
+
+## Submit A Report
+
+Open a structured [integration test report](https://github.com/rhein1/agoragentic-integrations/discussions/new?category=show-and-tell) and include:
+
+- integration and exact framework version;
+- operating system and language runtime version;
+- repository commit or package version;
+- offline-only, free-live, or both;
+- commands and minimal reproduction steps;
+- pass, partial, or fail outcome;
+- redacted output sufficient to reproduce the result.
+
+Never post API keys, wallet material, seed phrases, private keys, authorization headers, cookies, full environment dumps, or private repository content. Do not include a full receipt if it contains user, agent, or request data; report only whether a receipt was returned and whether its cost was `0`.
+
+## Evidence Labels
+
+- `community-test`: a submitted independent test report.
+- `testing-wanted`: an adapter currently seeking independent coverage.
+- `confirmed-by-user`: a maintainer checked that the report identifies a reproducible environment and outcome.
+- `needs-repro`: a reported failure needs another independent reproduction.
+
+`confirmed-by-user` does not mean security-audited, universally compatible, paid, settled, or endorsed by the upstream framework. One report remains one report; reports from different versions and environments stay visible separately.


### PR DESCRIPTION
## What changed

- adds a structured GitHub Show-and-tell form for independent integration test reports
- adds an honest community evidence matrix for eight ready integration paths
- routes test reports and questions through GitHub Discussions
- adds no-spend testing guidance to README and CONTRIBUTING
- creates the supporting community and framework labels through repository settings

## Evidence boundary

Repository conformance remains offline static and syntax evidence. Community reports remain one dated external environment result. Neither is described as a security audit, universal compatibility, paid settlement proof, or upstream endorsement.

The optional live lane requires a zero-price match before execution and tells testers to stop before any payment challenge, wallet request, or nonzero quote. It permits only disposable buyer registration plus free invocation/receipt records.

## Validation

- `python` YAML parse for both GitHub forms
- `node scripts/verify-integrations-json.js`
- `node scripts/verify-doc-links.mjs`
- `node --test test/adapter-conformance-agent.test.mjs`
- `node --test test/framework-adapter-contracts.test.mjs`
- offline conformance: 8 passed, 0 failed for the initial cohort
- `git diff --check`