### PR TITLE
Fix current AutoGen and LangChain quickstarts

### DIFF
--- a/autogen/README.md
+++ b/autogen/README.md
@@ -1,32 +1,56 @@
 # AutoGen Integration (Microsoft)
 
-Connect [AutoGen](https://github.com/microsoft/autogen) agents to the Agoragentic marketplace.
+Connect current [AutoGen AgentChat](https://github.com/microsoft/autogen) agents to Agoragentic Agent OS. The adapter keeps the legacy schema exports, but new projects should use the callable-tool factory below.
 
 ## Install
 
 ```bash
-pip install agoragentic pyautogen
+pip install requests autogen-agentchat "autogen-ext[openai]"
+curl -O https://raw.githubusercontent.com/rhein1/agoragentic-integrations/main/autogen/agoragentic_autogen.py
 ```
 
 ## Env Vars
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `AGORAGENTIC_API_KEY` | No (auto-register) | API key with `amk_` prefix |
+| `AGORAGENTIC_API_KEY` | Yes for match/execute | API key with `amk_` prefix; obtain it through quickstart or the register compatibility tool |
+| `OPENAI_API_KEY` | For this model example | Used by the AutoGen OpenAI model client, not by Agoragentic |
 
 ## Quick Start
 
 ```python
-from agoragentic_autogen import get_agoragentic_functions, FUNCTION_MAP
-import autogen
+import asyncio
+import os
 
-functions = get_agoragentic_functions(api_key="amk_your_key")
-assistant = autogen.AssistantAgent("marketplace-agent", llm_config={"functions": functions})
-user_proxy = autogen.UserProxyAgent("user", function_map=FUNCTION_MAP)
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.ui import Console
+from autogen_ext.models.openai import OpenAIChatCompletionClient
 
-user_proxy.initiate_chat(assistant, message="Find a research tool and invoke it")
+from agoragentic_autogen import get_agoragentic_tools
+
+
+async def main():
+    model_client = OpenAIChatCompletionClient(model="gpt-4.1-mini")
+    assistant = AssistantAgent(
+        "marketplace_agent",
+        model_client=model_client,
+        tools=get_agoragentic_tools(os.environ["AGORAGENTIC_API_KEY"]),
+    )
+    await Console(assistant.run_stream(
+        task="Preview providers for document summarization under $0.10. Do not execute.",
+    ))
+    await model_client.close()
+
+
+asyncio.run(main())
 ```
+
+The first task is deliberately no-spend. Call `agoragentic_execute` only after the user or agent policy explicitly accepts the displayed provider and price.
+
+## Legacy Compatibility
+
+Older `pyautogen` workflows may continue to import `get_agoragentic_functions` and `FUNCTION_MAP`. That API is compatibility-only; it is not the current AgentChat quickstart.
 
 ## Files
 
-- [`agoragentic_autogen.py`](./agoragentic_autogen.py) — AutoGen function definitions and map
+- [`agoragentic_autogen.py`](./agoragentic_autogen.py) - current callable tools plus legacy function definitions and map

--- a/autogen/adapter.test.py
+++ b/autogen/adapter.test.py
@@ -1,0 +1,49 @@
+import importlib.util
+import inspect
+import pathlib
+import sys
+import types
+import unittest
+
+
+class FakeResponse:
+    status_code = 200
+
+    @staticmethod
+    def json():
+        return {"providers": []}
+
+
+class AdapterContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.requests = types.SimpleNamespace()
+        sys.modules["requests"] = cls.requests
+        source = pathlib.Path(__file__).with_name("agoragentic_autogen.py")
+        spec = importlib.util.spec_from_file_location("agoragentic_autogen", source)
+        cls.adapter = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.adapter)
+
+    def test_modern_tools_have_stable_names_and_signatures(self):
+        tools = self.adapter.get_agoragentic_tools("amk_test")
+        self.assertEqual([tool.__name__ for tool in tools], list(self.adapter.FUNCTION_MAP))
+        execute = next(tool for tool in tools if tool.__name__ == "agoragentic_execute")
+        self.assertEqual(list(inspect.signature(execute).parameters), ["task", "input_data", "max_cost"])
+
+    def test_api_keys_are_isolated_per_tool_set(self):
+        seen = []
+
+        def fake_get(_url, **kwargs):
+            seen.append(kwargs["headers"].get("Authorization"))
+            return FakeResponse()
+
+        self.requests.get = fake_get
+        first = self.adapter.get_agoragentic_tools("amk_first")
+        second = self.adapter.get_agoragentic_tools("amk_second")
+        next(tool for tool in first if tool.__name__ == "agoragentic_match")("summarize")
+        next(tool for tool in second if tool.__name__ == "agoragentic_match")("summarize")
+        self.assertEqual(seen, ["Bearer amk_first", "Bearer amk_second"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/autogen/agoragentic_autogen.py
+++ b/autogen/agoragentic_autogen.py
@@ -1,5 +1,5 @@
 """
-Agoragentic AutoGen Integration — v2.0
+Agoragentic AutoGen Integration - v2.1
 =======================================
 
 Function tools for Microsoft AutoGen agents to use Agoragentic Agent OS:
@@ -7,28 +7,32 @@ preview providers with match(), route work with execute(), inspect receipts,
 and keep catalog/vault/passport helpers as compatibility paths.
 
 Install:
-    pip install pyautogen requests
+    pip install requests autogen-agentchat "autogen-ext[openai]"
 
-Usage:
-    from agoragentic_autogen import get_agoragentic_functions, FUNCTION_MAP
+Usage (AutoGen AgentChat 0.7+):
+    from autogen_agentchat.agents import AssistantAgent
+    from agoragentic_autogen import get_agoragentic_tools
 
-    functions = get_agoragentic_functions(api_key="amk_your_key")
+    tools = get_agoragentic_tools(api_key="amk_your_key")
+    assistant = AssistantAgent("agent", model_client=model_client, tools=tools)
 
-    assistant = autogen.AssistantAgent("agent", llm_config={"functions": functions})
-    user_proxy = autogen.UserProxyAgent("user", function_map=FUNCTION_MAP)
+Legacy schema exports remain available through get_agoragentic_functions()
+and FUNCTION_MAP.
 """
 
+from contextvars import ContextVar
+from functools import wraps
 import json
 import requests
-from typing import Optional
+from typing import Callable, List, Optional
 
 AGORAGENTIC_BASE_URL = "https://agoragentic.com"
-_API_KEY = ""
+_API_KEY = ContextVar("agoragentic_autogen_api_key", default="")
 
 
 def _headers(api_key: str = ""):
     h = {"Content-Type": "application/json"}
-    k = api_key or _API_KEY
+    k = api_key or _API_KEY.get()
     if k:
         h["Authorization"] = f"Bearer {k}"
     return h
@@ -218,9 +222,8 @@ def agoragentic_passport(action: str = "check", wallet_address: str = "") -> str
 # ─── AutoGen Function Schemas ─────────────────────────────
 
 def get_agoragentic_functions(api_key: str = ""):
-    """Get AutoGen-compatible function definitions for Agoragentic tools."""
-    global _API_KEY
-    _API_KEY = api_key
+    """Get legacy AutoGen function schemas and bind their function-map key."""
+    _API_KEY.set(api_key)
 
     return [
         {"name": "agoragentic_register", "description": "Compatibility helper for Agent OS quickstart. Returns API key.",
@@ -277,6 +280,24 @@ def get_agoragentic_functions(api_key: str = ""):
              "wallet_address": {"type": "string"}
          }}}
     ]
+
+
+def _bind_api_key(function: Callable, api_key: str) -> Callable:
+    """Bind one key to one callable without leaking it across agent instances."""
+    @wraps(function)
+    def bound(*args, **kwargs):
+        token = _API_KEY.set(api_key)
+        try:
+            return function(*args, **kwargs)
+        finally:
+            _API_KEY.reset(token)
+
+    return bound
+
+
+def get_agoragentic_tools(api_key: str = "") -> List[Callable]:
+    """Return callables accepted by AutoGen AgentChat AssistantAgent(tools=...)."""
+    return [_bind_api_key(function, api_key) for function in FUNCTION_MAP.values()]
 
 
 # Function map for AutoGen UserProxyAgent

--- a/integrations.json
+++ b/integrations.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.29.0",
-  "updated_at": "2026-07-23",
+  "version": "2.29.1",
+  "updated_at": "2026-07-27",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
   "packages": {
@@ -450,7 +450,7 @@
       "language": "python",
       "status": "ready",
       "path": "langchain/agoragentic_tools.py",
-      "install": "pip install agoragentic",
+      "install": "pip install requests langchain langchain-openai",
       "docs": "langchain/README.md"
     },
     {
@@ -486,7 +486,7 @@
       "language": "python",
       "status": "ready",
       "path": "autogen/agoragentic_autogen.py",
-      "install": "pip install agoragentic",
+      "install": "pip install requests autogen-agentchat autogen-ext[openai]",
       "docs": "autogen/README.md"
     },
     {

--- a/langchain/README.md
+++ b/langchain/README.md
@@ -5,36 +5,41 @@ Connect [LangChain](https://www.langchain.com/) agents to Agoragentic Agent OS f
 ## Install
 
 ```bash
-pip install agoragentic langchain langchain-openai
+pip install requests langchain langchain-openai
+curl -O https://raw.githubusercontent.com/rhein1/agoragentic-integrations/main/langchain/agoragentic_tools.py
 ```
 
 ## Env Vars
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `AGORAGENTIC_API_KEY` | No (auto-register) | API key with `amk_` prefix |
+| `AGORAGENTIC_API_KEY` | Yes for match/execute | API key with `amk_` prefix; obtain it through quickstart or the register compatibility tool |
 | `OPENAI_API_KEY` | Yes | For the LLM powering the agent |
 
 ## Quick Start
 
 ```python
+import os
+
 from agoragentic_tools import get_agoragentic_tools
-from langchain.agents import initialize_agent, AgentType
+from langchain.agents import create_agent
 from langchain_openai import ChatOpenAI
 
-llm = ChatOpenAI(model="gpt-4")
-tools = get_agoragentic_tools(api_key="amk_your_key_here")
+llm = ChatOpenAI(model="gpt-4.1-mini")
+tools = get_agoragentic_tools(api_key=os.environ["AGORAGENTIC_API_KEY"])
 
-agent = initialize_agent(
-    tools, llm,
-    agent=AgentType.STRUCTURED_CHAT_ZERO_SHOT_REACT_DESCRIPTION,
-    verbose=True
-)
+agent = create_agent(model=llm, tools=tools)
 
-agent.run("Preview providers that can summarize text under $0.10")
-agent.run("Execute a summarization task through Agent OS and return the receipt")
-agent.run("Use catalog search only if a specific provider needs to be chosen manually")
+result = agent.invoke({
+    "messages": [{
+        "role": "user",
+        "content": "Preview providers that can summarize text under $0.10. Do not execute.",
+    }]
+})
+print(result["messages"][-1].content)
 ```
+
+The first task is deliberately no-spend. Call `agoragentic_execute` only after the user or agent policy explicitly accepts the displayed provider and price.
 
 ## Tools Provided
 

--- a/langchain/adapter.test.py
+++ b/langchain/adapter.test.py
@@ -1,0 +1,49 @@
+import importlib.util
+import pathlib
+import sys
+import types
+import unittest
+
+
+class FakeBaseModel:
+    pass
+
+
+def fake_field(default=None, default_factory=None, **_kwargs):
+    return default_factory() if default_factory is not None else default
+
+
+class FakeBaseTool:
+    def __init__(self, **kwargs):
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+class AdapterContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        sys.modules["requests"] = types.SimpleNamespace()
+        sys.modules["pydantic"] = types.SimpleNamespace(BaseModel=FakeBaseModel, Field=fake_field)
+        sys.modules["langchain"] = types.ModuleType("langchain")
+        sys.modules["langchain.tools"] = types.SimpleNamespace(BaseTool=FakeBaseTool)
+        source = pathlib.Path(__file__).with_name("agoragentic_tools.py")
+        spec = importlib.util.spec_from_file_location("agoragentic_tools", source)
+        cls.adapter = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.adapter)
+
+    def test_tool_factory_keeps_execute_and_match_primary(self):
+        tools = self.adapter.get_agoragentic_tools("amk_test")
+        names = [tool.name for tool in tools]
+        self.assertEqual(names[:3], ["agoragentic_register", "agoragentic_execute", "agoragentic_match"])
+        self.assertNotIn("initialize_agent", self.adapter.__doc__)
+
+    def test_readme_uses_current_agent_constructor(self):
+        readme = pathlib.Path(__file__).with_name("README.md").read_text(encoding="utf-8")
+        self.assertIn("from langchain.agents import create_agent", readme)
+        self.assertIn("agent = create_agent(", readme)
+        self.assertNotIn("initialize_agent", readme)
+        self.assertNotIn("AgentType", readme)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/langchain/agoragentic_tools.py
+++ b/langchain/agoragentic_tools.py
@@ -1,5 +1,5 @@
 """
-Agoragentic LangChain Toolkit — v2.0
+Agoragentic LangChain Toolkit - v2.1
 ======================================
 
 Drop-in tools for LangChain agents to use Agoragentic Agent OS:
@@ -14,9 +14,9 @@ Usage:
     from agoragentic_tools import get_agoragentic_tools
 
     tools = get_agoragentic_tools(api_key="amk_your_key_here")
-    agent = initialize_agent(tools, llm, agent=AgentType.STRUCTURED_CHAT_ZERO_SHOT_REACT_DESCRIPTION)
-    agent.run("Preview the best summarizer under $0.10, then execute if it fits policy")
-    agent.run("Run the task through Agent OS and return the receipt")
+    agent = create_agent(model=llm, tools=tools)
+    agent.invoke({"messages": [{"role": "user", "content":
+        "Preview the best summarizer under $0.10. Do not execute."}]})
 
 Or register first:
     from agoragentic_tools import AgoragenticRegister
@@ -573,8 +573,9 @@ def get_agoragentic_tools(api_key: str = "") -> list:
     Example:
         from agoragentic_tools import get_agoragentic_tools
         tools = get_agoragentic_tools("amk_your_key")
-        agent = initialize_agent(tools, llm)
-        agent.run("Preview a summarizer under $0.10, execute it, and return the receipt")
+        agent = create_agent(model=llm, tools=tools)
+        agent.invoke({"messages": [{"role": "user", "content":
+            "Preview a summarizer under $0.10. Do not execute."}]})
     """
     tools = [AgoragenticRegister()]
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -64,11 +64,11 @@ The canonical inventory is `integrations.json` and contains 97 integration surfa
 
 | Framework | File | Install |
 |-----------|------|---------|
-| LangChain | langchain/agoragentic_tools.py | pip install agoragentic langchain |
+| LangChain | langchain/agoragentic_tools.py | pip install requests langchain langchain-openai |
 | LangGraph | langgraph/agoragentic_langgraph.py | pip install requests langgraph langchain-core |
 | LangChain Deep Agents | deepagents/README.md | pip install deepagents agoragentic |
 | CrewAI | crewai/agoragentic_crewai.py | pip install agoragentic crewai |
-| AutoGen | autogen/agoragentic_autogen.py | pip install agoragentic pyautogen |
+| AutoGen | autogen/agoragentic_autogen.py | pip install requests autogen-agentchat "autogen-ext[openai]" |
 | OpenAI Agents SDK | openai-agents/agoragentic_openai.py | pip install agoragentic |
 | Google ADK | google-adk/agoragentic_google_adk.py | pip install agoragentic google-adk |
 | pydantic-ai | pydantic-ai/agoragentic_pydantic.py | pip install agoragentic pydantic-ai |

--- a/test/framework-adapter-contracts.test.mjs
+++ b/test/framework-adapter-contracts.test.mjs
@@ -7,7 +7,9 @@ import { fileURLToPath } from "node:url";
 
 const repoRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const adapters = [
+  ["AutoGen", "autogen/adapter.test.py"],
   ["Griptape", "griptape/adapter.test.py"],
+  ["LangChain", "langchain/adapter.test.py"],
   ["LiveKit Agents", "livekit-agents/adapter.test.py"],
   ["Pipecat", "pipecat/adapter.test.py"],
 ];


### PR DESCRIPTION
## Summary

- add a current AutoGen AgentChat callable-tool factory while preserving legacy schema exports
- isolate AutoGen API keys per tool set instead of sharing one mutable process global
- update LangChain examples from removed `initialize_agent` APIs to `create_agent`
- synchronize machine-readable install commands and add hermetic adapter contracts

## Validation

- `node --test test/*.test.mjs` (60 passed)
- `node scripts/verify-integrations-json.js`
- `node scripts/verify-client-distribution.mjs`
- `node scripts/verify-doc-links.mjs`
- `node scripts/adapter-conformance-agent.mjs --jobs 4` (97 passed)
- `python -m py_compile ...`
- AutoGen `0.7.5`: `AssistantAgent` constructed with all 11 tools
- LangChain `1.3.14`: `create_agent` constructed with all 11 tools

No live API calls, credentials, wallets, or paid routes were used.