### PR TITLE
docs: prepare truthful external discovery packets

### DIFF
--- a/distribution/agent-payments-stack/README.md
+++ b/distribution/agent-payments-stack/README.md
@@ -1,0 +1,13 @@
+# Agent Payments Stack Correction Packet
+
+This packet records a maintainer-reviewed correction for Agoragentic's existing [Agent Payments Stack](https://agentpaymentsstack.com/) entry.
+
+The current directory copy freezes an old inventory count and describes the settlement layer as escrow. Both are unsafe to repeat: inventory changes continuously, and the public contract describes x402/USDC settlement on Base rather than a generic escrow service.
+
+`correction.json` replaces those claims with:
+
+- a stable product description;
+- live availability, metrics, and discovery authority URLs;
+- an explicit prepared-but-not-submitted state.
+
+No external form, issue, pull request, email, or directory mutation has been performed. Submission requires explicit owner authorization and a retained receipt.

--- a/distribution/agent-payments-stack/correction.json
+++ b/distribution/agent-payments-stack/correction.json
@@ -1,0 +1,51 @@
+{
+  "schema": "agoragentic.external-directory-correction.v1",
+  "prepared_at": "2026-07-28",
+  "directory": {
+    "id": "agent-payments-stack",
+    "name": "Agent Payments Stack",
+    "url": "https://agentpaymentsstack.com/",
+    "data_url": "https://agentpaymentsstack.com/data.json",
+    "existing_record_anchor": "https://agentpaymentsstack.com/#agoragentic"
+  },
+  "observed_record": {
+    "layer": "L5",
+    "status": "live",
+    "issues": [
+      {
+        "code": "static_inventory_drift",
+        "detail": "The record embeds a historical listing total and labels the inventory verified. Current counts must come from the live stats endpoint, and verified is reserved for sandbox listing verification."
+      },
+      {
+        "code": "settlement_model_overclaim",
+        "detail": "The record says escrow, while the public contract describes x402 and USDC settlement on Base and exposes current rail availability separately."
+      },
+      {
+        "code": "static_integration_count_drift",
+        "detail": "The framework integration count has changed. The public integrations index is the current authority."
+      }
+    ]
+  },
+  "proposed_record": {
+    "name": "Agoragentic",
+    "layer": "L5",
+    "status": "live",
+    "description": "Triptych OS (Agent OS) and a capability marketplace for AI agents. Agents discover and route task execution through one API with sandbox listing verification, receipts, MCP and A2A discovery, and x402/USDC settlement contracts on Base. Check the live availability document before paid execution and use the public stats endpoint for current inventory.",
+    "url": "https://agoragentic.com/",
+    "chain": "Base",
+    "github": "https://github.com/rhein1/agoragentic-integrations",
+    "documentation": "https://agoragentic.com/developers/"
+  },
+  "authority": {
+    "availability": "https://agoragentic.com/api/index.json",
+    "metrics": "https://agoragentic.com/api/stats",
+    "discovery_proof": "https://agoragentic.com/api/discovery/check",
+    "integration_index": "https://github.com/rhein1/agoragentic-integrations/blob/main/integrations.json",
+    "rule": "Do not copy current counts or payment availability into static directory prose; resolve them from the authority URLs at read time."
+  },
+  "submission": {
+    "status": "prepared_not_submitted",
+    "external_write_authorized": false,
+    "next_action": "Owner review, then submit through the directory's supported correction path and retain the receipt."
+  }
+}

--- a/distribution/context-hub/README.md
+++ b/distribution/context-hub/README.md
@@ -1,0 +1,22 @@
+# Context Hub Submission Packet
+
+This directory contains maintainer-authored Agoragentic documentation in the directory structure expected by [Context Hub](https://github.com/andrewyng/context-hub).
+
+## State
+
+- Prepared for upstream review.
+- Not submitted to Context Hub.
+- No external write is authorized by this packet.
+- No credentials, wallet authority, spend authority, deployment authority, or private runtime material are included.
+
+## Validate
+
+From a current Context Hub checkout, run:
+
+```bash
+node cli/bin/chub build /path/to/this/repository/distribution/context-hub/content --validate-only
+```
+
+Validation builds only the documentation packet. It does not register an agent, create an API key, execute a capability, spend funds, or publish content.
+
+Before submission, review the document against the live [`/api/index.json`](https://agoragentic.com/api/index.json) availability contract and increment its `revision` if the text changes.

--- a/distribution/context-hub/content/agoragentic/docs/agent-os-api/javascript/DOC.md
+++ b/distribution/context-hub/content/agoragentic/docs/agent-os-api/javascript/DOC.md
@@ -1,0 +1,157 @@
+---
+name: agent-os-api
+description: "Agoragentic Triptych OS Agent OS API for capability discovery, governed routing, receipts, MCP, A2A, and availability-aware x402 settlement"
+metadata:
+  languages: "javascript"
+  versions: "2.1.0"
+  revision: 1
+  updated-on: "2026-07-28"
+  source: maintainer
+  tags: "agoragentic,agent-os,triptych,router,marketplace,mcp,a2a,x402,receipts"
+---
+
+# Agoragentic Agent OS API for JavaScript
+
+## What It Is
+
+Agoragentic Triptych OS (Agent OS) is a hosted runtime and capability marketplace for deployed agents and swarms. Clients use HTTPS, MCP, or A2A to discover capabilities, ask the router to match a task, execute only within an explicit policy and cost boundary, and retrieve status and receipt evidence.
+
+The API contract version covered here is `2.1.0`. Operational availability can change independently of that version. Fetch the live index before every workflow that could spend money or cause an external side effect.
+
+## Safe Discovery First
+
+Node.js 18 and later include `fetch`:
+
+```javascript
+const BASE_URL = 'https://agoragentic.com';
+
+async function getJson(path, options = {}) {
+  const response = await fetch(`${BASE_URL}${path}`, options);
+  const body = await response.json();
+  if (!response.ok) {
+    throw new Error(`${response.status}: ${body.error || 'request_failed'}`);
+  }
+  return body;
+}
+
+const [index, stats, discovery, catalog] = await Promise.all([
+  getJson('/api/index.json'),
+  getJson('/api/stats'),
+  getJson('/api/discovery/check'),
+  getJson('/api/capabilities'),
+]);
+
+console.log({
+  availability: index.availability,
+  payment: index.payment,
+  currentStats: stats,
+  discoveryStatus: discovery.status,
+  capabilities: catalog.capabilities,
+});
+```
+
+These requests are public and read-only. Use `/api/stats` for current inventory and activity; do not cache a listing count from prose. Use `/api/discovery/check` to verify the machine discovery chain. A `PASS` result covers discovery consistency, not provider quality, settlement success, or permission to spend.
+
+## Availability Is Authoritative
+
+Read both the top-level availability contract and the payment contract returned by `/api/index.json`. For example, a response can report `platform_custody_frozen`, `paid_execution: "temporarily_unavailable"`, or payment rails whose `execution_ready` value is `false`.
+
+Stop before quote or execution when paid execution is unavailable:
+
+```javascript
+function assertPaidExecutionAvailable(index) {
+  const paid = index.availability?.paid_execution;
+  const paymentReady = index.payment?.status === 'available';
+
+  if (paid !== 'available' || !paymentReady) {
+    const reason = index.availability?.reason || index.payment?.reason || 'paid_execution_unavailable';
+    throw new Error(`Paid execution unavailable: ${reason}`);
+  }
+}
+```
+
+Do not treat an older README, directory listing, package version, or successful health check as authority for current payment availability.
+
+## Credentials
+
+Authenticated routes use a bearer API key with the `amk_` prefix. Create a key only when the operator has explicitly chosen to register an agent:
+
+```javascript
+const response = await fetch(`${BASE_URL}/api/quickstart`, {
+  method: 'POST',
+  headers: { 'content-type': 'application/json' },
+  body: JSON.stringify({ name: 'my-agent', intent: 'buyer' }),
+});
+const registration = await response.json();
+```
+
+Store the returned key in a secret manager. Never commit, log, embed, or send it to a provider. The documentation validation command does not run this example.
+
+## Match Before Execute
+
+Match a task before execution and inspect the returned providers, availability, advertised cost or price fields, and quote requirements:
+
+```javascript
+const apiKey = process.env.AGORAGENTIC_API_KEY;
+if (!apiKey) throw new Error('AGORAGENTIC_API_KEY is required');
+
+const task = 'summarize a public product changelog';
+const match = await getJson(`/api/execute/match?task=${encodeURIComponent(task)}`, {
+  headers: { authorization: `Bearer ${apiKey}` },
+});
+
+console.log(match.providers);
+```
+
+Do not execute unless all of these are true:
+
+- the live index says the relevant rail is available;
+- the chosen provider is acceptable under your policy;
+- the advertised cost is zero, or a human or governing policy explicitly approved it under a concrete cost ceiling;
+- the task input contains no secret or data the provider is not allowed to receive.
+
+Prefer `POST /api/execute` for router-selected work. Direct invocation by listing ID is an intentional exception, not the default. Execution can create side effects and can spend; it is deliberately omitted from this discovery-only example.
+
+## Status And Receipts
+
+After an authorized execution, retain the returned invocation and receipt identifiers. Use:
+
+- `GET /api/execute/status/{invocation_id}` for execution status;
+- `GET /api/commerce/receipts/{receipt_id}` for receipt evidence.
+
+A receipt records what the platform observed. It is evidence, not proof that a provider's output is correct or that a business outcome succeeded.
+
+## Trust Vocabulary
+
+The public listing verification states are `verified`, `reachable`, and `failed`. They describe deterministic sandbox listing verification. They do not mean identity proof, settlement confirmation, endorsement, or guaranteed output quality.
+
+Keep settlement evidence separate. Use the settlement-specific fields and receipt contract returned by the API rather than relabeling a sandbox state.
+
+## MCP And A2A Discovery
+
+Machine clients can discover the current protocol surfaces at:
+
+- MCP server document: `https://agoragentic.com/.well-known/mcp/server.json`
+- MCP transport: `https://agoragentic.com/api/mcp`
+- A2A Agent Card: `https://agoragentic.com/.well-known/agent-card.json`
+- OpenAPI: `https://agoragentic.com/openapi.yaml`
+
+For local MCP clients, run the pinned published package shown in the server document. Tool inventory is dynamic and authentication-dependent, so query the server instead of hardcoding a tool count.
+
+## Operational Checklist
+
+1. Fetch `/api/index.json` and honor its availability and payment fields.
+2. Fetch `/api/discovery/check` and require `status: "PASS"` for the discovery chain.
+3. Browse `/api/capabilities` or use `/api/execute/match` for a concrete task.
+4. Keep credentials out of prompts, logs, repositories, and provider payloads.
+5. Require explicit approval and a concrete cost ceiling before nonzero spend.
+6. Keep sandbox verification, settlement evidence, and output quality as separate claims.
+7. Retain status and receipt identifiers for reconciliation.
+
+## Canonical Sources
+
+- Live API index: `https://agoragentic.com/api/index.json`
+- Live stats: `https://agoragentic.com/api/stats`
+- Discovery self-test: `https://agoragentic.com/api/discovery/check`
+- Developer documentation: `https://agoragentic.com/developers/`
+- Public integrations: `https://github.com/rhein1/agoragentic-integrations`

--- a/distribution/context-hub/content/agoragentic/docs/agent-os-api/javascript/DOC.md
+++ b/distribution/context-hub/content/agoragentic/docs/agent-os-api/javascript/DOC.md
@@ -4,7 +4,7 @@ description: "Agoragentic Triptych OS Agent OS API for capability discovery, gov
 metadata:
   languages: "javascript"
   versions: "2.1.0"
-  revision: 1
+  revision: 2
   updated-on: "2026-07-28"
   source: maintainer
   tags: "agoragentic,agent-os,triptych,router,marketplace,mcp,a2a,x402,receipts"
@@ -59,7 +59,11 @@ Read both the top-level availability contract and the payment contract returned 
 Stop before quote or execution when paid execution is unavailable:
 
 ```javascript
-function assertPaidExecutionAvailable(index) {
+function assertPaidExecutionAvailable(index, { network, asset }) {
+  if (!network || !asset) {
+    throw new Error('Payment rail network and asset are required');
+  }
+
   const paid = index.availability?.paid_execution;
   const paymentReady = index.payment?.status === 'available';
 
@@ -67,7 +71,17 @@ function assertPaidExecutionAvailable(index) {
     const reason = index.availability?.reason || index.payment?.reason || 'paid_execution_unavailable';
     throw new Error(`Paid execution unavailable: ${reason}`);
   }
+
+  const rail = index.payment?.rails?.find(
+    (candidate) => candidate.network === network && candidate.asset === asset,
+  );
+  if (rail?.execution_ready !== true) {
+    const reason = rail?.status || 'payment_rail_unavailable';
+    throw new Error(`Payment rail unavailable (${network}/${asset}): ${reason}`);
+  }
 }
+
+assertPaidExecutionAvailable(index, { network: 'base', asset: 'USDC' });
 ```
 
 Do not treat an older README, directory listing, package version, or successful health check as authority for current payment availability.

--- a/docs/DISTRIBUTION.md
+++ b/docs/DISTRIBUTION.md
@@ -30,6 +30,15 @@ Do not submit the existing commerce MCP surface to the OpenAI public plugin dire
 
 The existing OpenAI Agents SDK adapters in this repository remain open-source framework integrations. They are not ChatGPT App Directory listings.
 
+## Documentation And Industry Maps
+
+| Surface | Prepared artifact | External state |
+|---|---|---|
+| Context Hub | [`distribution/context-hub/`](../distribution/context-hub/) | Maintainer documentation is prepared and validated locally; no upstream submission has been made |
+| Agent Payments Stack | [`correction.json`](../distribution/agent-payments-stack/correction.json) | The live record needs a metadata refresh; the correction packet is prepared but not submitted |
+
+Both packets use live machine endpoints as authority instead of freezing inventory or availability claims into directory copy. They do not grant credentials, spend authority, wallet authority, deployment authority, or permission to publish externally.
+
 ## Outstanding Distribution Work
 
 1. Complete the Cursor publisher application and retain a submission receipt; stop for owner terms acceptance.
@@ -37,5 +46,7 @@ The existing OpenAI Agents SDK adapters in this repository remain open-source fr
 3. Wait for or respond to Docker review on [PR #4524](https://github.com/docker/mcp-registry/pull/4524).
 4. Follow up with `mcp.so` support until the owned listing persists current metadata and duplicate records are consolidated.
 5. Confirm Gemini CLI gallery indexing separately from direct-install and repository-topic readiness.
+6. Review the Context Hub packet, then submit it upstream only with explicit owner authorization.
+7. Review and submit the Agent Payments Stack correction only with explicit owner authorization; retain the submission receipt.
 
 External status must be updated only after the corresponding service confirms submission or listing.

--- a/docs/catalog-profile.json
+++ b/docs/catalog-profile.json
@@ -1,7 +1,7 @@
 {
   "schema": "agoragentic.integration-distribution.v1",
-  "version": "1.0.1",
-  "updated_at": "2026-07-24",
+  "version": "1.0.2",
+  "updated_at": "2026-07-28",
   "product": {
     "name": "Agoragentic",
     "display_name": "Agoragentic for Triptych OS",
@@ -106,6 +106,20 @@
       "id": "openai-plugin-directory",
       "status": "blocked_policy",
       "note": "Do not submit the commerce MCP surface as a ChatGPT app/plugin while current OpenAI app rules prohibit digital-service commerce and execution of crypto transfers."
+    },
+    {
+      "id": "context-hub",
+      "status": "ready_for_submission",
+      "url": "https://github.com/andrewyng/context-hub",
+      "artifact": "distribution/context-hub/content/agoragentic/docs/agent-os-api/javascript/DOC.md",
+      "note": "Maintainer-authored Agent OS API documentation is prepared and locally validated; it has not been submitted upstream."
+    },
+    {
+      "id": "agent-payments-stack",
+      "status": "active_needs_metadata_refresh",
+      "url": "https://agentpaymentsstack.com/#agoragentic",
+      "artifact": "distribution/agent-payments-stack/correction.json",
+      "note": "The live directory record has stale inventory and escrow wording. A correction is prepared but has not been submitted."
     }
   ]
 }

--- a/integrations.json
+++ b/integrations.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.29.1",
-  "updated_at": "2026-07-27",
+  "version": "2.29.2",
+  "updated_at": "2026-07-28",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
   "packages": {
@@ -1202,6 +1202,9 @@
     "glama": "glama.json",
     "distribution_status": "docs/DISTRIBUTION.md",
     "distribution_profile": "docs/catalog-profile.json",
+    "context_hub_submission_packet": "distribution/context-hub/README.md",
+    "context_hub_agent_os_doc": "distribution/context-hub/content/agoragentic/docs/agent-os-api/javascript/DOC.md",
+    "agent_payments_stack_correction": "distribution/agent-payments-stack/correction.json",
     "cursor_plugin": ".cursor-plugin/plugin.json",
     "gemini_cli_extension": "gemini-extension.json",
     "claude_code_marketplace": ".claude-plugin/marketplace.json",

--- a/scripts/verify-client-distribution.mjs
+++ b/scripts/verify-client-distribution.mjs
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { runInNewContext } from 'node:vm';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -99,6 +100,53 @@ assert.match(contextHubDoc, /explicit.*approval.*cost ceiling/is);
 assert.doesNotMatch(contextHubDoc, /amk_[a-z0-9]{8,}/i);
 assert.doesNotMatch(contextHubDoc, /\b\d{2,}\+? (verified )?listings\b/i);
 assert.doesNotMatch(contextHubDoc, /Full ECF/i);
+
+const availabilitySnippet = contextHubDoc.match(
+  /```javascript\r?\n(function assertPaidExecutionAvailable[\s\S]*?\r?\n})\r?\n\r?\nassertPaidExecutionAvailable/,
+);
+assert.ok(availabilitySnippet, 'Context Hub doc must include an executable availability helper');
+const availabilityContext = {};
+runInNewContext(
+  `${availabilitySnippet[1]}\nglobalThis.assertPaidExecutionAvailable = assertPaidExecutionAvailable;`,
+  availabilityContext,
+);
+const mixedAvailabilityIndex = {
+  availability: { paid_execution: 'available' },
+  payment: {
+    status: 'available',
+    rails: [
+      { network: 'base', asset: 'USDC', execution_ready: true, status: 'available' },
+      {
+        network: 'solana',
+        asset: 'USDC',
+        execution_ready: false,
+        status: 'temporarily_unavailable',
+      },
+    ],
+  },
+};
+assert.doesNotThrow(() =>
+  availabilityContext.assertPaidExecutionAvailable(mixedAvailabilityIndex, {
+    network: 'base',
+    asset: 'USDC',
+  }),
+);
+assert.throws(
+  () =>
+    availabilityContext.assertPaidExecutionAvailable(mixedAvailabilityIndex, {
+      network: 'solana',
+      asset: 'USDC',
+    }),
+  /Payment rail unavailable \(solana\/USDC\): temporarily_unavailable/,
+);
+assert.throws(
+  () =>
+    availabilityContext.assertPaidExecutionAvailable(mixedAvailabilityIndex, {
+      network: 'base',
+      asset: 'ETH',
+    }),
+  /Payment rail unavailable \(base\/ETH\): payment_rail_unavailable/,
+);
 
 const paymentsCorrection = readJson(paymentsStackChannel.artifact);
 assert.equal(paymentsCorrection.schema, 'agoragentic.external-directory-correction.v1');

--- a/scripts/verify-client-distribution.mjs
+++ b/scripts/verify-client-distribution.mjs
@@ -64,6 +64,62 @@ assert.equal(
   'the commerce MCP surface must not be presented as OpenAI-directory eligible',
 );
 
+const contextHubChannel = profile.channels.find((channel) => channel.id === 'context-hub');
+assert.equal(contextHubChannel?.status, 'ready_for_submission');
+assert.equal(
+  contextHubChannel?.artifact,
+  'distribution/context-hub/content/agoragentic/docs/agent-os-api/javascript/DOC.md',
+);
+
+const paymentsStackChannel = profile.channels.find(
+  (channel) => channel.id === 'agent-payments-stack',
+);
+assert.equal(paymentsStackChannel?.status, 'active_needs_metadata_refresh');
+assert.equal(
+  paymentsStackChannel?.artifact,
+  'distribution/agent-payments-stack/correction.json',
+);
+
+const contextHubDoc = readText(contextHubChannel.artifact);
+assert.match(contextHubDoc, /^---\r?\nname: agent-os-api\r?\n/m);
+assert.match(contextHubDoc, /languages: "javascript"/);
+assert.match(contextHubDoc, /versions: "2\.1\.0"/);
+for (const route of [
+  '/api/index.json',
+  '/api/stats',
+  '/api/discovery/check',
+  '/api/capabilities',
+  '/api/execute/match',
+]) {
+  assert.match(contextHubDoc, new RegExp(route.replaceAll('/', '\\/')));
+}
+assert.match(contextHubDoc, /platform_custody_frozen/);
+assert.match(contextHubDoc, /verified.*reachable.*failed/is);
+assert.match(contextHubDoc, /explicit.*approval.*cost ceiling/is);
+assert.doesNotMatch(contextHubDoc, /amk_[a-z0-9]{8,}/i);
+assert.doesNotMatch(contextHubDoc, /\b\d{2,}\+? (verified )?listings\b/i);
+assert.doesNotMatch(contextHubDoc, /Full ECF/i);
+
+const paymentsCorrection = readJson(paymentsStackChannel.artifact);
+assert.equal(paymentsCorrection.schema, 'agoragentic.external-directory-correction.v1');
+assert.equal(paymentsCorrection.directory.id, 'agent-payments-stack');
+assert.equal(paymentsCorrection.submission.status, 'prepared_not_submitted');
+assert.equal(paymentsCorrection.submission.external_write_authorized, false);
+assert.equal(paymentsCorrection.proposed_record.layer, 'L5');
+assert.equal(paymentsCorrection.proposed_record.status, 'live');
+assert.equal(paymentsCorrection.authority.availability, 'https://agoragentic.com/api/index.json');
+assert.equal(paymentsCorrection.authority.metrics, 'https://agoragentic.com/api/stats');
+assert.equal(
+  paymentsCorrection.authority.discovery_proof,
+  'https://agoragentic.com/api/discovery/check',
+);
+const paymentsCorrectionText = JSON.stringify(paymentsCorrection);
+assert.doesNotMatch(paymentsCorrectionText, /170\+/i);
+assert.doesNotMatch(paymentsCorrectionText, /USDC escrow/i);
+assert.doesNotMatch(paymentsCorrection.proposed_record.description, /\b\d+\+? (verified )?listings\b/i);
+assert.match(paymentsCorrection.proposed_record.description, /live availability document/i);
+assert.doesNotMatch(paymentsCorrectionText, /amk_[a-z0-9]{8,}/i);
+
 const cursor = readJson('.cursor-plugin/plugin.json');
 assert.equal(cursor.name, 'agoragentic');
 assert.equal(cursor.skills, './skills/');


### PR DESCRIPTION
## Summary
- add a Context Hub-formatted, maintainer-authored Agent OS API guide that treats live availability as authoritative
- add an Agent Payments Stack correction packet that removes static inventory, escrow, and integration-count claims
- register both distribution surfaces with explicit prepared-but-not-submitted states
- add regression guards for credentials, private Full ECF wording, static counts, trust vocabulary, and external-write authority

## Boundaries
- no external Context Hub or Agent Payments Stack submission was made
- no credentials, wallet authority, spend, deployment, listing publication, or trust mutation
- current payment availability is read from `/api/index.json`; no claim that paid execution is enabled

## Validation
- Context Hub CLI: `Valid: 1 docs, 0 skills, 0 warnings`
- `node scripts/verify-integrations-json.js`
- `node scripts/verify-client-distribution.mjs`
- AJV Draft 2020 schema validation
- documentation link checker and tests
- payment and Solana payment safety contracts
- growth, ACP, Rust public-sync, Hermes, research-agent, and x402 preflight checks
- adapter contract tests and offline conformance: 97 passed, 0 failed