### PR TITLE
fix(n8n): accept shrinking advisory graph

### DIFF
--- a/n8n/scripts/audit-dev-dependencies.cjs
+++ b/n8n/scripts/audit-dev-dependencies.cjs
@@ -30,18 +30,20 @@ function validateAuditReport(report) {
 		),
 	);
 	const names = Object.keys(vulnerabilities);
+	const counts = report.metadata?.vulnerabilities;
+	if (!counts || counts.critical !== 0 || counts.high !== names.length) {
+		throw new Error(
+			`unexpected vulnerability counts: ${JSON.stringify(counts ?? null)}`,
+		);
+	}
 	if (names.length === 0) {
 		return { clean: true, allowed: [] };
 	}
 
 	const unexpectedPackages = names.filter((name) => !ALLOWED_PACKAGES.has(name));
-	const missingPackages = [...ALLOWED_PACKAGES].filter(
-		(name) => !Object.hasOwn(vulnerabilities, name),
-	);
-	if (unexpectedPackages.length || missingPackages.length) {
+	if (unexpectedPackages.length) {
 		throw new Error(
-			`unexpected audit package set; extra=${unexpectedPackages.join(',') || 'none'} ` +
-				`missing=${missingPackages.join(',') || 'none'}`,
+			`unexpected audit package set; extra=${unexpectedPackages.join(',')}`,
 		);
 	}
 
@@ -72,13 +74,6 @@ function validateAuditReport(report) {
 	) {
 		throw new Error(
 			`unexpected advisory set: ${[...advisoryUrls].sort().join(',') || 'none'}`,
-		);
-	}
-
-	const counts = report.metadata?.vulnerabilities;
-	if (!counts || counts.critical !== 0 || counts.high !== ALLOWED_PACKAGES.size) {
-		throw new Error(
-			`unexpected vulnerability counts: ${JSON.stringify(counts ?? null)}`,
 		);
 	}
 

--- a/n8n/test/audit-policy.test.cjs
+++ b/n8n/test/audit-policy.test.cjs
@@ -80,6 +80,19 @@ test('accepts a fully clean development audit', () => {
 	assert.deepEqual(validateAuditReport(report), { clean: true, allowed: [] });
 });
 
+test('accepts a shrinking subset of the documented advisory graph', () => {
+	const report = allowedReport();
+	for (const [name, vulnerability] of Object.entries(report.vulnerabilities)) {
+		if (name !== 'brace-expansion') vulnerability.severity = 'moderate';
+	}
+	report.metadata.vulnerabilities.high = 1;
+	report.metadata.vulnerabilities.moderate = allowedPackages.length - 1;
+	assert.deepEqual(validateAuditReport(report), {
+		clean: false,
+		allowed: ['brace-expansion'],
+	});
+});
+
 test('rejects a new advisory even when it affects an allowed package', () => {
 	const report = allowedReport();
 	report.vulnerabilities['brace-expansion'].via.push({
@@ -103,5 +116,14 @@ test('rejects changes to the affected package graph', () => {
 	assert.throws(
 		() => validateAuditReport(report),
 		/unexpected audit package set/,
+	);
+});
+
+test('rejects inconsistent high-severity counts', () => {
+	const report = allowedReport();
+	report.metadata.vulnerabilities.high -= 1;
+	assert.throws(
+		() => validateAuditReport(report),
+		/unexpected vulnerability counts/,
 	);
 });


### PR DESCRIPTION
## Summary
- allow the documented high-severity advisory graph to shrink as npm advisories are remediated or reclassified
- continue rejecting new high/critical packages, new advisory URLs, and inconsistent severity counts
- add regression coverage for subset acceptance and count validation

## Verification
- npm ci
- npm run check
- npm audit --omit=dev --audit-level=moderate
- npm run audit:dev
- npm pack --dry-run