### PR TITLE
security: clear high advisories and restore Dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+
+# This repository previously had no Dependabot configuration and no automated
+# security fixes, so nine open advisories (three of them high) sat with no
+# remediation pull request. Version updates are scoped to the two npm packages
+# that carry a committed lockfile.
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/mcp"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "npm"
+    directory: "/n8n"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -970,9 +970,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
             "dev": true,
             "funding": [
                 {
@@ -1117,9 +1117,9 @@
             }
         },
         "node_modules/hono": {
-            "version": "4.12.31",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
-            "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+            "version": "4.13.0",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+            "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -1173,9 +1173,9 @@
             "license": "ISC"
         },
         "node_modules/ip-address": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+            "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/n8n/TOOLCHAIN_AUDIT.md
+++ b/n8n/TOOLCHAIN_AUDIT.md
@@ -1,14 +1,57 @@
 # n8n Toolchain Audit
 
-Audit date: 2026-07-24
+Audit date: 2026-08-05 (supersedes 2026-07-24)
 
 ## Candidate
 
 - Package: `n8n-nodes-agoragentic@0.1.3`
 - Stable builder: `@n8n/node-cli@0.40.3`
-- Release helper: `release-it@20.2.1`
+- Release helper: `release-it@21.0.1`
 - Minimum Node.js: 20.19
 - Install mode: committed lockfile plus `npm ci`
+
+## 2026-08-05 revision
+
+Three high advisories entered the development graph and the fail-closed
+`npm run audit:dev` gate correctly rejected them
+(`unexpected audit package set; extra=ip-address,undici`, then
+`unexpected advisory set: ...,GHSA-rgw5-rvv9-x895`).
+
+**`ip-address` → 10.4.0.** Lockfile refresh only, satisfies `socks`'
+`^10.1.1`. No manifest change.
+
+**`brace-expansion` → 1.1.18 / 2.1.4 / 5.0.9.** GHSA-rgw5-rvv9-x895 is a
+bypass of the previously accepted GHSA-mh99-v99m-4gvg. The exception recorded
+below is now **stale**: patched releases exist on the 1.x and 2.x lines, so
+the eslint and n8n-cli consumers are fixed in place without being forced onto
+the API-incompatible 5.x line. Both advisories are now resolved rather than
+allowlisted.
+
+**`undici` → 7.29.0.** Reached through `@n8n/backend-network` (`^7.28.0`,
+satisfied directly) and through `release-it@20.2.1`, which pins `undici`
+to exactly `7.28.0`. Two candidate fixes were rejected:
+
+- A scoped `overrides` entry — **rejected by lint.** The
+  `@n8n/community-nodes/no-overrides-field` rule forbids the `overrides` field
+  in community node packages outright.
+- Staying on `release-it@20.x` — **no patched release exists.** `20.2.1` is
+  the final 20.x version.
+
+`release-it` is therefore bumped to `21.0.1`. Note this changes the
+deliberately locked release pin asserted in `test/release.test.cjs`, updated
+in the same change.
+
+`release-it@21` declares `engines.node ^22.21.0 || >=24.0.0`. This does **not**
+change what the published package supports: `engines.node` stays `>=20.19.0`
+for consumers, `release-it` is development-only and is not in the published
+`files` list, and the n8n CI job already runs on Node 22 ("Setup Node 22 for
+n8n toolchain"). Only a maintainer running `npm run release` locally now needs
+Node 22.21 or newer. `release-it` is not used by CI or by
+`publish-n8n.yml`, which publishes via npm trusted publishing.
+
+The `uuid` / LangChain moderates described below are unchanged and remain
+accepted under the existing policy. The gate covers high and critical only,
+so those stay visible rather than suppressed.
 
 ## Validation
 

--- a/n8n/package-lock.json
+++ b/n8n/package-lock.json
@@ -12,7 +12,7 @@
                 "@n8n/node-cli": "0.40.3",
                 "eslint": "9.32.0",
                 "prettier": "3.6.2",
-                "release-it": "20.2.1",
+                "release-it": "21.0.1",
                 "typescript": "5.9.2"
             },
             "engines": {
@@ -28,7 +28,6 @@
             "integrity": "sha512-IjLt0gd3L4jlOfilxVXTifn42FnVffMgDC04RJK1KDZpmkBWLv0XC92MVVmkxrFZNS/7l3xWgP/I3nqtX1sQHw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/node": "^18.11.18",
                 "@types/node-fetch": "^2.6.4",
@@ -88,7 +87,6 @@
             "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/Borewit"
@@ -100,7 +98,6 @@
             "integrity": "sha512-mPAuLRU9jWR7o0KJi9+gQnOBDUSIkoKbbFv4HjrA+80qWVcFacrNPlZmf4mguQnfZ0oP2t5c3ws6yuFyAX9vpA==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@types/node": "^18.11.18",
                 "@types/node-fetch": "^2.6.4",
@@ -117,7 +114,6 @@
             "integrity": "sha512-Hi/EzgMFWz+FKyepxHTrqfTPjpsuBS4zRy3e9sbMpBgLPv+9c0R+YZEvS7Bw4mTS66QtvvURRT6zgDGFotthVQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@anthropic-ai/sdk": "^0.27.3",
                 "@browserbasehq/sdk": "^2.0.0",
@@ -138,7 +134,6 @@
             "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "peerDependencies": {
                 "zod": "^3.25.28 || ^4"
             }
@@ -344,9 +339,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -422,9 +417,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -805,25 +800,25 @@
             }
         },
         "node_modules/@inquirer/prompts": {
-            "version": "8.4.2",
-            "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.4.2.tgz",
-            "integrity": "sha512-XJmn/wY4AX56l1BRU+ZjDrFtg9+2uBEi4JvJQj82kwJDQKiPgSn4CEsbfGGygS4Gw6rkL4W18oATjfVfaqub2Q==",
+            "version": "8.5.2",
+            "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.5.2.tgz",
+            "integrity": "sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inquirer/checkbox": "^5.1.4",
-                "@inquirer/confirm": "^6.0.12",
-                "@inquirer/editor": "^5.1.1",
-                "@inquirer/expand": "^5.0.13",
-                "@inquirer/input": "^5.0.12",
-                "@inquirer/number": "^4.0.12",
-                "@inquirer/password": "^5.0.12",
-                "@inquirer/rawlist": "^5.2.8",
-                "@inquirer/search": "^4.1.8",
-                "@inquirer/select": "^5.1.4"
+                "@inquirer/checkbox": "^5.2.1",
+                "@inquirer/confirm": "^6.1.1",
+                "@inquirer/editor": "^5.2.2",
+                "@inquirer/expand": "^5.1.1",
+                "@inquirer/input": "^5.1.2",
+                "@inquirer/number": "^4.1.1",
+                "@inquirer/password": "^5.1.1",
+                "@inquirer/rawlist": "^5.3.1",
+                "@inquirer/search": "^4.2.1",
+                "@inquirer/select": "^5.2.1"
             },
             "engines": {
-                "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+                "node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
             },
             "peerDependencies": {
                 "@types/node": ">=18"
@@ -1033,6 +1028,7 @@
             "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -1587,6 +1583,7 @@
             "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -1597,6 +1594,7 @@
             "integrity": "sha512-nXmyH0FbcsASlRmC9sbqX0gjQdxgB9KcS13vkw9PMaH0zzylwZkGFU9sY0XCPa2/AokmaNTU9DOW3IUDfAtQow==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cfworker/json-schema": "^4.0.2",
                 "@standard-schema/spec": "^1.1.0",
@@ -1779,6 +1777,7 @@
             "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -1952,9 +1951,9 @@
             }
         },
         "node_modules/@n8n/backend-network/node_modules/undici": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-            "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+            "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2142,9 +2141,9 @@
             "license": "MIT"
         },
         "node_modules/@n8n/node-cli/node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2158,6 +2157,7 @@
             "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -2572,6 +2572,7 @@
             "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@octokit/auth-token": "^6.0.0",
                 "@octokit/graphql": "^9.0.3",
@@ -2728,6 +2729,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
             "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -2749,6 +2751,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
             "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/semantic-conventions": "^1.29.0"
             },
@@ -2764,6 +2767,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
             "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/api-logs": "0.220.0",
                 "import-in-the-middle": "^3.0.0",
@@ -2814,6 +2818,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
             "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/core": "2.10.0",
                 "@opentelemetry/resources": "2.10.0",
@@ -3015,7 +3020,6 @@
             "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "debug": "^4.4.3",
                 "token-types": "^6.1.1"
@@ -3033,8 +3037,7 @@
             "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
             "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@ts-morph/common": {
             "version": "0.28.1",
@@ -3065,7 +3068,6 @@
             "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/ms": "*"
             }
@@ -3088,8 +3090,7 @@
             "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
             "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/node": {
             "version": "18.19.130",
@@ -3097,7 +3098,6 @@
             "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -3108,7 +3108,6 @@
             "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "form-data": "^4.0.4"
@@ -3126,8 +3125,7 @@
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
             "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/triple-beam": {
             "version": "1.3.5",
@@ -3171,6 +3169,7 @@
             "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.65.0",
                 "@typescript-eslint/types": "8.65.0",
@@ -3722,7 +3721,6 @@
             "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "event-target-shim": "^5.0.0"
             },
@@ -3736,6 +3734,7 @@
             "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3769,7 +3768,6 @@
             "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "humanize-ms": "^1.2.1"
             },
@@ -3941,6 +3939,7 @@
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
             "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
@@ -4053,16 +4052,16 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -4083,8 +4082,7 @@
             "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
             "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
             "dev": true,
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/buildcheck": {
             "version": "0.0.7",
@@ -4112,24 +4110,24 @@
             }
         },
         "node_modules/c12": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.3.tgz",
-            "integrity": "sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
+            "integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "chokidar": "^5.0.0",
-                "confbox": "^0.2.2",
-                "defu": "^6.1.4",
-                "dotenv": "^17.2.3",
+                "confbox": "^0.2.4",
+                "defu": "^6.1.6",
+                "dotenv": "^17.3.1",
                 "exsolve": "^1.0.8",
-                "giget": "^2.0.0",
+                "giget": "^3.2.0",
                 "jiti": "^2.6.1",
                 "ohash": "^2.0.11",
                 "pathe": "^2.0.3",
-                "perfect-debounce": "^2.0.0",
+                "perfect-debounce": "^2.1.0",
                 "pkg-types": "^2.3.0",
-                "rc9": "^2.1.2"
+                "rc9": "^3.0.1"
             },
             "peerDependencies": {
                 "magicast": "*"
@@ -4237,7 +4235,6 @@
             "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -4328,16 +4325,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/citty": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
-            "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "consola": "^3.2.3"
             }
         },
         "node_modules/cjs-module-lexer": {
@@ -4564,16 +4551,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/consola": {
-            "version": "3.4.2",
-            "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
-            "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^14.18.0 || >=16.10.0"
-            }
-        },
         "node_modules/content-type": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
@@ -4640,13 +4617,13 @@
             "license": "MIT"
         },
         "node_modules/data-uri-to-buffer": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-7.0.0.tgz",
-            "integrity": "sha512-CuRUx0TXGSbbWdEci3VK/XOZGP3n0P4pIKpsqpVtBqaIIuj3GKK8H45oAqA4Rg8FHipc+CzRdUzmD4YQXxv66Q==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-8.0.0.tgz",
+            "integrity": "sha512-6UHfyCux51b8PTGDgveqtz1tvphBku5DrMKKJbFAZAJOI2zsjDpDoYE1+QGj7FOMS4BdTFNJsJiR3zEB0xH0yQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 14"
+                "node": ">= 20"
             }
         },
         "node_modules/debug": {
@@ -4769,9 +4746,9 @@
             "license": "MIT"
         },
         "node_modules/degenerator": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-6.0.0.tgz",
-            "integrity": "sha512-j5MdXdefrecJeSqTpUrgZd4fBsD2IxZx0JlJD+n1Q7+aTf7/HcyXSfHsicPW6ekPurX159v1ZYla6OJgSPh2Dw==",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-7.0.1.tgz",
+            "integrity": "sha512-ABErK0IefDSyHjlPH7WUEenIAX2rPPnrDcDM+TS3z3+zu9TfyKKi07BQM+8rmxpdE2y1v5fjjdoAS/x4D2U60w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4780,10 +4757,10 @@
                 "esprima": "^4.0.1"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 20"
             },
             "peerDependencies": {
-                "quickjs-wasi": "^0.0.1"
+                "quickjs-wasi": "^2.2.0"
             }
         },
         "node_modules/degenerator/node_modules/ast-types": {
@@ -4849,7 +4826,6 @@
             "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             }
@@ -5105,6 +5081,7 @@
             "integrity": "sha512-4cdstYkKCyjumM2Q9NSI03K8D2a9F4Ssz33K2lv2hQa4KmR9jPLwk3uWGtNvclfqBrPGfGuMBwsGMbe6dMRbfg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/types": "^8.56.0",
                 "comment-parser": "^1.4.1",
@@ -5208,9 +5185,9 @@
             "license": "MIT"
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-            "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5330,9 +5307,9 @@
             }
         },
         "node_modules/eta": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/eta/-/eta-4.5.1.tgz",
-            "integrity": "sha512-EaNCGm+8XEIU7YNcc+THptWAO5NfKBHHARxt+wxZljj9bTr/+arRoOm9/MpGt4n6xn9fLnPFRSoLD0WFYGFUxQ==",
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/eta/-/eta-4.6.0.tgz",
+            "integrity": "sha512-lW6is4T1NFOYnmqGZIfvixqj7A7sSvScF+DN8EK6K58xI5MZ5UvYe0GjopxOXQtZvUn4eDdVuZ8XSoYWTMEKwA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5348,7 +5325,6 @@
             "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -5361,9 +5337,9 @@
             "license": "MIT"
         },
         "node_modules/exsolve": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
-            "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
+            "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
             "dev": true,
             "license": "MIT"
         },
@@ -5372,8 +5348,7 @@
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -5499,7 +5474,6 @@
             "integrity": "sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@tokenizer/inflate": "^0.4.1",
                 "strtok3": "^10.3.4",
@@ -5531,9 +5505,9 @@
             "license": "MIT"
         },
         "node_modules/filelist/node_modules/brace-expansion": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-            "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5694,8 +5668,7 @@
             "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
             "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/formdata-node": {
             "version": "4.4.1",
@@ -5703,7 +5676,6 @@
             "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "node-domexception": "1.0.0",
                 "web-streams-polyfill": "4.0.0-beta.3"
@@ -5723,7 +5695,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
@@ -5829,34 +5800,26 @@
             }
         },
         "node_modules/get-uri": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-7.0.0.tgz",
-            "integrity": "sha512-ZsC7KQxm1Hra8yO0RvMZ4lGJT7vnBtSNpEHKq39MPN7vjuvCiu1aQ8rkXUaIXG1y/TSDez97Gmv04ibnYqCp/A==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-8.0.1.tgz",
+            "integrity": "sha512-/5N/P4Lrh0p/mDwlDRi7Y1+P2o/OyzZI3l6Iz1Ov6XXwwm1y3RlZLuo3gVgML99djrEDtV980bBxSuOeHLk8ww==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "basic-ftp": "^5.0.2",
-                "data-uri-to-buffer": "7.0.0",
+                "basic-ftp": "^5.3.1",
+                "data-uri-to-buffer": "8.0.0",
                 "debug": "^4.3.4"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 20"
             }
         },
         "node_modules/giget": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
-            "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.1.tgz",
+            "integrity": "sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "citty": "^0.1.6",
-                "consola": "^3.4.0",
-                "defu": "^6.1.4",
-                "node-fetch-native": "^1.6.6",
-                "nypm": "^0.6.0",
-                "pathe": "^2.0.3"
-            },
             "bin": {
                 "giget": "dist/cli.mjs"
             }
@@ -6062,7 +6025,6 @@
             "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.0.0"
             }
@@ -6073,7 +6035,6 @@
             "integrity": "sha512-7balLY8WKk+bOhe5Vgg4zG2X6Z0zhpG/3VtYPC69evj+lVJSId8xYP7ISRzRfoeXAlJfzLNMbi2Na/0IdDiIkQ==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@types/debug": "4.1.12",
                 "@types/node": "18.19.80",
@@ -6102,7 +6063,6 @@
             "integrity": "sha512-kEWeMwMeIvxYkeg1gTc01awpwLbfMRZXdIhwRcakd/KlK53jmRC26LqcbIt7fnAQTu5GzlnWmzA3H6+l1u6xxQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -6113,7 +6073,6 @@
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -6132,7 +6091,6 @@
             "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -6145,8 +6103,7 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/iconv-lite": {
             "version": "0.6.3",
@@ -6180,8 +6137,7 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/ignore": {
             "version": "7.0.6",
@@ -6189,6 +6145,7 @@
             "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -6261,9 +6218,9 @@
             "license": "ISC"
         },
         "node_modules/ip-address": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+            "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6575,13 +6532,12 @@
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/issue-parser": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.1.tgz",
-            "integrity": "sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-7.0.2.tgz",
+            "integrity": "sha512-7atWPjhGEIX3JEtMrOYd8TKzboYlq+5sNbdl9POiLYOI14G5HZiQbZP0Xj5EZdrufQVXfJlpTV0hys0CuxwxZw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6642,6 +6598,7 @@
             "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
             }
@@ -6753,7 +6710,6 @@
             "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "jws": "^4.0.1",
                 "lodash.includes": "^4.3.0",
@@ -6786,7 +6742,6 @@
             "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "buffer-equal-constant-time": "^1.0.1",
                 "ecdsa-sig-formatter": "1.0.11",
@@ -6799,7 +6754,6 @@
             "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "jwa": "^2.0.1",
                 "safe-buffer": "^5.0.1"
@@ -6953,7 +6907,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=13.2.0"
             }
@@ -6978,7 +6931,8 @@
             "version": "4.18.1",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
             "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.capitalize": {
             "version": "4.2.1",
@@ -7006,32 +6960,28 @@
             "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
             "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/lodash.isboolean": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
             "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/lodash.isinteger": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
             "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/lodash.isnumber": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
             "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/lodash.isplainobject": {
             "version": "4.0.6",
@@ -7059,8 +7009,7 @@
             "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
             "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/lodash.uniqby": {
             "version": "4.7.0",
@@ -7489,7 +7438,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10.5.0"
             }
@@ -7500,7 +7448,6 @@
             "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },
@@ -7516,13 +7463,6 @@
                 }
             }
         },
-        "node_modules/node-fetch-native": {
-            "version": "1.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
-            "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/node-gyp-build": {
             "version": "4.8.4",
             "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
@@ -7533,31 +7473,6 @@
                 "node-gyp-build-optional": "optional.js",
                 "node-gyp-build-test": "build-test.js"
             }
-        },
-        "node_modules/nypm": {
-            "version": "0.6.8",
-            "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.8.tgz",
-            "integrity": "sha512-Q9K4Diu6l5u6xJQogeFSs/zKtyMSgFKFtRQV+tHP4kL7KPm2grpBU0dFIwFaXwNxN0MtfKWc43VpCugAa+LPsw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "citty": "^0.2.2",
-                "pathe": "^2.0.3",
-                "tinyexec": "^1.2.4"
-            },
-            "bin": {
-                "nypm": "dist/cli.mjs"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/nypm/node_modules/citty": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
-            "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/object-inspect": {
             "version": "1.13.4",
@@ -7729,9 +7644,9 @@
             }
         },
         "node_modules/ora": {
-            "version": "9.3.0",
-            "resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
-            "integrity": "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==",
+            "version": "9.4.1",
+            "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.1.tgz",
+            "integrity": "sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7741,7 +7656,7 @@
                 "is-interactive": "^2.0.0",
                 "is-unicode-supported": "^2.1.0",
                 "log-symbols": "^7.0.1",
-                "stdin-discarder": "^0.3.1",
+                "stdin-discarder": "^0.3.2",
                 "string-width": "^8.1.0"
             },
             "engines": {
@@ -7900,78 +7815,80 @@
             }
         },
         "node_modules/pac-proxy-agent": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-8.0.0.tgz",
-            "integrity": "sha512-HyCoVbyQ/nbVlQ/R6wBu0YXhbG2oAnEK5BQ3xMyj1OffQmU5NoOnpLzgPlKHaobUzz5NK0+AZHby4TdydAEBUA==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-9.1.0.tgz",
+            "integrity": "sha512-1aU+1mpj3DrQPfo3gh+3Gap3G5x+axnMx1P/y0ZF2ch7kb2meyOCAH8K2k9d27ROsTE7TnAerzxqF9aon2jqnA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "agent-base": "8.0.0",
+                "agent-base": "9.0.0",
                 "debug": "^4.3.4",
-                "get-uri": "7.0.0",
-                "http-proxy-agent": "8.0.0",
-                "https-proxy-agent": "8.0.0",
-                "pac-resolver": "8.0.0",
-                "quickjs-wasi": "^0.0.1",
-                "socks-proxy-agent": "9.0.0"
+                "get-uri": "8.0.1",
+                "http-proxy-agent": "9.1.0",
+                "https-proxy-agent": "9.1.0",
+                "pac-resolver": "9.0.1",
+                "quickjs-wasi": "^2.2.0",
+                "socks-proxy-agent": "10.1.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 20"
             }
         },
         "node_modules/pac-proxy-agent/node_modules/agent-base": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-8.0.0.tgz",
-            "integrity": "sha512-QT8i0hCz6C/KQ+KTAbSNwCHDGdmUJl2tp2ZpNlGSWCfhUNVbYG2WLE3MdZGBAgXPV4GAvjGMxo+C1hroyxmZEg==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+            "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 14"
+                "node": ">= 20"
             }
         },
         "node_modules/pac-proxy-agent/node_modules/http-proxy-agent": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-8.0.0.tgz",
-            "integrity": "sha512-7pose0uGgrCJeH2Qh4JcNhWZp3u/oNrWjNYDK4ydOLxOpTw8V8ogHFAmkz0VWq96JBFj4umVJpvmQi287rSYLg==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-9.1.0.tgz",
+            "integrity": "sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "agent-base": "8.0.0",
-                "debug": "^4.3.4"
+                "agent-base": "9.0.0",
+                "debug": "^4.3.4",
+                "proxy-agent-negotiate": "1.1.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 20"
             }
         },
         "node_modules/pac-proxy-agent/node_modules/https-proxy-agent": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-8.0.0.tgz",
-            "integrity": "sha512-YYeW+iCnAS3xhvj2dvVoWgsbca3RfQy/IlaNHHOtDmU0jMqPI9euIq3Y9BJETdxk16h9NHHCKqp/KB9nIMStCQ==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
+            "integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "agent-base": "8.0.0",
-                "debug": "^4.3.4"
+                "agent-base": "9.0.0",
+                "debug": "^4.3.4",
+                "proxy-agent-negotiate": "1.1.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 20"
             }
         },
         "node_modules/pac-resolver": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-8.0.0.tgz",
-            "integrity": "sha512-SVNzOxVq2zuTew3WAt7U8UghwzJzuWYuJryd3y8FxyLTZdjVoCzY8kLP39PpEqQCDvlMWdQXwViu0sYT3eiU2w==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-9.0.1.tgz",
+            "integrity": "sha512-lJbS008tmkj08VhoM8Hzuv/VE5tK9MS0OIQ/7+s0lIF+BYhiQWFYzkSpML7lXs9iBu2jfmzBTLzhe9n6BX+dYw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "degenerator": "6.0.0",
+                "degenerator": "7.0.1",
                 "netmask": "^2.0.2"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 20"
             },
             "peerDependencies": {
-                "quickjs-wasi": "^0.0.1"
+                "quickjs-wasi": "^2.2.0"
             }
         },
         "node_modules/package-json-from-dist": {
@@ -8096,6 +8013,7 @@
             "integrity": "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@napi-rs/canvas": "0.1.80",
                 "pdfjs-dist": "5.4.296"
@@ -8169,7 +8087,6 @@
             "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "playwright-core": "1.61.1"
             },
@@ -8189,7 +8106,6 @@
             "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "playwright-core": "cli.js"
             },
@@ -8277,61 +8193,63 @@
             "license": "MIT"
         },
         "node_modules/proxy-agent": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-7.0.0.tgz",
-            "integrity": "sha512-okTgt79rHTvMHkr/Ney5rZpgCHh3g1g3tI5uhkgN5b7OeI3n0Q/ui1uv9OdrnZNJM9WIZJqZPh/UJs+YtO/TMQ==",
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-8.0.2.tgz",
+            "integrity": "sha512-idLLRewuemWd7GH/BDJzGiB0dWGfT2SQs3jy6NtZtGWU9uPTTSdeC1/cdbqLwgzhfv027daGFuXX426e2Eg20A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "agent-base": "8.0.0",
+                "agent-base": "9.0.0",
                 "debug": "^4.3.4",
-                "http-proxy-agent": "8.0.0",
-                "https-proxy-agent": "8.0.0",
+                "http-proxy-agent": "9.1.0",
+                "https-proxy-agent": "9.1.0",
                 "lru-cache": "^7.14.1",
-                "pac-proxy-agent": "8.0.0",
-                "proxy-from-env": "^1.1.0",
-                "socks-proxy-agent": "9.0.0"
+                "pac-proxy-agent": "9.1.0",
+                "proxy-from-env": "^2.0.0",
+                "socks-proxy-agent": "10.1.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 20"
             }
         },
         "node_modules/proxy-agent/node_modules/agent-base": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-8.0.0.tgz",
-            "integrity": "sha512-QT8i0hCz6C/KQ+KTAbSNwCHDGdmUJl2tp2ZpNlGSWCfhUNVbYG2WLE3MdZGBAgXPV4GAvjGMxo+C1hroyxmZEg==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+            "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 14"
+                "node": ">= 20"
             }
         },
         "node_modules/proxy-agent/node_modules/http-proxy-agent": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-8.0.0.tgz",
-            "integrity": "sha512-7pose0uGgrCJeH2Qh4JcNhWZp3u/oNrWjNYDK4ydOLxOpTw8V8ogHFAmkz0VWq96JBFj4umVJpvmQi287rSYLg==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-9.1.0.tgz",
+            "integrity": "sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "agent-base": "8.0.0",
-                "debug": "^4.3.4"
+                "agent-base": "9.0.0",
+                "debug": "^4.3.4",
+                "proxy-agent-negotiate": "1.1.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 20"
             }
         },
         "node_modules/proxy-agent/node_modules/https-proxy-agent": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-8.0.0.tgz",
-            "integrity": "sha512-YYeW+iCnAS3xhvj2dvVoWgsbca3RfQy/IlaNHHOtDmU0jMqPI9euIq3Y9BJETdxk16h9NHHCKqp/KB9nIMStCQ==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
+            "integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "agent-base": "8.0.0",
-                "debug": "^4.3.4"
+                "agent-base": "9.0.0",
+                "debug": "^4.3.4",
+                "proxy-agent-negotiate": "1.1.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 20"
             }
         },
         "node_modules/proxy-agent/node_modules/lru-cache": {
@@ -8357,7 +8275,6 @@
             "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "punycode": "^2.3.1"
             },
@@ -8396,8 +8313,7 @@
             "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
             "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
@@ -8421,21 +8337,22 @@
             "license": "MIT"
         },
         "node_modules/quickjs-wasi": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-0.0.1.tgz",
-            "integrity": "sha512-fBWNLTBkxkLAhe1AzF1hyXEvuA+N+vV1WMP2D6iiMUblvmOt8Pp5t8zUcgvz7aYA1ldUdxDlgUse15dmcKjkNg==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-2.2.0.tgz",
+            "integrity": "sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/rc9": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
-            "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
+            "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "defu": "^6.1.4",
-                "destr": "^2.0.3"
+                "defu": "^6.1.6",
+                "destr": "^2.0.5"
             }
         },
         "node_modules/readable-stream": {
@@ -8503,9 +8420,9 @@
             "license": "Apache-2.0"
         },
         "node_modules/release-it": {
-            "version": "20.2.1",
-            "resolved": "https://registry.npmjs.org/release-it/-/release-it-20.2.1.tgz",
-            "integrity": "sha512-xd0mqTGduwQlEzVBKOJcoVZxDrRLzjmFv3W8tWwkPIPDYtwYBWYjULiSk6VhfuGKocfz7GmptAqViKMQV4Zzbw==",
+            "version": "21.0.1",
+            "resolved": "https://registry.npmjs.org/release-it/-/release-it-21.0.1.tgz",
+            "integrity": "sha512-xbPuv2tau3gb0Xw0NVqV3QjOhytFvbsBZDqzmURqlwtgNpFIlIbpDbuZG64ptytFOX4H/7k65bbPSLTwAL34/g==",
             "dev": true,
             "funding": [
                 {
@@ -8519,53 +8436,34 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "@inquirer/prompts": "8.4.2",
+                "@inquirer/prompts": "8.5.2",
                 "@octokit/rest": "22.0.1",
                 "@phun-ky/typeof": "2.0.3",
                 "async-retry": "1.3.3",
-                "c12": "3.3.3",
+                "c12": "3.3.4",
                 "ci-info": "^4.4.0",
                 "defu": "^6.1.7",
-                "eta": "4.5.1",
+                "eta": "4.6.0",
                 "git-url-parse": "16.1.0",
-                "issue-parser": "7.0.1",
+                "issue-parser": "7.0.2",
                 "lodash.merge": "4.6.2",
                 "mime-types": "3.0.2",
                 "new-github-release-url": "2.0.0",
                 "open": "11.0.0",
-                "ora": "9.3.0",
+                "ora": "9.4.1",
                 "os-name": "7.0.0",
-                "proxy-agent": "7.0.0",
-                "semver": "7.7.4",
-                "tinyglobby": "0.2.15",
-                "undici": "7.28.0",
+                "proxy-agent": "8.0.2",
+                "semver": "7.8.5",
+                "tinyglobby": "0.2.17",
+                "undici": "7.29.0",
                 "url-join": "5.0.0",
-                "wildcard-match": "5.1.4",
-                "yargs-parser": "22.0.0"
+                "wildcard-match": "5.1.4"
             },
             "bin": {
                 "release-it": "bin/release-it.js"
             },
             "engines": {
-                "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
-            }
-        },
-        "node_modules/release-it/node_modules/fdir": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "peerDependencies": {
-                "picomatch": "^3 || ^4"
-            },
-            "peerDependenciesMeta": {
-                "picomatch": {
-                    "optional": true
-                }
+                "node": "^22.21.0 || >=24.0.0"
             }
         },
         "node_modules/release-it/node_modules/mime-db": {
@@ -8595,67 +8493,14 @@
                 "url": "https://opencollective.com/express"
             }
         },
-        "node_modules/release-it/node_modules/picomatch": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
-            "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
-        "node_modules/release-it/node_modules/semver": {
-            "version": "7.7.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-            "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/release-it/node_modules/tinyglobby": {
-            "version": "0.2.15",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.3"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/SuperchupuDev"
-            }
-        },
         "node_modules/release-it/node_modules/undici": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-            "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+            "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=20.18.1"
-            }
-        },
-        "node_modules/release-it/node_modules/yargs-parser": {
-            "version": "22.0.0",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-            "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": "^20.19.0 || ^22.12.0 || >=23"
             }
         },
         "node_modules/require-directory": {
@@ -8685,8 +8530,7 @@
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
             "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/resolve-from": {
             "version": "4.0.0",
@@ -8741,7 +8585,6 @@
             "integrity": "sha512-pOLi+Gdll3JekwuFjXO3fTq+L9lzMQGcSq7M5gIjExcl3Gu1hd4XXuf5o3+LuSBsaULQH7DiNbsqPd1chVpQGQ==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=10.7.0"
             },
@@ -9074,28 +8917,28 @@
             }
         },
         "node_modules/socks-proxy-agent": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-9.0.0.tgz",
-            "integrity": "sha512-fFlbMlfsXhK02ZB8aZY7Hwxh/IHBV9b1Oq9bvBk6tkFWXvdAxUgA0wbw/NYR5liU3Y5+KI6U4FH3kYJt9QYv0w==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-10.1.0.tgz",
+            "integrity": "sha512-WlMj/67cEJ6MDI1OcsnjuYKDNDoyPCCYZ249kuuXPiMDw9F8PXkVaQ7YWu3siTydfQ/4BEZcvGzu+aYvz7dDCQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "agent-base": "8.0.0",
+                "agent-base": "9.0.0",
                 "debug": "^4.3.4",
                 "socks": "^2.8.3"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 20"
             }
         },
         "node_modules/socks-proxy-agent/node_modules/agent-base": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-8.0.0.tgz",
-            "integrity": "sha512-QT8i0hCz6C/KQ+KTAbSNwCHDGdmUJl2tp2ZpNlGSWCfhUNVbYG2WLE3MdZGBAgXPV4GAvjGMxo+C1hroyxmZEg==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+            "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">= 14"
+                "node": ">= 20"
             }
         },
         "node_modules/source-map": {
@@ -9254,7 +9097,6 @@
             "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@tokenizer/token": "^0.3.0"
             },
@@ -9294,16 +9136,6 @@
             "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/tinyexec": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-            "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            }
         },
         "node_modules/tinyglobby": {
             "version": "0.2.17",
@@ -9346,6 +9178,7 @@
             "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -9401,7 +9234,6 @@
             "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@borewit/text-codec": "^0.2.1",
                 "@tokenizer/token": "^0.3.0",
@@ -9421,7 +9253,6 @@
             "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "psl": "^1.1.33",
                 "punycode": "^2.1.1",
@@ -9437,8 +9268,7 @@
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/transliteration": {
             "version": "2.3.5",
@@ -9586,7 +9416,6 @@
             "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -9595,9 +9424,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "6.27.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-            "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+            "version": "6.28.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+            "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -9609,8 +9438,7 @@
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
             "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/universal-user-agent": {
             "version": "7.0.3",
@@ -9625,7 +9453,6 @@
             "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 4.0.0"
             }
@@ -9704,7 +9531,6 @@
             "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
@@ -9757,7 +9583,6 @@
             "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 14"
             }
@@ -9767,8 +9592,7 @@
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
             "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
             "dev": true,
-            "license": "BSD-2-Clause",
-            "peer": true
+            "license": "BSD-2-Clause"
         },
         "node_modules/whatwg-url": {
             "version": "5.0.0",
@@ -9776,7 +9600,6 @@
             "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
@@ -9998,7 +9821,6 @@
             "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -10153,9 +9975,9 @@
             }
         },
         "node_modules/yoctocolors": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-            "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+            "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -10170,6 +9992,7 @@
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
             "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -10182,6 +10005,34 @@
             "license": "ISC",
             "peerDependencies": {
                 "zod": "^3.23.3"
+            }
+        },
+        "node_modules/proxy-agent-negotiate": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
+            "integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "kerberos": "^2.0.0"
+            },
+            "peerDependenciesMeta": {
+                "kerberos": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/proxy-agent/node_modules/proxy-from-env": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
             }
         }
     }

--- a/n8n/package-lock.json
+++ b/n8n/package-lock.json
@@ -237,6 +237,31 @@
                 "kuler": "^2.0.0"
             }
         },
+        "node_modules/@emnapi/core": {
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+            "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.3",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+            "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@emnapi/wasi-threads": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",

--- a/n8n/package-lock.json
+++ b/n8n/package-lock.json
@@ -237,39 +237,13 @@
                 "kuler": "^2.0.0"
             }
         },
-        "node_modules/@emnapi/core": {
-            "version": "1.11.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-            "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.2",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@emnapi/runtime": {
-            "version": "1.11.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-            "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
         "node_modules/@emnapi/wasi-threads": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-            "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+            "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -6629,9 +6603,9 @@
             }
         },
         "node_modules/js-yaml": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "dev": true,
             "funding": [
                 {
@@ -8212,6 +8186,24 @@
                 "node": ">= 20"
             }
         },
+        "node_modules/proxy-agent-negotiate": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
+            "integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "kerberos": "^2.0.0"
+            },
+            "peerDependenciesMeta": {
+                "kerberos": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/proxy-agent/node_modules/agent-base": {
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
@@ -8260,6 +8252,16 @@
             "license": "ISC",
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/proxy-agent/node_modules/proxy-from-env": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/proxy-from-env": {
@@ -10005,34 +10007,6 @@
             "license": "ISC",
             "peerDependencies": {
                 "zod": "^3.23.3"
-            }
-        },
-        "node_modules/proxy-agent-negotiate": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
-            "integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 20"
-            },
-            "peerDependencies": {
-                "kerberos": "^2.0.0"
-            },
-            "peerDependenciesMeta": {
-                "kerberos": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/proxy-agent/node_modules/proxy-from-env": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
             }
         }
     }

--- a/n8n/package.json
+++ b/n8n/package.json
@@ -52,7 +52,7 @@
         "@n8n/node-cli": "0.40.3",
         "eslint": "9.32.0",
         "prettier": "3.6.2",
-        "release-it": "20.2.1",
+        "release-it": "21.0.1",
         "typescript": "5.9.2"
     },
     "peerDependencies": {

--- a/n8n/test/release.test.cjs
+++ b/n8n/test/release.test.cjs
@@ -14,7 +14,7 @@ test('0.1.3 release metadata is locked to the stable n8n toolchain', () => {
 
 	assert.equal(pkg.version, '0.1.3');
 	assert.equal(pkg.devDependencies['@n8n/node-cli'], '0.40.3');
-	assert.equal(pkg.devDependencies['release-it'], '20.2.1');
+	assert.equal(pkg.devDependencies['release-it'], '21.0.1');
 	assert.equal(pkg.engines.node, '>=20.19.0');
 	assert.equal(pkg.repository.directory, 'n8n');
 	assert.equal(lock.packages[''].version, pkg.version);


### PR DESCRIPTION
## Why

This repository had **no `.github/dependabot.yml`** and **automated security fixes disabled**. Nine advisories were open — three high — with **no remediation PR, and nothing that was ever going to file one**.

The repo's own fail-closed gate was already failing on a pristine checkout:

```
Development dependency audit rejected: unexpected audit package set; extra=ip-address,undici
```

## Fixes

| Package | To | Notes |
|---|---|---|
| `ip-address` | **10.4.0** | Lockfile only; satisfies `socks` `^10.1.1` |
| `brace-expansion` | **1.1.18 / 2.1.4 / 5.0.9** | Fixes GHSA-rgw5-rvv9-x895 |
| `undici` | **7.29.0** | Direct for `@n8n/backend-network` (`^7.28.0`) |
| `release-it` | **21.0.1** | Required — see below |

**`brace-expansion` — the recorded exception is now stale.** GHSA-rgw5-rvv9-x895 is a *bypass* of the previously accepted GHSA-mh99-v99m-4gvg. `TOOLCHAIN_AUDIT.md` said the only patched release was the API-incompatible 5.0.8 line. That is no longer true — **patched releases now exist on 1.x and 2.x**, so the eslint and n8n-cli consumers are fixed *in place* rather than forced across a major. Both advisories are now **resolved rather than allowlisted**.

**`release-it` — why the bump was unavoidable.** It pins `undici` to exactly `7.28.0`. Two alternatives were tried and rejected:

- A scoped `overrides` entry — **rejected by lint.** `@n8n/community-nodes/no-overrides-field` forbids the field outright in community node packages. *(I only found this by running `npm run check` for real.)*
- Staying on `release-it@20.x` — **no patched release exists;** `20.2.1` is the final 20.x.

> ⚠️ **Reviewer note:** this changes the deliberately locked release pin, so `test/release.test.cjs` is updated in the same commit. It does **not** change what the published package supports — `engines.node` stays `>=20.19.0`, `release-it` is dev-only and absent from the published `files` list, and the n8n CI job already runs on Node 22. Only a maintainer running `npm run release` locally now needs Node ≥22.21. `release-it` is used by neither CI nor `publish-n8n.yml`, which publishes via npm trusted publishing.

## Deliberately unchanged

The `uuid` / LangChain moderates. `TOOLCHAIN_AUDIT.md` records them as accepted, npm's only offered fix is an **invalid downgrade** of the builder from `0.40.3` to `0.20.0`, and the gate covers high/critical only — so they stay visible rather than suppressed.

## Recurrence prevention

Adds `.github/dependabot.yml` for npm in `/mcp` and `/n8n` plus `github-actions` at the root.

> Note: that file enables *version* updates. **Automated security fixes are a repository setting** and still need enabling in Settings → Code security — I did not change repo settings.

## Verification

Run locally against a clean `npm ci` in both packages — all exit 0:

| | n8n | mcp |
|---|---|---|
| `npm run check` (test + lint + build) | ✅ | ✅ |
| `npm run audit:dev` | ✅ | — |
| `npm audit` | ✅ `--omit=dev --audit-level=moderate` | ✅ `--audit-level=moderate` |
| `npm pack --dry-run` | ✅ | ✅ |

Lockfile integrity vs `origin/main`: mcp unchanged at **121** packages; n8n removals are **exactly the release-it 20 dependency subtree**, with the optional `@emnapi` peer shims preserved so **Linux `npm ci` stays in sync** — an earlier revision of this branch pruned them on Windows and broke CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
