### PR TITLE
Make Harness Core the flagship and add canonical ecosystem truth

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - '**/*.md'
       - '.github/workflows/validate.yml'
+      - 'ecosystem.json'
+      - 'ecosystem.schema.json'
       - 'integrations.json'
       - 'integrations.schema.json'
       - '.cursor-plugin/**'
@@ -118,6 +120,12 @@ jobs:
       - name: Validate integrations.json against schema
         run: ajv validate -s integrations.schema.json -d integrations.json --all-errors --spec=draft2020 -c ajv-formats
 
+      - name: Validate ecosystem.json against schema
+        run: ajv validate -s ecosystem.schema.json -d ecosystem.json --all-errors --spec=draft2020 -c ajv-formats
+
+      - name: Test ecosystem claim boundaries
+        run: node --test test/verify-ecosystem-profile.test.cjs
+
       - name: Validate integrations.json is valid JSON
         run: node -e "JSON.parse(require('fs').readFileSync('integrations.json','utf8')); console.log('✅ integrations.json is valid JSON')"
 
@@ -180,7 +188,7 @@ jobs:
 
       - name: Check required root files exist
         run: |
-          for f in integrations.json integrations.schema.json AGENTS.md SKILL.md llms.txt llms-full.txt gemini-extension.json GEMINI.md llms-install.md CITATION.cff CHANGELOG.md CONTRIBUTING.md SECURITY.md CODEOWNERS LICENSE README.md; do
+          for f in ecosystem.json ecosystem.schema.json integrations.json integrations.schema.json AGENTS.md SKILL.md llms.txt llms-full.txt gemini-extension.json GEMINI.md llms-install.md CITATION.cff CHANGELOG.md CONTRIBUTING.md SECURITY.md CODEOWNERS LICENSE README.md; do
             if [ ! -f "$f" ]; then
               echo "❌ Missing required file: $f"
               exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added a schema-backed canonical ecosystem profile, claim-boundary fixtures, and npm-package-safe Harness Core branding assets.
 - Added experimental, hermetically tested ClawTeam and World AgentKit adapters. The ClawTeam integration requires operators to disable the upstream skip-permissions default and keeps execution at a zero-USDC cap unless two local paid-authority inputs are present; World AgentKit performs only the official pre-payment access attempt and does not claim live server support.
 - Added client-native packages for Cursor, Gemini CLI, Claude Code, and Cline, all using the published MCP relay without embedding an API key.
 - Added a canonical distribution packet, external-channel status matrix, 400 by 400 plugin icon, and repository-owned validation for package metadata and no-spend boundaries.
-- Added the Harness Core 0.2.0 public-source candidate: middleware lifecycle, append-only run ledgers, local approvals and maker-checker review records, profiles, loopback runtime probes, refs-only context imports, owner inbox/status, schedule intent, worktree-session evidence, all public schemas, and framework-wrapping examples.
+- Added the published Harness Core 0.2.0 middleware kernel and the review-gated 0.2.1 packaging/truthfulness patch candidate: append-only run ledgers, local approvals and maker-checker review records, profiles, loopback runtime probes, refs-only context imports, owner inbox/status, schedule intent, worktree-session evidence, public schemas, and declarative framework mapping examples.
 - Added experimental documentation paths for Langflow, Browser Use, DSPy, AgentScope, VoltAgent, and Genkit. These entries do not claim tested package or runtime support.
 - Added beta, framework-native adapters for Griptape, LiveKit Agents, and Pipecat with hermetic contract tests and current-framework construction evidence.
 - Added a status-safe 1280x640 integrations banner and first-viewport discovery copy.
 
 ### Changed
+- Bumped the canonical manifest to `2.30.1`, made Micro ECF installation explicitly plan-first and approval-gated, and added ecosystem profile/schema discovery parity.
 - Bumped the canonical manifest to `2.30.0` with 99 indexed surfaces and explicit discovery pointers for ClawTeam and World AgentKit.
 - Superseded `agoragentic-mcp@1.3.5` with `1.3.6` after a clean downstream install proved npm does not propagate dependency-level overrides. The 1.3.6 package bundles the audited MCP SDK/Hono tree into a Node.js 20 CLI with zero runtime dependencies and adds a packed-consumer install, audit, and MCP fallback smoke gate; all client-native manifests and MCP registry metadata now target the corrected package.
 - Bumped the canonical manifest to `2.29.0` with 97 indexed surfaces and added machine discovery pointers for the native client packages.
@@ -24,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Recorded the current OpenAI public-plugin policy blocker instead of presenting the commerce MCP surface as submission-ready.
 - Prepared the `n8n-nodes-agoragentic` 0.1.3 candidate on stable `@n8n/node-cli` 0.40.3 with a committed lockfile, lint/build prepublish gate, exact release-tag validation, and locked CI installs; npm publication remains review- and trusted-publishing-gated.
 - Bumped the canonical manifest to `2.28.0`, added Harness Core package coordinates plus its npm-first install command, and made the package-index schema enumerate every currently declared package family.
-- Hardened Harness Core publication with a lockfile, exact version-tag validation, locked installs, and an out-of-repository packed-install/schema-export smoke test. npm publication remains gated on review, merge, the exact `harness-core-v0.2.0` release, and trusted publishing.
+- Hardened Harness Core publication with a lockfile, exact version-tag validation, locked installs, and an out-of-repository packed-install/schema-export smoke test. Version `0.2.0` was published on 2026-07-23; the `0.2.1` patch remains gated on review, merge, the exact release tag, and trusted publishing.
 - Bumped the canonical manifest to `2.27.0` with 93 indexed integration surfaces.
 - Restored 13 existing adapter directories that were missing from `integrations.json`: Dfns, fast-agent, Goose, Haystack, Kibble, LI.FI, MPPScan, Olas, Reown, Safe, Superfluid, Tempo MPP, and u402.
 - Updated Agent OS CLI discovery from the stale `1.6.8` pin to `@latest` (currently published as `1.6.9`).

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Use this chooser before picking a framework wrapper:
 | Call a self-hosted Rust framework runtime from TypeScript or Python | `AGORAGENTIC_RUST_AGENT_URL=http://127.0.0.1:8080` plus `rust-framework/` examples | HTTP/JSON runtime contract |
 | Expose Agoragentic tools inside MCP-native hosts | `npx agoragentic-mcp@latest` | MCP stdio relay |
 | Prepare local context, policy, source maps, and Harness exports before hosted deployment | `npx agoragentic-micro-ecf@latest` | Micro ECF local wedge |
-| Build no-spend local proof, receipt, Agent OS export, and listing-readiness artifacts | `npx agoragentic-harness-core@latest` (or `node harness-core/bin/agoragentic-harness.mjs`) | Harness Core (npm currently serves v0.1.1; this repository contains the review-gated v0.2.0 candidate) |
+| Build no-spend local configuration proof, receipt, Agent OS export, and listing-readiness artifacts | `npx agoragentic-harness-core@latest` (or `node harness-core/bin/agoragentic-harness.mjs`) | Harness Core (npm currently serves v0.2.0; this repository contains the review-gated v0.2.1 patch candidate) |
 | Run a local release premortem and safe self-heal plan before publishing an OSS agent | [`agoragentic-premortem-golden-loop`](https://github.com/rhein1/agoragentic-premortem-golden-loop) · `node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs` | Premortem Golden Loop source scaffold |
 | Run a self-hosted context-governance compiler without hosted wallets or marketplace execution | [`agoragentic-ecf-core`](https://github.com/rhein1/agoragentic-ecf-core) · `npx agoragentic-ecf-core@latest` | ECF Core |
 | Add quote, x402, execute, and receipt steps to n8n workflows | `npm install n8n-nodes-agoragentic` | n8n community node |
@@ -156,7 +156,7 @@ The hosted Triptych OS (Agent OS) control plane is not a downloadable npm packag
 | **[Agent OS CLI source](./sdk/agent-os-cli/)** | `npx agoragentic-os@latest` | Node ≥ 18 |
 | **MCP Server** | `npx agoragentic-mcp` | Node ≥ 18 |
 | **ACP Adapter** | `npx agoragentic-mcp --acp` | Node ≥ 18 |
-| **Micro ECF** | `npx agoragentic-micro-ecf@latest init` | Node ≥ 18 |
+| **Micro ECF** | `npx agoragentic-micro-ecf@latest plan --dir .`, then `npx agoragentic-micro-ecf@latest install --dir . --yes` only after explicit approval | Node ≥ 18 |
 | **Harness Core** | `npx agoragentic-harness-core@latest init` | Node ≥ 18 |
 | **Premortem Golden Loop Agent** | `node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs run --repo .` | Node ≥ 18 |
 
@@ -438,6 +438,8 @@ Your Agent  →  Integration (tools/MCP)  →  Agent OS + Agoragentic API
 |-------|------|
 | Machine-readable index | [`integrations.json`](./integrations.json) |
 | JSON Schema | [`integrations.schema.json`](./integrations.schema.json) |
+| Ecosystem profile | [`ecosystem.json`](./ecosystem.json) |
+| Ecosystem profile schema | [`ecosystem.schema.json`](./ecosystem.schema.json) |
 | Client distribution status | [`docs/DISTRIBUTION.md`](./docs/DISTRIBUTION.md) |
 | Canonical directory packet | [`docs/catalog-profile.json`](./docs/catalog-profile.json) |
 | Cursor plugin | [`.cursor-plugin/plugin.json`](./.cursor-plugin/plugin.json) |

--- a/docs/BRAND_SYSTEM.md
+++ b/docs/BRAND_SYSTEM.md
@@ -1,0 +1,251 @@
+# Agoragentic public brand system
+
+This is the source contract for Agoragentic repository heroes, social cards, README first screens, product-family navigation, and public proof language.
+
+It does not grant permission to publish, deploy, spend, change production, mutate trust, or alter repository social-preview settings. Those remain explicit owner actions.
+
+## Brand promise
+
+> **Control, proof, and transaction rails for autonomous agents.**
+
+Expanded:
+
+> Agoragentic gives agents bounded authority to act, evidence to be trusted, and transaction rails to buy and sell work.
+
+Use the expanded product language where the audience needs context. Use the short promise on social cards and narrow headers.
+
+## Product hierarchy
+
+```text
+Agoragentic
+├── Open/local
+│   ├── Harness Core — policy, approvals, evidence, local receipts
+│   ├── Micro ECF — lightweight persistent context boundary
+│   ├── ECF Core — self-hosted context governance and local MCP
+│   ├── Fable-5 — evidence-first engineering workflows
+│   └── Premortem Golden Loop — pre-launch audit and repair guidance
+├── Hosted
+│   ├── Triptych OS — governed deployed-agent runtime
+│   ├── Router / Marketplace — capability transactions
+│   └── Interchange — cross-market discovery and reconciliation
+└── Distribution
+    └── Agoragentic Integrations — hosts, frameworks, protocols, workflows, and rails
+```
+
+Do not present every project as a peer flagship. Public portfolio priority is:
+
+1. Harness Core
+2. Fable-5
+3. ECF Core
+4. Micro ECF
+5. Agoragentic Integrations
+6. Premortem Golden Loop
+7. acquisition examples
+
+## First-screen README contract
+
+Every flagship README should reveal the following before deep architecture or exhaustive qualification text:
+
+1. **Product name**
+2. **One user problem** in plain language
+3. **One command** or smallest useful action
+4. **Expected result or proof artifact**
+5. **Three reasons to use it**
+6. **Where it fits** in the Agoragentic product map
+7. **Clear product boundary**
+8. **Next funnel step**
+
+Recommended order:
+
+```text
+[hero]
+
+# Product
+## Problem-focused promise
+
+one sentence
+
+[Install] [Demo] [Docs] [Next step]
+
+$ one command
+
+Expected:
+✓ result
+✓ artifact
+✓ safety boundary
+
+[short proof image or GIF]
+
+Why use it
+Where it fits
+Product boundary
+Detailed reference
+```
+
+Do not lead with internal strategy terms such as `wedge`, `lane`, `surface`, `tranche`, or `full-stack thesis`. Those may remain in architecture and strategy documents.
+
+## Visual grammar
+
+All Agoragentic parent-brand assets should share:
+
+- dark navy field;
+- restrained cyan-to-orange accent;
+- strong left-aligned promise;
+- one system diagram or concrete product proof;
+- generous whitespace;
+- no decorative fake dashboards;
+- no mutable statistics in baked images;
+- no claims that cannot be verified from source or runtime evidence.
+
+Suggested base colors:
+
+| Role | Value |
+|---|---|
+| Background | `#081120` |
+| Elevated background | `#101A2E` |
+| Primary text | `#F8FAFC` |
+| Secondary text | `#B8C5D9` |
+| Cyan accent | `#45D6DF` |
+| Orange accent | `#FF7453` |
+| Structural line | `#2A3A56` |
+
+Product accents may differ, but the Agoragentic wordmark, grid, image dimensions, corner system, and evidence-first composition should remain recognizable.
+
+Fable-5 may retain its distinct brand. Connect it with a small line such as `Evidence-first engineering workflows from Agoragentic`; do not recolor it into the parent visual system.
+
+## Asset sizes
+
+Maintain source SVGs whenever possible.
+
+| Use | Size | Notes |
+|---|---:|---|
+| GitHub/OpenGraph social card | `1280 × 640` | Keep important text inside a 1120 × 520 safe area. |
+| README hero | `1600 × 900` or responsive SVG | Must remain legible at 640 px width. |
+| Architecture diagram | responsive SVG | Use text alternatives and meaningful group labels. |
+| Demo GIF/video poster | `1280 × 720` | Show real product behavior, not a simulated result unless labeled. |
+| Compact mark | `512 × 512` | No small text. |
+
+Repository owners must upload the final social preview in GitHub settings after review; committing an image does not change the repository social-preview setting.
+
+## Image content contract
+
+Each flagship repository should have three visual roles:
+
+### 1. What it is
+
+A strong hero with the user problem and product name.
+
+### 2. How it works
+
+A small architecture or lifecycle diagram.
+
+### 3. Proof it works
+
+A real terminal, browser, receipt, source-boundary, or test animation. Remove secrets, private paths, raw prompts, credentials, unredacted tool output, and private owner context.
+
+Do not bake mutable counts, package versions, call totals, star counts, prices, availability states, or verification timestamps into social cards. Link to live/canonical sources instead.
+
+## Product-specific visual subjects
+
+| Product | Primary visual subject |
+|---|---|
+| Harness Core | `intent → policy → approval → tool → receipt` |
+| Micro ECF | allowed sources, blocked sources, citations, persistent project contract |
+| ECF Core | query routing to exact source evidence and policy lookup |
+| Triptych OS | launch, run, prove, sell |
+| Marketplace | current capability cards with price, state, proof, and contract |
+| Interchange | governed buyer, marketplace A, seller/marketplace B, receipt, reconciliation |
+| Fable-5 | retain current skill/benchmark/workflow-trace identity |
+| Premortem | failure frame → findings → safe fixes → recheck |
+| Integrations | one canonical Agoragentic layer connecting multiple hosts and rails |
+
+## Copy rules
+
+Prefer:
+
+- `Give any agent a policy gate and a verifiable local receipt.`
+- `Give a coding agent a source-preserving context router before it edits.`
+- `Add a persistent, inspectable context boundary in one local command.`
+- `Browse current agent capabilities, prices, contracts, and proof.`
+- `Connect marketplaces without surrendering the owner's mandate.`
+
+Avoid:
+
+- raw inventory counts outside the canonical manifest;
+- `verified` without the exact verification scope;
+- `production-ready` without a named readiness contract;
+- `secure`, `safe`, or `trusted` as universal claims;
+- `receipt-backed outcome` when only execution evidence exists;
+- `certified`, `audited`, or `compliant` without the relevant independent scope;
+- describing local proof as settlement proof or marketplace verification.
+
+## Shared ecosystem block
+
+Repositories should use a short block, not a large duplicated family table:
+
+```markdown
+## Where this fits
+
+- **Local control:** Harness Core, Micro ECF, ECF Core
+- **Hosted runtime:** Triptych OS
+- **Agent commerce:** Router / Marketplace and Interchange
+- **Integration hub:** Agoragentic Integrations
+
+[See the canonical ecosystem profile](https://github.com/rhein1/agoragentic-integrations/blob/main/ecosystem.json).
+```
+
+The canonical ecosystem profile owns mutable portfolio metadata. Other repositories should not hard-code the integration inventory count.
+
+## Funnel rules
+
+Every repository must offer one primary next step:
+
+| Current product | Primary next step |
+|---|---|
+| Harness Core | integrate a host or preview an Agent OS handoff |
+| Micro ECF | continue locally or upgrade to ECF Core |
+| ECF Core | continue self-hosted or preview an Agent OS handoff |
+| Fable-5 | install and run one evidence-first workflow |
+| Premortem | run an audit and hand the repair prompt to an IDE agent |
+| Example repo | preview a marketplace match before any spend-capable path |
+| Integrations | choose a host/framework path, then use match/execute |
+| Marketplace | buy, sell, run, or connect a market |
+
+Do not present five equal calls to action above the fold.
+
+## Accessibility
+
+- Every image needs meaningful alt text.
+- Do not place required product meaning only inside an image.
+- Maintain at least WCAG AA contrast for text.
+- SVGs need `<title>` and `<desc>`.
+- Animations need a static explanation and should avoid rapid flashing.
+- Terminal proof should also be represented as text in the README.
+
+## Public truth sources
+
+Use current machine surfaces rather than copied status claims:
+
+- ecosystem profile: `ecosystem.json`
+- integration inventory: `integrations.json`
+- capability contracts: `https://agoragentic.com/api/capabilities`
+- public proof: `https://agoragentic.com/public-proof.json`
+- health: `https://agoragentic.com/api/health`
+- OpenAPI: `https://agoragentic.com/openapi.yaml`
+- agent discovery: `https://agoragentic.com/agents.txt`
+- MCP: `https://agoragentic.com/.well-known/mcp/server.json`
+- x402: `https://x402.agoragentic.com/.well-known/x402.json`
+
+## Review checklist
+
+Before merging a public README or asset change:
+
+- [ ] The product can be understood without prior Agoragentic knowledge.
+- [ ] One command or smallest useful action appears above deep reference material.
+- [ ] The expected result is concrete.
+- [ ] The product boundary is accurate.
+- [ ] There is one obvious next step.
+- [ ] No mutable count or runtime state is baked into an image.
+- [ ] No local receipt is presented as settlement, certification, or marketplace verification.
+- [ ] Alt text, mobile rendering, links, and generated metadata are validated.
+- [ ] Any referenced live status is linked rather than copied.

--- a/docs/BRAND_SYSTEM.md
+++ b/docs/BRAND_SYSTEM.md
@@ -149,7 +149,7 @@ Do not bake mutable counts, package versions, call totals, star counts, prices, 
 
 | Product | Primary visual subject |
 |---|---|
-| Harness Core | `intent → policy → approval → tool → receipt` |
+| Harness Core | `intent → policy → approval → host boundary → local receipt` |
 | Micro ECF | allowed sources, blocked sources, citations, persistent project contract |
 | ECF Core | query routing to exact source evidence and policy lookup |
 | Triptych OS | launch, run, prove, sell |
@@ -163,7 +163,7 @@ Do not bake mutable counts, package versions, call totals, star counts, prices, 
 
 Prefer:
 
-- `Give any agent a policy gate and a verifiable local receipt.`
+- `Give any agent a policy gate and an inspectable, schema-checkable local receipt.`
 - `Give a coding agent a source-preserving context router before it edits.`
 - `Add a persistent, inspectable context boundary in one local command.`
 - `Browse current agent capabilities, prices, contracts, and proof.`

--- a/docs/BRAND_SYSTEM.md
+++ b/docs/BRAND_SYSTEM.md
@@ -32,7 +32,7 @@ Agoragentic
     └── Agoragentic Integrations — hosts, frameworks, protocols, workflows, and rails
 ```
 
-Do not present every project as a peer flagship. Public portfolio priority is:
+Do not present every project as a peer flagship. Within the public OSS repository portfolio, priority is:
 
 1. Harness Core
 2. Fable-5

--- a/docs/ECOSYSTEM_PROFILE.md
+++ b/docs/ECOSYSTEM_PROFILE.md
@@ -1,0 +1,38 @@
+# Canonical ecosystem profile
+
+[`ecosystem.json`](../ecosystem.json) is the public coordination source for Agoragentic product names, durable positioning, repository roles, user funnels, and links to live truth surfaces.
+
+Use it for portfolio metadata that otherwise drifts across repositories. Do not use it as a substitute for current runtime state.
+
+## Owned here
+
+- durable brand promise;
+- product hierarchy;
+- repository roles;
+- primary user funnels;
+- canonical integration-manifest path and count parity;
+- links to current capability, proof, health, OpenAPI, agent, MCP, and x402 surfaces;
+- public authority and receipt boundaries.
+
+## Not owned here
+
+- current capability availability;
+- current price or payment requirement;
+- current verification or revocation state;
+- current service health;
+- owner approval, spend, wallet, deployment, publication, trust, or ranking state.
+
+Those must be read from the linked machine surfaces at decision time.
+
+## Repository rule
+
+Other Agoragentic repositories should link to this profile instead of copying the integration count or maintaining a large duplicated product-family table. A repository may still describe its own immediate next step and product boundary.
+
+## Validation
+
+```bash
+node scripts/verify-ecosystem-profile.js
+node scripts/verify-integrations-json.js
+```
+
+The second command includes the ecosystem-profile verifier and remains the machine-surface CI entrypoint.

--- a/docs/ECOSYSTEM_PROFILE.md
+++ b/docs/ECOSYSTEM_PROFILE.md
@@ -1,6 +1,6 @@
 # Canonical ecosystem profile
 
-[`ecosystem.json`](../ecosystem.json) is the public coordination source for Agoragentic product names, durable positioning, repository roles, user funnels, and links to live truth surfaces.
+[`ecosystem.json`](../ecosystem.json) is the public coordination source for Agoragentic product names, durable positioning, repository roles, user funnels, and links to live truth surfaces. Its included schema is [`ecosystem.schema.json`](../ecosystem.schema.json); consumers should resolve the profile's relative `$schema` against the profile file rather than a hosted application route.
 
 Use it for portfolio metadata that otherwise drifts across repositories. Do not use it as a substitute for current runtime state.
 
@@ -28,11 +28,15 @@ Those must be read from the linked machine surfaces at decision time.
 
 Other Agoragentic repositories should link to this profile instead of copying the integration count or maintaining a large duplicated product-family table. A repository may still describe its own immediate next step and product boundary.
 
+The Router / Marketplace human entrypoint is the deployed [`/start/browse/`](https://agoragentic.com/start/browse/) page. The former `/marketplace/` path is a homepage fallback and must not be used as a semantic marketplace URL.
+
 ## Validation
 
 ```bash
 node scripts/verify-ecosystem-profile.js
+node --test test/verify-ecosystem-profile.test.cjs
 node scripts/verify-integrations-json.js
+ajv validate -s ecosystem.schema.json -d ecosystem.json --all-errors --spec=draft2020 -c ajv-formats
 ```
 
 The second command includes the ecosystem-profile verifier and remains the machine-surface CI entrypoint.

--- a/ecosystem.json
+++ b/ecosystem.json
@@ -1,7 +1,7 @@
 {
-  "$schema": "https://agoragentic.com/schemas/ecosystem-profile.v1.json",
+  "$schema": "./ecosystem.schema.json",
   "schema": "agoragentic.ecosystem-profile.v1",
-  "updated_at": "2026-08-06",
+  "updated_at": "2026-08-08",
   "brand": {
     "name": "Agoragentic",
     "promise": "Bound what autonomous agents may do, record evidence of what they did, and connect governed buyers and sellers.",
@@ -31,7 +31,7 @@
     {
       "id": "buy-sell",
       "label": "Buy or sell agent work",
-      "entrypoint": "https://agoragentic.com/marketplace/",
+      "entrypoint": "https://agoragentic.com/start/browse/",
       "next": "https://agoragentic.com/api/capabilities"
     },
     {
@@ -46,7 +46,7 @@
       "id": "harness-core",
       "name": "Harness Core",
       "layer": "open-source-local",
-      "promise": "Policy gates, approvals, evidence, and clearly labeled local receipts for existing agent hosts.",
+      "promise": "Policy decisions, approval records, configuration proof, and clearly labeled local receipts for existing agent hosts.",
       "repository": "https://github.com/rhein1/agoragentic-integrations/tree/main/harness-core",
       "install": "npx agoragentic-harness-core@latest init",
       "receipt_class": "local"
@@ -55,9 +55,10 @@
       "id": "micro-ecf",
       "name": "Micro ECF",
       "layer": "open-source-local",
-      "promise": "A persistent, inspectable context boundary for a project in one local command.",
+      "promise": "A persistent, inspectable context boundary through an approval-gated local plan and install flow.",
       "repository": "https://github.com/rhein1/agoragentic-micro-ecf",
-      "install": "npx agoragentic-micro-ecf@latest init --dir ."
+      "install": "npx agoragentic-micro-ecf@latest plan --dir .",
+      "install_after_explicit_approval": "npx agoragentic-micro-ecf@latest install --dir . --yes"
     },
     {
       "id": "ecf-core",
@@ -86,7 +87,7 @@
       "name": "Router / Marketplace",
       "layer": "hosted-transaction-network",
       "promise": "Live capability discovery, bounded execution, current commerce contracts, and receipt-backed results.",
-      "url": "https://agoragentic.com/marketplace/",
+      "url": "https://agoragentic.com/start/browse/",
       "machine_catalog": "https://agoragentic.com/api/capabilities"
     },
     {

--- a/ecosystem.json
+++ b/ecosystem.json
@@ -1,0 +1,158 @@
+{
+  "$schema": "https://agoragentic.com/schemas/ecosystem-profile.v1.json",
+  "schema": "agoragentic.ecosystem-profile.v1",
+  "updated_at": "2026-08-06",
+  "brand": {
+    "name": "Agoragentic",
+    "promise": "Bound what autonomous agents may do, record evidence of what they did, and connect governed buyers and sellers.",
+    "short_positioning": "Control, proof, and transaction rails for autonomous agents.",
+    "public_home": "https://agoragentic.com/",
+    "github_profile": "https://github.com/rhein1"
+  },
+  "funnels": [
+    {
+      "id": "build",
+      "label": "Add controls to an agent",
+      "entrypoint": "https://github.com/rhein1/agoragentic-integrations/tree/main/harness-core",
+      "next": "https://agoragentic.com/agoragentic-harness/"
+    },
+    {
+      "id": "context",
+      "label": "Govern agent context",
+      "entrypoint": "https://github.com/rhein1/agoragentic-micro-ecf",
+      "next": "https://github.com/rhein1/agoragentic-ecf-core"
+    },
+    {
+      "id": "operate",
+      "label": "Launch and operate an agent",
+      "entrypoint": "https://agoragentic.com/agent-os/",
+      "next": "https://agoragentic.com/agent-os/start/"
+    },
+    {
+      "id": "buy-sell",
+      "label": "Buy or sell agent work",
+      "entrypoint": "https://agoragentic.com/marketplace/",
+      "next": "https://agoragentic.com/api/capabilities"
+    },
+    {
+      "id": "connect-market",
+      "label": "Connect a marketplace or agent network",
+      "entrypoint": "https://agoragentic.com/interchange/",
+      "next": "https://agoragentic.com/federate/"
+    }
+  ],
+  "products": [
+    {
+      "id": "harness-core",
+      "name": "Harness Core",
+      "layer": "open-source-local",
+      "promise": "Policy gates, approvals, evidence, and clearly labeled local receipts for existing agent hosts.",
+      "repository": "https://github.com/rhein1/agoragentic-integrations/tree/main/harness-core",
+      "install": "npx agoragentic-harness-core@latest init",
+      "receipt_class": "local"
+    },
+    {
+      "id": "micro-ecf",
+      "name": "Micro ECF",
+      "layer": "open-source-local",
+      "promise": "A persistent, inspectable context boundary for a project in one local command.",
+      "repository": "https://github.com/rhein1/agoragentic-micro-ecf",
+      "install": "npx agoragentic-micro-ecf@latest init --dir ."
+    },
+    {
+      "id": "ecf-core",
+      "name": "ECF Core",
+      "layer": "open-source-self-hosted",
+      "promise": "Source-preserving context governance and local MCP for coding agents.",
+      "repository": "https://github.com/rhein1/agoragentic-ecf-core",
+      "install": "npx agoragentic-ecf-core@latest init ."
+    },
+    {
+      "id": "fable5-codex",
+      "name": "Fable-5 for Codex",
+      "layer": "open-source-developer-tool",
+      "promise": "Evidence-first audits, reviews, fact checks, understanding, design options, and repo sweeps.",
+      "repository": "https://github.com/rhein1/fable5-codex"
+    },
+    {
+      "id": "triptych-os",
+      "name": "Triptych OS (Agent OS)",
+      "layer": "hosted-runtime",
+      "promise": "Mandates, budgets, approvals, stop controls, runtime state, receipts, and reconciliation for deployed agents.",
+      "url": "https://agoragentic.com/agent-os/"
+    },
+    {
+      "id": "router-marketplace",
+      "name": "Router / Marketplace",
+      "layer": "hosted-transaction-network",
+      "promise": "Live capability discovery, bounded execution, current commerce contracts, and receipt-backed results.",
+      "url": "https://agoragentic.com/marketplace/",
+      "machine_catalog": "https://agoragentic.com/api/capabilities"
+    },
+    {
+      "id": "interchange",
+      "name": "Agoragentic Interchange",
+      "layer": "hosted-cross-market-network",
+      "promise": "Cross-market discovery, mandate enforcement, receipt verification, and reconciliation.",
+      "url": "https://agoragentic.com/interchange/"
+    }
+  ],
+  "repositories": [
+    {
+      "name": "agoragentic-integrations",
+      "url": "https://github.com/rhein1/agoragentic-integrations",
+      "role": "canonical integration and distribution hub"
+    },
+    {
+      "name": "agoragentic-micro-ecf",
+      "url": "https://github.com/rhein1/agoragentic-micro-ecf",
+      "role": "lightweight local context boundary"
+    },
+    {
+      "name": "agoragentic-ecf-core",
+      "url": "https://github.com/rhein1/agoragentic-ecf-core",
+      "role": "self-hosted context-governance runtime"
+    },
+    {
+      "name": "fable5-codex",
+      "url": "https://github.com/rhein1/fable5-codex",
+      "role": "evidence-first Codex engineering workflows"
+    },
+    {
+      "name": "agoragentic-premortem-golden-loop",
+      "url": "https://github.com/rhein1/agoragentic-premortem-golden-loop",
+      "role": "pre-launch audit and release-readiness CLI"
+    },
+    {
+      "name": "agoragentic-openai-agents-example",
+      "url": "https://github.com/rhein1/agoragentic-openai-agents-example",
+      "role": "OpenAI Agents SDK acquisition example"
+    },
+    {
+      "name": "agoragentic-summarizer-agent",
+      "url": "https://github.com/rhein1/agoragentic-summarizer-agent",
+      "role": "minimal Python Router example"
+    }
+  ],
+  "inventory": {
+    "integration_manifest": "./integrations.json",
+    "integration_count": 99,
+    "count_rule": "integration_count must equal integrations.json.integrations.length",
+    "public_copy_rule": "Other repositories should link to this inventory instead of hard-coding the count."
+  },
+  "live_truth": {
+    "capabilities": "https://agoragentic.com/api/capabilities",
+    "public_proof": "https://agoragentic.com/public-proof.json",
+    "health": "https://agoragentic.com/api/health",
+    "openapi": "https://agoragentic.com/openapi.yaml",
+    "agents": "https://agoragentic.com/agents.txt",
+    "mcp": "https://agoragentic.com/.well-known/mcp/server.json",
+    "x402": "https://x402.agoragentic.com/.well-known/x402.json"
+  },
+  "boundaries": [
+    "A public listing does not by itself mean the capability is invocable.",
+    "A local receipt is not a settlement receipt, certification, endorsement, or marketplace verification.",
+    "Documentation and metadata do not grant spend, deployment, publication, wallet, trust, ranking, or hosted-memory authority.",
+    "Live availability, pricing, verification, retry guidance, and payment requirements must be read from current machine surfaces."
+  ]
+}

--- a/ecosystem.schema.json
+++ b/ecosystem.schema.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Agoragentic Ecosystem Profile",
+  "description": "Durable public portfolio positioning and links to current machine truth surfaces.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schema",
+    "updated_at",
+    "brand",
+    "funnels",
+    "products",
+    "repositories",
+    "inventory",
+    "live_truth",
+    "boundaries"
+  ],
+  "properties": {
+    "$schema": {
+      "const": "./ecosystem.schema.json"
+    },
+    "schema": {
+      "const": "agoragentic.ecosystem-profile.v1"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date"
+    },
+    "brand": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "promise", "short_positioning", "public_home", "github_profile"],
+      "properties": {
+        "name": { "const": "Agoragentic" },
+        "promise": { "type": "string", "minLength": 1 },
+        "short_positioning": { "type": "string", "minLength": 1 },
+        "public_home": { "type": "string", "format": "uri" },
+        "github_profile": { "type": "string", "format": "uri" }
+      }
+    },
+    "funnels": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "label", "entrypoint", "next"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "label": { "type": "string", "minLength": 1 },
+          "entrypoint": { "type": "string", "format": "uri" },
+          "next": { "type": "string", "format": "uri" }
+        }
+      }
+    },
+    "products": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "name", "layer", "promise"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "name": { "type": "string", "minLength": 1 },
+          "layer": { "type": "string", "minLength": 1 },
+          "promise": { "type": "string", "minLength": 1 },
+          "repository": { "type": "string", "format": "uri" },
+          "url": { "type": "string", "format": "uri" },
+          "machine_catalog": { "type": "string", "format": "uri" },
+          "install": { "type": "string", "minLength": 1 },
+          "install_after_explicit_approval": { "type": "string", "minLength": 1 },
+          "receipt_class": { "type": "string", "enum": ["local"] }
+        },
+        "anyOf": [
+          { "required": ["repository"] },
+          { "required": ["url"] }
+        ]
+      }
+    },
+    "repositories": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "url", "role"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "url": { "type": "string", "format": "uri" },
+          "role": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "inventory": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["integration_manifest", "integration_count", "count_rule", "public_copy_rule"],
+      "properties": {
+        "integration_manifest": { "const": "./integrations.json" },
+        "integration_count": { "type": "integer", "minimum": 1 },
+        "count_rule": { "type": "string", "minLength": 1 },
+        "public_copy_rule": { "type": "string", "minLength": 1 }
+      }
+    },
+    "live_truth": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["capabilities", "public_proof", "health", "openapi", "agents", "mcp", "x402"],
+      "properties": {
+        "capabilities": { "type": "string", "format": "uri" },
+        "public_proof": { "type": "string", "format": "uri" },
+        "health": { "type": "string", "format": "uri" },
+        "openapi": { "type": "string", "format": "uri" },
+        "agents": { "type": "string", "format": "uri" },
+        "mcp": { "type": "string", "format": "uri" },
+        "x402": { "type": "string", "format": "uri" }
+      }
+    },
+    "boundaries": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    }
+  }
+}

--- a/examples/harness-core-frameworks/README.md
+++ b/examples/harness-core-frameworks/README.md
@@ -1,8 +1,8 @@
 # Harness Core Framework Wrapping Examples
 
-These examples pin the selective OSS scope from issue #855. They show how Harness Core wraps existing frameworks and local runtimes with policy, proof, receipts, and Agent OS preview export.
+These declarative examples pin the selective OSS scope from issue #855. They define mapping inputs for existing frameworks and local runtimes; they are not executable adapters and do not prove that a framework action ran. In the package adapter catalog, these paths remain `status: "stub"` with `authority: "local_no_spend_mapping_only"`.
 
-The examples do not replace framework runtimes and do not grant hosted provisioning, wallet spend, x402 activation, marketplace publication, trust mutation, provider dispatch, private ECF export, or owner-approval bypass.
+The examples do not replace framework runtimes and do not grant hosted provisioning, wallet spend, x402 activation, marketplace publication, trust mutation, provider dispatch, private ECF export, or owner-approval bypass. Claude Code `PreToolUse` enforcement is a separate packaged adapter and is not represented by this example inventory.
 
 Inventory:
 

--- a/harness-core/CHANGELOG.md
+++ b/harness-core/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## 0.2.0 - Unreleased
+## 0.2.1 - Unreleased
+
+- Added the packaged Harness Core hero and installed-package README link verification.
+- Narrowed receipt and adapter claims to the configuration/proposal evidence emitted by the package.
+
+## 0.2.0 - 2026-07-23
 
 - Added the local middleware kernel, lifecycle events, append-only run ledger, profiles, approvals, review gates, runtime metadata probes, context-reference imports, owner inbox, schedule intent, and worktree-session evidence.
 - Added package exports for every shipped schema and retained the original proof, receipt, readiness, and Agent OS Harness schemas.

--- a/harness-core/README.md
+++ b/harness-core/README.md
@@ -30,16 +30,15 @@ Expected local outputs include:
 agent.yaml
 policy.yaml
 .agoragentic/
-├── runs/<run_id>/
-│   ├── state.json
-│   ├── events.jsonl
-│   ├── local-proof.json
-│   ├── local-receipt.json
-│   └── summary.md
-├── approvals/
-├── runtime-probes/
-├── listing-readiness.json
-└── agent-os-harness.json
+├── local-proof.json
+├── local-receipt.json
+└── runs/<run_id>/
+    ├── state.json
+    ├── events.jsonl
+    ├── local-proof.json
+    ├── local-receipt.json
+    ├── agent-os-harness.json
+    └── summary.md
 ```
 
 **Local receipts are not settlement receipts, certifications, endorsements, or marketplace verification.** The v0.2 receipt records the configured agent name and primary goal, proof status, local artifact references, zero-spend state, and explicit boundaries showing that no Router invocation, x402 payment, marketplace publication, hosted provisioning, or hosted-memory write occurred. It does not claim that the task text was executed or that a host result was produced.

--- a/harness-core/README.md
+++ b/harness-core/README.md
@@ -1,116 +1,162 @@
 # Agoragentic Harness Core
 
-Harness Core is the open, local, no-spend bridge from a self-hosted or framework-specific agent into Triptych OS (Agent OS) preview. It is a policy, event, proof, and receipt harness around local agent runtimes, not a hosted executor.
+![Harness Core — put a policy gate and a receipt around any agent action](assets/harness-core-product-hero.svg)
 
-It does not deploy infrastructure, spend funds, publish marketplace listings, create x402 paid routes, rank providers, expose private connectors, or grant Full ECF access.
+## Put a policy gate and a receipt around any agent action.
 
-## Selective OSS Scope
+**Harness Core is an open, local governance kernel for existing agent hosts and frameworks.** It gives a proposed action a bounded lifecycle:
 
-Harness Core is the open-source package boundary for policy, evidence, receipts, readiness, CLI, schemas, profiles, local run ledger, and host/framework adapters. It wraps existing agent frameworks instead of replacing them.
-
-The canonical release boundary ships as [Selective OSS Release Scope](RELEASE_SCOPE.md). Public framework examples live in [Harness Core framework wrapping examples](https://github.com/rhein1/agoragentic-integrations/tree/main/examples/harness-core-frameworks) and cover LangGraph, CrewAI, MCP, Codex, Hermes, and the Rust reference runtime with preview/readiness-only authority flags.
-
-## Install Locally
-
-```bash
-npm install
-node harness-core/bin/agoragentic-harness.mjs init
+```text
+intent
+→ policy
+→ approval when required
+→ tool execution by the host
+→ evidence capture
+→ clearly labeled local receipt
 ```
 
-When published as a standalone package, the intended entrypoint is:
+Harness Core can observe, allow, ask, deny, record, and export local evidence. It does **not** become the agent runtime or grant itself authority to execute tools, spend, deploy, publish, settle, mutate trust, or control a wallet.
 
 ```bash
-npx agoragentic-harness-core init
+npx agoragentic-harness-core@latest init
+npx agoragentic-harness-core@latest run \
+  --profile local_no_spend \
+  --task "Inspect this repository and produce local proof"
 ```
 
-Version `0.2.0` is the middleware-kernel release: local run ledgers, lifecycle events, review artifacts, runtime metadata probes, context refs, profiles, schedule intent, and worktree-session evidence remain local and no-spend.
+Expected local outputs include:
 
-## Commands
+```text
+agent.yaml
+policy.yaml
+.agoragentic/
+├── runs/<run_id>/
+│   ├── state.json
+│   ├── events.jsonl
+│   ├── local-proof.json
+│   ├── local-receipt.json
+│   └── summary.md
+├── approvals/
+├── runtime-probes/
+├── listing-readiness.json
+└── agent-os-harness.json
+```
+
+**Local receipts are not settlement receipts, certifications, endorsements, or marketplace verification.** They record supported local policy, lifecycle, evidence, and result facts.
+
+<p>
+  <a href="#five-minute-proof"><strong>Run the proof</strong></a>
+  ·
+  <a href="#live-enforcement"><strong>Enforce a live host</strong></a>
+  ·
+  <a href="#framework-and-host-adapters"><strong>Wrap a framework</strong></a>
+  ·
+  <a href="#agent-os-preview"><strong>Preview Agent OS</strong></a>
+</p>
+
+## Why Harness Core
+
+Agent frameworks are good at running tools. They are not all designed to answer the same governance questions:
+
+- What was the agent trying to do?
+- Which policy applied before the action?
+- Did the action require owner review?
+- What tool was proposed and what actually ran?
+- Which evidence supports the reported result?
+- What remains blocked or unknown?
+- Can the run be handed to a hosted control plane without granting authority early?
+
+Harness Core adds that common control and evidence layer without replacing LangGraph, CrewAI, Codex, Claude Code, MCP, Hermes, a Rust runtime, or another executor.
+
+## Five-minute proof
+
+### 1. Initialize a local harness project
 
 ```bash
-agoragentic-harness init [template]
-agoragentic-harness validate
-agoragentic-harness proof
-agoragentic-harness proof --record
-agoragentic-harness run --profile local_no_spend --task "..."
-agoragentic-harness loop seller-listing-readiness --once --write-inbox
-agoragentic-harness schedule plan seller-listing-readiness --interval daily
-agoragentic-harness schedule list
-agoragentic-harness schedule due
-agoragentic-harness worktree attach --path ../agent-worktree --branch codex/example
-agoragentic-harness worktree status
-agoragentic-harness worktree detach
-agoragentic-harness review gates init --maker local_maker --checker owner_checker
-agoragentic-harness review request --gate listing-readiness --maker local_maker --checker owner_checker
-agoragentic-harness review decide review_<id> --decision approve --checker owner_checker
-agoragentic-harness review list
-agoragentic-harness export --to agent-os
-agoragentic-harness listing check
-agoragentic-harness guard check --policy guard-policy.json --action action.json
-agoragentic-harness runtime probe --url http://127.0.0.1:8080 --contract agoragentic-rust-http
-agoragentic-harness context import --from micro-ecf
-agoragentic-harness context status
-agoragentic-harness approvals list
-agoragentic-harness approvals show approval_<id>
-agoragentic-harness approvals decide approval_<id> --decision approve --note "local review"
-agoragentic-harness runs list
-agoragentic-harness runs show run_<id>
-agoragentic-harness events tail --run run_<id> --limit 50
-agoragentic-harness profiles list
-agoragentic-harness profiles show local_no_spend
-agoragentic-harness status --write
-agoragentic-harness adapters
-agoragentic-harness review init|list|status
-agoragentic-harness review request --gate listing-readiness --maker <label>
-agoragentic-harness review decide review_<id> --decision approve --checker <label>
-agoragentic-harness tools manifest init
-agoragentic-harness tools list
-agoragentic-harness tools inspect agent_os.preview_submit
-agoragentic-harness improve suggest
-agoragentic-harness improve decide improve_<id> --decision accept
-agoragentic-harness owner-inbox
-agoragentic-harness budget init|status
-agoragentic-harness retry init|status
+npx agoragentic-harness-core@latest init
 ```
 
-## Artifacts
+Review the generated `agent.yaml` and `policy.yaml` before running a host or tool.
 
-Harness Core creates:
+### 2. Validate the contract
 
-- `agent.yaml`
-- `policy.yaml`
-- `.agoragentic/runs/<run_id>/state.json`
-- `.agoragentic/runs/<run_id>/events.jsonl`
-- `.agoragentic/runs/<run_id>/local-proof.json`
-- `.agoragentic/runs/<run_id>/local-receipt.json`
-- `.agoragentic/runs/<run_id>/summary.md`
-- `.agoragentic/local-proof.json`
-- `.agoragentic/local-receipt.json`
-- `.agoragentic/agent-os-harness.json`
-- `.agoragentic/listing-readiness.json`
-- `.agoragentic/guard-receipts/*.json` when `guard check --write-receipt` is used
-- `.agoragentic/approvals/approval_<id>.json`
-- `.agoragentic/runtime-probes/<probe_id>.json`
-- `.agoragentic/context-imports/<source>.json`
-- `.agoragentic/status.json` and `.agoragentic/status.md` when `status --write` is used
-- `.agoragentic/owner-inbox.json` and `.agoragentic/owner-inbox.md` when the local loop writes an owner review packet
-- `.agoragentic/review-gates.json` when local maker-checker review gates are initialized or used
-- `.agoragentic/harness-schedule.json` when a local schedule intent is planned
-- `.agoragentic/worktree-session.json` when a coding-agent worktree session is attached
+```bash
+npx agoragentic-harness-core@latest validate
+```
 
-The generated export packet matches `agoragentic.agent-os.harness.v1` and is meant for `POST /api/hosting/agent-os/preview` through the hosted Agent OS flow.
+### 3. Record a no-spend run
 
-Harness projects may include `guard_policy` or `wallet_action_policy` in `policy.yaml`. Harness validates that budgeted or spend-capable packets have a Guard-style policy and exports that policy as preview metadata only. It does not sign transactions, call `/api/execute`, settle x402 payments, mutate wallets, or grant marketplace execution authority.
+```bash
+npx agoragentic-harness-core@latest run \
+  --profile local_no_spend \
+  --task "Create an evidence-backed readiness summary"
+```
 
-## Run Ledger
+### 4. Inspect the ledger and receipt
 
-`agoragentic-harness run` records a local run ledger under `.agoragentic/runs/<run_id>/`. The ledger includes append-only events, state, run-scoped proof/receipt artifacts, and a Markdown summary. `proof --record` is an alias for the recorded run path. The legacy `proof` command still writes only `.agoragentic/local-proof.json` and `.agoragentic/local-receipt.json` for compatibility.
+```bash
+npx agoragentic-harness-core@latest runs list
+npx agoragentic-harness-core@latest runs show run_<id>
+npx agoragentic-harness-core@latest events tail --run run_<id> --limit 50
+```
 
-Local run receipts are not settlement receipts. They prove local policy checks and evidence capture only.
+Success means the run has an append-only event stream, a terminal state, source/evidence references, and a local receipt whose claims match the recorded lifecycle. Missing evidence should remain blocked or unknown rather than being invented.
 
-### Middleware Lifecycle
+## Live enforcement
 
-Adapter authors can import `executeHarnessRun` from `agoragentic-harness-core/kernel/run` and `MiddlewareRegistry` from `agoragentic-harness-core/kernel/middleware-registry`. A passing recorded run dispatches these hooks in boundary order:
+Harness Core can enforce policy in-path when a host exposes a pre-tool hook.
+
+### Claude Code `PreToolUse`
+
+The packaged hook maps a proposed tool call to a capability, checks `policy.yaml`, scans for prompt-injection, secret-exfiltration, and unauthorized-spend signals, writes a redacted decision record, and returns:
+
+```text
+allow
+ask
+or
+deny
+```
+
+Generate the configuration:
+
+```bash
+npx agoragentic-harness-core@latest hooks config
+```
+
+Add the emitted hook to `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx agoragentic-harness-core@latest hook pretooluse"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The hook can block or request review. It does not execute the proposed tool itself. Read-only tools may be allowed by policy; writes, shell, network, and MCP calls may require review; irreversible, publication, wallet, or other prohibited actions may be denied.
+
+Decision records are redacted and stored locally under `.agoragentic/`. Do not treat a hook decision as proof that every downstream side effect occurred safely or correctly.
+
+## Middleware lifecycle
+
+Adapter authors can use the public kernel:
+
+```js
+import { executeHarnessRun } from 'agoragentic-harness-core/kernel/run';
+import { MiddlewareRegistry } from 'agoragentic-harness-core/kernel/middleware-registry';
+```
+
+A recorded run dispatches lifecycle hooks in boundary order:
 
 ```text
 before_agent
@@ -127,85 +173,332 @@ after_agent
 run_completed
 ```
 
-Any hook through `after_agent` may fail closed before the run is marked passed. `after_export` receives the generated packet and local artifact path after the export is written; `before_export` runs before either exists. Hooks observe, validate, record, or block local work; registering middleware does not execute a framework or tool and grants no wallet, x402, marketplace, hosted runtime, provider, trust, public execute/invoke, private ECF, owner-bypass, shell, or process-control authority.
+Hooks through `after_agent` may fail closed before the run is marked passed. `before_export` runs before an Agent OS packet exists; `after_export` receives the generated packet and local artifact reference.
 
-## Local Loop
+Middleware may observe, validate, redact, record, or block. Registering middleware does not grant shell, process-control, provider-dispatch, wallet, x402, public execute/invoke, trust-mutation, hosted-runtime, private ECF, or owner-bypass authority.
 
-`agoragentic-harness loop seller-listing-readiness --once --write-inbox` runs the `seller_listing_readiness` profile once, writes the normal run packet, refreshes status, writes the top-level Agent OS Harness export, runs the proposal-only listing readiness check, and writes `.agoragentic/owner-inbox.json` plus `.md` for owner review.
+## Framework and host adapters
 
-The owner inbox stores refs, statuses, blockers, pending approvals, and next owner actions only. It does not inline raw private payloads, raw prompts, raw tool outputs, private ECF payloads, secrets, or the full Agent OS export packet. It is not a scheduler and does not grant process-control authority.
+List the packaged adapters:
 
-## Local Schedule Intent
-
-`agoragentic-harness schedule plan seller-listing-readiness --interval daily` records local schedule intent in `.agoragentic/harness-schedule.json`. `schedule list` shows planned loop intents. `schedule due` computes whether a loop is due from the latest passed matching local run and the planned interval.
-
-The schedule layer is due-state metadata only. It does not start a background process, daemon, cron job, Task Scheduler job, systemd timer, hosted automation, shell, service, SSH session, tunnel, or loop run. A due loop must still be invoked manually with `agoragentic-harness loop seller-listing-readiness --once --write-inbox`.
-
-## Worktree Session
-
-`agoragentic-harness worktree attach --path <path> --branch <branch>` records which local coding-agent worktree, branch, optional commit SHA, optional PR ref, dirty-state label, and owner-review state the harness is reviewing. `worktree status` reads the local metadata plus latest Harness run ref. `worktree detach` marks the session inactive.
-
-Worktree sessions are refs/status/receipt tracking only. Harness Core does not run `git`, create branches, push, open pull requests, execute shell commands, execute framework tools, dispatch providers, mutate hosted state, or write hosted memory.
-
-## Maker-Checker Review Gates
-
-`agoragentic-harness review gates init` creates `.agoragentic/review-gates.json` with a local `listing-readiness` gate. `review request --gate listing-readiness` records a pending maker-checker request with required evidence refs and blocked actions. `review decide <review_id> --decision approve|reject|needs_changes --checker <label>` records the checker decision.
-
-Review decisions are local records only. They do not execute approvals, submit Agent OS previews, publish listings, activate x402, spend funds, mutate trust, dispatch providers, write hosted memory, bypass owner approval, or change public execute/invoke behavior. Approvals require explicit checker metadata; a maker cannot approve their own review as checker.
-
-## Runtime Probe
-
-`runtime probe` is a metadata/readiness check for local runtimes. It accepts loopback URLs only by default and uses HTTP GET for `/health`, `/.well-known/agent-card.json`, `/tools`, `/openapi.json`, and `/schema/agoragentic-rust-framework.json`. It does not invoke the agent, call `/api/execute`, call `/api/invoke`, make paid calls, shell out, dispatch providers, or provision hosted runtime.
-
-Tool specs are sanitized before export and rejected if they imply wallet, x402, marketplace publication, trust mutation, provider dispatch, process control, global execute/invoke, private ECF export, or owner-approval bypass authority.
-
-## Context Import
-
-`context import` records references and hashes for Micro ECF or ECF Core artifacts. It does not inline raw source content, raw prompts, raw tool output, private ECF payloads, secrets, or raw database content.
-
-## Approvals
-
-Approval artifacts are local decision records only. `approvals decide` records approve/reject/edit intent and explicitly does not execute the requested action or bypass Agent OS owner approval controls.
-
-## Live Enforcement (Claude Code)
-
-Harness Core can enforce policy on a live Claude Code agent through a PreToolUse
-hook — turning the policy from a description into an in-path gate. Before every
-tool call, the hook maps the proposed action to a capability, scans it for prompt
-injection / secret exfiltration / unauthorized-spend phrasing, checks it against
-`policy.yaml` (`denied_tools`, `blocked_paths`) plus built-in safe-by-default
-rules, records a redacted decision to `.agoragentic/claude-code-hook-decisions.jsonl`,
-and returns `allow`, `ask`, or `deny`.
-
-It can only **block** — it never executes a tool, spends, settles, publishes, or
-grants authority. Read-only tools are allowed; writes, shell, network, and MCP
-calls require review; irreversible / publish / wallet actions are denied.
-
-Enable it by adding the snippet from `agoragentic-harness hooks config` to your
-`.claude/settings.json`:
-
-```json
-{
-  "hooks": {
-    "PreToolUse": [
-      { "matcher": "*", "hooks": [{ "type": "command", "command": "npx agoragentic-harness-core hook pretooluse" }] }
-    ]
-  }
-}
+```bash
+npx agoragentic-harness-core@latest adapters
 ```
 
-## Boundary
+Public framework examples live in [`examples/harness-core-frameworks`](../examples/harness-core-frameworks/) and cover paths such as:
 
-Harness Core is proposal and proof infrastructure only. It keeps all live authority outside the package:
+- LangGraph;
+- CrewAI;
+- MCP;
+- Codex;
+- Claude Code;
+- Hermes;
+- the Agoragentic Rust reference runtime.
 
-- No hosted billing
-- No cloud provisioning
-- No marketplace publication
-- No hosted runtime secrets
-- No wallet custody
-- No settlement or payout orchestration
-- No router ranking or trust mutation
-- No Full ECF internals
-- No provider dispatch
-- No public execute/invoke behavior changes
-- No process control or arbitrary shell execution
+The adapter boundary is intentionally thin:
+
+```text
+external host or framework
+        ↓
+Harness middleware lifecycle
+        ↓
+local policy + approvals + evidence + receipt
+        ↓
+optional owner-reviewed Agent OS preview export
+```
+
+An adapter must not duplicate the policy engine, create a competing receipt family, persist raw tool output by default, or imply that installing it grants hosted or financial authority.
+
+## Policy, approvals, and review gates
+
+### Approval records
+
+```bash
+npx agoragentic-harness-core@latest approvals list
+npx agoragentic-harness-core@latest approvals show approval_<id>
+npx agoragentic-harness-core@latest approvals decide approval_<id> \
+  --decision approve \
+  --note "Reviewed locally"
+```
+
+An approval artifact records a local decision. It does not perform the requested action or bypass a separate Agent OS owner approval.
+
+### Maker-checker gates
+
+```bash
+npx agoragentic-harness-core@latest review gates init \
+  --maker local_maker \
+  --checker owner_checker
+
+npx agoragentic-harness-core@latest review request \
+  --gate listing-readiness \
+  --maker local_maker \
+  --checker owner_checker
+
+npx agoragentic-harness-core@latest review decide review_<id> \
+  --decision approve \
+  --checker owner_checker
+```
+
+A maker cannot approve their own review as checker. Review decisions remain local records and do not publish a listing, activate x402, spend, dispatch a provider, write hosted memory, or mutate trust.
+
+## Run ledger and proof artifacts
+
+`run` records a run-scoped ledger under `.agoragentic/runs/<run_id>/`.
+
+```bash
+npx agoragentic-harness-core@latest proof --record
+```
+
+`proof --record` uses the recorded run path. The legacy `proof` command remains available for compatibility and writes the top-level local proof and receipt files.
+
+Core run artifacts:
+
+| Artifact | Purpose |
+|---|---|
+| `state.json` | terminal and intermediate run state |
+| `events.jsonl` | append-only lifecycle evidence |
+| `local-proof.json` | supported local proof claims and blockers |
+| `local-receipt.json` | local run identity, policy/result facts, evidence refs, and next safe action |
+| `summary.md` | human-readable bounded summary |
+
+Receipts should retain hashes and references rather than secret-bearing raw payloads. Raw prompts, private tool output, private ECF payloads, credentials, and wallet material should not be copied into public or owner-inbox artifacts.
+
+## Runtime probes
+
+Probe a local runtime contract without invoking its business tool:
+
+```bash
+npx agoragentic-harness-core@latest runtime probe \
+  --url http://127.0.0.1:8080 \
+  --contract agoragentic-rust-http
+```
+
+The default probe accepts loopback targets and uses read-only HTTP GET requests for declared metadata such as:
+
+```text
+/health
+/.well-known/agent-card.json
+/tools
+/openapi.json
+/schema/agoragentic-rust-framework.json
+```
+
+A runtime probe does not call `/api/execute`, call `/api/invoke`, make a paid request, shell out, dispatch a provider, or provision hosted runtime.
+
+Tool specifications are sanitized before export and rejected when they imply prohibited wallet, settlement, marketplace-publication, trust-mutation, process-control, owner-bypass, private-ECF, or unrestricted execute/invoke authority.
+
+## Context imports
+
+Import references and hashes from a supported local context system:
+
+```bash
+npx agoragentic-harness-core@latest context import --from micro-ecf
+npx agoragentic-harness-core@latest context status
+```
+
+Context import records bounded artifact references. It does not inline raw repository source, prompts, tool output, database contents, secrets, or private Full ECF payloads.
+
+Use:
+
+- [Micro ECF](https://github.com/rhein1/agoragentic-micro-ecf) for a lightweight persistent project boundary;
+- [ECF Core](https://github.com/rhein1/agoragentic-ecf-core) for richer self-hosted context routing, evidence, grounding evaluation, and local MCP.
+
+## Local readiness loop
+
+Run the proposal-only seller-listing readiness profile once:
+
+```bash
+npx agoragentic-harness-core@latest loop \
+  seller-listing-readiness \
+  --once \
+  --write-inbox
+```
+
+The loop writes the normal run packet, refreshes local status, exports the current Harness packet, evaluates proposal-only listing readiness, and creates an owner inbox with refs, blockers, pending approvals, and next owner actions.
+
+It does not publish a listing or start an unattended background process.
+
+### Schedule intent
+
+```bash
+npx agoragentic-harness-core@latest schedule plan \
+  seller-listing-readiness \
+  --interval daily
+
+npx agoragentic-harness-core@latest schedule list
+npx agoragentic-harness-core@latest schedule due
+```
+
+The schedule is due-state metadata only. It does not install cron, Task Scheduler, systemd, a daemon, a service, a tunnel, an SSH session, a shell process, or hosted automation. A due loop still requires an explicit invocation.
+
+## Coding-agent worktree sessions
+
+Attach the local branch/worktree being reviewed:
+
+```bash
+npx agoragentic-harness-core@latest worktree attach \
+  --path ../agent-worktree \
+  --branch codex/example
+
+npx agoragentic-harness-core@latest worktree status
+npx agoragentic-harness-core@latest worktree detach
+```
+
+This records refs, dirty-state labels, optional commit/PR references, owner-review state, and the latest Harness run. It does not run Git, create branches, push, open pull requests, execute shell commands, invoke tools, or mutate hosted state.
+
+## Agent OS preview
+
+Generate a no-spend preview packet:
+
+```bash
+npx agoragentic-harness-core@latest export --to agent-os
+```
+
+The export follows `agoragentic.agent-os.harness.v1` and is intended for the hosted preview route:
+
+```text
+POST /api/hosting/agent-os/preview
+```
+
+Harness can include `guard_policy` or `wallet_action_policy` metadata and validate that a spend-capable proposal declares an appropriate policy. It does not sign transactions, call a paid capability, settle x402, mutate a wallet, rank providers, publish a listing, or create a hosted runtime.
+
+Preview validates a handoff. Deployment, funding, public exposure, selling, and paid execution remain separate owner-reviewed steps.
+
+## Listing readiness
+
+```bash
+npx agoragentic-harness-core@latest listing check
+```
+
+The command produces a proposal/readiness artifact. `ready` means the configured local evidence contract passed; it does not mean the listing is published, independently verified, currently invocable, payment-ready, or approved by a marketplace operator.
+
+## Guard receipts
+
+Evaluate an action against a local guard policy:
+
+```bash
+npx agoragentic-harness-core@latest guard check \
+  --policy guard-policy.json \
+  --action action.json \
+  --write-receipt
+```
+
+Guard receipts are local policy-decision records. They are not transaction signatures or settlement evidence.
+
+## Tool manifests and bounded improvement
+
+```bash
+npx agoragentic-harness-core@latest tools manifest init
+npx agoragentic-harness-core@latest tools list
+npx agoragentic-harness-core@latest tools inspect agent_os.preview_submit
+
+npx agoragentic-harness-core@latest improve suggest
+npx agoragentic-harness-core@latest improve decide improve_<id> \
+  --decision accept
+```
+
+Improvement candidates remain proposals. Accepting a local candidate does not automatically promote, publish, deploy, change Router trust, or mutate a hosted skill.
+
+## Command map
+
+```text
+init [template]
+validate
+proof
+proof --record
+run --profile <profile> --task "..."
+
+approvals list|show|decide
+runs list|show
+events tail
+profiles list|show
+status --write
+adapters
+
+review init|list|status
+review gates init
+review request
+review decide
+
+runtime probe
+context import|status
+worktree attach|status|detach
+schedule plan|list|due
+loop seller-listing-readiness --once --write-inbox
+
+listing check
+guard check
+tools manifest init
+tools list|inspect
+improve suggest|decide
+owner-inbox
+budget init|status
+retry init|status
+export --to agent-os
+```
+
+Use `--help` on the relevant command for exact options supported by the installed version.
+
+## Source development
+
+The source tree declares Harness Core `0.2.0`. The npm `@latest` tag reflects current registry state and may trail this branch until a reviewed release is published.
+
+```bash
+git clone https://github.com/rhein1/agoragentic-integrations.git
+cd agoragentic-integrations/harness-core
+npm install
+npm test
+npm run pack:smoke
+```
+
+The package requires Node.js 18 or newer.
+
+## Selective OSS boundary
+
+Harness Core is the public package boundary for:
+
+- policy and lifecycle events;
+- approval and review records;
+- local run ledgers;
+- proof and local receipt schemas;
+- readiness and status artifacts;
+- runtime metadata probes;
+- context references;
+- host/framework adapters;
+- Agent OS preview exports.
+
+See [Selective OSS Release Scope](RELEASE_SCOPE.md).
+
+It does not include or grant:
+
+- hosted billing or cloud provisioning;
+- marketplace publication;
+- hosted runtime secrets;
+- wallet custody, transaction signing, settlement, or payout orchestration;
+- Router ranking, fraud scoring, or trust mutation;
+- provider dispatch or unrestricted public execute/invoke behavior;
+- private Full ECF internals;
+- arbitrary shell or process control;
+- owner-approval bypass.
+
+## Where this fits
+
+```text
+Existing agent host or framework
+→ Harness Core policy, approval, evidence, and local receipts
+→ optional Micro ECF / ECF Core context references
+→ optional owner-reviewed Triptych OS preview
+→ separately authorized deployment or marketplace flow
+```
+
+- [Agoragentic ecosystem profile](../ecosystem.json)
+- [Brand and README contract](../docs/BRAND_SYSTEM.md)
+- [Framework examples](../examples/harness-core-frameworks/)
+- [Triptych OS](https://agoragentic.com/agent-os/)
+- [Marketplace](https://agoragentic.com/marketplace/)
+- [Interchange](https://agoragentic.com/interchange/)
+
+## License
+
+Apache-2.0. See [LICENSE](LICENSE).

--- a/harness-core/README.md
+++ b/harness-core/README.md
@@ -1,21 +1,21 @@
 # Agoragentic Harness Core
 
-![Harness Core — put a policy gate and a receipt around any agent action](assets/harness-core-product-hero.svg)
+![Harness Core — policy and local proof for a proposed agent action](assets/harness-core-product-hero.svg)
 
-## Put a policy gate and a receipt around any agent action.
+## Put a policy gate and local proof around a proposed agent action.
 
-**Harness Core is an open, local governance kernel for existing agent hosts and frameworks.** It gives a proposed action a bounded lifecycle:
+**Harness Core is an open, local governance kernel for existing agent hosts and frameworks.** The generic `run` command evaluates configuration and policy, records lifecycle events, and emits local proof and receipt artifacts:
 
 ```text
 intent
 → policy
 → approval when required
-→ tool execution by the host
-→ evidence capture
+→ host boundary
+→ configuration and proof references
 → clearly labeled local receipt
 ```
 
-Harness Core can observe, allow, ask, deny, record, and export local evidence. It does **not** become the agent runtime or grant itself authority to execute tools, spend, deploy, publish, settle, mutate trust, or control a wallet.
+Host execution is outside the generic `run` path. A host may separately integrate Harness middleware around its own action, and the packaged Claude Code `PreToolUse` adapter can enforce an allow/ask/deny decision before a Claude Code tool call. Harness Core does **not** become the agent runtime or grant itself authority to execute tools, spend, deploy, publish, settle, mutate trust, or control a wallet.
 
 ```bash
 npx agoragentic-harness-core@latest init
@@ -42,7 +42,7 @@ policy.yaml
 └── agent-os-harness.json
 ```
 
-**Local receipts are not settlement receipts, certifications, endorsements, or marketplace verification.** They record supported local policy, lifecycle, evidence, and result facts.
+**Local receipts are not settlement receipts, certifications, endorsements, or marketplace verification.** The v0.2 receipt records the configured agent name and primary goal, proof status, local artifact references, zero-spend state, and explicit boundaries showing that no Router invocation, x402 payment, marketplace publication, hosted provisioning, or hosted-memory write occurred. It does not claim that the task text was executed or that a host result was produced.
 
 <p>
   <a href="#five-minute-proof"><strong>Run the proof</strong></a>
@@ -61,8 +61,8 @@ Agent frameworks are good at running tools. They are not all designed to answer 
 - What was the agent trying to do?
 - Which policy applied before the action?
 - Did the action require owner review?
-- What tool was proposed and what actually ran?
-- Which evidence supports the reported result?
+- Which host action is being proposed, and where is the host boundary?
+- Which configuration and proof references support the local decision record?
 - What remains blocked or unknown?
 - Can the run be handed to a hosted control plane without granting authority early?
 
@@ -100,7 +100,7 @@ npx agoragentic-harness-core@latest runs show run_<id>
 npx agoragentic-harness-core@latest events tail --run run_<id> --limit 50
 ```
 
-Success means the run has an append-only event stream, a terminal state, source/evidence references, and a local receipt whose claims match the recorded lifecycle. Missing evidence should remain blocked or unknown rather than being invented.
+Success means the run has an append-only event stream, a terminal state, configuration/proof references, and a local receipt whose claims match the recorded no-execution boundary. The `--task` value labels run state; it is not proof that a host executed that task. Missing evidence should remain blocked or unknown rather than being invented.
 
 ## Live enforcement
 
@@ -179,13 +179,15 @@ Middleware may observe, validate, redact, record, or block. Registering middlewa
 
 ## Framework and host adapters
 
-List the packaged adapters:
+List the packaged adapter contracts:
 
 ```bash
 npx agoragentic-harness-core@latest adapters
 ```
 
-Public framework examples live in [`examples/harness-core-frameworks`](../examples/harness-core-frameworks/) and cover paths such as:
+Only Claude Code currently reports `status: "enforcement"` and exposes a packaged live pre-tool decision hook. Every other catalog entry reports `status: "stub"` with `authority: "local_no_spend_mapping_only"`. Those entries are mapping contracts, not executable framework adapters.
+
+Public declarative mapping examples live in [the repository examples directory](https://github.com/rhein1/agoragentic-integrations/tree/main/examples/harness-core-frameworks) and cover:
 
 - LangGraph;
 - CrewAI;
@@ -207,7 +209,7 @@ local policy + approvals + evidence + receipt
 optional owner-reviewed Agent OS preview export
 ```
 
-An adapter must not duplicate the policy engine, create a competing receipt family, persist raw tool output by default, or imply that installing it grants hosted or financial authority.
+A mapping contract must not be presented as executable integration support. Any future executable adapter must add framework-specific tests and must not duplicate the policy engine, create a competing receipt family, persist raw tool output by default, or imply that installing it grants hosted or financial authority.
 
 ## Policy, approvals, and review gates
 
@@ -259,7 +261,7 @@ Core run artifacts:
 | `state.json` | terminal and intermediate run state |
 | `events.jsonl` | append-only lifecycle evidence |
 | `local-proof.json` | supported local proof claims and blockers |
-| `local-receipt.json` | local run identity, policy/result facts, evidence refs, and next safe action |
+| `local-receipt.json` | receipt/proof IDs, configured agent and primary goal, proof status, local artifact refs, zero-spend state, and explicit non-execution boundaries |
 | `summary.md` | human-readable bounded summary |
 
 Receipts should retain hashes and references rather than secret-bearing raw payloads. Raw prompts, private tool output, private ECF payloads, credentials, and wallet material should not be copied into public or owner-inbox artifacts.
@@ -442,7 +444,7 @@ Use `--help` on the relevant command for exact options supported by the installe
 
 ## Source development
 
-The source tree declares Harness Core `0.2.0`. The npm `@latest` tag reflects current registry state and may trail this branch until a reviewed release is published.
+The source tree declares the review-gated Harness Core `0.2.1` patch candidate. npm `@latest` currently serves `0.2.0`; publication remains a separate reviewed release action.
 
 ```bash
 git clone https://github.com/rhein1/agoragentic-integrations.git
@@ -492,11 +494,11 @@ Existing agent host or framework
 → separately authorized deployment or marketplace flow
 ```
 
-- [Agoragentic ecosystem profile](../ecosystem.json)
-- [Brand and README contract](../docs/BRAND_SYSTEM.md)
-- [Framework examples](../examples/harness-core-frameworks/)
+- [Agoragentic ecosystem profile](https://github.com/rhein1/agoragentic-integrations/blob/main/ecosystem.json)
+- [Brand and README contract](https://github.com/rhein1/agoragentic-integrations/blob/main/docs/BRAND_SYSTEM.md)
+- [Framework mapping examples](https://github.com/rhein1/agoragentic-integrations/tree/main/examples/harness-core-frameworks)
 - [Triptych OS](https://agoragentic.com/agent-os/)
-- [Marketplace](https://agoragentic.com/marketplace/)
+- [Router / Marketplace](https://agoragentic.com/start/browse/)
 - [Interchange](https://agoragentic.com/interchange/)
 
 ## License

--- a/harness-core/TRUSTED_PUBLISHING.md
+++ b/harness-core/TRUSTED_PUBLISHING.md
@@ -24,7 +24,7 @@ Publish only after:
 
 1. Configure npm Trusted Publishing for the package.
 2. Merge the release-ready PR.
-3. Create a GitHub release with the exact package tag `harness-core-v0.2.0`.
+3. Create a GitHub release with the exact package tag `harness-core-v0.2.1`.
 4. The workflow publishes from `harness-core/`.
 
 Do not add `NPM_TOKEN` for this package unless Trusted Publishing is unavailable and the token has been scoped, rotated, and documented.

--- a/harness-core/assets/harness-core-product-hero.svg
+++ b/harness-core/assets/harness-core-product-hero.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="640" viewBox="0 0 1280 640" role="img" aria-labelledby="title desc">
+  <title id="title">Agoragentic Harness Core</title>
+  <desc id="desc">An agent intent passes through policy and approval gates before a tool runs, then produces evidence and a clearly labeled local receipt.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#081120"/><stop offset="1" stop-color="#16233b"/></linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0"><stop stop-color="#45d6df"/><stop offset="1" stop-color="#ff7453"/></linearGradient>
+  </defs>
+  <rect width="1280" height="640" fill="url(#bg)"/>
+  <path d="M0 108H1280M0 320H1280M0 532H1280M170 0V640M640 0V640M1110 0V640" stroke="#263550" opacity="0.52"/>
+  <rect x="58" y="54" width="7" height="532" rx="3" fill="url(#accent)"/>
+  <text x="104" y="122" fill="#45d6df" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="750" letter-spacing="2">HARNESS CORE</text>
+  <text x="104" y="218" fill="#f8fafc" font-family="Inter, Arial, sans-serif" font-size="62" font-weight="760">Put a policy gate</text>
+  <text x="104" y="290" fill="#f8fafc" font-family="Inter, Arial, sans-serif" font-size="62" font-weight="760">and a receipt around</text>
+  <text x="104" y="362" fill="#f8fafc" font-family="Inter, Arial, sans-serif" font-size="62" font-weight="760">any agent action.</text>
+  <text x="104" y="430" fill="#b8c5d9" font-family="Inter, Arial, sans-serif" font-size="24">Intent → policy → approval → tool → evidence → receipt</text>
+  <text x="104" y="518" fill="#ff9279" font-family="JetBrains Mono, Consolas, monospace" font-size="18">npx agoragentic-harness-core@latest init</text>
+
+  <g transform="translate(716 70)">
+    <rect width="500" height="500" rx="28" fill="#0b1527" stroke="#2a3a56" stroke-width="2"/>
+    <g transform="translate(28 28)">
+      <rect width="444" height="72" rx="16" fill="#101d33" stroke="#45d6df" stroke-opacity="0.5"/>
+      <text x="22" y="29" fill="#75edf3" font-family="JetBrains Mono, Consolas, monospace" font-size="13">INTENT</text>
+      <text x="22" y="53" fill="#f8fafc" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="750">What is the agent trying to do?</text>
+    </g>
+    <path d="M250 102V126" stroke="url(#accent)" stroke-width="5" stroke-linecap="round"/>
+    <g transform="translate(28 130)">
+      <rect width="210" height="116" rx="16" fill="#101d33" stroke="#ff7453" stroke-opacity="0.55"/>
+      <text x="20" y="29" fill="#ff9b84" font-family="JetBrains Mono, Consolas, monospace" font-size="13">POLICY</text>
+      <text x="20" y="59" fill="#f8fafc" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="750">allow · ask · deny</text>
+      <text x="20" y="86" fill="#91a3be" font-family="Inter, Arial, sans-serif" font-size="14">budget · data · tools</text>
+    </g>
+    <g transform="translate(262 130)">
+      <rect width="210" height="116" rx="16" fill="#101d33" stroke="#45d6df" stroke-opacity="0.5"/>
+      <text x="20" y="29" fill="#75edf3" font-family="JetBrains Mono, Consolas, monospace" font-size="13">APPROVAL</text>
+      <text x="20" y="59" fill="#f8fafc" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="750">owner-readable gate</text>
+      <text x="20" y="86" fill="#91a3be" font-family="Inter, Arial, sans-serif" font-size="14">explicit decision record</text>
+    </g>
+    <path d="M250 248V272" stroke="url(#accent)" stroke-width="5" stroke-linecap="round"/>
+    <g transform="translate(28 276)">
+      <rect width="444" height="82" rx="16" fill="#101d33" stroke="#ff7453" stroke-opacity="0.55"/>
+      <text x="22" y="30" fill="#ff9b84" font-family="JetBrains Mono, Consolas, monospace" font-size="13">TOOL EXECUTION</text>
+      <text x="22" y="58" fill="#f8fafc" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="750">Only after policy and approval permit it</text>
+    </g>
+    <path d="M250 360V384" stroke="url(#accent)" stroke-width="5" stroke-linecap="round"/>
+    <g transform="translate(28 388)">
+      <rect width="444" height="82" rx="16" fill="#101d33" stroke="#45d6df" stroke-opacity="0.5"/>
+      <text x="22" y="30" fill="#75edf3" font-family="JetBrains Mono, Consolas, monospace" font-size="13">LOCAL RECEIPT</text>
+      <text x="22" y="58" fill="#f8fafc" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="750">what ran · evidence · status · next safe action</text>
+    </g>
+  </g>
+</svg>

--- a/harness-core/assets/harness-core-product-hero.svg
+++ b/harness-core/assets/harness-core-product-hero.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1280" height="640" viewBox="0 0 1280 640" role="img" aria-labelledby="title desc">
   <title id="title">Agoragentic Harness Core</title>
-  <desc id="desc">An agent intent passes through policy and approval gates before a tool runs, then produces evidence and a clearly labeled local receipt.</desc>
+  <desc id="desc">A proposed agent action passes through local policy and approval checks, stops at the host boundary, and produces configuration proof with a clearly labeled local receipt.</desc>
   <defs>
     <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1"><stop stop-color="#081120"/><stop offset="1" stop-color="#16233b"/></linearGradient>
     <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0"><stop stop-color="#45d6df"/><stop offset="1" stop-color="#ff7453"/></linearGradient>
@@ -9,10 +9,11 @@
   <path d="M0 108H1280M0 320H1280M0 532H1280M170 0V640M640 0V640M1110 0V640" stroke="#263550" opacity="0.52"/>
   <rect x="58" y="54" width="7" height="532" rx="3" fill="url(#accent)"/>
   <text x="104" y="122" fill="#45d6df" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="750" letter-spacing="2">HARNESS CORE</text>
-  <text x="104" y="218" fill="#f8fafc" font-family="Inter, Arial, sans-serif" font-size="62" font-weight="760">Put a policy gate</text>
-  <text x="104" y="290" fill="#f8fafc" font-family="Inter, Arial, sans-serif" font-size="62" font-weight="760">and a receipt around</text>
-  <text x="104" y="362" fill="#f8fafc" font-family="Inter, Arial, sans-serif" font-size="62" font-weight="760">any agent action.</text>
-  <text x="104" y="430" fill="#b8c5d9" font-family="Inter, Arial, sans-serif" font-size="24">Intent → policy → approval → tool → evidence → receipt</text>
+  <text x="104" y="218" fill="#f8fafc" font-family="Inter, Arial, sans-serif" font-size="54" font-weight="760">Put a policy gate</text>
+  <text x="104" y="290" fill="#f8fafc" font-family="Inter, Arial, sans-serif" font-size="54" font-weight="760">and local proof around</text>
+  <text x="104" y="362" fill="#f8fafc" font-family="Inter, Arial, sans-serif" font-size="54" font-weight="760">a proposed action.</text>
+  <text x="104" y="420" fill="#b8c5d9" font-family="Inter, Arial, sans-serif" font-size="21">Intent → policy → approval</text>
+  <text x="104" y="452" fill="#b8c5d9" font-family="Inter, Arial, sans-serif" font-size="21">host boundary → local receipt</text>
   <text x="104" y="518" fill="#ff9279" font-family="JetBrains Mono, Consolas, monospace" font-size="18">npx agoragentic-harness-core@latest init</text>
 
   <g transform="translate(716 70)">
@@ -38,14 +39,14 @@
     <path d="M250 248V272" stroke="url(#accent)" stroke-width="5" stroke-linecap="round"/>
     <g transform="translate(28 276)">
       <rect width="444" height="82" rx="16" fill="#101d33" stroke="#ff7453" stroke-opacity="0.55"/>
-      <text x="22" y="30" fill="#ff9b84" font-family="JetBrains Mono, Consolas, monospace" font-size="13">TOOL EXECUTION</text>
-      <text x="22" y="58" fill="#f8fafc" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="750">Only after policy and approval permit it</text>
+      <text x="22" y="30" fill="#ff9b84" font-family="JetBrains Mono, Consolas, monospace" font-size="13">HOST BOUNDARY</text>
+      <text x="22" y="58" fill="#f8fafc" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="750">Execution remains with the integrating host</text>
     </g>
     <path d="M250 360V384" stroke="url(#accent)" stroke-width="5" stroke-linecap="round"/>
     <g transform="translate(28 388)">
       <rect width="444" height="82" rx="16" fill="#101d33" stroke="#45d6df" stroke-opacity="0.5"/>
-      <text x="22" y="30" fill="#75edf3" font-family="JetBrains Mono, Consolas, monospace" font-size="13">LOCAL RECEIPT</text>
-      <text x="22" y="58" fill="#f8fafc" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="750">what ran · evidence · status · next safe action</text>
+      <text x="22" y="30" fill="#75edf3" font-family="JetBrains Mono, Consolas, monospace" font-size="13">CONFIGURATION RECEIPT</text>
+      <text x="22" y="58" fill="#f8fafc" font-family="Inter, Arial, sans-serif" font-size="18" font-weight="750">agent · goal · proof status · artifact refs</text>
     </g>
   </g>
 </svg>

--- a/harness-core/package-lock.json
+++ b/harness-core/package-lock.json
@@ -11,13 +11,93 @@
       "dependencies": {
         "yaml": "^2.5.0"
       },
-      "engines": {
-        "node": ">=18.0.0"
-      },
       "bin": {
         "agora-harness": "bin/agoragentic-harness.mjs",
         "agoragentic-harness": "bin/agoragentic-harness.mjs",
         "agoragentic-harness-core": "bin/agoragentic-harness.mjs"
+      },
+      "devDependencies": {
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/yaml": {

--- a/harness-core/package-lock.json
+++ b/harness-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agoragentic-harness-core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agoragentic-harness-core",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "yaml": "^2.5.0"

--- a/harness-core/package.json
+++ b/harness-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agoragentic-harness-core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Local no-spend Agent OS Harness Core for Micro ECF policy, first proof, receipts, listing readiness, and Triptych OS preview export.",
   "type": "module",
   "license": "Apache-2.0",
@@ -43,6 +43,7 @@
     "./schema/worktree-session.v1.json": "./schema/worktree-session.v1.json"
   },
   "files": [
+    "assets/",
     "bin/",
     "src/",
     "profiles/",

--- a/harness-core/package.json
+++ b/harness-core/package.json
@@ -86,5 +86,9 @@
     "agent-harness",
     "x402",
     "receipts"
-  ]
+  ],
+  "devDependencies": {
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1"
+  }
 }

--- a/harness-core/scripts/pack-smoke.mjs
+++ b/harness-core/scripts/pack-smoke.mjs
@@ -74,6 +74,27 @@ try {
   if (!existsSync(installedHeroPath)) fail('installed package is missing assets/harness-core-product-hero.svg');
 
   const installedReadme = readFileSync(installedReadmePath, 'utf8');
+  const expectedReadmeArtifactTree = [
+    'Expected local outputs include:',
+    '',
+    '```text',
+    'agent.yaml',
+    'policy.yaml',
+    '.agoragentic/',
+    '├── local-proof.json',
+    '├── local-receipt.json',
+    '└── runs/<run_id>/',
+    '    ├── state.json',
+    '    ├── events.jsonl',
+    '    ├── local-proof.json',
+    '    ├── local-receipt.json',
+    '    ├── agent-os-harness.json',
+    '    └── summary.md',
+    '```',
+  ].join('\n');
+  if (!installedReadme.replace(/\r\n/g, '\n').includes(expectedReadmeArtifactTree)) {
+    fail('installed README must document the init/run artifact tree exactly');
+  }
   for (const target of localMarkdownTargets(installedReadme)) {
     const fileTarget = decodeURIComponent(target.split('#')[0].split('?')[0]);
     if (!fileTarget) continue;
@@ -117,6 +138,26 @@ try {
   if (!validate.ok) fail(`validate reported issues: ${JSON.stringify(validate.issues || [])}`);
   const result = JSON.parse(run(process.execPath, [bin, 'run'], consumer));
   if (result.status !== 'passed') fail(`run status was ${result.status}`);
+
+  if (typeof result.run_path !== 'string' || !result.run_path) {
+    fail('run did not return a run_path');
+  }
+  for (const artifact of [
+    'agent.yaml',
+    'policy.yaml',
+    path.join('.agoragentic', 'local-proof.json'),
+    path.join('.agoragentic', 'local-receipt.json'),
+    path.join(result.run_path, 'state.json'),
+    path.join(result.run_path, 'events.jsonl'),
+    path.join(result.run_path, 'local-proof.json'),
+    path.join(result.run_path, 'local-receipt.json'),
+    path.join(result.run_path, 'agent-os-harness.json'),
+    path.join(result.run_path, 'summary.md'),
+  ]) {
+    if (!existsSync(path.join(consumer, artifact))) {
+      fail(`installed init/run artifact is missing: ${artifact}`);
+    }
+  }
 
   console.log('SMOKE OK: packed, installed outside the monorepo, README assets/links, subpath imports, and init/validate/run all passed.');
   cleanup();

--- a/harness-core/scripts/pack-smoke.mjs
+++ b/harness-core/scripts/pack-smoke.mjs
@@ -8,10 +8,18 @@
 // — the failure modes that pass inside the monorepo but break after `npm
 // publish`. Exits non-zero on any failure.
 //
-//   node packages/harness-core/scripts/pack-smoke.mjs
+//   node harness-core/scripts/pack-smoke.mjs
 
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, rmSync, readdirSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  readdirSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -38,6 +46,17 @@ function fail(message) {
   process.exit(1);
 }
 
+function localMarkdownTargets(markdown) {
+  const inlineTargets = [...markdown.matchAll(/!?\[[^\]]*\]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g)]
+    .map((match) => match[1]);
+  const referenceTargets = [...markdown.matchAll(/^\s{0,3}\[[^\]]+\]:\s*(\S+)/gm)]
+    .map((match) => match[1]);
+
+  return [...new Set([...inlineTargets, ...referenceTargets])]
+    .map((target) => target.replace(/^<|>$/g, ''))
+    .filter((target) => target && !/^(?:https?:|mailto:|#)/i.test(target));
+}
+
 try {
   run(npm, ['pack', '--pack-destination', packDest], pkgDir, true);
   const tgz = readdirSync(packDest).find((file) => file.endsWith('.tgz'));
@@ -49,6 +68,23 @@ try {
     `${JSON.stringify({ name: 'smoke-consumer', private: true, version: '1.0.0' }, null, 2)}\n`,
   );
   run(npm, ['install', tarball, '--no-audit', '--no-fund'], consumer, true);
+  const installedPackageRoot = path.join(consumer, 'node_modules', 'agoragentic-harness-core');
+  const installedReadmePath = path.join(installedPackageRoot, 'README.md');
+  const installedHeroPath = path.join(installedPackageRoot, 'assets', 'harness-core-product-hero.svg');
+  if (!existsSync(installedHeroPath)) fail('installed package is missing assets/harness-core-product-hero.svg');
+
+  const installedReadme = readFileSync(installedReadmePath, 'utf8');
+  for (const target of localMarkdownTargets(installedReadme)) {
+    const fileTarget = decodeURIComponent(target.split('#')[0].split('?')[0]);
+    if (!fileTarget) continue;
+    const resolved = path.resolve(installedPackageRoot, fileTarget);
+    const relative = path.relative(installedPackageRoot, resolved);
+    if (relative.startsWith('..') || path.isAbsolute(relative)) {
+      fail(`installed README link escapes the npm package: ${target}`);
+    }
+    if (!existsSync(resolved)) fail(`installed README link target is missing: ${target}`);
+  }
+
   const schemaFiles = readdirSync(path.join(pkgDir, 'schema'))
     .filter((file) => file.endsWith('.json'))
     .sort();
@@ -82,7 +118,7 @@ try {
   const result = JSON.parse(run(process.execPath, [bin, 'run'], consumer));
   if (result.status !== 'passed') fail(`run status was ${result.status}`);
 
-  console.log('SMOKE OK: packed, installed outside the monorepo, subpath imports and init/validate/run all passed.');
+  console.log('SMOKE OK: packed, installed outside the monorepo, README assets/links, subpath imports, and init/validate/run all passed.');
   cleanup();
   process.exit(0);
 } catch (err) {

--- a/harness-core/src/index.mjs
+++ b/harness-core/src/index.mjs
@@ -288,7 +288,7 @@ export function buildAgentOsExport(project, options = {}) {
     generated_at: generatedAt,
     generated_from: {
       source: 'agoragentic-harness-core',
-      package_version: '0.2.0',
+      package_version: '0.2.1',
       local_only: true,
     },
     schema_artifacts: {

--- a/harness-core/test/cli.test.cjs
+++ b/harness-core/test/cli.test.cjs
@@ -47,7 +47,7 @@ function validateSchema(schemaRelPath, payload) {
 test('Harness Core package exposes local no-spend CLI bins', () => {
   const pkg = readJson(path.join(packageRoot, 'package.json'));
   assert.equal(pkg.name, 'agoragentic-harness-core');
-  assert.equal(pkg.version, '0.2.0');
+  assert.equal(pkg.version, '0.2.1');
   assert.equal(pkg.bin['agoragentic-harness'], './bin/agoragentic-harness.mjs');
   assert.equal(pkg.bin['agora-harness'], './bin/agoragentic-harness.mjs');
   assert.match(pkg.description, /Local no-spend Agent OS Harness Core/);
@@ -108,7 +108,7 @@ test('export emits a schema-valid Agent OS Harness packet for preview only', () 
   assert.equal(packet.public_boundary.no_spend_export, true);
   assert.equal(packet.public_boundary.hosted_billing, false);
   assert.equal(packet.agent_os_preview_request.deployment_packet.source, 'harness_core_local');
-  assert.equal(packet.generated_from.package_version, '0.2.0');
+  assert.equal(packet.generated_from.package_version, '0.2.1');
   assert.equal(packet.agent_os_export.preview_endpoint, 'POST /api/hosting/agent-os/preview');
   validateSchema('schema/agent-os-harness.v1.json', packet);
 });

--- a/harness-core/test/cli.test.cjs
+++ b/harness-core/test/cli.test.cjs
@@ -7,9 +7,13 @@ const os = require('node:os');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
 const { pathToFileURL } = require('node:url');
+const Ajv = require('ajv');
+const addFormats = require('ajv-formats');
 
 const packageRoot = path.join(__dirname, '..');
 const cliPath = path.join(packageRoot, 'bin', 'agoragentic-harness.mjs');
+const ajv = new Ajv({ allErrors: true, strict: false });
+addFormats(ajv);
 
 function tmpDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'agoragentic-harness-core-'));
@@ -34,14 +38,20 @@ function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
 }
 
+for (const schemaFile of fs.readdirSync(path.join(packageRoot, 'schema'))
+  .filter((file) => file.endsWith('.json'))) {
+  ajv.addSchema(readJson(path.join(packageRoot, 'schema', schemaFile)));
+}
+
 function validateSchema(schemaRelPath, payload) {
   const schema = readJson(path.join(packageRoot, schemaRelPath));
-  for (const key of schema.required || []) {
-    assert.ok(Object.hasOwn(payload, key), `${schemaRelPath} requires ${key}`);
-  }
-  if (schema.properties?.schema?.const) {
-    assert.equal(payload.schema, schema.properties.schema.const);
-  }
+  const validate = ajv.getSchema(schema.$id);
+  assert.ok(validate, `${schemaRelPath} must be registered with Ajv`);
+  assert.equal(
+    validate(payload),
+    true,
+    `${schemaRelPath} validation failed: ${ajv.errorsText(validate.errors)}`,
+  );
 }
 
 test('Harness Core package exposes local no-spend CLI bins', () => {
@@ -92,7 +102,15 @@ test('proof writes schema-valid no-spend proof and receipt artifacts', () => {
   assert.equal(proofRun.json.receipt.receipt_boundary.x402_payment_attempted, false);
 
   validateSchema('schema/local-proof.v1.json', readJson(path.join(dir, '.agoragentic', 'local-proof.json')));
-  validateSchema('schema/local-receipt.v1.json', readJson(path.join(dir, '.agoragentic', 'local-receipt.json')));
+  const receipt = readJson(path.join(dir, '.agoragentic', 'local-receipt.json'));
+  validateSchema('schema/local-receipt.v1.json', receipt);
+  assert.throws(
+    () => validateSchema('schema/local-receipt.v1.json', {
+      ...receipt,
+      spend: { ...receipt.spend, amount_usdc: 1 },
+    }),
+    /amount_usdc.*constant/,
+  );
 });
 
 test('export emits a schema-valid Agent OS Harness packet for preview only', () => {

--- a/integrations.json
+++ b/integrations.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.30.0",
-  "updated_at": "2026-07-28",
+  "version": "2.30.1",
+  "updated_at": "2026-08-08",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
   "packages": {
@@ -42,7 +42,8 @@
     },
     "micro_ecf": {
       "name": "agoragentic-micro-ecf",
-      "install": "npx agoragentic-micro-ecf init",
+      "install": "npx agoragentic-micro-ecf@latest plan --dir .",
+      "install_after_explicit_approval": "npx agoragentic-micro-ecf@latest install --dir . --yes",
       "registry": "https://www.npmjs.com/package/agoragentic-micro-ecf",
       "min_node": "18"
     },
@@ -441,7 +442,8 @@
       "language": "javascript",
       "status": "beta",
       "path": "micro-ecf/bin/micro-ecf.mjs",
-      "install": "npx agoragentic-micro-ecf plan --dir . && npx agoragentic-micro-ecf install --dir . --yes && npx agoragentic-micro-ecf doctor --dir .",
+      "install": "npx agoragentic-micro-ecf@latest plan --dir .",
+      "install_after_explicit_approval": "npx agoragentic-micro-ecf@latest install --dir . --yes",
       "docs": "micro-ecf/README.md"
     },
     {
@@ -1216,6 +1218,8 @@
     }
   ],
   "discovery": {
+    "ecosystem_profile": "ecosystem.json",
+    "ecosystem_profile_schema": "ecosystem.schema.json",
     "skill_md": "SKILL.md",
     "glama": "glama.json",
     "distribution_status": "docs/DISTRIBUTION.md",

--- a/integrations.schema.json
+++ b/integrations.schema.json
@@ -164,6 +164,10 @@
         "min_node": {
           "type": "string",
           "description": "Minimum Node.js version."
+        },
+        "install_after_explicit_approval": {
+          "type": "string",
+          "description": "Install command that may run only after the plan has received explicit approval."
         }
       }
     },
@@ -243,6 +247,10 @@
         "docs": {
           "type": "string",
           "description": "Relative path to the integration README."
+        },
+        "install_after_explicit_approval": {
+          "type": "string",
+          "description": "Install command that may run only after the plan has received explicit approval."
         }
       }
     }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -10,8 +10,8 @@ The published packages and repo-local CLIs are:
 - **Python SDK**: `pip install agoragentic` (PyPI, Python ≥3.8)
 - **Node.js SDK**: `npm install agoragentic` (npm, Node ≥16)
 - **MCP Server**: `npx agoragentic-mcp` (npm, Node ≥18)
-- **Micro ECF**: `npx agoragentic-micro-ecf@latest init` (npm, Node ≥18)
-- **Harness Core**: `npx agoragentic-harness-core@latest init` (npm currently serves v0.1.1; this repo carries the review-gated v0.2.0 middleware-kernel candidate, Node ≥18)
+- **Micro ECF**: run `npx agoragentic-micro-ecf@latest plan --dir .` first; only after explicit approval run `npx agoragentic-micro-ecf@latest install --dir . --yes` (npm, Node ≥18)
+- **Harness Core**: `npx agoragentic-harness-core@latest init` (npm currently serves v0.2.0; this repo carries the review-gated v0.2.1 patch candidate, Node ≥18)
 - **Premortem Golden Loop Agent**: `node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs run --repo .` or `heal --repo .` (free local Node ≥18 CLI; no repo contents sent anywhere by default)
 - **Agoragentic Rust Framework HTTP Runtime examples**: `rust-framework/` contains TypeScript/Node and Python clients for a local or self-hosted Rust runtime plus a public-safe Agent OS Harness packet example. It does not publish crates, provision hosted runtimes, spend, settle x402, publish listings, mutate trust, or require native bindings.
 
@@ -232,6 +232,8 @@ Full spec: specs/ACP-SPEC.md
 |-------|----------|
 | Machine index | integrations.json |
 | JSON Schema | integrations.schema.json |
+| Ecosystem profile | ecosystem.json |
+| Ecosystem profile schema | ecosystem.schema.json |
 | Client distribution status | docs/DISTRIBUTION.md |
 | Canonical directory packet | docs/catalog-profile.json |
 | Cursor plugin | .cursor-plugin/plugin.json |

--- a/llms.txt
+++ b/llms.txt
@@ -9,8 +9,8 @@
 - Node.js SDK: `npm install agoragentic` (npm, Node ≥16)
 - MCP: `npx agoragentic-mcp` (npm, Node ≥18)
 - ACP: `npx agoragentic-mcp --acp` (Agent Client Protocol adapter, Node ≥18)
-- Micro ECF: `npx agoragentic-micro-ecf@latest init` (package-ready local context CLI, Node ≥18)
-- Harness Core: `npx agoragentic-harness-core@latest init` (published local no-spend CLI; npm is v0.1.1 while this repo carries the review-gated v0.2.0 middleware-kernel candidate, Node ≥18)
+- Micro ECF: run `npx agoragentic-micro-ecf@latest plan --dir .` first; only after explicit approval run `npx agoragentic-micro-ecf@latest install --dir . --yes` (local context CLI, Node ≥18)
+- Harness Core: `npx agoragentic-harness-core@latest init` (published local no-spend CLI; npm is v0.2.0 while this repo carries the review-gated v0.2.1 patch candidate, Node ≥18)
 - Premortem Golden Loop Agent: `node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs run --repo .` or `heal --repo .` (free local Node ≥18 CLI; no repo contents sent anywhere by default)
 - Rust Framework HTTP runtime examples: `AGORAGENTIC_RUST_AGENT_URL=http://127.0.0.1:8080 node rust-framework/typescript-call-rust-agent.mjs` or `python rust-framework/python_call_rust_agent.py` (client examples only; no hosted provisioning or spend)
 
@@ -37,6 +37,8 @@
 ## Machine Index
 - integrations.json — structured index of all integrations, tools, packages
 - integrations.schema.json — JSON Schema for validation
+- ecosystem.json — durable public portfolio profile and live-truth links
+- ecosystem.schema.json — included JSON Schema for the ecosystem profile
 - docs/catalog-profile.json — canonical descriptions, assets, package coordinate, authority boundary, and channel status
 - docs/DISTRIBUTION.md — client-native install and external-submission status
 - .cursor-plugin/plugin.json — Cursor plugin manifest

--- a/scripts/verify-ecosystem-profile.js
+++ b/scripts/verify-ecosystem-profile.js
@@ -101,13 +101,14 @@ if (!ecosystem || !integrations) {
   }
 
   const brandSystem = fs.readFileSync(path.join(root, 'docs', 'BRAND_SYSTEM.md'), 'utf8');
+  const normalizedBrandSystem = brandSystem.toLowerCase();
   if (!brandSystem.includes('First-screen README contract')) {
     fail('docs/BRAND_SYSTEM.md must define the first-screen README contract');
   }
   if (!brandSystem.includes('Do not bake mutable counts')) {
     fail('docs/BRAND_SYSTEM.md must prohibit mutable counts in images');
   }
-  if (!brandSystem.includes('local receipt is not')) {
+  if (!normalizedBrandSystem.includes('no local receipt is presented as settlement')) {
     fail('docs/BRAND_SYSTEM.md must preserve the local-receipt boundary');
   }
 }

--- a/scripts/verify-ecosystem-profile.js
+++ b/scripts/verify-ecosystem-profile.js
@@ -111,6 +111,35 @@ if (!ecosystem || !integrations) {
   if (!normalizedBrandSystem.includes('no local receipt is presented as settlement')) {
     fail('docs/BRAND_SYSTEM.md must preserve the local-receipt boundary');
   }
+
+  const harnessReadmePath = path.join(root, 'harness-core', 'README.md');
+  const harnessHeroPath = path.join(root, 'harness-core', 'assets', 'harness-core-product-hero.svg');
+  const harnessReadme = fs.readFileSync(harnessReadmePath, 'utf8');
+  const harnessHero = fs.readFileSync(harnessHeroPath, 'utf8');
+
+  for (const required of [
+    'Put a policy gate and a receipt around any agent action.',
+    'npx agoragentic-harness-core@latest init',
+    'Local receipts are not settlement receipts',
+    'Claude Code `PreToolUse`',
+    'before_policy',
+    'after_receipt',
+    'Agent OS preview',
+  ]) {
+    if (!harnessReadme.includes(required)) {
+      fail(`harness-core/README.md is missing flagship contract text: ${required}`);
+    }
+  }
+
+  if (!harnessHero.includes('<title id="title">Agoragentic Harness Core</title>')) {
+    fail('Harness Core hero must include an accessible title');
+  }
+  if (!harnessHero.includes('<desc id="desc">')) {
+    fail('Harness Core hero must include an accessible description');
+  }
+  if (/\b\d+\s+(?:services|listings|calls|agents)\b/i.test(harnessHero)) {
+    fail('Harness Core hero must not bake mutable public counts into the image');
+  }
 }
 
 if (!process.exitCode) console.log('✅ ecosystem profile verification passed');

--- a/scripts/verify-ecosystem-profile.js
+++ b/scripts/verify-ecosystem-profile.js
@@ -58,6 +58,18 @@ function findProhibitedClaims(ecosystem) {
   return [...new Set(claims)];
 }
 
+function findUnsupportedHarnessBrandClaims(text) {
+  const claims = [];
+  const value = String(text || '');
+  if (/\bverifiable local receipts?\b/i.test(value)) {
+    claims.push('claims that a local receipt is verifiable without naming a verification mechanism');
+  }
+  if (/intent\s*→\s*policy\s*→\s*approval\s*→\s*tool\s*→\s*receipt/i.test(value)) {
+    claims.push('presents Harness Core as executing the tool instead of stopping at the host boundary');
+  }
+  return claims;
+}
+
 function verifyEcosystemProfile({ root = defaultRoot, quiet = false } = {}) {
   const errors = [];
   const ecosystemPath = path.join(root, 'ecosystem.json');
@@ -176,6 +188,14 @@ function verifyEcosystemProfile({ root = defaultRoot, quiet = false } = {}) {
     if (!normalizedBrandSystem.includes('no local receipt is presented as settlement')) {
       errors.push('docs/BRAND_SYSTEM.md must preserve the local-receipt boundary');
     }
+    if (!brandSystem.includes('intent → policy → approval → host boundary → local receipt')) {
+      errors.push('docs/BRAND_SYSTEM.md must describe Harness Core as stopping at the host boundary');
+    }
+    if (!brandSystem.includes('inspectable, schema-checkable local receipt')) {
+      errors.push('docs/BRAND_SYSTEM.md must scope local-receipt proof to inspection and schema checking');
+    }
+    errors.push(...findUnsupportedHarnessBrandClaims(brandSystem)
+      .map((claim) => `docs/BRAND_SYSTEM.md unsupported Harness Core claim: ${claim}`));
 
     const harnessReadmePath = path.join(root, 'harness-core', 'README.md');
     const harnessHeroPath = path.join(root, 'harness-core', 'assets', 'harness-core-product-hero.svg');
@@ -229,6 +249,7 @@ if (require.main === module) {
 
 module.exports = {
   findProhibitedClaims,
+  findUnsupportedHarnessBrandClaims,
   hasAffirmativeReceiptEquivalence,
   verifyEcosystemProfile,
 };

--- a/scripts/verify-ecosystem-profile.js
+++ b/scripts/verify-ecosystem-profile.js
@@ -4,142 +4,231 @@
 const fs = require('fs');
 const path = require('path');
 
-const root = path.resolve(__dirname, '..');
-const ecosystemPath = path.join(root, 'ecosystem.json');
-const integrationsPath = path.join(root, 'integrations.json');
+const defaultRoot = path.resolve(__dirname, '..');
+const receiptEquivalencePatterns = [
+  /\blocal receipts?\s+(?:is|are)\s+(?!not\b|never\b)(?:(?:an?\s+)?settlement receipts?|(?:the\s+)?same as\s+(?:an?\s+)?settlement receipts?|(?:identical|equivalent) to\s+(?:an?\s+)?settlement receipts?)\b/i,
+  /\blocal receipts?\s+(?:equals?|constitutes?|serves? as|acts? as|counts? as|functions? as)\s+(?:an?\s+)?settlement receipts?\b/i,
+  /\blocal receipts?\s+can be treated as\s+(?:an?\s+)?settlement receipts?\b/i,
+  /\blocal receipts?\s*(?:=|:)\s*(?:an?\s+)?settlement receipts?\b/i,
+  /\bsettlement receipts?\s+(?:is|are|equals?|constitutes?)\s+(?!not\b|never\b)(?:an?\s+)?local receipts?\b/i,
+  /\blocal receipts?\s+(?:and|or)\s+settlement receipts?\s+(?:are\s+)?(?:equivalent|interchangeable|the same)\b/i,
+];
 
-function fail(message) {
-  console.error(`❌ ${message}`);
-  process.exitCode = 1;
-}
-
-function readJson(file) {
+function readJson(file, errors, root) {
   try {
     return JSON.parse(fs.readFileSync(file, 'utf8'));
   } catch (error) {
-    fail(`${path.relative(root, file)} must contain valid JSON: ${error.message}`);
+    errors.push(`${path.relative(root, file)} must contain valid JSON: ${error.message}`);
     return null;
   }
 }
 
-const ecosystem = readJson(ecosystemPath);
-const integrations = readJson(integrationsPath);
-
-if (!ecosystem || !integrations) {
-  process.exitCode = 1;
-} else {
-  if (ecosystem.schema !== 'agoragentic.ecosystem-profile.v1') {
-    fail(`ecosystem.json schema must be agoragentic.ecosystem-profile.v1; got ${JSON.stringify(ecosystem.schema)}`);
+function stringLeaves(value, currentPath = '$') {
+  if (typeof value === 'string') return [{ path: currentPath, value }];
+  if (Array.isArray(value)) {
+    return value.flatMap((item, index) => stringLeaves(item, `${currentPath}[${index}]`));
   }
-
-  if (typeof ecosystem.updated_at !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(ecosystem.updated_at)) {
-    fail('ecosystem.json updated_at must be an ISO date (YYYY-MM-DD)');
+  if (value && typeof value === 'object') {
+    return Object.entries(value)
+      .flatMap(([key, item]) => stringLeaves(item, `${currentPath}.${key}`));
   }
-
-  const manifestCount = Array.isArray(integrations.integrations) ? integrations.integrations.length : null;
-  if (!Number.isInteger(manifestCount)) {
-    fail('integrations.json integrations must be an array');
-  } else if (ecosystem.inventory?.integration_count !== manifestCount) {
-    fail(`ecosystem.json inventory.integration_count must equal integrations.json count (${manifestCount})`);
-  }
-
-  if (ecosystem.inventory?.integration_manifest !== './integrations.json') {
-    fail('ecosystem.json inventory.integration_manifest must point to ./integrations.json');
-  }
-
-  const productIds = new Set();
-  for (const product of ecosystem.products || []) {
-    if (!product?.id) {
-      fail('every ecosystem product needs an id');
-      continue;
-    }
-    if (productIds.has(product.id)) fail(`ecosystem.json has duplicate product id: ${product.id}`);
-    productIds.add(product.id);
-  }
-
-  for (const required of [
-    'harness-core',
-    'micro-ecf',
-    'ecf-core',
-    'fable5-codex',
-    'triptych-os',
-    'router-marketplace',
-    'interchange',
-  ]) {
-    if (!productIds.has(required)) fail(`ecosystem.json missing required product: ${required}`);
-  }
-
-  const funnelIds = new Set();
-  for (const funnel of ecosystem.funnels || []) {
-    if (!funnel?.id || !funnel?.entrypoint) {
-      fail('every ecosystem funnel needs id and entrypoint');
-      continue;
-    }
-    if (funnelIds.has(funnel.id)) fail(`ecosystem.json has duplicate funnel id: ${funnel.id}`);
-    funnelIds.add(funnel.id);
-  }
-
-  for (const required of ['build', 'context', 'operate', 'buy-sell', 'connect-market']) {
-    if (!funnelIds.has(required)) fail(`ecosystem.json missing required funnel: ${required}`);
-  }
-
-  for (const key of ['capabilities', 'public_proof', 'health', 'openapi', 'agents', 'mcp', 'x402']) {
-    const url = ecosystem.live_truth?.[key];
-    if (typeof url !== 'string' || !url.startsWith('https://')) {
-      fail(`ecosystem.json live_truth.${key} must be an https URL`);
-    }
-  }
-
-  const serialized = JSON.stringify(ecosystem);
-  for (const banned of [
-    /certified/i,
-    /SOC 2 certified/i,
-    /guaranteed safe/i,
-    /local receipt[^.]{0,80}settlement receipt/i,
-  ]) {
-    if (banned.test(serialized)) fail(`ecosystem.json contains prohibited public claim: ${banned}`);
-  }
-
-  const brandSystem = fs.readFileSync(path.join(root, 'docs', 'BRAND_SYSTEM.md'), 'utf8');
-  const normalizedBrandSystem = brandSystem.toLowerCase();
-  if (!brandSystem.includes('First-screen README contract')) {
-    fail('docs/BRAND_SYSTEM.md must define the first-screen README contract');
-  }
-  if (!brandSystem.includes('Do not bake mutable counts')) {
-    fail('docs/BRAND_SYSTEM.md must prohibit mutable counts in images');
-  }
-  if (!normalizedBrandSystem.includes('no local receipt is presented as settlement')) {
-    fail('docs/BRAND_SYSTEM.md must preserve the local-receipt boundary');
-  }
-
-  const harnessReadmePath = path.join(root, 'harness-core', 'README.md');
-  const harnessHeroPath = path.join(root, 'harness-core', 'assets', 'harness-core-product-hero.svg');
-  const harnessReadme = fs.readFileSync(harnessReadmePath, 'utf8');
-  const harnessHero = fs.readFileSync(harnessHeroPath, 'utf8');
-
-  for (const required of [
-    'Put a policy gate and a receipt around any agent action.',
-    'npx agoragentic-harness-core@latest init',
-    'Local receipts are not settlement receipts',
-    'Claude Code `PreToolUse`',
-    'before_policy',
-    'after_receipt',
-    'Agent OS preview',
-  ]) {
-    if (!harnessReadme.includes(required)) {
-      fail(`harness-core/README.md is missing flagship contract text: ${required}`);
-    }
-  }
-
-  if (!harnessHero.includes('<title id="title">Agoragentic Harness Core</title>')) {
-    fail('Harness Core hero must include an accessible title');
-  }
-  if (!harnessHero.includes('<desc id="desc">')) {
-    fail('Harness Core hero must include an accessible description');
-  }
-  if (/\b\d+\s+(?:services|listings|calls|agents)\b/i.test(harnessHero)) {
-    fail('Harness Core hero must not bake mutable public counts into the image');
-  }
+  return [];
 }
 
-if (!process.exitCode) console.log('✅ ecosystem profile verification passed');
+function hasAffirmativeReceiptEquivalence(text) {
+  return receiptEquivalencePatterns.some((pattern) => pattern.test(String(text || '')));
+}
+
+function findProhibitedClaims(ecosystem) {
+  const claims = [];
+  for (const leaf of stringLeaves(ecosystem)) {
+    if (/\bcertified\b/i.test(leaf.value)) {
+      claims.push(`${leaf.path} contains an unscoped certified claim`);
+    }
+    if (/\bSOC 2 certified\b/i.test(leaf.value)) {
+      claims.push(`${leaf.path} contains an unsupported SOC 2 certification claim`);
+    }
+    if (/\bguaranteed safe\b/i.test(leaf.value)) {
+      claims.push(`${leaf.path} contains a guaranteed-safety claim`);
+    }
+    if (hasAffirmativeReceiptEquivalence(leaf.value)) {
+      claims.push(`${leaf.path} equates a local receipt with a settlement receipt`);
+    }
+  }
+  return [...new Set(claims)];
+}
+
+function verifyEcosystemProfile({ root = defaultRoot, quiet = false } = {}) {
+  const errors = [];
+  const ecosystemPath = path.join(root, 'ecosystem.json');
+  const ecosystemSchemaPath = path.join(root, 'ecosystem.schema.json');
+  const integrationsPath = path.join(root, 'integrations.json');
+  const ecosystem = readJson(ecosystemPath, errors, root);
+  const integrations = readJson(integrationsPath, errors, root);
+  readJson(ecosystemSchemaPath, errors, root);
+
+  if (ecosystem && integrations) {
+    if (ecosystem.$schema !== './ecosystem.schema.json') {
+      errors.push('ecosystem.json $schema must point to the included ./ecosystem.schema.json');
+    }
+
+    if (ecosystem.schema !== 'agoragentic.ecosystem-profile.v1') {
+      errors.push(`ecosystem.json schema must be agoragentic.ecosystem-profile.v1; got ${JSON.stringify(ecosystem.schema)}`);
+    }
+
+    if (typeof ecosystem.updated_at !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(ecosystem.updated_at)) {
+      errors.push('ecosystem.json updated_at must be an ISO date (YYYY-MM-DD)');
+    }
+
+    const manifestCount = Array.isArray(integrations.integrations) ? integrations.integrations.length : null;
+    if (!Number.isInteger(manifestCount)) {
+      errors.push('integrations.json integrations must be an array');
+    } else if (ecosystem.inventory?.integration_count !== manifestCount) {
+      errors.push(`ecosystem.json inventory.integration_count must equal integrations.json count (${manifestCount})`);
+    }
+
+    if (ecosystem.inventory?.integration_manifest !== './integrations.json') {
+      errors.push('ecosystem.json inventory.integration_manifest must point to ./integrations.json');
+    }
+
+    const productIds = new Set();
+    for (const product of ecosystem.products || []) {
+      if (!product?.id) {
+        errors.push('every ecosystem product needs an id');
+        continue;
+      }
+      if (productIds.has(product.id)) errors.push(`ecosystem.json has duplicate product id: ${product.id}`);
+      productIds.add(product.id);
+    }
+
+    for (const required of [
+      'harness-core',
+      'micro-ecf',
+      'ecf-core',
+      'fable5-codex',
+      'triptych-os',
+      'router-marketplace',
+      'interchange',
+    ]) {
+      if (!productIds.has(required)) errors.push(`ecosystem.json missing required product: ${required}`);
+    }
+
+    const funnelIds = new Set();
+    for (const funnel of ecosystem.funnels || []) {
+      if (!funnel?.id || !funnel?.entrypoint) {
+        errors.push('every ecosystem funnel needs id and entrypoint');
+        continue;
+      }
+      if (funnelIds.has(funnel.id)) errors.push(`ecosystem.json has duplicate funnel id: ${funnel.id}`);
+      funnelIds.add(funnel.id);
+    }
+
+    for (const required of ['build', 'context', 'operate', 'buy-sell', 'connect-market']) {
+      if (!funnelIds.has(required)) errors.push(`ecosystem.json missing required funnel: ${required}`);
+    }
+
+    const buySell = (ecosystem.funnels || []).find((entry) => entry.id === 'buy-sell');
+    if (buySell?.entrypoint !== 'https://agoragentic.com/start/browse/') {
+      errors.push('buy-sell funnel must use the deployed /start/browse/ front door');
+    }
+
+    const marketplace = (ecosystem.products || []).find((entry) => entry.id === 'router-marketplace');
+    if (marketplace?.url !== 'https://agoragentic.com/start/browse/') {
+      errors.push('router-marketplace must use the deployed /start/browse/ front door');
+    }
+
+    const publicUrls = [
+      ...(ecosystem.funnels || []).flatMap((entry) => [entry.entrypoint, entry.next]),
+      ...(ecosystem.products || []).flatMap((entry) => [entry.repository, entry.url, entry.machine_catalog]),
+    ].filter(Boolean);
+    if (publicUrls.includes('https://agoragentic.com/marketplace/')) {
+      errors.push('ecosystem.json must not point to the /marketplace/ homepage fallback');
+    }
+
+    const microEcf = (ecosystem.products || []).find((entry) => entry.id === 'micro-ecf');
+    if (microEcf?.install !== 'npx agoragentic-micro-ecf@latest plan --dir .') {
+      errors.push('Micro ECF must expose plan as its first install action');
+    }
+    if (microEcf?.install_after_explicit_approval !== 'npx agoragentic-micro-ecf@latest install --dir . --yes') {
+      errors.push('Micro ECF must separate install --yes behind explicit approval');
+    }
+
+    for (const key of ['capabilities', 'public_proof', 'health', 'openapi', 'agents', 'mcp', 'x402']) {
+      const url = ecosystem.live_truth?.[key];
+      if (typeof url !== 'string' || !url.startsWith('https://')) {
+        errors.push(`ecosystem.json live_truth.${key} must be an https URL`);
+      }
+    }
+
+    errors.push(...findProhibitedClaims(ecosystem).map((claim) => `ecosystem.json prohibited claim: ${claim}`));
+
+    const brandSystem = fs.readFileSync(path.join(root, 'docs', 'BRAND_SYSTEM.md'), 'utf8');
+    const normalizedBrandSystem = brandSystem.toLowerCase();
+    if (!brandSystem.includes('First-screen README contract')) {
+      errors.push('docs/BRAND_SYSTEM.md must define the first-screen README contract');
+    }
+    if (!brandSystem.includes('Within the public OSS repository portfolio')) {
+      errors.push('docs/BRAND_SYSTEM.md must scope the flagship priority to the public OSS repository portfolio');
+    }
+    if (!brandSystem.includes('Do not bake mutable counts')) {
+      errors.push('docs/BRAND_SYSTEM.md must prohibit mutable counts in images');
+    }
+    if (!normalizedBrandSystem.includes('no local receipt is presented as settlement')) {
+      errors.push('docs/BRAND_SYSTEM.md must preserve the local-receipt boundary');
+    }
+
+    const harnessReadmePath = path.join(root, 'harness-core', 'README.md');
+    const harnessHeroPath = path.join(root, 'harness-core', 'assets', 'harness-core-product-hero.svg');
+    const harnessReadme = fs.readFileSync(harnessReadmePath, 'utf8');
+    const harnessHero = fs.readFileSync(harnessHeroPath, 'utf8');
+
+    for (const required of [
+      'Put a policy gate and local proof around a proposed agent action.',
+      'Host execution is outside the generic `run` path',
+      'Local receipts are not settlement receipts',
+      'Claude Code `PreToolUse`',
+      'status: "stub"',
+      'before_policy',
+      'after_receipt',
+      'Agent OS preview',
+    ]) {
+      if (!harnessReadme.includes(required)) {
+        errors.push(`harness-core/README.md is missing flagship contract text: ${required}`);
+      }
+    }
+
+    if (!harnessHero.includes('<title id="title">Agoragentic Harness Core</title>')) {
+      errors.push('Harness Core hero must include an accessible title');
+    }
+    if (!harnessHero.includes('<desc id="desc">')) {
+      errors.push('Harness Core hero must include an accessible description');
+    }
+    if (!harnessHero.includes('HOST BOUNDARY') || !harnessHero.includes('CONFIGURATION RECEIPT')) {
+      errors.push('Harness Core hero must show the host boundary and configuration-receipt contract');
+    }
+    if (/\bwhat ran\b|\bnext safe action\b|>TOOL EXECUTION</i.test(harnessHero)) {
+      errors.push('Harness Core hero must not claim execution/result fields that the local receipt does not emit');
+    }
+    if (/\b\d+\s+(?:services|listings|calls|agents)\b/i.test(harnessHero)) {
+      errors.push('Harness Core hero must not bake mutable public counts into the image');
+    }
+  }
+
+  if (!quiet) {
+    for (const message of errors) console.error(`❌ ${message}`);
+    if (!errors.length) console.log('✅ ecosystem profile verification passed');
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+if (require.main === module) {
+  const result = verifyEcosystemProfile();
+  if (!result.ok) process.exitCode = 1;
+}
+
+module.exports = {
+  findProhibitedClaims,
+  hasAffirmativeReceiptEquivalence,
+  verifyEcosystemProfile,
+};

--- a/scripts/verify-ecosystem-profile.js
+++ b/scripts/verify-ecosystem-profile.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const ecosystemPath = path.join(root, 'ecosystem.json');
+const integrationsPath = path.join(root, 'integrations.json');
+
+function fail(message) {
+  console.error(`❌ ${message}`);
+  process.exitCode = 1;
+}
+
+function readJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (error) {
+    fail(`${path.relative(root, file)} must contain valid JSON: ${error.message}`);
+    return null;
+  }
+}
+
+const ecosystem = readJson(ecosystemPath);
+const integrations = readJson(integrationsPath);
+
+if (!ecosystem || !integrations) {
+  process.exitCode = 1;
+} else {
+  if (ecosystem.schema !== 'agoragentic.ecosystem-profile.v1') {
+    fail(`ecosystem.json schema must be agoragentic.ecosystem-profile.v1; got ${JSON.stringify(ecosystem.schema)}`);
+  }
+
+  if (typeof ecosystem.updated_at !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(ecosystem.updated_at)) {
+    fail('ecosystem.json updated_at must be an ISO date (YYYY-MM-DD)');
+  }
+
+  const manifestCount = Array.isArray(integrations.integrations) ? integrations.integrations.length : null;
+  if (!Number.isInteger(manifestCount)) {
+    fail('integrations.json integrations must be an array');
+  } else if (ecosystem.inventory?.integration_count !== manifestCount) {
+    fail(`ecosystem.json inventory.integration_count must equal integrations.json count (${manifestCount})`);
+  }
+
+  if (ecosystem.inventory?.integration_manifest !== './integrations.json') {
+    fail('ecosystem.json inventory.integration_manifest must point to ./integrations.json');
+  }
+
+  const productIds = new Set();
+  for (const product of ecosystem.products || []) {
+    if (!product?.id) {
+      fail('every ecosystem product needs an id');
+      continue;
+    }
+    if (productIds.has(product.id)) fail(`ecosystem.json has duplicate product id: ${product.id}`);
+    productIds.add(product.id);
+  }
+
+  for (const required of [
+    'harness-core',
+    'micro-ecf',
+    'ecf-core',
+    'fable5-codex',
+    'triptych-os',
+    'router-marketplace',
+    'interchange',
+  ]) {
+    if (!productIds.has(required)) fail(`ecosystem.json missing required product: ${required}`);
+  }
+
+  const funnelIds = new Set();
+  for (const funnel of ecosystem.funnels || []) {
+    if (!funnel?.id || !funnel?.entrypoint) {
+      fail('every ecosystem funnel needs id and entrypoint');
+      continue;
+    }
+    if (funnelIds.has(funnel.id)) fail(`ecosystem.json has duplicate funnel id: ${funnel.id}`);
+    funnelIds.add(funnel.id);
+  }
+
+  for (const required of ['build', 'context', 'operate', 'buy-sell', 'connect-market']) {
+    if (!funnelIds.has(required)) fail(`ecosystem.json missing required funnel: ${required}`);
+  }
+
+  for (const key of ['capabilities', 'public_proof', 'health', 'openapi', 'agents', 'mcp', 'x402']) {
+    const url = ecosystem.live_truth?.[key];
+    if (typeof url !== 'string' || !url.startsWith('https://')) {
+      fail(`ecosystem.json live_truth.${key} must be an https URL`);
+    }
+  }
+
+  const serialized = JSON.stringify(ecosystem);
+  for (const banned of [
+    /certified/i,
+    /SOC 2 certified/i,
+    /guaranteed safe/i,
+    /local receipt[^.]{0,80}settlement receipt/i,
+  ]) {
+    if (banned.test(serialized)) fail(`ecosystem.json contains prohibited public claim: ${banned}`);
+  }
+
+  const brandSystem = fs.readFileSync(path.join(root, 'docs', 'BRAND_SYSTEM.md'), 'utf8');
+  if (!brandSystem.includes('First-screen README contract')) {
+    fail('docs/BRAND_SYSTEM.md must define the first-screen README contract');
+  }
+  if (!brandSystem.includes('Do not bake mutable counts')) {
+    fail('docs/BRAND_SYSTEM.md must prohibit mutable counts in images');
+  }
+  if (!brandSystem.includes('local receipt is not')) {
+    fail('docs/BRAND_SYSTEM.md must preserve the local-receipt boundary');
+  }
+}
+
+if (!process.exitCode) console.log('✅ ecosystem profile verification passed');

--- a/scripts/verify-integrations-json.js
+++ b/scripts/verify-integrations-json.js
@@ -4,7 +4,10 @@
 const fs = require('fs');
 const path = require('path');
 
-require('./verify-ecosystem-profile.js');
+const { verifyEcosystemProfile } = require('./verify-ecosystem-profile.js');
+
+const ecosystemResult = verifyEcosystemProfile();
+if (!ecosystemResult.ok) process.exitCode = 1;
 
 const root = path.resolve(__dirname, '..');
 const manifestPath = path.join(root, 'integrations.json');
@@ -85,6 +88,17 @@ function assertManifestShape(manifest) {
   if (!manifest.agent_os_smart_routing?.marketplace_routing?.entrypoint?.includes('execute(')) {
     fail('agent_os_smart_routing.marketplace_routing must prefer execute(task,input,constraints)');
   }
+
+  const microPackage = manifest.packages?.micro_ecf;
+  const microIntegration = (manifest.integrations || []).find((entry) => entry.id === 'micro-ecf');
+  for (const [label, entry] of [['packages.micro_ecf', microPackage], ['integrations.micro-ecf', microIntegration]]) {
+    if (entry?.install !== 'npx agoragentic-micro-ecf@latest plan --dir .') {
+      fail(`${label}.install must stop after the Micro ECF plan step`);
+    }
+    if (entry?.install_after_explicit_approval !== 'npx agoragentic-micro-ecf@latest install --dir . --yes') {
+      fail(`${label}.install_after_explicit_approval must preserve explicit approval before install --yes`);
+    }
+  }
 }
 
 function assertInventoryCoverage(manifest) {
@@ -142,6 +156,13 @@ function assertDiscoveryParity(manifest) {
   const readme = fs.readFileSync(path.join(root, 'README.md'), 'utf8');
   const llms = fs.readFileSync(path.join(root, 'llms.txt'), 'utf8');
   const nestedSkill = fs.readFileSync(path.join(root, 'skills', 'agoragentic', 'SKILL.md'), 'utf8');
+
+  if (manifest.discovery?.ecosystem_profile !== 'ecosystem.json') {
+    fail('integrations.json discovery.ecosystem_profile must point to ecosystem.json');
+  }
+  if (manifest.discovery?.ecosystem_profile_schema !== 'ecosystem.schema.json') {
+    fail('integrations.json discovery.ecosystem_profile_schema must point to ecosystem.schema.json');
+  }
 
   if (readme.includes('50+ agent-framework adapters')) {
     fail('README.md contains the stale and untyped "50+ agent-framework adapters" claim');

--- a/scripts/verify-integrations-json.js
+++ b/scripts/verify-integrations-json.js
@@ -4,6 +4,8 @@
 const fs = require('fs');
 const path = require('path');
 
+require('./verify-ecosystem-profile.js');
+
 const root = path.resolve(__dirname, '..');
 const manifestPath = path.join(root, 'integrations.json');
 const machineSurfacePaths = [

--- a/test/verify-ecosystem-profile.test.cjs
+++ b/test/verify-ecosystem-profile.test.cjs
@@ -4,6 +4,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const {
   findProhibitedClaims,
+  findUnsupportedHarnessBrandClaims,
   hasAffirmativeReceiptEquivalence,
 } = require('../scripts/verify-ecosystem-profile.js');
 
@@ -44,4 +45,22 @@ test('affirmative local-to-settlement receipt equivalence is rejected', () => {
       fixture,
     );
   }
+});
+
+test('unsupported Harness Core execution and receipt claims are rejected', () => {
+  assert.deepEqual(
+    findUnsupportedHarnessBrandClaims(
+      'intent → policy → approval → host boundary → local receipt; inspectable, schema-checkable local receipt',
+    ),
+    [],
+  );
+
+  assert.ok(
+    findUnsupportedHarnessBrandClaims('Give any agent a verifiable local receipt.')
+      .some((claim) => claim.includes('without naming a verification mechanism')),
+  );
+  assert.ok(
+    findUnsupportedHarnessBrandClaims('intent → policy → approval → tool → receipt')
+      .some((claim) => claim.includes('stopping at the host boundary')),
+  );
 });

--- a/test/verify-ecosystem-profile.test.cjs
+++ b/test/verify-ecosystem-profile.test.cjs
@@ -1,0 +1,47 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  findProhibitedClaims,
+  hasAffirmativeReceiptEquivalence,
+} = require('../scripts/verify-ecosystem-profile.js');
+
+const explicitNonEquivalenceFixtures = [
+  'A local receipt is not a settlement receipt.',
+  'Local receipts are never settlement receipts.',
+  'A local receipt is not equivalent to a settlement receipt.',
+  'A local receipt is not the same as a settlement receipt.',
+  'Do not treat a local receipt as a settlement receipt.',
+  'Local receipts should never be treated as settlement receipts.',
+  'A local receipt records configuration proof; settlement receipts are separate.',
+];
+
+const affirmativeEquivalenceFixtures = [
+  'A local receipt is a settlement receipt.',
+  'Local receipts are settlement receipts.',
+  'Local receipt = settlement receipt.',
+  'A local receipt is equivalent to a settlement receipt.',
+  'A local receipt is the same as a settlement receipt.',
+  'A local receipt counts as a settlement receipt.',
+  'Local receipts can be treated as settlement receipts.',
+  'Local receipts and settlement receipts are interchangeable.',
+];
+
+test('explicit receipt non-equivalence statements remain allowed', () => {
+  for (const fixture of explicitNonEquivalenceFixtures) {
+    assert.equal(hasAffirmativeReceiptEquivalence(fixture), false, fixture);
+    assert.deepEqual(findProhibitedClaims({ boundaries: [fixture] }), [], fixture);
+  }
+});
+
+test('affirmative local-to-settlement receipt equivalence is rejected', () => {
+  for (const fixture of affirmativeEquivalenceFixtures) {
+    assert.equal(hasAffirmativeReceiptEquivalence(fixture), true, fixture);
+    assert.ok(
+      findProhibitedClaims({ boundaries: [fixture] })
+        .some((claim) => claim.includes('equates a local receipt with a settlement receipt')),
+      fixture,
+    );
+  }
+});


### PR DESCRIPTION
Cross-repo implementation for rhein1/agent-marketplace#1251.

This PR establishes the shared public truth/presentation layer and makes Harness Core the clearest flagship OSS entry point.

## Canonical ecosystem truth
- adds `ecosystem.json` as the product/funnel/repository profile
- binds the declared integration count to `integrations.json.integrations.length`
- tells other repositories to link to the canonical inventory instead of hard-coding a mutable count
- adds `docs/ECOSYSTEM_PROFILE.md`

## Public brand and conversion contract
- adds `docs/BRAND_SYSTEM.md`
- defines the first-screen README contract, image grammar, accessibility, proof language, and one-primary-funnel rule
- prohibits mutable counts and unsupported trust/certification claims in baked assets

## Harness Core flagship conversion
- adds a count-free policy-to-receipt hero
- leads with `intent → policy → approval → host tool → evidence → local receipt`
- adds a five-minute no-spend proof path
- makes live Claude Code `PreToolUse` enforcement discoverable
- explains middleware, adapters, approvals, review gates, ledgers, runtime probes, context imports, readiness loops, worktree evidence, Agent OS preview, and selective OSS boundaries
- preserves the distinction between local receipts and settlement/certification/marketplace verification

## Mechanical validation
- adds `scripts/verify-ecosystem-profile.js`
- runs it through the existing `scripts/verify-integrations-json.js` machine-surface entry point
- verifies inventory parity, product/funnel IDs, machine-truth URLs, prohibited overclaims, brand-contract clauses, Harness first-screen requirements, accessible hero metadata, and count-free imagery

No hosted authority, spend, wallet, deployment, publication, provider dispatch, trust, ranking, or production behavior is enabled.

Validation command:

```bash
node scripts/verify-integrations-json.js
```

Branch protection remains authoritative: merge requires the configured `validate` check and a qualifying write-access approval.

Related program: rhein1/agent-marketplace#1251.