### PR TITLE
Add a bounded Agoragentic governance extension for Prime Agent

### DIFF
--- a/.github/workflows/prime-agent-governance.yml
+++ b/.github/workflows/prime-agent-governance.yml
@@ -1,0 +1,60 @@
+name: Prime Agent Governance Extension
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'prime-agent-governance/**'
+      - 'integrations.json'
+      - 'integrations.schema.json'
+      - 'scripts/integration-inventory-holds.js'
+      - 'scripts/verify-integrations-json.js'
+      - 'test/integration-inventory-holds.test.mjs'
+      - '.github/workflows/prime-agent-governance.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'prime-agent-governance/**'
+      - 'integrations.json'
+      - 'integrations.schema.json'
+      - 'scripts/integration-inventory-holds.js'
+      - 'scripts/verify-integrations-json.js'
+      - 'test/integration-inventory-holds.test.mjs'
+      - '.github/workflows/prime-agent-governance.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['22.8.0', '24']
+    env:
+      AGORAGENTIC_NO_SPEND: '1'
+      AGORAGENTIC_ALLOW_REAL_SPEND: '0'
+      AGORAGENTIC_ALLOW_NETWORK_CANARIES: '0'
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Syntax checks
+        working-directory: prime-agent-governance
+        run: npm run check
+      - name: Unit and host-contract tests
+        working-directory: prime-agent-governance
+        run: npm test
+      - name: Package dry run
+        working-directory: prime-agent-governance
+        run: npm run pack:dry
+      - name: Central inventory hold tests
+        run: node --test test/integration-inventory-holds.test.mjs
+      - name: Root machine-surface verifier
+        run: node scripts/verify-integrations-json.js

--- a/integrations.json
+++ b/integrations.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.30.1",
+  "version": "2.31.0",
   "updated_at": "2026-08-08",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
@@ -307,6 +307,32 @@
       "id": "agoragentic_job_runs",
       "description": "Inspect per-job or cross-job run history for scheduled execute work",
       "cost": "free"
+    }
+  ],
+  "inventory_holds": [
+    {
+      "directory": "prime-agent-governance",
+      "status": "unpublished_alpha",
+      "reason": "Exact Prime Agent v0.7.1 package and event fixtures pass, but an external host run is still required before public catalog inclusion.",
+      "owner": "repository-maintainers",
+      "tracking_ref": "https://github.com/rhein1/agoragentic-integrations/pull/258",
+      "review_by": "2026-09-08",
+      "published": false,
+      "external_compatibility_verified": false,
+      "ready_for_manifest": false,
+      "authority_granted": false
+    },
+    {
+      "directory": "transaction-assurance",
+      "status": "unpublished_alpha",
+      "reason": "Core and evaluator evidence are merged, but an official external protocol adapter must complete conformance and packaging review before public catalog inclusion.",
+      "owner": "repository-maintainers",
+      "tracking_ref": "https://github.com/rhein1/agoragentic-integrations/issues/241",
+      "review_by": "2026-09-08",
+      "published": false,
+      "external_compatibility_verified": false,
+      "ready_for_manifest": false,
+      "authority_granted": false
     }
   ],
   "integrations": [

--- a/integrations.schema.json
+++ b/integrations.schema.json
@@ -10,6 +10,7 @@
     "canonical_url",
     "packages",
     "tools",
+    "inventory_holds",
     "integrations"
   ],
   "properties": {
@@ -92,6 +93,13 @@
       "description": "Canonical tool definitions exposed by all integrations.",
       "items": {
         "$ref": "#/$defs/tool"
+      }
+    },
+    "inventory_holds": {
+      "type": "array",
+      "description": "Centrally governed, time-bounded holds for top-level integrations that are not eligible for public catalog inclusion.",
+      "items": {
+        "$ref": "#/$defs/inventoryHold"
       }
     },
     "integrations": {
@@ -194,6 +202,59 @@
             "listing_price"
           ],
           "description": "Whether this tool is free or costs the listing price."
+        }
+      }
+    },
+    "inventoryHold": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "directory",
+        "status",
+        "reason",
+        "owner",
+        "tracking_ref",
+        "review_by",
+        "published",
+        "external_compatibility_verified",
+        "ready_for_manifest",
+        "authority_granted"
+      ],
+      "properties": {
+        "directory": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]*$"
+        },
+        "status": {
+          "const": "unpublished_alpha"
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 24
+        },
+        "owner": {
+          "const": "repository-maintainers"
+        },
+        "tracking_ref": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^https://github\\.com/rhein1/agoragentic-integrations/(issues|pull)/[0-9]+$"
+        },
+        "review_by": {
+          "type": "string",
+          "format": "date"
+        },
+        "published": {
+          "const": false
+        },
+        "external_compatibility_verified": {
+          "const": false
+        },
+        "ready_for_manifest": {
+          "const": false
+        },
+        "authority_granted": {
+          "const": false
         }
       }
     },

--- a/prime-agent-governance/README.md
+++ b/prime-agent-governance/README.md
@@ -1,0 +1,73 @@
+# Agoragentic Prime Agent extension
+
+Put a bounded Agoragentic policy and evidence boundary around Prime Agent lifecycle and tool events.
+
+```text
+Prime Agent session
+-> classify proposed tool call
+-> allow / interactive review / deny
+-> observe redacted result evidence
+-> produce a clearly labeled local receipt
+```
+
+## What this alpha implements
+
+- Prime Agent lifecycle registration for session, agent, tool, compaction, and shutdown events;
+- conservative read/write/network/spend/deploy/publish/trust classification, including `ipython` `input.code`;
+- exact principal, agent, session, tool-call, capability, and input-hash binding for high-impact actions;
+- mandatory synchronous verification by a host-trusted principal-authority verifier;
+- one-time consumption of authority IDs and action hashes to reject local replay;
+- fail-closed behavior when authority or interactive review is unavailable;
+- proposal-only authority requests with a maximum 15-minute lifetime;
+- bounded redaction and hash-based evidence;
+- `/agora-status` and `agoragentic_status` read-only surfaces;
+- local receipts that explicitly are not settlement, certification, trust endorsement, or marketplace verification.
+
+Local policy allowlists and interactive confirmation cannot authorize spend, deploy, publish, or trust actions. Those actions require an active exact grant plus a trusted verifier supplied by the host. Unknown IPython code also fails closed.
+
+## Prime Agent v0.7.1 contract
+
+The package metadata and deterministic fixture target Prime Agent `v0.7.1` at commit `95afd319a78ae017a41241d50b013d656a0685ce`:
+
+- the root `package.json` declares `pi.extensions: ["./index.mjs"]` and the `pi-package` keyword;
+- the Node.js floor matches Prime Agent's `>=22.8.0` engine;
+- session fixtures use `type`, `reason`, and optional `previousSessionFile`;
+- tool fixtures use `type`, `toolCallId`, `toolName`, and `input.code` for IPython.
+
+Install or test the local package with the upstream package path shape:
+
+```bash
+prime-agent package install ./prime-agent-governance
+prime-agent -e ./prime-agent-governance
+```
+
+The default export has no authority provider and therefore denies every high-impact call. A host wrapper that enables such calls must instantiate `createAgoragenticPrimeExtension()` with trusted `principalRef`, `agentRef`, and `sessionRef` values, an action-time `resolveAuthority` callback, and a synchronous `verifyAuthority` callback.
+
+An accepted grant uses `agoragentic.prime-agent.authority-grant.v1` and must contain a nonempty `authority_id`, valid `issued_at` and `expires_at`, exact principal/agent/session references, the exact action hash returned by `buildAuthorityBinding()`, and the exact capability. `verifyAuthority(grant, binding)` must independently verify the principal's signature or equivalent integrity proof and return literal `true`. The extension consumes a successful authority ID and action hash before execution; a production verifier should enforce the same nonce rule durably across process restarts.
+
+## Local validation
+
+From this directory:
+
+```bash
+npm run check
+npm test
+npm run pack:dry
+```
+
+From the repository root:
+
+```bash
+node --test test/integration-inventory-holds.test.mjs
+node scripts/verify-integrations-json.js
+```
+
+The package remains absent from the public integration list. Its centrally owned, expiring inventory hold lives in `integrations.json`; package-local files cannot grant or extend that hold.
+
+## Hard boundary
+
+Prime Agent executes model-generated Python and project commands with the user's operating-system permissions. Its daemon, workers, and kernels improve lifecycle containment, not security isolation. Static classification cannot prove that every nested Python side effect was observed.
+
+For payment-bearing or production use, run Prime Agent inside a restricted Agent OS lane and enforce network, filesystem, process, credential, and payment operations at external chokepoints.
+
+The package and fixtures target the exact version above. No partnership or end-to-end runtime compatibility claim is made until an external Prime Agent host run is reviewed and the central inventory hold is deliberately removed.

--- a/prime-agent-governance/SKILL.md
+++ b/prime-agent-governance/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: agoragentic-prime-agent
+description: Govern Prime Agent tool calls with bounded policy, principal-authority checks, redacted evidence, and local receipts. Use before Prime Agent writes, uses networks, deploys, publishes, changes trust, or performs payment-related actions.
+---
+
+# Agoragentic for Prime Agent
+
+1. Start with read-only inspection and no-spend proof.
+2. Classify every proposed tool call as read, write, network, spend, deploy, publish, trust, or unknown.
+3. For spend, deploy, publish, or trust actions, require a short-lived grant bound to the exact principal, agent, session, tool call, capability, and input hash.
+4. Ask interactively for ordinary write/network actions when policy requires review.
+5. Fail closed when review is required but no UI is available.
+6. Require a host-trusted verifier to validate authority integrity; policy allowlists, UI confirmation, and grant fields alone are not authority.
+7. Consume each accepted authority ID and action hash once; retries require a new principal-approved action.
+8. Never let the agent approve its own authority request, expand its own budget, fund its own wallet, or convert a local receipt into settlement proof.
+9. Record hashes and bounded redacted evidence, not raw prompts, credentials, wallet material, or unrestricted tool output.
+10. Reconcile ambiguous paid outcomes before retrying.
+
+A Prime Agent extension is an application policy layer. Prime Agent's worker and kernel processes are not security sandboxes. Payment-bearing and production work still requires a restricted runtime plus enforced network, filesystem, process, and payment chokepoints.

--- a/prime-agent-governance/examples/package.json
+++ b/prime-agent-governance/examples/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "agoragentic-prime-agent-example",
+  "private": true,
+  "pi": {
+    "extensions": ["../index.mjs"]
+  }
+}

--- a/prime-agent-governance/index.mjs
+++ b/prime-agent-governance/index.mjs
@@ -1,0 +1,611 @@
+import { createHash, randomUUID } from 'node:crypto';
+
+const SECRET_KEY_PATTERN = /(api[_-]?key|authorization|cookie|credential|password|private[_-]?key|secret|seed|token|payment[_-]?signature|wallet[_-]?private)/i;
+const SPEND_PATTERN = /(pay|payment|purchase|charge|transfer|send[_-]?funds|wallet|settle|payout|refund|usdc|eth_sendtransaction|sendtransaction|signandsend)/i;
+const PUBLISH_PATTERN = /(publish|release|git(?:\s+|[_-])push|npm\s+publish|gh\s+release)/i;
+const DEPLOY_PATTERN = /(deploy|provision|push[_-]?image|create[_-]?pod|start[_-]?service|kubectl\s+(apply|create|delete|patch|replace|rollout)|helm\s+(install|upgrade|uninstall)|terraform\s+(apply|destroy)|docker\s+(push|run)|systemctl\s+(start|restart|enable))/i;
+const TRUST_PATTERN = /(trust|rank|reputation|verify[_-]?seller|approve[_-]?listing|gh\s+pr\s+(merge|review)|merge[_ -]?pull[_ -]?request)/i;
+const WRITE_PATTERN = /(write|edit|patch|delete|remove|rename|move|mkdir|create[_-]?file|git[_-]?commit|git[_-]?push)/i;
+const NETWORK_PATTERN = /(fetch|http|request|browser|web|mcp|ssh|curl|wget|email|message|slack|discord)/i;
+const AUTHORITY_GRANT_SCHEMA = 'agoragentic.prime-agent.authority-grant.v1';
+const AUTHORITY_BINDING_SCHEMA = 'agoragentic.prime-agent.authority-binding.v1';
+const DEFAULT_AUTHORITY_TTL_MS = 15 * 60 * 1000;
+const IPYTHON_CODE_MAX_LENGTH = 100_000;
+const READ_ONLY_IPYTHON_EXPRESSION = /^[\d\s()+\-*/%.,:[\]{}'"_<>=!&|^~]+$/;
+const HIGH_IMPACT_SIDE_EFFECT_CLASSES = Object.freeze(['spend', 'deploy', 'publish', 'trust']);
+const ABSOLUTE_DENIED_CAPABILITIES = Object.freeze([
+  'wallet.fund',
+  'wallet.export_private_material',
+  'authority.self_approve',
+  'authority.expand_scope',
+  'trust.mutate',
+]);
+
+export const DEFAULT_POLICY = Object.freeze({
+  policy_id: 'agoragentic.prime-agent.local.v1',
+  allow_read_only: true,
+  require_interactive_review_for: Object.freeze(['write', 'network']),
+  require_principal_authority_for: HIGH_IMPACT_SIDE_EFFECT_CLASSES,
+  denied_capabilities: ABSOLUTE_DENIED_CAPABILITIES,
+  allowed_capabilities: Object.freeze([]),
+  max_authority_ttl_ms: DEFAULT_AUTHORITY_TTL_MS,
+  max_evidence_events: 500,
+  max_string_length: 2000,
+});
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeString(value, fallback = '', maxLength = 2000) {
+  if (value === undefined || value === null) return fallback;
+  const text = String(value).trim();
+  return text ? text.slice(0, maxLength) : fallback;
+}
+
+function stableSort(value) {
+  if (Array.isArray(value)) return value.map(stableSort);
+  if (!isPlainObject(value)) return value;
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => [key, stableSort(value[key])]),
+  );
+}
+
+export function canonicalize(value) {
+  return JSON.stringify(stableSort(value));
+}
+
+export function hashValue(value) {
+  const input = typeof value === 'string' ? value : canonicalize(value);
+  return `sha256:${createHash('sha256').update(input, 'utf8').digest('hex')}`;
+}
+
+export function sanitizeEvidence(value, options = {}, depth = 0) {
+  const maxDepth = Number.isInteger(options.maxDepth) ? options.maxDepth : 6;
+  const maxItems = Number.isInteger(options.maxItems) ? options.maxItems : 100;
+  const maxStringLength = Number.isInteger(options.maxStringLength)
+    ? options.maxStringLength
+    : DEFAULT_POLICY.max_string_length;
+
+  if (depth > maxDepth) return '[TRUNCATED_DEPTH]';
+  if (value === undefined || value === null || typeof value === 'boolean' || typeof value === 'number') {
+    return value;
+  }
+  if (typeof value === 'string') return value.slice(0, maxStringLength);
+  if (Array.isArray(value)) {
+    return value.slice(0, maxItems).map((entry) => sanitizeEvidence(entry, options, depth + 1));
+  }
+  if (!isPlainObject(value)) return normalizeString(value, '[UNSERIALIZABLE]', maxStringLength);
+
+  const output = {};
+  for (const [key, child] of Object.entries(value).slice(0, maxItems)) {
+    output[key] = SECRET_KEY_PATTERN.test(key)
+      ? '[REDACTED]'
+      : sanitizeEvidence(child, options, depth + 1);
+  }
+  return output;
+}
+
+function normalizedToolText(event = {}) {
+  return [
+    event.toolName,
+    event.name,
+    event.input?.command,
+    normalizeString(event.input?.code, '', IPYTHON_CODE_MAX_LENGTH),
+    event.input?.path,
+    event.input?.url,
+    event.input?.action,
+  ]
+    .map((value) => normalizeString(value, '', IPYTHON_CODE_MAX_LENGTH).toLowerCase())
+    .filter(Boolean)
+    .join(' ');
+}
+
+function isObviouslyReadOnlyIpythonCode(value) {
+  if (typeof value !== 'string' || value.length > IPYTHON_CODE_MAX_LENGTH) return false;
+  const code = normalizeString(value, '', IPYTHON_CODE_MAX_LENGTH);
+  return Boolean(code) && READ_ONLY_IPYTHON_EXPRESSION.test(code);
+}
+
+export function classifyPrimeToolCall(event = {}) {
+  const toolName = normalizeString(event.toolName || event.name, 'unknown');
+  const normalizedToolName = toolName.toLowerCase();
+  const text = normalizedToolText(event);
+  const toolCallId = normalizeString(event.toolCallId || event.tool_call_id, '', 500) || null;
+  const inputHash = hashValue(event.input ?? {});
+  let sideEffectClass = 'unknown';
+  let capability = `tool.${toolName}`;
+
+  if (SPEND_PATTERN.test(text)) {
+    sideEffectClass = 'spend';
+    capability = text.includes('fund') ? 'wallet.fund' : 'payment.execute';
+  } else if (TRUST_PATTERN.test(text)) {
+    sideEffectClass = 'trust';
+    capability = 'trust.mutate';
+  } else if (PUBLISH_PATTERN.test(text)) {
+    sideEffectClass = 'publish';
+    capability = 'publication.execute';
+  } else if (DEPLOY_PATTERN.test(text)) {
+    sideEffectClass = 'deploy';
+    capability = 'deployment.execute';
+  } else if (WRITE_PATTERN.test(text) || ['write', 'edit'].includes(normalizedToolName)) {
+    sideEffectClass = 'write';
+    capability = normalizedToolName.includes('git') ? 'repository.mutate' : 'workspace.mutate';
+  } else if (NETWORK_PATTERN.test(text)) {
+    sideEffectClass = 'network';
+    capability = 'network.request';
+  } else if (normalizedToolName === 'ipython' && isObviouslyReadOnlyIpythonCode(event.input?.code)) {
+    sideEffectClass = 'read';
+    capability = 'workspace.read';
+  } else if (normalizedToolName === 'agoragentic_status') {
+    sideEffectClass = 'read';
+    capability = 'workspace.read';
+  }
+
+  return Object.freeze({
+    tool_name: toolName,
+    tool_call_id: toolCallId,
+    capability,
+    side_effect_class: sideEffectClass,
+    input_hash: inputHash,
+  });
+}
+
+export function buildAuthorityBinding(event, context = {}) {
+  const classification = classifyPrimeToolCall(event);
+  const fields = {
+    schema: AUTHORITY_BINDING_SCHEMA,
+    principal_ref: normalizeString(context.principal_ref || context.principalRef),
+    agent_ref: normalizeString(context.agent_ref || context.agentRef),
+    session_ref: normalizeString(context.session_ref || context.sessionRef),
+    tool_call_id: classification.tool_call_id,
+    capability: classification.capability,
+    side_effect_class: classification.side_effect_class,
+    input_hash: classification.input_hash,
+  };
+  return Object.freeze({ ...fields, action_hash: hashValue(fields) });
+}
+
+function invalidAuthority(reason, authorityId = null) {
+  return Object.freeze({ valid: false, reason, authority_id: authorityId });
+}
+
+export function validatePrincipalAuthority(authority, binding, options = {}) {
+  const authorityId = normalizeString(authority?.authority_id || authority?.authorityId) || null;
+  if (!isPlainObject(authority)) return invalidAuthority('principal authority is missing');
+  if (authority.schema !== AUTHORITY_GRANT_SCHEMA) {
+    return invalidAuthority(`principal authority must use ${AUTHORITY_GRANT_SCHEMA}`, authorityId);
+  }
+  if (!authorityId) return invalidAuthority('principal authority_id is required');
+  if (authority.status !== 'active') return invalidAuthority('principal authority is not active', authorityId);
+  if (!isPlainObject(binding)) return invalidAuthority('authority binding is missing', authorityId);
+
+  for (const field of ['principal_ref', 'agent_ref', 'session_ref', 'tool_call_id', 'action_hash']) {
+    if (!normalizeString(binding[field])) {
+      return invalidAuthority(`authority binding ${field} is required`, authorityId);
+    }
+  }
+
+  const now = options.now instanceof Date ? options.now : new Date(options.now ?? Date.now());
+  if (Number.isNaN(now.getTime())) return invalidAuthority('authority evaluation time is invalid', authorityId);
+  const issuedAt = new Date(authority.issued_at || '');
+  const expiresAt = new Date(authority.expires_at || '');
+  if (Number.isNaN(issuedAt.getTime())) return invalidAuthority('principal authority issued_at is invalid', authorityId);
+  if (Number.isNaN(expiresAt.getTime())) return invalidAuthority('principal authority expires_at is invalid', authorityId);
+  if (issuedAt.getTime() > now.getTime()) return invalidAuthority('principal authority is not active yet', authorityId);
+  if (expiresAt.getTime() <= now.getTime()) return invalidAuthority('principal authority is expired', authorityId);
+  if (expiresAt.getTime() <= issuedAt.getTime()) {
+    return invalidAuthority('principal authority expiry must follow issuance', authorityId);
+  }
+
+  const maxTtlMs = Number.isInteger(options.maxTtlMs) && options.maxTtlMs > 0
+    ? Math.min(options.maxTtlMs, DEFAULT_AUTHORITY_TTL_MS)
+    : DEFAULT_AUTHORITY_TTL_MS;
+  if (expiresAt.getTime() - issuedAt.getTime() > maxTtlMs) {
+    return invalidAuthority(`principal authority exceeds the ${maxTtlMs}ms lifetime limit`, authorityId);
+  }
+
+  for (const field of ['principal_ref', 'agent_ref', 'session_ref', 'action_hash']) {
+    if (normalizeString(authority[field]) !== normalizeString(binding[field])) {
+      return invalidAuthority(`principal authority ${field} does not match this action`, authorityId);
+    }
+  }
+
+  const allowed = Array.isArray(authority.allowed_capabilities)
+    ? authority.allowed_capabilities.map((value) => normalizeString(value)).filter(Boolean)
+    : [];
+  if (!allowed.includes(binding.capability)) {
+    return invalidAuthority('principal authority does not cover this exact capability', authorityId);
+  }
+
+  if (typeof options.verifyAuthority !== 'function') {
+    return invalidAuthority('trusted principal-authority verifier is required', authorityId);
+  }
+  let verified = false;
+  try {
+    verified = options.verifyAuthority(authority, binding);
+  } catch {
+    return invalidAuthority('trusted principal-authority verifier failed', authorityId);
+  }
+  if (verified && typeof verified.then === 'function') {
+    return invalidAuthority('trusted principal-authority verifier must be synchronous', authorityId);
+  }
+  if (verified !== true) return invalidAuthority('principal authority integrity verification failed', authorityId);
+
+  if (typeof options.isAuthorityConsumed !== 'function') {
+    return invalidAuthority('trusted principal-authority replay guard is required', authorityId);
+  }
+  let consumed = false;
+  try {
+    consumed = options.isAuthorityConsumed(authorityId, binding);
+  } catch {
+    return invalidAuthority('trusted principal-authority replay guard failed', authorityId);
+  }
+  if (consumed && typeof consumed.then === 'function') {
+    return invalidAuthority('trusted principal-authority replay guard must be synchronous', authorityId);
+  }
+  if (consumed !== false) return invalidAuthority('principal authority or action was already consumed', authorityId);
+
+  return Object.freeze({ valid: true, reason: 'principal authority is valid for this exact action', authority_id: authorityId });
+}
+
+export function evaluatePrimeToolCall(event, context = {}, policy = DEFAULT_POLICY) {
+  const classification = classifyPrimeToolCall(event);
+  const binding = buildAuthorityBinding(event, context);
+  const denied = new Set([...ABSOLUTE_DENIED_CAPABILITIES, ...(policy.denied_capabilities || [])]);
+  const explicitlyAllowed = new Set(policy.allowed_capabilities || []);
+  const principalRequired = new Set([
+    ...HIGH_IMPACT_SIDE_EFFECT_CLASSES,
+    ...(policy.require_principal_authority_for || []),
+  ]);
+  const reviewRequired = new Set(policy.require_interactive_review_for || []);
+  const evaluatedAt = context.now ? new Date(context.now) : new Date();
+
+  let decision = 'deny';
+  let reason = 'unknown tool effect; explicit review is required';
+  let authorityValidation = null;
+
+  if (denied.has(classification.capability)) {
+    decision = 'deny';
+    reason = `capability ${classification.capability} is denied by policy`;
+  } else if (classification.side_effect_class === 'read' && policy.allow_read_only === true) {
+    decision = 'allow';
+    reason = 'read-only action allowed by local policy';
+  } else if (principalRequired.has(classification.side_effect_class)) {
+    authorityValidation = validatePrincipalAuthority(context.authority, binding, {
+      now: evaluatedAt,
+      maxTtlMs: policy.max_authority_ttl_ms,
+      verifyAuthority: context.verifyAuthority,
+      isAuthorityConsumed: context.isAuthorityConsumed,
+    });
+    if (authorityValidation.valid) {
+      decision = 'allow';
+      reason = 'verified principal authority covers this exact principal, session, and action';
+    } else {
+      decision = 'deny';
+      reason = authorityValidation.reason;
+    }
+  } else if (explicitlyAllowed.has(classification.capability)) {
+    decision = 'allow';
+    reason = 'capability explicitly allowed by local policy';
+  } else if (reviewRequired.has(classification.side_effect_class)) {
+    decision = 'ask';
+    reason = 'local policy requires interactive review before this side effect';
+  }
+
+  return Object.freeze({
+    schema: 'agoragentic.prime-agent.policy-decision.v1',
+    decision,
+    reason,
+    classification,
+    authority_binding: principalRequired.has(classification.side_effect_class) ? binding : null,
+    authority_validation: authorityValidation,
+    evaluated_at: Number.isNaN(evaluatedAt.getTime()) ? new Date().toISOString() : evaluatedAt.toISOString(),
+    authority_granted_by_decision: false,
+  });
+}
+
+export function buildAuthorityRequest(input = {}) {
+  const principalRef = normalizeString(input.principal_ref || input.principalRef);
+  const agentRef = normalizeString(input.agent_ref || input.agentRef);
+  const sessionRef = normalizeString(input.session_ref || input.sessionRef);
+  const actionHash = normalizeString(input.action_hash || input.actionHash);
+  const purpose = normalizeString(input.purpose);
+  const capabilities = [...new Set((input.allowed_capabilities || input.allowedCapabilities || [])
+    .map((value) => normalizeString(value))
+    .filter(Boolean))];
+  if (!principalRef) throw new TypeError('principal_ref is required');
+  if (!agentRef) throw new TypeError('agent_ref is required');
+  if (!sessionRef) throw new TypeError('session_ref is required');
+  if (!/^sha256:[a-f0-9]{64}$/.test(actionHash)) throw new TypeError('action_hash must be a sha256 reference');
+  if (!purpose) throw new TypeError('purpose is required');
+  if (capabilities.length === 0) throw new TypeError('at least one allowed capability is required');
+
+  const createdAt = new Date(input.created_at || input.createdAt || Date.now());
+  if (Number.isNaN(createdAt.getTime())) throw new TypeError('created_at must be a valid date');
+  const expiresAt = new Date(input.expires_at || input.expiresAt || createdAt.getTime() + DEFAULT_AUTHORITY_TTL_MS);
+  if (Number.isNaN(expiresAt.getTime())) throw new TypeError('expires_at must be a valid date');
+  if (expiresAt.getTime() <= createdAt.getTime()) throw new TypeError('expires_at must follow created_at');
+  if (expiresAt.getTime() - createdAt.getTime() > DEFAULT_AUTHORITY_TTL_MS) {
+    throw new TypeError(`authority request lifetime must not exceed ${DEFAULT_AUTHORITY_TTL_MS}ms`);
+  }
+
+  return Object.freeze({
+    schema: 'agoragentic.prime-agent.authority-request.v1',
+    request_id: normalizeString(input.request_id || input.requestId, `par_${randomUUID()}`),
+    created_at: createdAt.toISOString(),
+    expires_at: expiresAt.toISOString(),
+    principal_ref: principalRef,
+    agent_ref: agentRef,
+    session_ref: sessionRef,
+    action_hash: actionHash,
+    purpose,
+    requested_authority: {
+      allowed_capabilities: capabilities,
+      allowed_side_effect_classes: [...new Set((input.allowed_side_effect_classes || [])
+        .map((value) => normalizeString(value))
+        .filter(Boolean))],
+      max_amount: normalizeString(input.max_amount || input.maxAmount, '0'),
+      currency: normalizeString(input.currency, 'USD', 20),
+    },
+    status: 'pending_principal_approval',
+    request_grants_authority: false,
+    can_self_approve: false,
+    can_fund_wallet: false,
+    can_expand_scope: false,
+  });
+}
+
+export function createLocalReceipt(state, status = 'completed') {
+  const events = Array.isArray(state.events) ? state.events : [];
+  return Object.freeze({
+    schema: 'agoragentic.prime-agent.local-receipt.v1',
+    receipt_id: `parc_${randomUUID()}`,
+    run_id: state.run_id || null,
+    session_id: state.session_id || null,
+    status,
+    event_count: events.length,
+    event_chain_hash: hashValue(events),
+    latest_policy_decision: state.latest_policy_decision || null,
+    created_at: new Date().toISOString(),
+    local_receipt_only: true,
+    settlement_receipt: false,
+    certification: false,
+    marketplace_verification: false,
+    trust_endorsement: false,
+    authority_granted: false,
+  });
+}
+
+function appendBoundedEvent(state, event, policy) {
+  const max = Number.isInteger(policy.max_evidence_events) ? policy.max_evidence_events : 500;
+  const bounded = sanitizeEvidence({
+    id: `evt_${randomUUID()}`,
+    at: new Date().toISOString(),
+    ...event,
+  });
+  state.events.push(bounded);
+  if (state.events.length > max) state.events.splice(0, state.events.length - max);
+  return bounded;
+}
+
+function maybeAppendPrimeEntry(pi, type, data) {
+  if (typeof pi.appendEntry !== 'function') return;
+  pi.appendEntry(type, sanitizeEvidence(data));
+}
+
+export function createAgoragenticPrimeExtension(options = {}) {
+  const policy = Object.freeze({ ...DEFAULT_POLICY, ...(options.policy || {}) });
+  const configuredPrincipalRef = normalizeString(options.principal_ref || options.principalRef);
+  const configuredAgentRef = normalizeString(options.agent_ref || options.agentRef);
+  const configuredSessionRef = normalizeString(options.session_ref || options.sessionRef);
+  const state = {
+    run_id: null,
+    session_id: null,
+    principal_ref: configuredPrincipalRef || null,
+    agent_ref: configuredAgentRef || null,
+    authority: options.authority || null,
+    latest_authority_id: null,
+    latest_authority_status: options.authority ? 'unverified' : 'missing',
+    consumed_authority_ids: new Set(),
+    consumed_action_hashes: new Set(),
+    events: [],
+    latest_policy_decision: null,
+    latest_receipt: null,
+  };
+
+  return function install(pi) {
+    if (!pi || typeof pi.on !== 'function') {
+      throw new TypeError('Prime Agent ExtensionAPI with on() is required');
+    }
+
+    pi.on('session_start', async (event = {}) => {
+      state.run_id = `parun_${randomUUID()}`;
+      state.session_id = configuredSessionRef || state.run_id;
+      const recorded = appendBoundedEvent(state, {
+        type: 'session_started',
+        reason: event.reason || 'unknown',
+        previous_session_file_hash: event.previousSessionFile
+          ? hashValue(normalizeString(event.previousSessionFile))
+          : null,
+      }, policy);
+      maybeAppendPrimeEntry(pi, 'agoragentic.session', recorded);
+    });
+
+    pi.on('before_agent_start', async () => {
+      const recorded = appendBoundedEvent(state, {
+        type: 'agent_start_requested',
+        authority_status: state.latest_authority_status,
+      }, policy);
+      maybeAppendPrimeEntry(pi, 'agoragentic.agent', recorded);
+    });
+
+    pi.on('tool_call', async (event = {}, ctx = {}) => {
+      const classification = classifyPrimeToolCall(event);
+      const authorityBinding = buildAuthorityBinding(event, {
+        principal_ref: state.principal_ref,
+        agent_ref: state.agent_ref,
+        session_ref: state.session_id,
+      });
+      const principalRequired = new Set([
+        ...HIGH_IMPACT_SIDE_EFFECT_CLASSES,
+        ...(policy.require_principal_authority_for || []),
+      ]);
+      let authority = state.authority;
+      if (principalRequired.has(classification.side_effect_class) && typeof options.resolveAuthority === 'function') {
+        try {
+          authority = await options.resolveAuthority(Object.freeze({
+            event,
+            classification,
+            binding: authorityBinding,
+          }));
+        } catch {
+          authority = null;
+        }
+      }
+      const decision = evaluatePrimeToolCall(event, {
+        authority,
+        principal_ref: state.principal_ref,
+        agent_ref: state.agent_ref,
+        session_ref: state.session_id,
+        verifyAuthority: options.verifyAuthority,
+        isAuthorityConsumed: (authorityId, binding) => (
+          state.consumed_authority_ids.has(authorityId)
+          || state.consumed_action_hashes.has(binding.action_hash)
+        ),
+      }, policy);
+      state.latest_policy_decision = decision;
+      state.latest_authority_id = decision.authority_validation?.authority_id || null;
+      state.latest_authority_status = decision.authority_validation
+        ? (decision.authority_validation.valid ? 'verified' : 'invalid')
+        : (authority ? 'unverified' : 'missing');
+      if (decision.authority_validation?.valid) {
+        state.consumed_authority_ids.add(decision.authority_validation.authority_id);
+        state.consumed_action_hashes.add(decision.authority_binding.action_hash);
+      }
+      const recorded = appendBoundedEvent(state, {
+        type: 'tool_policy_decision',
+        tool_name: decision.classification.tool_name,
+        capability: decision.classification.capability,
+        side_effect_class: decision.classification.side_effect_class,
+        input_hash: decision.classification.input_hash,
+        decision: decision.decision,
+        reason: decision.reason,
+        action_hash: decision.authority_binding?.action_hash || null,
+        authority_id: state.latest_authority_id,
+        authority_status: state.latest_authority_status,
+      }, policy);
+      maybeAppendPrimeEntry(pi, 'agoragentic.policy', recorded);
+
+      if (decision.decision === 'deny') {
+        return { block: true, reason: decision.reason };
+      }
+      if (decision.decision === 'ask') {
+        if (!ctx.hasUI || !ctx.ui || typeof ctx.ui.confirm !== 'function') {
+          return { block: true, reason: `${decision.reason}; no interactive principal review is available` };
+        }
+        const approved = await ctx.ui.confirm(
+          'Agoragentic policy review',
+          `${decision.classification.tool_name}: ${decision.reason}`,
+        );
+        appendBoundedEvent(state, {
+          type: 'interactive_review',
+          capability: decision.classification.capability,
+          approved: approved === true,
+        }, policy);
+        if (approved !== true) return { block: true, reason: 'blocked by interactive principal review' };
+      }
+      return undefined;
+    });
+
+    pi.on('tool_result', async (event = {}) => {
+      const recorded = appendBoundedEvent(state, {
+        type: 'tool_result_observed',
+        tool_name: normalizeString(event.toolName || event.name, 'unknown'),
+        result_hash: hashValue(sanitizeEvidence(event.result ?? event.output ?? event.content ?? null)),
+        is_error: event.isError === true || event.error === true,
+      }, policy);
+      maybeAppendPrimeEntry(pi, 'agoragentic.evidence', recorded);
+      return undefined;
+    });
+
+    pi.on('session_before_compact', async () => {
+      const recorded = appendBoundedEvent(state, {
+        type: 'pre_compaction_checkpoint',
+        event_chain_hash: hashValue(state.events),
+      }, policy);
+      maybeAppendPrimeEntry(pi, 'agoragentic.checkpoint', recorded);
+    });
+
+    pi.on('agent_end', async (event = {}) => {
+      appendBoundedEvent(state, {
+        type: 'agent_ended',
+        reason: event.type === 'agent_end' ? 'agent_end' : 'unknown',
+      }, policy);
+      state.latest_receipt = createLocalReceipt(state, 'completed');
+      maybeAppendPrimeEntry(pi, 'agoragentic.receipt', state.latest_receipt);
+    });
+
+    pi.on('session_shutdown', async () => {
+      if (!state.latest_receipt) {
+        state.latest_receipt = createLocalReceipt(state, 'incomplete');
+        maybeAppendPrimeEntry(pi, 'agoragentic.receipt', state.latest_receipt);
+      }
+    });
+
+    if (typeof pi.registerCommand === 'function') {
+      pi.registerCommand('agora-status', {
+        description: 'Show the local Agoragentic policy and receipt state for this Prime Agent session.',
+        handler: async (_args, ctx = {}) => {
+          const summary = {
+            run_id: state.run_id,
+            session_id: state.session_id,
+            authority_status: state.latest_authority_status,
+            authority_id: state.latest_authority_id,
+            event_count: state.events.length,
+            latest_decision: state.latest_policy_decision?.decision || null,
+            latest_receipt_id: state.latest_receipt?.receipt_id || null,
+            authority_granted_by_extension: false,
+          };
+          if (ctx.ui && typeof ctx.ui.notify === 'function') {
+            ctx.ui.notify(JSON.stringify(summary, null, 2), 'info');
+          }
+          return summary;
+        },
+      });
+    }
+
+    if (typeof pi.registerTool === 'function') {
+      pi.registerTool({
+        name: 'agoragentic_status',
+        label: 'Agoragentic Status',
+        description: 'Read the local policy, authority, evidence, and receipt status. This tool grants no authority.',
+        parameters: { type: 'object', properties: {}, additionalProperties: false },
+        async execute() {
+          return {
+            content: [{
+              type: 'text',
+              text: JSON.stringify({
+                run_id: state.run_id,
+                session_id: state.session_id,
+                authority_status: state.latest_authority_status,
+                authority_id: state.latest_authority_id,
+                event_count: state.events.length,
+                latest_policy_decision: state.latest_policy_decision,
+                latest_receipt: state.latest_receipt,
+                authority_granted: false,
+              }, null, 2),
+            }],
+            details: {},
+          };
+        },
+      });
+    }
+
+    return Object.freeze({ state, policy });
+  };
+}
+
+export default createAgoragenticPrimeExtension();

--- a/prime-agent-governance/package.json
+++ b/prime-agent-governance/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@agoragentic/prime-agent",
+  "version": "0.1.0-alpha.0",
+  "description": "Bounded Prime Agent policy, principal-authority, evidence, and local receipt extension.",
+  "type": "module",
+  "private": true,
+  "license": "Apache-2.0",
+  "keywords": [
+    "pi-package",
+    "prime-agent",
+    "agoragentic",
+    "governance"
+  ],
+  "engines": {
+    "node": ">=22.8.0"
+  },
+  "pi": {
+    "extensions": [
+      "./index.mjs"
+    ]
+  },
+  "exports": {
+    ".": "./index.mjs"
+  },
+  "files": [
+    "index.mjs",
+    "SKILL.md",
+    "README.md",
+    "examples/"
+  ],
+  "scripts": {
+    "check": "node --check index.mjs && node --check test/extension.test.mjs",
+    "test": "node --test test/*.test.mjs",
+    "pack:dry": "npm pack --dry-run"
+  }
+}

--- a/prime-agent-governance/test/extension.test.mjs
+++ b/prime-agent-governance/test/extension.test.mjs
@@ -1,0 +1,399 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  DEFAULT_POLICY,
+  buildAuthorityBinding,
+  buildAuthorityRequest,
+  classifyPrimeToolCall,
+  createAgoragenticPrimeExtension,
+  evaluatePrimeToolCall,
+  sanitizeEvidence,
+  validatePrincipalAuthority,
+} from '../index.mjs';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = resolve(TEST_DIR, '..');
+const UPSTREAM = JSON.parse(readFileSync(resolve(TEST_DIR, 'fixtures', 'prime-agent-v0.7.1.json'), 'utf8'));
+const FIXED_NOW = '2026-08-08T12:00:00.000Z';
+
+function fakePi() {
+  const handlers = new Map();
+  const commands = new Map();
+  const tools = new Map();
+  const entries = [];
+  return {
+    handlers,
+    commands,
+    tools,
+    entries,
+    on(name, handler) {
+      handlers.set(name, handler);
+    },
+    registerCommand(name, value) {
+      commands.set(name, value);
+    },
+    registerTool(value) {
+      tools.set(value.name, value);
+    },
+    appendEntry(type, data) {
+      entries.push({ type, data });
+    },
+  };
+}
+
+function authorizedCall(event, options = {}) {
+  const principalRef = options.principalRef || 'owner:1';
+  const agentRef = options.agentRef || 'agent:1';
+  const sessionRef = options.sessionRef || 'session:1';
+  const binding = buildAuthorityBinding(event, {
+    principal_ref: principalRef,
+    agent_ref: agentRef,
+    session_ref: sessionRef,
+  });
+  const authority = {
+    schema: 'agoragentic.prime-agent.authority-grant.v1',
+    authority_id: 'pauth_test_1',
+    status: 'active',
+    issued_at: '2026-08-08T11:55:00.000Z',
+    expires_at: '2026-08-08T12:10:00.000Z',
+    principal_ref: principalRef,
+    agent_ref: agentRef,
+    session_ref: sessionRef,
+    action_hash: binding.action_hash,
+    allowed_capabilities: [binding.capability],
+    proof: 'test-principal-signature',
+    ...(options.authority || {}),
+  };
+  return {
+    binding,
+    authority,
+    context: {
+      authority,
+      principal_ref: principalRef,
+      agent_ref: agentRef,
+      session_ref: sessionRef,
+      now: FIXED_NOW,
+      verifyAuthority: options.verifyAuthority || ((grant, candidate) => (
+        grant.proof === 'test-principal-signature'
+        && grant.action_hash === candidate.action_hash
+      )),
+      isAuthorityConsumed: options.isAuthorityConsumed || (() => false),
+    },
+  };
+}
+
+test('package follows the exact Prime Agent v0.7.1 discovery contract', () => {
+  const packageJson = JSON.parse(readFileSync(resolve(PACKAGE_ROOT, 'package.json'), 'utf8'));
+  assert.equal(UPSTREAM.tag, 'v0.7.1');
+  assert.equal(UPSTREAM.commit, '95afd319a78ae017a41241d50b013d656a0685ce');
+  assert.equal(packageJson.engines.node, UPSTREAM.node_engine);
+  assert.ok(packageJson.keywords.includes(UPSTREAM.package_contract.discovery_keyword));
+  assert.deepEqual(packageJson.pi.extensions, ['./index.mjs']);
+  assert.ok(existsSync(resolve(PACKAGE_ROOT, packageJson.pi.extensions[0])));
+});
+
+test('classifies exact v0.7.1 IPython event shapes conservatively', () => {
+  const events = UPSTREAM.events;
+  assert.equal(classifyPrimeToolCall(events.ipython_read).side_effect_class, 'read');
+  assert.equal(classifyPrimeToolCall(events.ipython_network).side_effect_class, 'network');
+  assert.equal(classifyPrimeToolCall(events.ipython_write).side_effect_class, 'write');
+  assert.equal(classifyPrimeToolCall(events.ipython_payment).side_effect_class, 'spend');
+  assert.equal(classifyPrimeToolCall(events.ipython_unknown).side_effect_class, 'unknown');
+  assert.equal(evaluatePrimeToolCall(events.ipython_unknown).decision, 'deny');
+  assert.equal(classifyPrimeToolCall({
+    ...events.ipython_read,
+    input: { code: `${'1'.repeat(100_001)}\nwallet.transfer('merchant', 1)` },
+  }).side_effect_class, 'unknown');
+});
+
+test('shell orchestration cannot downgrade deploy, publish, trust, or unknown effects to ordinary writes', () => {
+  const shellEvent = (toolCallId, command) => ({
+    type: 'tool_call',
+    toolCallId,
+    toolName: 'bash',
+    input: { command },
+  });
+  assert.equal(classifyPrimeToolCall(shellEvent('call-deploy', 'kubectl apply -f service.yml')).side_effect_class, 'deploy');
+  assert.equal(classifyPrimeToolCall(shellEvent('call-publish', 'git push origin main')).side_effect_class, 'publish');
+  assert.equal(classifyPrimeToolCall(shellEvent('call-trust', 'gh pr merge 258')).side_effect_class, 'trust');
+  const unknown = shellEvent('call-unknown', 'echo hello');
+  assert.equal(classifyPrimeToolCall(unknown).side_effect_class, 'unknown');
+  assert.equal(evaluatePrimeToolCall(unknown).decision, 'deny');
+});
+
+test('unverified custom tools cannot gain read-only authority from their names', () => {
+  const customRead = {
+    type: 'tool_call',
+    toolCallId: 'call-custom-read',
+    toolName: 'read',
+    input: { resource: 'arbitrary-provider' },
+  };
+  assert.equal(classifyPrimeToolCall(customRead).side_effect_class, 'unknown');
+  assert.equal(evaluatePrimeToolCall(customRead).decision, 'deny');
+  assert.equal(classifyPrimeToolCall({
+    type: 'tool_call',
+    toolCallId: 'call-status',
+    toolName: 'agoragentic_status',
+    input: {},
+  }).side_effect_class, 'read');
+});
+
+test('action bindings cover principal, agent, session, tool call, and complete input', () => {
+  const event = UPSTREAM.events.ipython_payment;
+  const first = buildAuthorityBinding(event, {
+    principal_ref: 'owner:1',
+    agent_ref: 'agent:1',
+    session_ref: 'session:1',
+  });
+  const changedSession = buildAuthorityBinding(event, {
+    principal_ref: 'owner:1',
+    agent_ref: 'agent:1',
+    session_ref: 'session:2',
+  });
+  const changedPrincipal = buildAuthorityBinding(event, {
+    principal_ref: 'owner:2',
+    agent_ref: 'agent:1',
+    session_ref: 'session:1',
+  });
+  const changedAgent = buildAuthorityBinding(event, {
+    principal_ref: 'owner:1',
+    agent_ref: 'agent:2',
+    session_ref: 'session:1',
+  });
+  const changedToolCall = buildAuthorityBinding({ ...event, toolCallId: 'call-ipython-payment-2' }, {
+    principal_ref: 'owner:1',
+    agent_ref: 'agent:1',
+    session_ref: 'session:1',
+  });
+  const changedInput = buildAuthorityBinding({
+    ...event,
+    input: { code: `${'1'.repeat(2500)} + 2` },
+  }, {
+    principal_ref: 'owner:1',
+    agent_ref: 'agent:1',
+    session_ref: 'session:1',
+  });
+  const otherChangedInput = buildAuthorityBinding({
+    ...event,
+    input: { code: `${'1'.repeat(2500)} + 3` },
+  }, {
+    principal_ref: 'owner:1',
+    agent_ref: 'agent:1',
+    session_ref: 'session:1',
+  });
+  assert.notEqual(first.action_hash, changedPrincipal.action_hash);
+  assert.notEqual(first.action_hash, changedAgent.action_hash);
+  assert.notEqual(first.action_hash, changedSession.action_hash);
+  assert.notEqual(first.action_hash, changedToolCall.action_hash);
+  assert.notEqual(changedInput.action_hash, otherChangedInput.action_hash);
+});
+
+test('local policy cannot bypass principal authority for high-impact actions', () => {
+  const policy = {
+    ...DEFAULT_POLICY,
+    require_principal_authority_for: [],
+    denied_capabilities: [],
+    allowed_capabilities: ['payment.execute'],
+  };
+  const decision = evaluatePrimeToolCall(UPSTREAM.events.ipython_payment, {}, policy);
+  assert.equal(decision.decision, 'deny');
+  assert.match(decision.reason, /principal authority is missing/i);
+});
+
+test('local policy cannot remove absolute authority boundaries or extend authority lifetime', () => {
+  const fundEvent = {
+    ...UPSTREAM.events.ipython_payment,
+    toolCallId: 'call-wallet-fund',
+    input: { code: "wallet.fund('agent', 1)" },
+  };
+  const fundCall = authorizedCall(fundEvent);
+  const fundDecision = evaluatePrimeToolCall(fundEvent, fundCall.context, {
+    ...DEFAULT_POLICY,
+    denied_capabilities: [],
+  });
+  assert.equal(fundDecision.decision, 'deny');
+  assert.match(fundDecision.reason, /denied by policy/);
+
+  const paymentCall = authorizedCall(UPSTREAM.events.ipython_payment, {
+    authority: {
+      issued_at: '2026-08-08T11:50:00.000Z',
+      expires_at: '2026-08-08T12:10:00.000Z',
+    },
+  });
+  const paymentDecision = evaluatePrimeToolCall(UPSTREAM.events.ipython_payment, paymentCall.context, {
+    ...DEFAULT_POLICY,
+    max_authority_ttl_ms: Number.MAX_SAFE_INTEGER,
+  });
+  assert.equal(paymentDecision.decision, 'deny');
+  assert.match(paymentDecision.reason, /lifetime limit/);
+});
+
+test('valid exact principal authority permits only its bound payment action', () => {
+  const event = UPSTREAM.events.ipython_payment;
+  const { context, binding } = authorizedCall(event);
+  const decision = evaluatePrimeToolCall(event, context);
+  assert.equal(decision.decision, 'allow');
+  assert.equal(decision.authority_binding.action_hash, binding.action_hash);
+  assert.equal(decision.authority_validation.authority_id, 'pauth_test_1');
+  assert.equal(decision.authority_granted_by_decision, false);
+});
+
+test('principal authority fails closed for malformed, stale, or mismatched grants', async (t) => {
+  const event = UPSTREAM.events.ipython_payment;
+  const cases = [
+    ['missing expiry', { expires_at: undefined }, /expires_at is invalid/],
+    ['invalid expiry', { expires_at: 'not-a-date' }, /expires_at is invalid/],
+    ['expired', { expires_at: '2026-08-08T11:59:59.000Z' }, /expired/],
+    ['future issuance', { issued_at: '2026-08-08T12:01:00.000Z' }, /not active yet/],
+    ['overlong lifetime', { issued_at: '2026-08-08T11:50:00.000Z', expires_at: '2026-08-08T12:10:00.000Z' }, /lifetime limit/],
+    ['wrong principal', { principal_ref: 'owner:other' }, /principal_ref does not match/],
+    ['wrong agent', { agent_ref: 'agent:other' }, /agent_ref does not match/],
+    ['wrong session', { session_ref: 'session:other' }, /session_ref does not match/],
+    ['wrong action', { action_hash: `sha256:${'0'.repeat(64)}` }, /action_hash does not match/],
+    ['wrong capability', { allowed_capabilities: ['deployment.execute'] }, /exact capability/],
+  ];
+
+  for (const [name, authority, reason] of cases) {
+    await t.test(name, () => {
+      const call = authorizedCall(event, { authority });
+      const decision = evaluatePrimeToolCall(event, call.context);
+      assert.equal(decision.decision, 'deny');
+      assert.match(decision.reason, reason);
+    });
+  }
+});
+
+test('authority data cannot authorize without trusted integrity and replay guards', () => {
+  const event = UPSTREAM.events.ipython_payment;
+  const call = authorizedCall(event);
+  delete call.context.verifyAuthority;
+  assert.match(evaluatePrimeToolCall(event, call.context).reason, /verifier is required/);
+
+  const rejected = authorizedCall(event, { verifyAuthority: () => false });
+  assert.match(evaluatePrimeToolCall(event, rejected.context).reason, /integrity verification failed/);
+
+  const noReplayGuard = authorizedCall(event);
+  delete noReplayGuard.context.isAuthorityConsumed;
+  assert.match(evaluatePrimeToolCall(event, noReplayGuard.context).reason, /replay guard is required/);
+
+  const consumed = authorizedCall(event, { isAuthorityConsumed: () => true });
+  assert.match(evaluatePrimeToolCall(event, consumed.context).reason, /already consumed/);
+});
+
+test('authority request is exact, bounded, proposal-only, and cannot self-approve', () => {
+  const event = UPSTREAM.events.ipython_payment;
+  const binding = buildAuthorityBinding(event, {
+    principal_ref: 'owner:1',
+    agent_ref: 'agent:1',
+    session_ref: 'session:1',
+  });
+  const request = buildAuthorityRequest({
+    principal_ref: 'owner:1',
+    agent_ref: 'agent:1',
+    session_ref: 'session:1',
+    action_hash: binding.action_hash,
+    purpose: 'Buy bounded research',
+    allowed_capabilities: ['payment.execute'],
+    created_at: '2026-08-08T12:00:00.000Z',
+    expires_at: '2026-08-08T12:10:00.000Z',
+  });
+  assert.equal(request.status, 'pending_principal_approval');
+  assert.equal(request.session_ref, 'session:1');
+  assert.equal(request.action_hash, binding.action_hash);
+  assert.equal(request.request_grants_authority, false);
+  assert.equal(request.can_self_approve, false);
+});
+
+test('authority validator rejects a binding without upstream toolCallId', () => {
+  const event = { toolName: 'payment_execute', input: { amount: '1' } };
+  const call = authorizedCall(event);
+  const validation = validatePrincipalAuthority(call.authority, call.binding, {
+    now: FIXED_NOW,
+    verifyAuthority: call.context.verifyAuthority,
+    isAuthorityConsumed: call.context.isAuthorityConsumed,
+  });
+  assert.equal(validation.valid, false);
+  assert.match(validation.reason, /tool_call_id is required/);
+});
+
+test('redacts common credential fields', () => {
+  const safe = sanitizeEvidence({ apiKey: 'secret', nested: { Authorization: 'Bearer x' }, value: 'ok' });
+  assert.equal(safe.apiKey, '[REDACTED]');
+  assert.equal(safe.nested.Authorization, '[REDACTED]');
+  assert.equal(safe.value, 'ok');
+});
+
+test('extension resolves and verifies exact per-action authority through the v0.7.1 host shape', async () => {
+  const pi = fakePi();
+  const installed = createAgoragenticPrimeExtension({
+    principalRef: 'owner:1',
+    agentRef: 'agent:1',
+    sessionRef: 'session:1',
+    resolveAuthority: async ({ binding }) => {
+      const issuedAt = new Date(Date.now() - 1000);
+      const expiresAt = new Date(issuedAt.getTime() + 5 * 60 * 1000);
+      return {
+        schema: 'agoragentic.prime-agent.authority-grant.v1',
+        authority_id: 'pauth_runtime_1',
+        status: 'active',
+        issued_at: issuedAt.toISOString(),
+        expires_at: expiresAt.toISOString(),
+        principal_ref: binding.principal_ref,
+        agent_ref: binding.agent_ref,
+        session_ref: binding.session_ref,
+        action_hash: binding.action_hash,
+        allowed_capabilities: [binding.capability],
+        proof: 'runtime-principal-signature',
+      };
+    },
+    verifyAuthority: (grant, binding) => (
+      grant.proof === 'runtime-principal-signature'
+      && grant.action_hash === binding.action_hash
+    ),
+  })(pi);
+
+  await pi.handlers.get('session_start')(UPSTREAM.events.session_start);
+  const result = await pi.handlers.get('tool_call')(UPSTREAM.events.ipython_payment, { hasUI: false });
+  assert.equal(result, undefined);
+  assert.equal(installed.state.session_id, 'session:1');
+  assert.equal(installed.state.latest_authority_status, 'verified');
+  assert.equal(installed.state.latest_authority_id, 'pauth_runtime_1');
+
+  const replayed = await pi.handlers.get('tool_call')(UPSTREAM.events.ipython_payment, { hasUI: false });
+  assert.equal(replayed.block, true);
+  assert.match(replayed.reason, /already consumed/);
+});
+
+test('extension fails closed for headless writes and records a local receipt', async () => {
+  const pi = fakePi();
+  const installed = createAgoragenticPrimeExtension()(pi);
+  assert.ok(pi.handlers.has('tool_call'));
+  assert.ok(pi.commands.has('agora-status'));
+  assert.ok(pi.tools.has('agoragentic_status'));
+
+  await pi.handlers.get('session_start')(UPSTREAM.events.session_start);
+  const blocked = await pi.handlers.get('tool_call')(UPSTREAM.events.ipython_write, { hasUI: false });
+  assert.equal(blocked.block, true);
+  assert.match(blocked.reason, /no interactive principal review/i);
+
+  await pi.handlers.get('agent_end')({ type: 'agent_end', messages: [] });
+  assert.equal(installed.state.latest_receipt.local_receipt_only, true);
+  assert.equal(installed.state.latest_receipt.settlement_receipt, false);
+  assert.ok(pi.entries.some((entry) => entry.type === 'agoragentic.receipt'));
+});
+
+test('interactive review can allow an ordinary write without granting durable authority', async () => {
+  const pi = fakePi();
+  const installed = createAgoragenticPrimeExtension()(pi);
+  await pi.handlers.get('session_start')(UPSTREAM.events.session_start);
+  const result = await pi.handlers.get('tool_call')(
+    UPSTREAM.events.ipython_write,
+    { hasUI: true, ui: { confirm: async () => true } },
+  );
+  assert.equal(result, undefined);
+  assert.equal(installed.state.authority, null);
+  assert.equal(installed.state.latest_policy_decision.authority_granted_by_decision, false);
+});

--- a/prime-agent-governance/test/fixtures/prime-agent-v0.7.1.json
+++ b/prime-agent-governance/test/fixtures/prime-agent-v0.7.1.json
@@ -1,0 +1,57 @@
+{
+  "source": "https://github.com/PrimeIntellect-ai/prime-agent",
+  "tag": "v0.7.1",
+  "commit": "95afd319a78ae017a41241d50b013d656a0685ce",
+  "node_engine": ">=22.8.0",
+  "package_contract": {
+    "manifest_key": "pi",
+    "extensions_key": "extensions",
+    "discovery_keyword": "pi-package"
+  },
+  "events": {
+    "session_start": {
+      "type": "session_start",
+      "reason": "startup"
+    },
+    "ipython_read": {
+      "type": "tool_call",
+      "toolCallId": "call-ipython-read",
+      "toolName": "ipython",
+      "input": {
+        "code": "(40 + 2) / 2"
+      }
+    },
+    "ipython_network": {
+      "type": "tool_call",
+      "toolCallId": "call-ipython-network",
+      "toolName": "ipython",
+      "input": {
+        "code": "import requests\nrequests.get('https://example.com/health')"
+      }
+    },
+    "ipython_write": {
+      "type": "tool_call",
+      "toolCallId": "call-ipython-write",
+      "toolName": "ipython",
+      "input": {
+        "code": "from pathlib import Path\nPath('result.txt').write_text('done')"
+      }
+    },
+    "ipython_payment": {
+      "type": "tool_call",
+      "toolCallId": "call-ipython-payment",
+      "toolName": "ipython",
+      "input": {
+        "code": "wallet.transfer('merchant', 1)"
+      }
+    },
+    "ipython_unknown": {
+      "type": "tool_call",
+      "toolCallId": "call-ipython-unknown",
+      "toolName": "ipython",
+      "input": {
+        "code": "import local_module\nlocal_module.run()"
+      }
+    }
+  }
+}

--- a/scripts/integration-inventory-holds.js
+++ b/scripts/integration-inventory-holds.js
@@ -1,0 +1,106 @@
+'use strict';
+
+const HOLD_KEYS = Object.freeze([
+  'directory',
+  'status',
+  'reason',
+  'owner',
+  'tracking_ref',
+  'review_by',
+  'published',
+  'external_compatibility_verified',
+  'ready_for_manifest',
+  'authority_granted',
+]);
+const HOLD_KEY_SET = new Set(HOLD_KEYS);
+const DIRECTORY_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+const TRACKING_REF_PATTERN = /^https:\/\/github\.com\/rhein1\/agoragentic-integrations\/(issues|pull)\/[0-9]+$/;
+const MAX_HOLD_DAYS = 90;
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isValidDateOnly(value) {
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+}
+
+function validateInventoryHolds(manifest, options = {}) {
+  const errors = [];
+  const heldDirectories = new Set();
+  const seenDirectories = new Set();
+  const integrationDirectories = new Set(options.integrationDirectories || []);
+  const representedDirectories = new Set(options.representedDirectories || []);
+  const today = options.today || new Date().toISOString().slice(0, 10);
+  const holds = manifest?.inventory_holds;
+
+  if (!isValidDateOnly(today)) {
+    return { errors: [`inventory hold validation date is invalid: ${today}`], heldDirectories };
+  }
+  if (!Array.isArray(holds)) {
+    return { errors: ['integrations.json inventory_holds must be an array'], heldDirectories };
+  }
+
+  holds.forEach((hold, index) => {
+    const prefix = `integrations.json inventory_holds[${index}]`;
+    const startErrorCount = errors.length;
+    if (!isPlainObject(hold)) {
+      errors.push(`${prefix} must be an object`);
+      return;
+    }
+
+    for (const key of HOLD_KEYS) {
+      if (!(key in hold)) errors.push(`${prefix}.${key} is required`);
+    }
+    for (const key of Object.keys(hold)) {
+      if (!HOLD_KEY_SET.has(key)) errors.push(`${prefix} contains unsupported field: ${key}`);
+    }
+
+    const directory = hold.directory;
+    if (typeof directory !== 'string' || !DIRECTORY_PATTERN.test(directory)) {
+      errors.push(`${prefix}.directory must be a safe top-level directory name`);
+    } else {
+      if (seenDirectories.has(directory)) errors.push(`${prefix}.directory is duplicated: ${directory}`);
+      seenDirectories.add(directory);
+      if (!integrationDirectories.has(directory)) errors.push(`${prefix}.directory does not exist as an integration: ${directory}`);
+      if (representedDirectories.has(directory)) errors.push(`${prefix}.directory is already represented in integrations.json: ${directory}`);
+    }
+
+    if (hold.status !== 'unpublished_alpha') errors.push(`${prefix}.status must be unpublished_alpha`);
+    if (typeof hold.reason !== 'string' || hold.reason.trim().length < 24) {
+      errors.push(`${prefix}.reason must explain the temporary hold`);
+    }
+    if (hold.owner !== 'repository-maintainers') errors.push(`${prefix}.owner must be repository-maintainers`);
+    if (typeof hold.tracking_ref !== 'string' || !TRACKING_REF_PATTERN.test(hold.tracking_ref)) {
+      errors.push(`${prefix}.tracking_ref must identify a repository issue or pull request`);
+    }
+    if (!isValidDateOnly(hold.review_by)) {
+      errors.push(`${prefix}.review_by must be a valid ISO date`);
+    } else if (hold.review_by < today) {
+      errors.push(`${prefix} expired on ${hold.review_by}`);
+    } else {
+      const holdTime = new Date(`${hold.review_by}T00:00:00.000Z`).getTime();
+      const todayTime = new Date(`${today}T00:00:00.000Z`).getTime();
+      if (holdTime - todayTime > MAX_HOLD_DAYS * 24 * 60 * 60 * 1000) {
+        errors.push(`${prefix}.review_by exceeds the ${MAX_HOLD_DAYS}-day limit`);
+      }
+    }
+
+    for (const field of ['published', 'external_compatibility_verified', 'ready_for_manifest', 'authority_granted']) {
+      if (hold[field] !== false) errors.push(`${prefix}.${field} must remain false`);
+    }
+
+    if (errors.length === startErrorCount) heldDirectories.add(directory);
+  });
+
+  return { errors, heldDirectories };
+}
+
+module.exports = {
+  HOLD_KEYS,
+  MAX_HOLD_DAYS,
+  isValidDateOnly,
+  validateInventoryHolds,
+};

--- a/scripts/verify-integrations-json.js
+++ b/scripts/verify-integrations-json.js
@@ -4,6 +4,7 @@
 const fs = require('fs');
 const path = require('path');
 
+const { validateInventoryHolds } = require('./integration-inventory-holds.js');
 const { verifyEcosystemProfile } = require('./verify-ecosystem-profile.js');
 
 const ecosystemResult = verifyEcosystemProfile();
@@ -16,7 +17,6 @@ const machineSurfacePaths = [
   path.join(root, 'a2a', 'agent-card.json'),
   path.join(root, 'dify', 'agoragentic_provider.json'),
 ];
-const CATALOG_EXCEPTION_FILE = '.agoragentic-integration.json';
 
 function fail(message) {
   console.error(`❌ ${message}`);
@@ -101,34 +101,6 @@ function assertManifestShape(manifest) {
   }
 }
 
-function hasApprovedCatalogException(directory) {
-  const markerPath = path.join(root, directory, CATALOG_EXCEPTION_FILE);
-  if (!fs.existsSync(markerPath)) return false;
-
-  let marker;
-  try {
-    marker = JSON.parse(fs.readFileSync(markerPath, 'utf8'));
-  } catch (error) {
-    fail(`${directory}/${CATALOG_EXCEPTION_FILE} must be valid JSON: ${error.message}`);
-    return true;
-  }
-
-  const requirements = [
-    [marker.schema === 'agoragentic.integration-catalog-exception.v1', 'schema must be agoragentic.integration-catalog-exception.v1'],
-    [marker.catalog_status === 'unpublished_alpha', 'catalog_status must be unpublished_alpha'],
-    [typeof marker.reason === 'string' && marker.reason.trim().length >= 24, 'reason must explain the temporary catalog exception'],
-    [marker.published === false, 'published must remain false'],
-    [marker.external_compatibility_verified === false, 'external_compatibility_verified must remain false'],
-    [marker.ready_for_manifest === false, 'ready_for_manifest must remain false'],
-    [marker.authority_granted === false, 'authority_granted must remain false'],
-  ];
-
-  for (const [valid, message] of requirements) {
-    if (!valid) fail(`${directory}/${CATALOG_EXCEPTION_FILE}: ${message}`);
-  }
-  return true;
-}
-
 function assertInventoryCoverage(manifest) {
   const ids = new Set();
   const representedDirectories = new Set();
@@ -166,8 +138,14 @@ function assertInventoryCoverage(manifest) {
     .filter((entry) => fs.existsSync(path.join(root, entry.name, 'README.md')))
     .map((entry) => entry.name);
 
+  const holdValidation = validateInventoryHolds(manifest, {
+    integrationDirectories,
+    representedDirectories,
+  });
+  for (const error of holdValidation.errors) fail(error);
+
   for (const directory of integrationDirectories) {
-    if (!representedDirectories.has(directory) && !hasApprovedCatalogException(directory)) {
+    if (!representedDirectories.has(directory) && !holdValidation.heldDirectories.has(directory)) {
       fail(`top-level integration directory is missing from integrations.json: ${directory}`);
     }
   }

--- a/test/integration-inventory-holds.test.mjs
+++ b/test/integration-inventory-holds.test.mjs
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const { validateInventoryHolds } = require('../scripts/integration-inventory-holds.js');
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const MANIFEST = JSON.parse(readFileSync(resolve(ROOT, 'integrations.json'), 'utf8'));
+const REPRESENTED = (MANIFEST.integrations || [])
+  .flatMap((integration) => [integration.path, integration.docs])
+  .filter(Boolean)
+  .map((value) => value.split('/')[0]);
+
+function cloneManifest() {
+  return JSON.parse(JSON.stringify(MANIFEST));
+}
+
+function validate(manifest, options = {}) {
+  return validateInventoryHolds(manifest, {
+    integrationDirectories: ['prime-agent-governance', 'transaction-assurance'],
+    representedDirectories: REPRESENTED,
+    today: '2026-08-08',
+    ...options,
+  });
+}
+
+test('current central inventory hold is bounded and valid', () => {
+  const result = validate(MANIFEST);
+  assert.deepEqual(result.errors, []);
+  assert.deepEqual([...result.heldDirectories], ['prime-agent-governance', 'transaction-assurance']);
+});
+
+test('expired inventory holds fail closed', () => {
+  const result = validate(MANIFEST, { today: '2026-09-09' });
+  assert.equal(result.heldDirectories.size, 0);
+  assert.ok(result.errors.some((error) => error.includes('expired on 2026-09-08')));
+});
+
+test('inventory holds cannot delegate ownership or extend beyond 90 days', () => {
+  const delegated = cloneManifest();
+  delegated.inventory_holds[0].owner = 'prime-agent-governance';
+  assert.ok(validate(delegated).errors.some((error) => error.includes('owner must be repository-maintainers')));
+
+  const unbounded = cloneManifest();
+  unbounded.inventory_holds[0].review_by = '2027-01-01';
+  assert.ok(validate(unbounded).errors.some((error) => error.includes('exceeds the 90-day limit')));
+});
+
+test('unknown, represented, duplicate, or authority-bearing holds are rejected', () => {
+  const unknown = cloneManifest();
+  unknown.inventory_holds[0].directory = 'not-present';
+  assert.ok(validate(unknown).errors.some((error) => error.includes('does not exist as an integration')));
+
+  const represented = cloneManifest();
+  represented.inventory_holds[0].directory = 'agent-os';
+  const representedResult = validateInventoryHolds(represented, {
+    integrationDirectories: ['agent-os'],
+    representedDirectories: ['agent-os'],
+    today: '2026-08-08',
+  });
+  assert.ok(representedResult.errors.some((error) => error.includes('already represented')));
+
+  const duplicate = cloneManifest();
+  duplicate.inventory_holds.push({ ...duplicate.inventory_holds[0] });
+  assert.ok(validate(duplicate).errors.some((error) => error.includes('duplicated')));
+
+  const authorityBearing = cloneManifest();
+  authorityBearing.inventory_holds[0].authority_granted = true;
+  assert.ok(validate(authorityBearing).errors.some((error) => error.includes('authority_granted must remain false')));
+});
+
+test('inventory verifier has no package-local exception channel', () => {
+  const verifier = readFileSync(resolve(ROOT, 'scripts', 'verify-integrations-json.js'), 'utf8');
+  assert.doesNotMatch(verifier, /\.agoragentic-integration\.json/);
+  assert.doesNotMatch(verifier, /hasApprovedCatalogException/);
+  assert.match(verifier, /validateInventoryHolds/);
+});

--- a/transaction-assurance/.agoragentic-integration.json
+++ b/transaction-assurance/.agoragentic-integration.json
@@ -1,9 +1,0 @@
-{
-  "schema": "agoragentic.integration-catalog-exception.v1",
-  "catalog_status": "unpublished_alpha",
-  "reason": "The transaction-assurance package remains private until parent CI, version-specific verifier adapters, and packaging review are complete.",
-  "published": false,
-  "external_compatibility_verified": false,
-  "ready_for_manifest": false,
-  "authority_granted": false
-}


### PR DESCRIPTION
## Scope

Adds a bounded Agoragentic governance extension for the exact Prime Agent v0.7.1 host contract (upstream commit `95afd...`). The package remains private and unpublished; no partnership or external compatibility claim is made.

## What ships

- exact Prime Agent package discovery and lifecycle event fixtures;
- conservative read/write/network/spend/deploy/publish/trust classification;
- fail-closed high-impact decisions bound to principal, agent, session, tool call, capability, and complete input;
- synchronous external integrity and replay checks for principal grants;
- bounded 15-minute proposal-only authority packets that cannot self-approve;
- deterministic redacted local evidence and receipts;
- a centralized, maintainer-owned, time-bounded inventory hold with no authority or publication effect.

The same central hold mechanism now covers the unpublished Transaction Assurance package and removes both package-local catalog-exception channels.

## Safety boundaries

This extension does not create or fund wallets, sign or move money, grant authority, deploy, publish, rank, mutate trust, or claim OS sandboxing. Local evidence is not settlement, certification, endorsement, or marketplace verification.

## Verification

- Prime Agent syntax checks
- Prime Agent host-contract and policy tests: 26/26
- central inventory-hold tests: 5/5
- package dry run
- root machine-surface verifier
- CI matrix: Node 22.8 and 24 (current head)

External host compatibility remains unverified and is explicitly blocked from catalog publication pending a real host run.