### PR TITLE
Attach versioned evaluator evidence to Transaction Assurance envelopes

### DIFF
--- a/.github/workflows/transaction-assurance-evaluator-evidence.yml
+++ b/.github/workflows/transaction-assurance-evaluator-evidence.yml
@@ -1,19 +1,18 @@
-name: Transaction Assurance
+name: Transaction Assurance Evaluator Evidence
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 on:
   pull_request:
-    branches: [main]
     paths:
       - 'transaction-assurance/**'
-      - '.github/workflows/transaction-assurance.yml'
+      - '.github/workflows/transaction-assurance-evaluator-evidence.yml'
   push:
     branches: [main]
     paths:
       - 'transaction-assurance/**'
-      - '.github/workflows/transaction-assurance.yml'
+      - '.github/workflows/transaction-assurance-evaluator-evidence.yml'
   workflow_dispatch:
 
 permissions:
@@ -35,29 +34,18 @@ jobs:
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Parse package JSON and schemas
-        working-directory: transaction-assurance
-        run: |
-          node -e "for (const file of [
-            'package.json',
-            'schema/normalized-authority.v1.json',
-            'schema/transaction-assurance-evaluation.v1.json',
-            'schema/transaction-evaluation-evidence.v1.json',
-            'examples/native-mandate.json',
-            'examples/authority-request-input.json'
-          ]) { JSON.parse(require('node:fs').readFileSync(file, 'utf8')); console.log('parsed', file); }"
       - name: Syntax checks
         working-directory: transaction-assurance
         run: npm run check
-      - name: Unit and conformance tests
+      - name: Full package tests
         working-directory: transaction-assurance
         run: npm test
       - name: No-network self-test
         working-directory: transaction-assurance
         run: npm run self-test
-      - name: Runnable example
+      - name: Build example envelope
         working-directory: transaction-assurance
-        run: node examples/build-envelope.mjs > /tmp/transaction-assurance-example.json
+        run: node examples/build-envelope.mjs
       - name: Package dry run
         working-directory: transaction-assurance
         run: npm run pack:dry

--- a/transaction-assurance/EVALUATION_EVIDENCE.md
+++ b/transaction-assurance/EVALUATION_EVIDENCE.md
@@ -1,0 +1,115 @@
+# Transaction Assurance evaluator evidence
+
+Transaction Assurance can attach scoped outcome-evaluation evidence without treating a score as proof that the entire commercial transaction is complete.
+
+```javascript
+import { sha256Ref } from '@agoragentic/transaction-assurance';
+import {
+  attachEvaluationEvidence,
+  computeEvaluationEvidenceHash,
+  normalizeEvaluationEvidence,
+  summarizeEvaluationEvidence,
+  verifyEvaluationEvidence,
+} from '@agoragentic/transaction-assurance/evaluation-evidence';
+```
+
+## Evidence shape
+
+Each entry requires:
+
+- environment identifier, version, and SHA-256 hash;
+- task identifier;
+- harness identifier and version;
+- exact evaluator identifiers, versions, types, results, and bounded scores;
+- a model reference for every model judge;
+- a rubric hash and at least one evidence reference for every evaluator;
+- a trace hash, artifact references, and observation timestamp;
+- a detached hash over the complete canonical evidence record.
+
+Evaluator types are explicit:
+
+```text
+deterministic
+model_judge
+human_review
+external_attestation
+```
+
+Model-judge-only evidence remains `review` even when its scoped result is `pass`. A deterministic failure produces a failed scoped summary. A passing scoped summary still keeps:
+
+```text
+complete_transaction_verified = false
+certification = false
+authority_granted = false
+```
+
+## Normalize and verify
+
+```javascript
+const evidence = normalizeEvaluationEvidence({
+  environment_id: 'agoragentic-transaction-assurance-v1',
+  environment_version: '0.1.0',
+  environment_hash: sha256Ref({ environment: 'pinned-definition' }),
+  task_id: 'payment-without-delivery',
+  harness: { id: 'prime-agent', version: '0.1.0' },
+  evaluators: [
+    {
+      id: 'delivery-contract-verifier',
+      version: '1.0.0',
+      type: 'deterministic',
+      result: 'pass',
+      score: 1,
+      rubric_hash: sha256Ref({ rubric: 'delivery-contract-v1' }),
+      evidence_refs: ['receipt://example']
+    }
+  ],
+  trace_hash: sha256Ref({ trace: 'access-controlled-trace' }),
+  artifact_refs: ['receipt://example'],
+  observed_at: new Date().toISOString()
+});
+
+verifyEvaluationEvidence(evidence);
+```
+
+`computeEvaluationEvidenceHash()` hashes the canonical record with only `evidence_hash` replaced by `null`. `verifyEvaluationEvidence()` checks that detached hash and then requires the complete canonical shape. A matching `schema` string never bypasses field, provenance, privacy-state, or hash checks.
+
+The required hashes establish integrity for the declared record and its referenced lineage. This package does not dereference artifacts, verify an external evaluator's identity, or prove that a referenced trace or rubric is trustworthy.
+
+## Attach to an envelope
+
+```javascript
+const updated = attachEvaluationEvidence(envelope, evidence);
+```
+
+Attachment verifies the source envelope hash, verifies every previously attached schema-tagged entry, normalizes or verifies each new entry, updates the envelope, clears `complete_chain_verified`, and computes the parent envelope hash last. The normal Transaction Assurance evaluation must still establish authority, terms, payment, execution, delivery, finality, and reconciliation.
+
+## Privacy boundary
+
+The module does not contain a content scanner. It therefore emits:
+
+```text
+redaction_state = not_verified
+source_exactness.normalization_lossless = false
+source_exactness.verification_status = not_verified
+```
+
+Caller assertions such as `public_safe` are not propagated. Free-text notes and references are preserved, so callers must still scrub or access-control them before publication. Original trace bodies have no dedicated field and are not embedded by the normalizer, but a reference, note, or identifier can still contain sensitive text if a caller supplies it.
+
+## Truth boundary
+
+```text
+payment settled
+!= task succeeded
+
+task returned output
+!= output passed evaluation
+
+scoped evaluation passed
+!= complete transaction verified
+
+self-hash verified
+!= external provenance verified
+
+receipt produced
+!= certification or trust endorsement
+```

--- a/transaction-assurance/package.json
+++ b/transaction-assurance/package.json
@@ -12,7 +12,8 @@
     "agora-assure": "./bin/agora-assure.mjs"
   },
   "exports": {
-    ".": "./src/index.mjs"
+    ".": "./src/index.mjs",
+    "./evaluation-evidence": "./src/evaluation-evidence.mjs"
   },
   "files": [
     "bin/",
@@ -21,11 +22,12 @@
     "examples/",
     "SKILL.md",
     "README.md",
+    "EVALUATION_EVIDENCE.md",
     "LICENSE"
   ],
   "scripts": {
     "test": "node --test test/*.test.mjs",
-    "check": "node --check src/index.mjs && node --check bin/agora-assure.mjs",
+    "check": "node --check src/index.mjs && node --check src/evaluation-evidence.mjs && node --check bin/agora-assure.mjs",
     "self-test": "node bin/agora-assure.mjs self-test",
     "pack:dry": "npm pack --dry-run"
   },

--- a/transaction-assurance/schema/transaction-evaluation-evidence.v1.json
+++ b/transaction-assurance/schema/transaction-evaluation-evidence.v1.json
@@ -1,0 +1,146 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agoragentic.com/schemas/transaction-evaluation-evidence.v1.json",
+  "title": "Agoragentic Transaction Evaluation Evidence v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "evidence_id",
+    "environment_id",
+    "environment_version",
+    "environment_hash",
+    "task_id",
+    "harness",
+    "evaluators",
+    "trace_hash",
+    "artifact_refs",
+    "observed_at",
+    "redaction_state",
+    "source_exactness",
+    "authority_flags",
+    "evidence_hash"
+  ],
+  "properties": {
+    "schema": { "const": "agoragentic.transaction-evaluation-evidence.v1" },
+    "evidence_id": { "type": "string", "minLength": 1 },
+    "environment_id": { "type": "string", "minLength": 1 },
+    "environment_version": { "type": "string", "minLength": 1 },
+    "environment_hash": { "$ref": "#/$defs/sha256" },
+    "task_id": { "type": "string", "minLength": 1 },
+    "harness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "version"],
+      "properties": {
+        "id": { "$ref": "#/$defs/ref" },
+        "version": { "$ref": "#/$defs/ref" }
+      }
+    },
+    "evaluators": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "evaluator_id",
+          "evaluator_version",
+          "type",
+          "result",
+          "score",
+          "model_ref",
+          "rubric_hash",
+          "evidence_refs",
+          "notes"
+        ],
+        "properties": {
+          "evaluator_id": { "type": "string", "minLength": 1 },
+          "evaluator_version": { "type": "string", "minLength": 1 },
+          "type": {
+            "enum": ["deterministic", "model_judge", "human_review", "external_attestation"]
+          },
+          "result": { "enum": ["pass", "fail", "review", "unknown"] },
+          "score": { "type": ["number", "null"], "minimum": 0, "maximum": 1 },
+          "model_ref": {
+            "oneOf": [
+              { "$ref": "#/$defs/ref" },
+              { "type": "null" }
+            ]
+          },
+          "rubric_hash": { "$ref": "#/$defs/sha256" },
+          "evidence_refs": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 100,
+            "uniqueItems": true,
+            "items": { "$ref": "#/$defs/ref" }
+          },
+          "notes": { "type": ["string", "null"], "maxLength": 1000 }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": { "type": { "const": "model_judge" } },
+              "required": ["type"]
+            },
+            "then": { "properties": { "model_ref": { "$ref": "#/$defs/ref" } } },
+            "else": { "properties": { "model_ref": { "type": "null" } } }
+          }
+        ]
+      }
+    },
+    "trace_hash": { "$ref": "#/$defs/sha256" },
+    "artifact_refs": {
+      "type": "array",
+      "maxItems": 100,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/ref" }
+    },
+    "observed_at": { "type": "string", "format": "date-time" },
+    "redaction_state": { "const": "not_verified" },
+    "source_exactness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "original_trace_embedded",
+        "normalized_representation",
+        "normalization_lossless",
+        "verification_status"
+      ],
+      "properties": {
+        "original_trace_embedded": { "const": false },
+        "normalized_representation": { "const": true },
+        "normalization_lossless": { "const": false },
+        "verification_status": { "const": "not_verified" }
+      }
+    },
+    "authority_flags": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "evaluation_grants_authority",
+        "can_spend",
+        "can_fund_wallet",
+        "can_deploy",
+        "can_publish",
+        "can_change_trust",
+        "can_expand_scope"
+      ],
+      "properties": {
+        "evaluation_grants_authority": { "const": false },
+        "can_spend": { "const": false },
+        "can_fund_wallet": { "const": false },
+        "can_deploy": { "const": false },
+        "can_publish": { "const": false },
+        "can_change_trust": { "const": false },
+        "can_expand_scope": { "const": false }
+      }
+    },
+    "evidence_hash": { "$ref": "#/$defs/sha256" }
+  },
+  "$defs": {
+    "ref": { "type": "string", "minLength": 1, "maxLength": 2000 },
+    "sha256": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
+  }
+}

--- a/transaction-assurance/src/evaluation-evidence.mjs
+++ b/transaction-assurance/src/evaluation-evidence.mjs
@@ -1,0 +1,239 @@
+import {
+  canonicalize,
+  computeEnvelopeHash,
+  sha256Ref,
+} from './index.mjs';
+
+const EVIDENCE_SCHEMA = 'agoragentic.transaction-evaluation-evidence.v1';
+const SUMMARY_SCHEMA = 'agoragentic.transaction-evaluation-summary.v1';
+const TYPES = new Set(['deterministic', 'model_judge', 'human_review', 'external_attestation']);
+const RESULTS = new Set(['pass', 'fail', 'review', 'unknown']);
+const SHA256_PATTERN = /^sha256:[0-9a-f]{64}$/;
+
+function isObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function text(value, field, { required = false, max = 2000 } = {}) {
+  const normalized = value === undefined || value === null ? '' : String(value).trim();
+  if (required && !normalized) throw new TypeError(`${field} is required`);
+  return normalized ? normalized.slice(0, max) : null;
+}
+
+function list(value, field, { required = false, maxItems = 100 } = {}) {
+  const source = value === undefined || value === null
+    ? []
+    : Array.isArray(value) ? value : [value];
+  const normalized = [...new Set(
+    source.map((item) => text(item, `${field} item`)).filter(Boolean),
+  )].slice(0, maxItems);
+  if (required && normalized.length === 0) throw new TypeError(`${field} requires at least one item`);
+  return normalized;
+}
+
+function hashRef(value, field, { required = false } = {}) {
+  const normalized = text(value, field, { required });
+  if (!normalized) return null;
+  if (!SHA256_PATTERN.test(normalized)) {
+    throw new TypeError(`${field} must be a sha256:<64 lowercase hex characters> reference`);
+  }
+  return normalized;
+}
+
+function dateTime(value, field, { defaultNow = false } = {}) {
+  const source = value ?? (defaultNow ? Date.now() : null);
+  if (source === null || source === '') throw new TypeError(`${field} is required`);
+  const parsed = new Date(source);
+  if (Number.isNaN(parsed.getTime())) throw new TypeError(`${field} must be a valid date-time`);
+  return parsed.toISOString();
+}
+
+function normalizeHarness(value) {
+  if (!isObject(value)) throw new TypeError('harness must be an object');
+  return {
+    id: text(value.id, 'harness.id', { required: true }),
+    version: text(value.version, 'harness.version', { required: true }),
+  };
+}
+
+function boundedScore(value, field) {
+  if (value === undefined || value === null || value === '') return null;
+  const number = Number(value);
+  if (!Number.isFinite(number) || number < 0 || number > 1) {
+    throw new TypeError(`${field} must be between 0 and 1`);
+  }
+  return Number(number.toFixed(6));
+}
+
+function normalizeEvaluator(value, index) {
+  if (!isObject(value)) throw new TypeError(`evaluators[${index}] must be an object`);
+  const type = text(value.type, `evaluators[${index}].type`, { required: true });
+  const result = text(value.result, `evaluators[${index}].result`, { required: true });
+  if (!TYPES.has(type)) throw new TypeError(`unsupported evaluator type: ${type}`);
+  if (!RESULTS.has(result)) throw new TypeError(`unsupported evaluator result: ${result}`);
+  const modelRef = text(value.model_ref ?? value.model, `evaluators[${index}].model_ref`);
+  if (type === 'model_judge' && !modelRef) {
+    throw new TypeError(`evaluators[${index}].model_ref is required for model_judge`);
+  }
+  return {
+    evaluator_id: text(value.evaluator_id ?? value.id, `evaluators[${index}].evaluator_id`, { required: true }),
+    evaluator_version: text(value.evaluator_version ?? value.version, `evaluators[${index}].evaluator_version`, { required: true }),
+    type,
+    result,
+    score: boundedScore(value.score, `evaluators[${index}].score`),
+    model_ref: type === 'model_judge' ? modelRef : null,
+    rubric_hash: hashRef(value.rubric_hash, `evaluators[${index}].rubric_hash`, { required: true }),
+    evidence_refs: list(value.evidence_refs, `evaluators[${index}].evidence_refs`, { required: true }),
+    notes: text(value.notes, `evaluators[${index}].notes`, { max: 1000 }),
+  };
+}
+
+function authorityFlags() {
+  return {
+    evaluation_grants_authority: false,
+    can_spend: false,
+    can_fund_wallet: false,
+    can_deploy: false,
+    can_publish: false,
+    can_change_trust: false,
+    can_expand_scope: false,
+  };
+}
+
+export function normalizeEvaluationEvidence(input = {}) {
+  if (!isObject(input)) throw new TypeError('evaluation evidence must be an object');
+  const evaluators = Array.isArray(input.evaluators)
+    ? input.evaluators.map(normalizeEvaluator)
+    : [];
+  if (evaluators.length === 0) throw new TypeError('at least one evaluator is required');
+  const environmentId = text(input.environment_id, 'environment_id', { required: true });
+  const environmentVersion = text(input.environment_version, 'environment_version', { required: true });
+  const environmentHash = hashRef(input.environment_hash, 'environment_hash', { required: true });
+  const taskId = text(input.task_id, 'task_id', { required: true });
+  const harness = normalizeHarness(input.harness);
+  const traceHash = hashRef(input.trace_hash, 'trace_hash', { required: true });
+  const artifactRefs = list(input.artifact_refs, 'artifact_refs');
+  const observedAt = dateTime(input.observed_at, 'observed_at', { defaultNow: true });
+  const evidence = {
+    schema: EVIDENCE_SCHEMA,
+    evidence_id: text(input.evidence_id) || `taev_${sha256Ref({
+      environment: environmentId,
+      version: environmentVersion,
+      environmentHash,
+      task: taskId,
+      harness,
+      traceHash,
+      evaluators,
+    }).slice(7, 23)}`,
+    environment_id: environmentId,
+    environment_version: environmentVersion,
+    environment_hash: environmentHash,
+    task_id: taskId,
+    harness,
+    evaluators,
+    trace_hash: traceHash,
+    artifact_refs: artifactRefs,
+    observed_at: observedAt,
+    redaction_state: 'not_verified',
+    source_exactness: {
+      original_trace_embedded: false,
+      normalized_representation: true,
+      normalization_lossless: false,
+      verification_status: 'not_verified',
+    },
+    authority_flags: authorityFlags(),
+    evidence_hash: null,
+  };
+  evidence.evidence_hash = computeEvaluationEvidenceHash(evidence);
+  return evidence;
+}
+
+export function computeEvaluationEvidenceHash(evidence) {
+  if (!isObject(evidence)) throw new TypeError('evaluation evidence must be an object');
+  return sha256Ref({
+    ...structuredClone(evidence),
+    evidence_hash: null,
+  });
+}
+
+export function verifyEvaluationEvidence(evidence) {
+  if (!isObject(evidence) || evidence.schema !== EVIDENCE_SCHEMA) {
+    throw new TypeError(`evaluation evidence must use ${EVIDENCE_SCHEMA}`);
+  }
+  hashRef(evidence.evidence_hash, 'evidence_hash', { required: true });
+  if (evidence.evidence_hash !== computeEvaluationEvidenceHash(evidence)) {
+    throw new TypeError('evaluation evidence hash mismatch');
+  }
+  const normalized = normalizeEvaluationEvidence(evidence);
+  if (canonicalize(evidence) !== canonicalize(normalized)) {
+    throw new TypeError('evaluation evidence is not canonical or contains unverified claims');
+  }
+  return normalized;
+}
+
+function normalizeOrVerify(entry) {
+  return entry?.schema === EVIDENCE_SCHEMA
+    ? verifyEvaluationEvidence(entry)
+    : normalizeEvaluationEvidence(entry);
+}
+
+export function summarizeEvaluationEvidence(entries = []) {
+  if (!Array.isArray(entries)) throw new TypeError('entries must be an array');
+  const normalized = entries.map(normalizeOrVerify);
+  const evaluators = normalized.flatMap((entry) => entry.evaluators || []);
+  const deterministic = evaluators.filter((entry) => entry.type === 'deterministic');
+  const failed = evaluators.filter((entry) => entry.result === 'fail');
+  const review = evaluators.filter((entry) => entry.result === 'review');
+  const scores = evaluators.map((entry) => entry.score).filter((value) => typeof value === 'number');
+  let status = 'unknown';
+  if (failed.length > 0) status = 'failed';
+  else if (review.length > 0 || deterministic.length === 0) status = 'review';
+  else if (evaluators.length > 0 && evaluators.every((entry) => entry.result === 'pass')) status = 'passed';
+
+  return {
+    schema: SUMMARY_SCHEMA,
+    status,
+    evidence_count: normalized.length,
+    evaluator_count: evaluators.length,
+    deterministic_evaluator_count: deterministic.length,
+    failed_evaluator_ids: failed.map((entry) => entry.evaluator_id),
+    review_evaluator_ids: review.map((entry) => entry.evaluator_id),
+    mean_score: scores.length
+      ? Number((scores.reduce((sum, score) => sum + score, 0) / scores.length).toFixed(6))
+      : null,
+    complete_transaction_verified: false,
+    certification: false,
+    authority_granted: false,
+  };
+}
+
+export function attachEvaluationEvidence(envelope, entries) {
+  if (!isObject(envelope) || envelope.schema !== 'agoragentic.transaction-assurance-envelope.v1') {
+    throw new TypeError('envelope must use agoragentic.transaction-assurance-envelope.v1');
+  }
+  if (envelope.evidence?.envelope_hash !== computeEnvelopeHash(envelope)) {
+    throw new TypeError('envelope hash mismatch');
+  }
+  const source = Array.isArray(entries) ? entries : [entries];
+  if (source.length === 0) throw new TypeError('at least one evaluation evidence entry is required');
+  const existing = Array.isArray(envelope.evaluation_evidence)
+    ? envelope.evaluation_evidence.map(verifyEvaluationEvidence)
+    : [];
+  const normalized = source.map(normalizeOrVerify);
+  const attached = structuredClone(envelope);
+  attached.evaluation_evidence = [
+    ...existing,
+    ...normalized,
+  ];
+  attached.evaluation_summary = summarizeEvaluationEvidence(attached.evaluation_evidence);
+  attached.updated_at = new Date().toISOString();
+  attached.authority_flags = {
+    ...(attached.authority_flags || {}),
+    envelope_grants_authority: false,
+  };
+  if (!isObject(attached.evidence)) attached.evidence = {};
+  attached.evidence.complete_chain_verified = false;
+  attached.evidence.envelope_hash = null;
+  attached.evidence.envelope_hash = computeEnvelopeHash(attached);
+  return attached;
+}

--- a/transaction-assurance/test/evaluation-evidence.test.mjs
+++ b/transaction-assurance/test/evaluation-evidence.test.mjs
@@ -1,0 +1,246 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  attachEvaluationEvidence,
+  computeEvaluationEvidenceHash,
+  normalizeEvaluationEvidence,
+  summarizeEvaluationEvidence,
+  verifyEvaluationEvidence,
+} from '../src/evaluation-evidence.mjs';
+import {
+  buildTransactionAssuranceEnvelope,
+  computeEnvelopeHash,
+  normalizeAuthorityArtifact,
+  sha256Ref,
+} from '../src/index.mjs';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const EVIDENCE_SCHEMA = 'agoragentic.transaction-evaluation-evidence.v1';
+const HASH_A = `sha256:${'a'.repeat(64)}`;
+const HASH_B = `sha256:${'b'.repeat(64)}`;
+const HASH_C = `sha256:${'c'.repeat(64)}`;
+const OBSERVED_AT = '2026-08-06T00:02:00.000Z';
+
+const base = {
+  environment_id: 'agoragentic-transaction-assurance-v1',
+  environment_version: '0.1.0',
+  environment_hash: HASH_A,
+  task_id: 'ambiguous-paid-timeout',
+  harness: { id: 'prime-agent', version: '0.1.0' },
+  trace_hash: HASH_B,
+  artifact_refs: ['artifact:receipt'],
+  observed_at: OBSERVED_AT,
+  redaction_state: 'public_safe',
+  normalization_lossless: true,
+};
+
+function deterministicEvaluator(overrides = {}) {
+  return {
+    id: 'duplicate-retry',
+    version: '1',
+    type: 'deterministic',
+    result: 'pass',
+    score: 1,
+    rubric_hash: HASH_C,
+    evidence_refs: ['artifact:receipt'],
+    ...overrides,
+  };
+}
+
+function evidenceInput(overrides = {}) {
+  return {
+    ...base,
+    evaluators: [deterministicEvaluator()],
+    ...overrides,
+  };
+}
+
+function transactionEnvelope() {
+  const normalizedAuthority = normalizeAuthorityArtifact({
+    schema: 'agoragentic.agent-commerce.mandate.v1',
+    owner_id: 'owner:test',
+    buyer_agent_id: 'agent:test',
+    scope: {
+      allowed_actions: ['execute:research'],
+      allowed_sellers: ['seller:test'],
+      allowed_categories: ['research'],
+      allowed_payment_rails: ['x402'],
+    },
+    budget: {
+      currency: 'USDC',
+      max_per_action: '0.10',
+      max_daily: '1.00',
+      max_total: '5.00',
+    },
+  });
+
+  return buildTransactionAssuranceEnvelope({
+    createdAt: '2026-08-06T00:01:00Z',
+    updatedAt: '2026-08-06T00:01:00Z',
+    now: '2026-08-06T00:01:00Z',
+    normalizedAuthority,
+    commercialIntent: {
+      action: 'execute:research',
+      taskRef: 'task:test',
+      sellerRef: 'seller:test',
+      capabilityRef: 'capability:test',
+      category: 'research',
+      quotedAmount: '0.05',
+      currency: 'USDC',
+    },
+    payment: {
+      paymentIdentifier: 'payment:test',
+      rail: 'x402',
+      amount: '0.05',
+      currency: 'USDC',
+    },
+    execution: {
+      idempotencyKeyHash: sha256Ref('idempotency:test'),
+      inputHash: sha256Ref({ query: 'test' }),
+    },
+  });
+}
+
+test('normalizes lineage-complete evidence and verifies its detached hash', () => {
+  const evidence = normalizeEvaluationEvidence(evidenceInput());
+  assert.equal(evidence.schema, EVIDENCE_SCHEMA);
+  assert.equal(evidence.evidence_hash, computeEvaluationEvidenceHash(evidence));
+  assert.deepEqual(verifyEvaluationEvidence(evidence), evidence);
+  assert.equal(evidence.redaction_state, 'not_verified');
+  assert.equal(evidence.source_exactness.normalization_lossless, false);
+  assert.equal(evidence.source_exactness.verification_status, 'not_verified');
+  assert.equal(evidence.authority_flags.evaluation_grants_authority, false);
+});
+
+test('requires hashes and evaluator provenance before accepting evidence', () => {
+  assert.throws(() => normalizeEvaluationEvidence({ evaluators: [] }), /at least one evaluator/);
+  assert.throws(() => normalizeEvaluationEvidence(evidenceInput({ environment_hash: null })), /environment_hash is required/);
+  assert.throws(() => normalizeEvaluationEvidence(evidenceInput({ harness: null })), /harness must be an object/);
+  assert.throws(() => normalizeEvaluationEvidence(evidenceInput({ trace_hash: 'sha256:short' })), /trace_hash must be a sha256/);
+  assert.throws(() => normalizeEvaluationEvidence(evidenceInput({
+    evaluators: [deterministicEvaluator({ rubric_hash: null })],
+  })), /rubric_hash is required/);
+  assert.throws(() => normalizeEvaluationEvidence(evidenceInput({
+    evaluators: [deterministicEvaluator({ evidence_refs: [] })],
+  })), /evidence_refs requires at least one item/);
+  assert.throws(() => normalizeEvaluationEvidence(evidenceInput({
+    evaluators: [deterministicEvaluator({ type: 'model_judge', model_ref: null })],
+  })), /model_ref is required/);
+});
+
+test('rejects unsupported evaluator types and scores outside the bounded range', () => {
+  assert.throws(() => normalizeEvaluationEvidence(evidenceInput({
+    evaluators: [deterministicEvaluator({ type: 'unsupported' })],
+  })), /unsupported evaluator type/);
+  assert.throws(() => normalizeEvaluationEvidence(evidenceInput({
+    evaluators: [deterministicEvaluator({ score: 2 })],
+  })), /between 0 and 1/);
+});
+
+test('deterministic passing evidence can produce only a scoped passed summary', () => {
+  const normalized = normalizeEvaluationEvidence(evidenceInput());
+  const summary = summarizeEvaluationEvidence([normalized]);
+  assert.equal(summary.status, 'passed');
+  assert.equal(summary.complete_transaction_verified, false);
+  assert.equal(summary.certification, false);
+  assert.equal(summary.authority_granted, false);
+});
+
+test('model-judge-only evidence remains review even with complete model lineage', () => {
+  const summary = summarizeEvaluationEvidence([evidenceInput({
+    evaluators: [deterministicEvaluator({
+      id: 'semantic',
+      type: 'model_judge',
+      model_ref: 'model:1',
+      score: 0.9,
+    })],
+  })]);
+  assert.equal(summary.status, 'review');
+  assert.equal(summary.mean_score, 0.9);
+});
+
+test('any failed evaluator fails the scoped evaluation summary', () => {
+  const summary = summarizeEvaluationEvidence([evidenceInput({
+    evaluators: [deterministicEvaluator({ id: 'delivery', result: 'fail', score: 0 })],
+  })]);
+  assert.equal(summary.status, 'failed');
+  assert.deepEqual(summary.failed_evaluator_ids, ['delivery']);
+});
+
+test('a matching schema tag cannot bypass required fields or hash verification', () => {
+  assert.throws(() => summarizeEvaluationEvidence([{
+    schema: EVIDENCE_SCHEMA,
+    evaluators: [deterministicEvaluator()],
+  }]), /evidence_hash is required/);
+
+  const evidence = normalizeEvaluationEvidence(evidenceInput());
+  const tampered = structuredClone(evidence);
+  tampered.evaluators[0].result = 'fail';
+  assert.throws(() => summarizeEvaluationEvidence([tampered]), /hash mismatch/);
+});
+
+test('rehashed caller privacy claims remain non-canonical and are rejected', () => {
+  const evidence = normalizeEvaluationEvidence(evidenceInput());
+  const rehashedClaim = {
+    ...evidence,
+    redaction_state: 'public_safe',
+  };
+  rehashedClaim.evidence_hash = computeEvaluationEvidenceHash(rehashedClaim);
+  assert.throws(() => verifyEvaluationEvidence(rehashedClaim), /unverified claims/);
+});
+
+test('arbitrary text remains explicitly unreviewed instead of being labeled public-safe', () => {
+  const sentinel = 'NOT_A_REAL_SECRET_SENTINEL_123456';
+  const evidence = normalizeEvaluationEvidence(evidenceInput({
+    evaluators: [deterministicEvaluator({ notes: sentinel })],
+    redaction_state: 'public_safe',
+  }));
+  assert.equal(evidence.evaluators[0].notes, sentinel);
+  assert.equal(evidence.redaction_state, 'not_verified');
+  assert.equal(evidence.source_exactness.verification_status, 'not_verified');
+});
+
+test('attaches verified evidence and recomputes the parent envelope hash last', () => {
+  const envelope = transactionEnvelope();
+  const attached = attachEvaluationEvidence(envelope, evidenceInput());
+  assert.equal(attached.evaluation_evidence.length, 1);
+  assert.equal(attached.evaluation_summary.status, 'passed');
+  assert.equal(attached.evidence.complete_chain_verified, false);
+  assert.equal(attached.evidence.envelope_hash, computeEnvelopeHash(attached));
+  assert.deepEqual(verifyEvaluationEvidence(attached.evaluation_evidence[0]), attached.evaluation_evidence[0]);
+  assert.equal(envelope.evaluation_evidence, undefined);
+});
+
+test('rejects a stale envelope hash and tampered previously attached evidence', () => {
+  const staleEnvelope = transactionEnvelope();
+  staleEnvelope.payment.amount = '0.06';
+  assert.throws(() => attachEvaluationEvidence(staleEnvelope, evidenceInput()), /envelope hash mismatch/);
+
+  const attached = attachEvaluationEvidence(transactionEnvelope(), evidenceInput());
+  attached.evaluation_evidence[0].evaluators[0].result = 'fail';
+  attached.evidence.envelope_hash = computeEnvelopeHash(attached);
+  assert.throws(() => attachEvaluationEvidence(attached, evidenceInput({
+    task_id: 'second-evaluation',
+  })), /evaluation evidence hash mismatch/);
+});
+
+test('schema and package metadata preserve the integrity and export contracts', () => {
+  const schema = JSON.parse(fs.readFileSync(
+    path.join(root, 'schema', 'transaction-evaluation-evidence.v1.json'),
+    'utf8',
+  ));
+  for (const field of ['environment_hash', 'harness', 'trace_hash', 'artifact_refs', 'evidence_hash']) {
+    assert.ok(schema.required.includes(field), `${field} must remain required`);
+  }
+  assert.equal(schema.properties.redaction_state.const, 'not_verified');
+  assert.equal(schema.properties.source_exactness.properties.normalization_lossless.const, false);
+  assert.equal(schema.properties.source_exactness.properties.verification_status.const, 'not_verified');
+
+  const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+  assert.equal(pkg.exports['./evaluation-evidence'], './src/evaluation-evidence.mjs');
+  assert.ok(pkg.files.includes('EVALUATION_EVIDENCE.md'));
+  assert.match(pkg.scripts.check, /src\/evaluation-evidence\.mjs/);
+});


### PR DESCRIPTION
Builds on the merged Transaction Assurance core from #240 and implements the evaluator-evidence layer identified by the Braintrust and Prime Verifiers audits.

## Product change

Extends the local record with scoped outcome-evaluation evidence while keeping authority, settlement, delivery, and complete-chain verification independent.

## What ships

- `@agoragentic/transaction-assurance/evaluation-evidence` package export
- versioned, closed JSON Schema
- required environment, harness, task, trace, rubric, model, and artifact lineage
- deterministic, model-judge, human-review, and external-attestation types
- detached canonical evidence hashes and verified attachment to a valid source envelope
- fail-closed handling for schema-tag spoofing, stale hashes, tampering, and caller privacy claims
- truthful `not_verified` redaction/source-exactness states
- scoped summaries that never grant authority, certification, or complete-chain verification
- 12 focused evidence tests plus the 23 core tests

## Validation on exact head

- `npm test` — 35/35
- `npm run check`
- `npm run self-test` — no network, no spend
- package dry-run/install/import smoke performed during repair
- `node scripts/verify-integrations-json.js`
- dedicated Node 20/22/24 workflow plus the full Transaction Assurance workflow

This remains a private alpha package surface. It makes no network call, moves no money, invokes no provider, and grants no deployment, publication, wallet, trust, or scope authority.