### PR TITLE
Add a scoped TOPLOC inference-attestation adapter

### DIFF
--- a/.github/workflows/transaction-assurance-toploc-evidence.yml
+++ b/.github/workflows/transaction-assurance-toploc-evidence.yml
@@ -1,0 +1,62 @@
+name: Transaction Assurance TOPLOC Evidence
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'transaction-assurance/**'
+      - '.github/workflows/transaction-assurance-toploc-evidence.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'transaction-assurance/**'
+      - '.github/workflows/transaction-assurance-toploc-evidence.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22, 24]
+    env:
+      AGORAGENTIC_NO_SPEND: '1'
+      AGORAGENTIC_ALLOW_REAL_SPEND: '0'
+      AGORAGENTIC_ALLOW_NETWORK_CANARIES: '0'
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Parse package JSON and TOPLOC schema
+        working-directory: transaction-assurance
+        run: |
+          node -e "for (const file of [
+            'package.json',
+            'schema/toploc-inference-attestation.v1.json'
+          ]) { JSON.parse(require('node:fs').readFileSync(file, 'utf8')); console.log('parsed', file); }"
+      - name: Syntax checks
+        working-directory: transaction-assurance
+        run: npm run check
+      - name: Full package tests
+        working-directory: transaction-assurance
+        run: npm test
+      - name: No-network self-test
+        working-directory: transaction-assurance
+        run: npm run self-test
+      - name: Build example envelope
+        working-directory: transaction-assurance
+        run: node examples/build-envelope.mjs
+      - name: Package export smoke
+        working-directory: transaction-assurance
+        run: node -e "Promise.all([import('@agoragentic/transaction-assurance'), import('@agoragentic/transaction-assurance/evaluation-evidence'), import('@agoragentic/transaction-assurance/toploc-evidence')]).then(() => console.log('package exports loaded'))"
+      - name: Package dry run
+        working-directory: transaction-assurance
+        run: npm run pack:dry

--- a/transaction-assurance/TOPLOC_EVIDENCE.md
+++ b/transaction-assurance/TOPLOC_EVIDENCE.md
@@ -1,0 +1,53 @@
+# Optional TOPLOC Evidence
+
+Transaction Assurance can carry a scoped TOPLOC result reference as one untrusted piece of inference evidence.
+
+```javascript
+import {
+  attachToplocEvidence,
+  computeToplocAttestationHash,
+  normalizeToplocEvidence,
+  summarizeToplocEvidence,
+  verifyToplocEvidence,
+} from '@agoragentic/transaction-assurance/toploc-evidence';
+```
+
+## Scope
+
+The adapter records the result declared by its caller for one model, configuration, proof, validator, and execution scope:
+
+```text
+scope = model_configuration_execution
+```
+
+It requires an exact TOPLOC scheme version, model reference, lowercase SHA-256 configuration hash, proof reference and hash, validator reference and version, status, validation timestamp for final statuses, and optional bounded evidence references. Each collection is capped at 100 attestations and rejects duplicate `attestation_id` values. Raw activations and raw proof payload fields are rejected; keep source material in an access-controlled evidence store.
+
+## Verification Boundary
+
+This adapter does not run TOPLOC, authenticate the validator, retrieve the referenced proof, compare source bytes, or scan caller strings for private data. Consequently every normalized v1 record is explicit about these states:
+
+```text
+trust.verification_status = not_verified
+provenance.verification_status = not_verified
+privacy.verification_status = not_verified
+privacy.public_safe_status = not_verified
+source_exactness.verification_status = not_verified
+```
+
+An `accept` status is the caller's declared validator result. It is not trusted proof. Summaries preserve the declared result but never report a trusted acceptance; absent a declared rejection, their actionable status remains `review`.
+
+The adapter rejects caller-supplied authority, certification, trust, public-safety, and source-exactness fields. A future adapter may promote those states only after a real, separately reviewed scanner or verifier runs and supplies durable evidence.
+
+## Reproducible Hashes
+
+`attestation_hash` is SHA-256 over the canonical UTF-8 JSON of the complete attestation with only `attestation_hash` replaced by `null`. `computeToplocAttestationHash(attestation)` reproduces this value. The hash is assigned after every other attestation field is final.
+
+`verifyToplocEvidence(attestation)` requires JSON-only values, checks the embedded hash, and then reconstructs the exact canonical v1 object. A matching self-hash detects mutation; it does not authenticate the caller, validator, source proof, or provenance.
+
+`attachToplocEvidence(envelope, entries, { updatedAt })` first verifies the parent envelope hash, every existing schema-tagged TOPLOC entry, and any existing summary. It then attaches normalized evidence, clears `complete_chain_verified`, finalizes `updated_at`, and computes `evidence.envelope_hash` last with the parent package's `computeEnvelopeHash` recipe.
+
+## Non-claims
+
+A TOPLOC attestation does not by itself prove output correctness, task fulfillment, seller identity, payment settlement, delivery, full transaction reconciliation, certification, trust, or authority. The Transaction Assurance evaluator must still bind principal authority, seller and terms, payment, execution, delivery, outcome validation, and reconciliation.
+
+This is a generic evidence adapter, not a partnership or validated package-compatibility claim. The package remains private and unpublished while external compatibility and release provenance are incomplete.

--- a/transaction-assurance/package.json
+++ b/transaction-assurance/package.json
@@ -13,7 +13,8 @@
   },
   "exports": {
     ".": "./src/index.mjs",
-    "./evaluation-evidence": "./src/evaluation-evidence.mjs"
+    "./evaluation-evidence": "./src/evaluation-evidence.mjs",
+    "./toploc-evidence": "./src/toploc-evidence.mjs"
   },
   "files": [
     "bin/",
@@ -23,11 +24,12 @@
     "SKILL.md",
     "README.md",
     "EVALUATION_EVIDENCE.md",
+    "TOPLOC_EVIDENCE.md",
     "LICENSE"
   ],
   "scripts": {
     "test": "node --test test/*.test.mjs",
-    "check": "node --check src/index.mjs && node --check src/evaluation-evidence.mjs && node --check bin/agora-assure.mjs",
+    "check": "node --check src/index.mjs && node --check src/evaluation-evidence.mjs && node --check src/toploc-evidence.mjs && node --check bin/agora-assure.mjs",
     "self-test": "node bin/agora-assure.mjs self-test",
     "pack:dry": "npm pack --dry-run"
   },

--- a/transaction-assurance/schema/toploc-inference-attestation.v1.json
+++ b/transaction-assurance/schema/toploc-inference-attestation.v1.json
@@ -1,0 +1,166 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agoragentic.com/schemas/toploc-inference-attestation.v1.json",
+  "title": "Agoragentic TOPLOC Inference Attestation v1",
+  "description": "A caller-supplied, self-hashed TOPLOC result reference. The record is not trusted proof, privacy verification, public-safety verification, or source-exactness verification.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "attestation_id",
+    "scheme",
+    "scheme_version",
+    "model_ref",
+    "configuration_hash",
+    "proof_ref",
+    "proof_hash",
+    "validator",
+    "status",
+    "checked_at",
+    "evidence_refs",
+    "scope",
+    "source_artifact_embedded",
+    "trust",
+    "provenance",
+    "privacy",
+    "source_exactness",
+    "non_claims",
+    "authority_flags",
+    "attestation_hash"
+  ],
+  "properties": {
+    "schema": { "const": "agoragentic.toploc-inference-attestation.v1" },
+    "attestation_id": { "type": "string", "minLength": 1, "maxLength": 500 },
+    "scheme": { "const": "toploc" },
+    "scheme_version": { "type": "string", "minLength": 1, "maxLength": 500 },
+    "model_ref": { "type": "string", "minLength": 1, "maxLength": 2000 },
+    "configuration_hash": { "$ref": "#/$defs/sha256" },
+    "proof_ref": { "type": "string", "minLength": 1, "maxLength": 2000 },
+    "proof_hash": { "$ref": "#/$defs/sha256" },
+    "validator": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ref", "version"],
+      "properties": {
+        "ref": { "type": "string", "minLength": 1, "maxLength": 2000 },
+        "version": { "type": "string", "minLength": 1, "maxLength": 500 }
+      }
+    },
+    "status": { "enum": ["accept", "reject", "pending", "not_checked", "error"] },
+    "checked_at": { "type": ["string", "null"], "format": "date-time" },
+    "evidence_refs": {
+      "type": "array",
+      "maxItems": 100,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1, "maxLength": 2000 }
+    },
+    "scope": { "const": "model_configuration_execution" },
+    "source_artifact_embedded": { "const": false },
+    "trust": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["verification_status", "trusted_proof", "caller_supplied"],
+      "properties": {
+        "verification_status": { "const": "not_verified" },
+        "trusted_proof": { "const": false },
+        "caller_supplied": { "const": true }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "verification_status",
+        "validator_identity_verified",
+        "proof_binding_verified"
+      ],
+      "properties": {
+        "verification_status": { "const": "not_verified" },
+        "validator_identity_verified": { "const": false },
+        "proof_binding_verified": { "const": false }
+      }
+    },
+    "privacy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["verification_status", "public_safe_status"],
+      "properties": {
+        "verification_status": { "const": "not_verified" },
+        "public_safe_status": { "const": "not_verified" }
+      }
+    },
+    "source_exactness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["verification_status", "exact_source_verified"],
+      "properties": {
+        "verification_status": { "const": "not_verified" },
+        "exact_source_verified": { "const": false }
+      }
+    },
+    "non_claims": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "output_correctness_proven",
+        "task_fulfillment_proven",
+        "seller_identity_proven",
+        "payment_settlement_proven",
+        "delivery_proven",
+        "complete_transaction_verified",
+        "certification",
+        "trust_endorsement"
+      ],
+      "properties": {
+        "output_correctness_proven": { "const": false },
+        "task_fulfillment_proven": { "const": false },
+        "seller_identity_proven": { "const": false },
+        "payment_settlement_proven": { "const": false },
+        "delivery_proven": { "const": false },
+        "complete_transaction_verified": { "const": false },
+        "certification": { "const": false },
+        "trust_endorsement": { "const": false }
+      }
+    },
+    "authority_flags": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "attestation_grants_authority",
+        "can_spend",
+        "can_fund_wallet",
+        "can_deploy",
+        "can_publish",
+        "can_change_trust",
+        "can_expand_scope"
+      ],
+      "properties": {
+        "attestation_grants_authority": { "const": false },
+        "can_spend": { "const": false },
+        "can_fund_wallet": { "const": false },
+        "can_deploy": { "const": false },
+        "can_publish": { "const": false },
+        "can_change_trust": { "const": false },
+        "can_expand_scope": { "const": false }
+      }
+    },
+    "attestation_hash": { "$ref": "#/$defs/sha256" }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "status": { "enum": ["accept", "reject"] } },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": { "checked_at": { "type": "string", "format": "date-time" } }
+      }
+    }
+  ],
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^sha256:[0-9a-f]{64}$"
+    }
+  }
+}

--- a/transaction-assurance/src/toploc-evidence.mjs
+++ b/transaction-assurance/src/toploc-evidence.mjs
@@ -1,0 +1,350 @@
+import { canonicalize, computeEnvelopeHash, sha256Ref } from './index.mjs';
+
+export const TOPLOC_ATTESTATION_SCHEMA = 'agoragentic.toploc-inference-attestation.v1';
+export const TOPLOC_SUMMARY_SCHEMA = 'agoragentic.toploc-inference-attestation-summary.v1';
+
+const STATUSES = new Set(['accept', 'reject', 'pending', 'not_checked', 'error']);
+const FINAL_STATUSES = new Set(['accept', 'reject']);
+const SHA256_PATTERN = /^sha256:[0-9a-f]{64}$/;
+const RAW_INPUT_FIELDS = new Set([
+  'attestation_id',
+  'scheme_version',
+  'model_ref',
+  'configuration_hash',
+  'proof_ref',
+  'proof_hash',
+  'validator_ref',
+  'validator_version',
+  'status',
+  'checked_at',
+  'evidence_refs',
+]);
+const RAW_PAYLOAD_FIELDS = new Set([
+  'proof',
+  'raw_proof',
+  'raw_proof_payload',
+  'activations',
+  'raw_activations',
+]);
+
+function isObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function assertJsonValue(value, field) {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return;
+  if (typeof value === 'number' && Number.isFinite(value)) return;
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      if (!Object.hasOwn(value, index)) throw new TypeError(`${field}[${index}] must contain a JSON value`);
+      assertJsonValue(value[index], `${field}[${index}]`);
+    }
+    return;
+  }
+  if (isObject(value)) {
+    for (const [key, child] of Object.entries(value)) {
+      assertJsonValue(child, `${field}.${key}`);
+    }
+    return;
+  }
+  throw new TypeError(`${field} must contain JSON values only`);
+}
+
+function requiredText(value, field, maxLength = 2000) {
+  if (typeof value !== 'string') throw new TypeError(`${field} must be a string`);
+  const normalized = value.trim();
+  if (!normalized) throw new TypeError(`${field} is required`);
+  if (normalized.length > maxLength) throw new TypeError(`${field} exceeds ${maxLength} characters`);
+  return normalized;
+}
+
+function optionalText(value, field, maxLength = 2000) {
+  if (value === undefined || value === null) return null;
+  return requiredText(value, field, maxLength);
+}
+
+function requiredSha256(value, field) {
+  const normalized = requiredText(value, field, 71);
+  if (!SHA256_PATTERN.test(normalized)) {
+    throw new TypeError(`${field} must be a lowercase sha256:<64 hex characters> reference`);
+  }
+  return normalized;
+}
+
+function normalizeDate(value, field, required = false) {
+  if (value === undefined || value === null || value === '') {
+    if (required) throw new TypeError(`${field} is required for final validator statuses`);
+    return null;
+  }
+  if (typeof value !== 'string' && !(value instanceof Date)) {
+    throw new TypeError(`${field} must be a valid date-time`);
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) throw new TypeError(`${field} must be a valid date-time`);
+  return parsed.toISOString();
+}
+
+function normalizeEvidenceRefs(value) {
+  if (value === undefined || value === null) return [];
+  const source = Array.isArray(value) ? value : [value];
+  if (source.length > 100) throw new TypeError('evidence_refs must contain at most 100 entries');
+  const normalized = [];
+  for (let index = 0; index < source.length; index += 1) {
+    if (!Object.hasOwn(source, index)) {
+      throw new TypeError(`evidence_refs[${index}] must contain a string`);
+    }
+    normalized.push(requiredText(source[index], `evidence_refs[${index}]`, 2000));
+  }
+  return [...new Set(normalized)];
+}
+
+function nonClaims() {
+  return {
+    output_correctness_proven: false,
+    task_fulfillment_proven: false,
+    seller_identity_proven: false,
+    payment_settlement_proven: false,
+    delivery_proven: false,
+    complete_transaction_verified: false,
+    certification: false,
+    trust_endorsement: false,
+  };
+}
+
+function authorityFlags() {
+  return {
+    attestation_grants_authority: false,
+    can_spend: false,
+    can_fund_wallet: false,
+    can_deploy: false,
+    can_publish: false,
+    can_change_trust: false,
+    can_expand_scope: false,
+  };
+}
+
+function assertRawInputFields(input) {
+  for (const field of Object.keys(input)) {
+    if (RAW_PAYLOAD_FIELDS.has(field)) {
+      throw new TypeError('embed no raw proof or activations; use references and SHA-256 hashes');
+    }
+    if (!RAW_INPUT_FIELDS.has(field)) {
+      throw new TypeError(`unsupported TOPLOC evidence field: ${field}`);
+    }
+  }
+}
+
+export function computeToplocAttestationHash(attestation) {
+  if (!isObject(attestation)) throw new TypeError('TOPLOC attestation must be an object');
+  return sha256Ref({
+    ...attestation,
+    attestation_hash: null,
+  });
+}
+
+function buildToplocEvidence(input) {
+  assertRawInputFields(input);
+  const status = requiredText(input.status, 'status', 32);
+  if (!STATUSES.has(status)) throw new TypeError(`unsupported TOPLOC validation status: ${status}`);
+
+  const schemeVersion = requiredText(input.scheme_version, 'scheme_version', 500);
+  const modelRef = requiredText(input.model_ref, 'model_ref');
+  const configurationHash = requiredSha256(input.configuration_hash, 'configuration_hash');
+  const proofRef = requiredText(input.proof_ref, 'proof_ref');
+  const proofHash = requiredSha256(input.proof_hash, 'proof_hash');
+  const validatorRef = requiredText(input.validator_ref, 'validator_ref');
+  const validatorVersion = requiredText(input.validator_version, 'validator_version', 500);
+  const checkedAt = normalizeDate(input.checked_at, 'checked_at', FINAL_STATUSES.has(status));
+  const evidenceRefs = normalizeEvidenceRefs(input.evidence_refs);
+  const attestationId = optionalText(input.attestation_id, 'attestation_id', 500)
+    || `toploc_${sha256Ref({
+      scheme_version: schemeVersion,
+      model_ref: modelRef,
+      configuration_hash: configurationHash,
+      proof_ref: proofRef,
+      proof_hash: proofHash,
+      validator_ref: validatorRef,
+      validator_version: validatorVersion,
+      status,
+      checked_at: checkedAt,
+    }).slice(7, 23)}`;
+
+  const attestation = {
+    schema: TOPLOC_ATTESTATION_SCHEMA,
+    attestation_id: attestationId,
+    scheme: 'toploc',
+    scheme_version: schemeVersion,
+    model_ref: modelRef,
+    configuration_hash: configurationHash,
+    proof_ref: proofRef,
+    proof_hash: proofHash,
+    validator: {
+      ref: validatorRef,
+      version: validatorVersion,
+    },
+    status,
+    checked_at: checkedAt,
+    evidence_refs: evidenceRefs,
+    scope: 'model_configuration_execution',
+    source_artifact_embedded: false,
+    trust: {
+      verification_status: 'not_verified',
+      trusted_proof: false,
+      caller_supplied: true,
+    },
+    provenance: {
+      verification_status: 'not_verified',
+      validator_identity_verified: false,
+      proof_binding_verified: false,
+    },
+    privacy: {
+      verification_status: 'not_verified',
+      public_safe_status: 'not_verified',
+    },
+    source_exactness: {
+      verification_status: 'not_verified',
+      exact_source_verified: false,
+    },
+    non_claims: nonClaims(),
+    authority_flags: authorityFlags(),
+    attestation_hash: null,
+  };
+
+  attestation.attestation_hash = computeToplocAttestationHash(attestation);
+  return attestation;
+}
+
+export function verifyToplocEvidence(attestation) {
+  if (!isObject(attestation) || attestation.schema !== TOPLOC_ATTESTATION_SCHEMA) {
+    throw new TypeError(`TOPLOC attestation must use ${TOPLOC_ATTESTATION_SCHEMA}`);
+  }
+  assertJsonValue(attestation, 'TOPLOC attestation');
+  const suppliedHash = requiredSha256(attestation.attestation_hash, 'attestation_hash');
+  const expectedHash = computeToplocAttestationHash(attestation);
+  if (suppliedHash !== expectedHash) throw new TypeError('TOPLOC attestation hash mismatch');
+
+  const normalized = buildToplocEvidence({
+    attestation_id: attestation.attestation_id,
+    scheme_version: attestation.scheme_version,
+    model_ref: attestation.model_ref,
+    configuration_hash: attestation.configuration_hash,
+    proof_ref: attestation.proof_ref,
+    proof_hash: attestation.proof_hash,
+    validator_ref: attestation.validator?.ref,
+    validator_version: attestation.validator?.version,
+    status: attestation.status,
+    checked_at: attestation.checked_at,
+    evidence_refs: attestation.evidence_refs,
+  });
+  if (canonicalize(attestation) !== canonicalize(normalized)) {
+    throw new TypeError('TOPLOC attestation is not the canonical v1 shape');
+  }
+  return normalized;
+}
+
+export function normalizeToplocEvidence(input = {}) {
+  if (!isObject(input)) throw new TypeError('TOPLOC evidence must be an object');
+  if (Object.hasOwn(input, 'schema')) {
+    if (input.schema !== TOPLOC_ATTESTATION_SCHEMA) {
+      throw new TypeError(`unsupported TOPLOC evidence schema: ${input.schema}`);
+    }
+    return verifyToplocEvidence(input);
+  }
+  return buildToplocEvidence(input);
+}
+
+function normalizeEntries(entries) {
+  if (entries.length > 100) throw new TypeError('entries must contain at most 100 TOPLOC attestations');
+  const normalized = [];
+  const attestationIds = new Set();
+  for (let index = 0; index < entries.length; index += 1) {
+    if (!Object.hasOwn(entries, index)) {
+      throw new TypeError(`entries[${index}] must contain a TOPLOC attestation`);
+    }
+    const attestation = normalizeToplocEvidence(entries[index]);
+    if (attestationIds.has(attestation.attestation_id)) {
+      throw new TypeError(`duplicate TOPLOC attestation_id: ${attestation.attestation_id}`);
+    }
+    attestationIds.add(attestation.attestation_id);
+    normalized.push(attestation);
+  }
+  return normalized;
+}
+
+export function summarizeToplocEvidence(entries = []) {
+  if (!Array.isArray(entries)) throw new TypeError('entries must be an array');
+  const normalized = normalizeEntries(entries);
+  const declaredAcceptCount = normalized.filter((entry) => entry.status === 'accept').length;
+  const declaredRejectCount = normalized.filter((entry) => entry.status === 'reject').length;
+  const declaredReviewCount = normalized.length - declaredAcceptCount - declaredRejectCount;
+  const declaredValidationResult = declaredRejectCount > 0
+    ? 'rejected'
+    : declaredAcceptCount === normalized.length && normalized.length > 0
+      ? 'accepted'
+      : 'review';
+
+  return {
+    schema: TOPLOC_SUMMARY_SCHEMA,
+    status: declaredRejectCount > 0 ? 'rejected' : 'review',
+    declared_validation_result: declaredValidationResult,
+    attestation_count: normalized.length,
+    declared_accept_count: declaredAcceptCount,
+    declared_reject_count: declaredRejectCount,
+    declared_review_count: declaredReviewCount,
+    scope: 'model_configuration_execution',
+    verification_status: 'not_verified',
+    provenance_verification_status: 'not_verified',
+    source_exactness_verification_status: 'not_verified',
+    privacy_verification_status: 'not_verified',
+    public_safe_verification_status: 'not_verified',
+    trusted_proof: false,
+    ...nonClaims(),
+    authority_granted: false,
+  };
+}
+
+function verifyEnvelopeHash(envelope) {
+  if (!isObject(envelope.evidence)) throw new TypeError('envelope.evidence must be an object');
+  const suppliedHash = requiredSha256(envelope.evidence.envelope_hash, 'envelope.evidence.envelope_hash');
+  if (suppliedHash !== computeEnvelopeHash(envelope)) {
+    throw new TypeError('transaction assurance envelope hash mismatch');
+  }
+}
+
+export function attachToplocEvidence(envelope, entries, options = {}) {
+  if (!isObject(envelope) || envelope.schema !== 'agoragentic.transaction-assurance-envelope.v1') {
+    throw new TypeError('envelope must use agoragentic.transaction-assurance-envelope.v1');
+  }
+  assertJsonValue(envelope, 'envelope');
+  if (!isObject(options)) throw new TypeError('options must be an object');
+  for (const field of Object.keys(options)) {
+    if (field !== 'updatedAt') throw new TypeError(`unsupported attach option: ${field}`);
+  }
+  verifyEnvelopeHash(envelope);
+
+  if (envelope.inference_attestations !== undefined
+    && !Array.isArray(envelope.inference_attestations)) {
+    throw new TypeError('envelope.inference_attestations must be an array');
+  }
+  const existing = normalizeEntries(envelope.inference_attestations || []);
+  const expectedExistingSummary = summarizeToplocEvidence(existing);
+  if (envelope.inference_attestation_summary !== undefined
+    && canonicalize(envelope.inference_attestation_summary) !== canonicalize(expectedExistingSummary)) {
+    throw new TypeError('existing TOPLOC attestation summary mismatch');
+  }
+
+  const source = Array.isArray(entries) ? entries : [entries];
+  if (source.length === 0) throw new TypeError('at least one TOPLOC attestation is required');
+  const normalized = normalizeEntries(source);
+  const updatedAt = normalizeDate(options.updatedAt ?? new Date(), 'updatedAt', true);
+  const attached = structuredClone(envelope);
+  attached.inference_attestations = [...existing, ...normalized];
+  attached.inference_attestation_summary = summarizeToplocEvidence(attached.inference_attestations);
+  attached.evidence.complete_chain_verified = false;
+  attached.updated_at = updatedAt;
+  attached.evidence.envelope_hash = null;
+  attached.evidence.envelope_hash = computeEnvelopeHash(attached);
+  return attached;
+}

--- a/transaction-assurance/test/toploc-evidence.test.mjs
+++ b/transaction-assurance/test/toploc-evidence.test.mjs
@@ -1,0 +1,327 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  buildTransactionAssuranceEnvelope,
+  computeEnvelopeHash,
+  evaluateTransactionAssuranceEnvelope,
+  normalizeAuthorityArtifact,
+  sha256Ref,
+} from '../src/index.mjs';
+import {
+  attachToplocEvidence,
+  computeToplocAttestationHash,
+  normalizeToplocEvidence,
+  summarizeToplocEvidence,
+  TOPLOC_ATTESTATION_SCHEMA,
+  verifyToplocEvidence,
+} from '../src/toploc-evidence.mjs';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const NOW = '2026-08-07T00:01:00.000Z';
+
+function acceptedInput(overrides = {}) {
+  return {
+    scheme_version: 'paper-2025-01',
+    model_ref: 'model:qwen:test-fixture',
+    configuration_hash: sha256Ref({ model: 'qwen', configuration: 'fixture' }),
+    proof_ref: 'vault://toploc/proof/1',
+    proof_hash: sha256Ref({ proof: 'fixture' }),
+    validator_ref: 'validator://toploc/test-fixture',
+    validator_version: '0.1.0-test',
+    status: 'accept',
+    checked_at: '2026-08-07T00:00:00.000Z',
+    evidence_refs: ['evidence:toploc:test-fixture'],
+    ...overrides,
+  };
+}
+
+function buildEnvelope() {
+  const normalizedAuthority = normalizeAuthorityArtifact({
+    schema: 'agoragentic.agent-commerce.mandate.v1',
+    owner_id: 'owner:test',
+    buyer_agent_id: 'agent:test',
+    issued_at: '2026-08-07T00:00:00.000Z',
+    expires_at: '2026-08-08T00:00:00.000Z',
+    scope: {
+      allowed_actions: ['execute:research'],
+      allowed_sellers: ['seller:test'],
+      allowed_categories: ['research'],
+      allowed_payment_rails: ['x402'],
+    },
+    budget: {
+      currency: 'USDC',
+      max_per_action: '0.10',
+      max_daily: '1.00',
+      max_total: '5.00',
+    },
+  }, {
+    artifactRef: 'fixture:mandate',
+    verification: {
+      status: 'verified',
+      verifierRef: 'fixture:authority-verifier',
+      evidenceRef: 'fixture:authority-proof',
+      checkedAt: '2026-08-07T00:00:01.000Z',
+    },
+    revocation: {
+      status: 'active',
+      evidenceRef: 'fixture:revocation-proof',
+      checkedAt: '2026-08-07T00:00:02.000Z',
+    },
+  });
+
+  return buildTransactionAssuranceEnvelope({
+    createdAt: NOW,
+    updatedAt: NOW,
+    now: NOW,
+    principalRef: 'owner:test',
+    principalType: 'human',
+    principalIdentityVerification: 'verified',
+    principalIdentityEvidenceRef: 'fixture:principal-identity',
+    agentRef: 'agent:test',
+    agentIdentityVerification: 'verified',
+    agentIdentityEvidenceRef: 'fixture:agent-identity',
+    normalizedAuthority,
+    commercialIntent: {
+      action: 'execute:research',
+      taskRef: 'task:test',
+      sellerRef: 'seller:test',
+      capabilityRef: 'capability:test',
+      category: 'research',
+      quoteRef: 'quote:test',
+      quoteHash: sha256Ref({ amount: '0.05', currency: 'USDC' }),
+      quotedAmount: '0.05',
+      currency: 'USDC',
+      termsRef: 'terms:test',
+      termsHash: sha256Ref({ delivery: 'json' }),
+      termsMatchStatus: 'match',
+    },
+    payment: {
+      paymentIdentifier: 'payment:test',
+      rail: 'x402',
+      amount: '0.05',
+      currency: 'USDC',
+      dailySpendBefore: '0',
+      totalSpendBefore: '0',
+      budgetUsageRef: 'fixture:budget-usage',
+    },
+    execution: {
+      idempotencyKeyHash: sha256Ref('idempotency:test'),
+      inputHash: sha256Ref({ query: 'test' }),
+    },
+    evidenceRefs: ['fixture:authority-chain'],
+  });
+}
+
+test('normalization creates a canonical self-hashed record without trusted claims', () => {
+  const evidence = normalizeToplocEvidence(acceptedInput());
+  assert.equal(evidence.schema, TOPLOC_ATTESTATION_SCHEMA);
+  assert.equal(evidence.scope, 'model_configuration_execution');
+  assert.equal(evidence.attestation_hash, computeToplocAttestationHash(evidence));
+  assert.deepEqual(verifyToplocEvidence(evidence), evidence);
+  assert.equal(evidence.trust.verification_status, 'not_verified');
+  assert.equal(evidence.trust.trusted_proof, false);
+  assert.equal(evidence.provenance.verification_status, 'not_verified');
+  assert.equal(evidence.provenance.validator_identity_verified, false);
+  assert.equal(evidence.provenance.proof_binding_verified, false);
+  assert.equal(evidence.privacy.verification_status, 'not_verified');
+  assert.equal(evidence.privacy.public_safe_status, 'not_verified');
+  assert.equal(evidence.source_exactness.verification_status, 'not_verified');
+  assert.equal(evidence.source_exactness.exact_source_verified, false);
+  assert.equal(evidence.non_claims.complete_transaction_verified, false);
+  assert.equal(evidence.authority_flags.attestation_grants_authority, false);
+});
+
+test('hashes and identifiers are reproducible after all fields are final', () => {
+  const first = normalizeToplocEvidence(acceptedInput());
+  const second = normalizeToplocEvidence(acceptedInput());
+  assert.deepEqual(second, first);
+  assert.match(first.configuration_hash, /^sha256:[0-9a-f]{64}$/);
+  assert.match(first.proof_hash, /^sha256:[0-9a-f]{64}$/);
+  assert.match(first.attestation_hash, /^sha256:[0-9a-f]{64}$/);
+  assert.equal(computeToplocAttestationHash(first), first.attestation_hash);
+});
+
+test('rejects raw payloads, malformed hashes, and incomplete final provenance', () => {
+  assert.throws(
+    () => normalizeToplocEvidence({ ...acceptedInput(), activations: [1, 2] }),
+    /no raw proof or activations/,
+  );
+  assert.throws(
+    () => normalizeToplocEvidence({ ...acceptedInput(), proof: 'raw' }),
+    /no raw proof or activations/,
+  );
+  assert.throws(
+    () => normalizeToplocEvidence({ ...acceptedInput(), configuration_hash: 'sha256:configuration' }),
+    /64 hex characters/,
+  );
+  assert.throws(
+    () => normalizeToplocEvidence({ ...acceptedInput(), proof_hash: 'sha256:proof' }),
+    /64 hex characters/,
+  );
+  const { checked_at: checkedAt, ...withoutCheckedAt } = acceptedInput();
+  assert.equal(checkedAt, '2026-08-07T00:00:00.000Z');
+  assert.throws(() => normalizeToplocEvidence(withoutCheckedAt), /checked_at is required/);
+  assert.throws(
+    () => normalizeToplocEvidence({ ...acceptedInput(), validator_version: '' }),
+    /validator_version is required/,
+  );
+});
+
+test('a schema tag never bypasses canonical validation or hash verification', () => {
+  assert.throws(
+    () => summarizeToplocEvidence([{ schema: TOPLOC_ATTESTATION_SCHEMA, status: 'accept' }]),
+    /attestation_hash/,
+  );
+
+  const tampered = normalizeToplocEvidence(acceptedInput());
+  tampered.status = 'reject';
+  assert.throws(() => verifyToplocEvidence(tampered), /attestation hash mismatch/);
+
+  const rehashedEscalation = normalizeToplocEvidence(acceptedInput());
+  rehashedEscalation.trust.trusted_proof = true;
+  rehashedEscalation.attestation_hash = computeToplocAttestationHash(rehashedEscalation);
+  assert.throws(() => verifyToplocEvidence(rehashedEscalation), /not the canonical v1 shape/);
+
+  const nonJsonEscalation = normalizeToplocEvidence(acceptedInput());
+  nonJsonEscalation.unserialized_claim = undefined;
+  assert.throws(() => verifyToplocEvidence(nonJsonEscalation), /JSON values only/);
+
+  const sparseRefs = acceptedInput();
+  sparseRefs.evidence_refs = new Array(1);
+  assert.throws(() => normalizeToplocEvidence(sparseRefs), /must contain a string/);
+
+  const sparseEntries = new Array(1);
+  assert.throws(() => summarizeToplocEvidence(sparseEntries), /must contain a TOPLOC attestation/);
+});
+
+test('caller-supplied trust, authority, privacy, and source-exactness claims fail closed', () => {
+  for (const [field, value] of [
+    ['trusted_proof', true],
+    ['authority_granted', true],
+    ['public_safe', true],
+    ['source_exactness_verified', true],
+  ]) {
+    assert.throws(
+      () => normalizeToplocEvidence({ ...acceptedInput(), [field]: value }),
+      new RegExp(`unsupported TOPLOC evidence field: ${field}`),
+    );
+  }
+
+  const unscanned = normalizeToplocEvidence(acceptedInput({
+    evidence_refs: ['opaque:unscanned-sentinel'],
+  }));
+  assert.deepEqual(unscanned.evidence_refs, ['opaque:unscanned-sentinel']);
+  assert.equal(unscanned.privacy.public_safe_status, 'not_verified');
+  assert.equal(unscanned.source_exactness.verification_status, 'not_verified');
+});
+
+test('summaries preserve declared results but never promote accept to trusted proof', () => {
+  const acceptedSummary = summarizeToplocEvidence([acceptedInput()]);
+  assert.equal(acceptedSummary.status, 'review');
+  assert.equal(acceptedSummary.declared_validation_result, 'accepted');
+  assert.equal(acceptedSummary.declared_accept_count, 1);
+  assert.equal(acceptedSummary.verification_status, 'not_verified');
+  assert.equal(acceptedSummary.provenance_verification_status, 'not_verified');
+  assert.equal(acceptedSummary.public_safe_verification_status, 'not_verified');
+  assert.equal(acceptedSummary.trusted_proof, false);
+  assert.equal(acceptedSummary.complete_transaction_verified, false);
+  assert.equal(acceptedSummary.authority_granted, false);
+
+  const rejectedSummary = summarizeToplocEvidence([
+    acceptedInput(),
+    acceptedInput({
+      proof_ref: 'vault://toploc/proof/2',
+      proof_hash: sha256Ref({ proof: 'fixture-2' }),
+      status: 'reject',
+    }),
+  ]);
+  assert.equal(rejectedSummary.status, 'rejected');
+  assert.equal(rejectedSummary.declared_validation_result, 'rejected');
+  assert.equal(rejectedSummary.declared_reject_count, 1);
+});
+
+test('attachment verifies parent and child integrity, clears completion, and hashes last', () => {
+  const envelope = buildEnvelope();
+  const original = structuredClone(envelope);
+  const attached = attachToplocEvidence(envelope, acceptedInput(), {
+    updatedAt: '2026-08-07T00:02:00.000Z',
+  });
+
+  assert.deepEqual(envelope, original);
+  assert.equal(attached.updated_at, '2026-08-07T00:02:00.000Z');
+  assert.equal(attached.inference_attestations.length, 1);
+  assert.equal(attached.inference_attestation_summary.status, 'review');
+  assert.equal(attached.evidence.complete_chain_verified, false);
+  assert.equal(attached.evidence.envelope_hash, computeEnvelopeHash(attached));
+
+  const evaluation = evaluateTransactionAssuranceEnvelope(attached, {
+    phase: 'pre_execution',
+    now: '2026-08-07T00:03:00.000Z',
+  });
+  assert.equal(evaluation.decision, 'allow');
+  assert.equal(evaluation.blockers.includes('envelope_hash_mismatch'), false);
+  assert.equal(evaluation.complete_chain_verified, false);
+});
+
+test('attachment rejects stale parent hashes and tampered existing attestations', () => {
+  const staleEnvelope = buildEnvelope();
+  staleEnvelope.payment.amount = '0.06';
+  assert.throws(
+    () => attachToplocEvidence(staleEnvelope, acceptedInput(), { updatedAt: NOW }),
+    /envelope hash mismatch/,
+  );
+
+  const attached = attachToplocEvidence(buildEnvelope(), acceptedInput(), { updatedAt: NOW });
+  attached.inference_attestations[0].status = 'reject';
+  attached.evidence.envelope_hash = computeEnvelopeHash(attached);
+  assert.throws(
+    () => attachToplocEvidence(attached, acceptedInput(), { updatedAt: NOW }),
+    /attestation hash mismatch/,
+  );
+});
+
+test('attachment rejects a forged existing summary even when the outer hash was recomputed', () => {
+  const attached = attachToplocEvidence(buildEnvelope(), acceptedInput(), { updatedAt: NOW });
+  attached.inference_attestation_summary.trusted_proof = true;
+  attached.evidence.envelope_hash = computeEnvelopeHash(attached);
+  assert.throws(
+    () => attachToplocEvidence(attached, acceptedInput(), { updatedAt: NOW }),
+    /summary mismatch/,
+  );
+});
+
+test('schema and package subpath remain parseable and exported', async () => {
+  const schema = JSON.parse(fs.readFileSync(
+    path.join(root, 'schema', 'toploc-inference-attestation.v1.json'),
+    'utf8',
+  ));
+  assert.equal(schema.properties.configuration_hash.$ref, '#/$defs/sha256');
+  assert.ok(schema.properties.non_claims.required.includes('complete_transaction_verified'));
+  assert.ok(schema.properties.authority_flags.required.includes('can_expand_scope'));
+  assert.equal(schema.properties.trust.properties.trusted_proof.const, false);
+  assert.equal(schema.properties.provenance.properties.proof_binding_verified.const, false);
+  assert.equal(schema.properties.privacy.properties.public_safe_status.const, 'not_verified');
+
+  const selfImport = await import('@agoragentic/transaction-assurance/toploc-evidence');
+  assert.equal(selfImport.TOPLOC_ATTESTATION_SCHEMA, TOPLOC_ATTESTATION_SCHEMA);
+  assert.equal(typeof selfImport.verifyToplocEvidence, 'function');
+});
+
+test('attestation collections are bounded and reject duplicate identities', () => {
+  const duplicate = normalizeToplocEvidence(acceptedInput());
+  assert.throws(
+    () => summarizeToplocEvidence([duplicate, duplicate]),
+    /duplicate TOPLOC attestation_id/,
+  );
+
+  const oversized = Array.from({ length: 101 }, (_, index) => acceptedInput({
+    attestation_id: `toploc_bounded_${index}`,
+  }));
+  assert.throws(
+    () => summarizeToplocEvidence(oversized),
+    /at most 100 TOPLOC attestations/,
+  );
+});


### PR DESCRIPTION
## Summary
- add a generic, optional TOPLOC-shaped inference-attestation adapter to the private Transaction Assurance alpha package
- require canonical reconstruction and self-hash verification for schema-tagged records and verify the parent envelope before attachment
- keep validator identity, proof binding, privacy, public safety, source exactness, and trusted proof explicitly `not_verified`
- cap each collection at 100 attestations, reject duplicate attestation IDs, reject raw proof/activation fields, and recompute parent/child hashes only after final fields
- export the adapter subpath, strict schema, boundary documentation, and Node 20/22/24 workflow

## Verification
- combined Transaction Assurance tests: 46/46 on Node 20, 22, and 24
- package syntax check and no-network self-test passed
- 17-file dry pack and package exports passed
- root machine-surface verifier passed

## Boundary
An `accept` value remains a caller-declared result and yields `review`, never trusted proof. No real TOPLOC validator, provenance verifier, privacy scanner, network call, provider action, spend, trust mutation, or publication occurs.