### PR TITLE
Add a bounded signed-workspace evidence bridge for Block Buzz

### DIFF
--- a/.github/workflows/buzz-signed-workspace-evidence.yml
+++ b/.github/workflows/buzz-signed-workspace-evidence.yml
@@ -5,11 +5,17 @@ on:
     branches: [main]
     paths:
       - 'examples/buzz-signed-workspace-evidence/**'
+      - 'README.md'
+      - 'llms.txt'
+      - 'integrations.json'
       - '.github/workflows/buzz-signed-workspace-evidence.yml'
   push:
     branches: [main]
     paths:
       - 'examples/buzz-signed-workspace-evidence/**'
+      - 'README.md'
+      - 'llms.txt'
+      - 'integrations.json'
       - '.github/workflows/buzz-signed-workspace-evidence.yml'
   workflow_dispatch:
 
@@ -41,6 +47,6 @@ jobs:
           npm test
       - name: Parse machine contracts
         run: |
-          node -e "for (const file of ['listing-candidates.json','receipt-reference.schema.json']) JSON.parse(require('node:fs').readFileSync(file, 'utf8'))"
+          node -e "for (const file of ['listing-candidates.json','receipt-reference.schema.json','receipt-reference.example.json','upstream-provenance.json']) JSON.parse(require('node:fs').readFileSync(file, 'utf8'))"
       - name: Package dry run
         run: npm run pack:dry

--- a/.github/workflows/buzz-signed-workspace-evidence.yml
+++ b/.github/workflows/buzz-signed-workspace-evidence.yml
@@ -1,0 +1,46 @@
+name: Buzz Signed Workspace Evidence
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'examples/buzz-signed-workspace-evidence/**'
+      - '.github/workflows/buzz-signed-workspace-evidence.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'examples/buzz-signed-workspace-evidence/**'
+      - '.github/workflows/buzz-signed-workspace-evidence.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22, 24]
+    env:
+      AGORAGENTIC_NO_SPEND: '1'
+      AGORAGENTIC_ALLOW_REAL_SPEND: '0'
+      AGORAGENTIC_ALLOW_NETWORK_CANARIES: '0'
+    defaults:
+      run:
+        working-directory: examples/buzz-signed-workspace-evidence
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Syntax and tests
+        run: |
+          npm run check
+          npm test
+      - name: Parse machine contracts
+        run: |
+          node -e "for (const file of ['listing-candidates.json','receipt-reference.schema.json']) JSON.parse(require('node:fs').readFileSync(file, 'utf8'))"
+      - name: Package dry run
+        run: npm run pack:dry

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,6 +30,7 @@ on:
       - 'zoneless/**'
       - 'scripts/**'
       - 'docs/**'
+      - 'examples/buzz-signed-workspace-evidence/**'
       - 'examples/governed-research-agent/**'
       - 'examples/agoragentic-growth/**'
       - 'test/**'
@@ -99,6 +100,17 @@ jobs:
           npm test
           npm run pack:smoke
           npm pack --dry-run
+
+      - name: Validate Buzz signed workspace evidence package
+        working-directory: examples/buzz-signed-workspace-evidence
+        env:
+          AGORAGENTIC_NO_SPEND: '1'
+          AGORAGENTIC_ALLOW_REAL_SPEND: '0'
+          AGORAGENTIC_ALLOW_NETWORK_CANARIES: '0'
+        run: |
+          npm run check
+          node --test test.mjs
+          npm run pack:dry
 
       - name: Setup Node 22 for n8n toolchain
         uses: actions/setup-node@v7

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Agoragentic integrations: connect agents, route work, keep receipts](./assets/agoragentic-integrations-social.png)
 
-**99 public integration surfaces for Triptych OS (Agent OS), Router execution, local governance, MCP, A2A, client-native plugins, frameworks, workflows, wallets, and receipt-aware agent commerce.**
+**100 public integration surfaces for Triptych OS (Agent OS), Router execution, local governance, MCP, A2A, client-native plugins, frameworks, workflows, wallets, and receipt-aware agent commerce.**
 
 [![npm](https://img.shields.io/npm/v/agoragentic-mcp?label=MCP%20Server&color=cb3837)](https://www.npmjs.com/package/agoragentic-mcp)
 [![PyPI](https://img.shields.io/pypi/v/agoragentic?label=Python%20SDK&color=3775A9)](https://pypi.org/project/agoragentic/)
@@ -53,7 +53,7 @@ curl "https://agoragentic.com/api/commerce/receipts/rcpt_YOUR_RECEIPT" \
 
 | Repo / package | What it is |
 |---|---|
-| **[agoragentic-integrations](https://github.com/rhein1/agoragentic-integrations)** | 99 indexed surfaces across client plugins, frameworks, protocols, wallets, workflows, local providers, SDKs, and MCP |
+| **[agoragentic-integrations](https://github.com/rhein1/agoragentic-integrations)** | 100 indexed surfaces across client plugins, frameworks, protocols, wallets, workflows, local providers, SDKs, and MCP |
 | [agoragentic-ecf-core](https://github.com/rhein1/agoragentic-ecf-core) | Self-hosted context-governance runtime (npm `agoragentic-ecf-core`) |
 | [Micro ECF](https://github.com/rhein1/agoragentic-micro-ecf) | Open local context wedge (npm `agoragentic-micro-ecf`) |
 | [agoragentic-premortem-golden-loop](https://github.com/rhein1/agoragentic-premortem-golden-loop) | Pre-launch release-readiness CLI (npm `agoragentic-premortem-golden-loop`) |
@@ -184,7 +184,7 @@ The canonical descriptions, assets, package coordinate, authority boundary, and 
 
 ## Featured Integration Paths
 
-The table below highlights useful entry points. The complete canonical inventory contains **99** surfaces in [`integrations.json`](./integrations.json), including client plugins, framework adapters, protocols, wallets, workflow tools, local providers, and reference integrations.
+The table below highlights useful entry points. The complete canonical inventory contains **100** surfaces in [`integrations.json`](./integrations.json), including client plugins, framework adapters, protocols, wallets, workflow tools, local providers, and reference integrations.
 
 | Framework | Language | Status | Path | Docs |
 |-----------|----------|--------|------|------|
@@ -195,6 +195,7 @@ The table below highlights useful entry points. The complete canonical inventory
 | [**Financial Research Provider Lane**](financial-research/) | Json | Experimental | `financial-research/repo-intake.v1.json` | [README](financial-research/README.md) |
 | [**OpenFang**](openfang/) | Javascript | Beta | `openfang/agoragentic_openfang.mjs` | [README](openfang/README.md) |
 | [**pdf-mcp**](pdf-mcp/) | Javascript | Beta | `pdf-mcp/agoragentic_pdf_mcp.mjs` | [README](pdf-mcp/README.md) |
+| [**Buzz Signed Workspace Evidence**](examples/buzz-signed-workspace-evidence/) | Javascript | Experimental (local-only) | `examples/buzz-signed-workspace-evidence/buzz-event-evidence.mjs` | [README](examples/buzz-signed-workspace-evidence/README.md) |
 | [**CashClaw**](cashclaw/) | Typescript | Beta | `cashclaw/README.md` | [README](cashclaw/README.md) |
 | [**LangChain Deep Agents**](deepagents/) | Python | Beta | `deepagents/README.md` | [README](deepagents/README.md) |
 | [**ClawTeam**](clawteam/) | Python | Experimental | `clawteam/agoragentic_clawteam.py` | [README](clawteam/README.md) |

--- a/README.md
+++ b/README.md
@@ -561,4 +561,4 @@ See [SECURITY.md](./SECURITY.md). Report vulnerabilities to `security@agoragenti
 
 ## License
 
-[MIT](./LICENSE), except `micro-ecf/` and `harness-core/`, which carry their own Apache-2.0 package licenses.
+[MIT](./LICENSE), except `micro-ecf/`, `harness-core/`, and `examples/buzz-signed-workspace-evidence/`, which carry their own Apache-2.0 package licenses.

--- a/assets/agoragentic-agent-commerce-banner.svg
+++ b/assets/agoragentic-agent-commerce-banner.svg
@@ -13,7 +13,7 @@
   <text x="104" y="312" fill="#f7f9fc" font-family="Inter, Arial, sans-serif" font-size="38" font-weight="600">Route work. Keep proof.</text>
   <text x="104" y="394" fill="#bbc7da" font-family="Inter, Arial, sans-serif" font-size="24">Frameworks, SDKs, MCP, A2A,</text>
   <text x="104" y="428" fill="#bbc7da" font-family="Inter, Arial, sans-serif" font-size="24">local governance, and receipts.</text>
-  <text x="104" y="536" fill="#ff8a70" font-family="JetBrains Mono, Consolas, monospace" font-size="20">99 public surfaces  |  one governed router</text>
+  <text x="104" y="536" fill="#ff8a70" font-family="JetBrains Mono, Consolas, monospace" font-size="20">100 public surfaces  |  one governed router</text>
   <g transform="translate(792 112)">
     <rect x="0" y="18" width="142" height="78" rx="6" fill="#111b30" stroke="#55d7de" stroke-width="4"/>
     <text x="19" y="52" fill="#f7f9fc" font-family="Inter, Arial, sans-serif" font-size="19" font-weight="700">FRAMEWORK</text>

--- a/ecosystem.json
+++ b/ecosystem.json
@@ -137,7 +137,7 @@
   ],
   "inventory": {
     "integration_manifest": "./integrations.json",
-    "integration_count": 99,
+    "integration_count": 100,
     "count_rule": "integration_count must equal integrations.json.integrations.length",
     "public_copy_rule": "Other repositories should link to this inventory instead of hard-coding the count."
   },

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,5 @@
+# Scoped Examples
+
+This directory contains bounded examples that are intentionally outside the primary framework-adapter directories. An example is not a hosted capability, marketplace listing, or authorization to connect to an external service.
+
+- [Buzz Signed Workspace Evidence](./buzz-signed-workspace-evidence/README.md) — experimental local compiler for exported Block Buzz/Nostr events. It does not connect to a relay, sign or post events, handle funds, or publish a listing.

--- a/examples/buzz-signed-workspace-evidence/LICENSE
+++ b/examples/buzz-signed-workspace-evidence/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/examples/buzz-signed-workspace-evidence/README.md
+++ b/examples/buzz-signed-workspace-evidence/README.md
@@ -2,9 +2,11 @@
 
 > **Use Buzz as the signed human-agent workspace; use Agoragentic as the economic authority, policy, outcome-proof, and reconciliation layer.**
 
-This experimental adapter normalizes signed [Block Buzz](https://github.com/block/buzz) / Nostr events into bounded Agoragentic evidence.
+This experimental adapter normalizes exported [Block Buzz](https://github.com/block/buzz) / Nostr events into bounded Agoragentic evidence.
 
-It does not connect to a relay, verify Schnorr signatures by itself, post to Buzz, operate a wallet, pay, deploy, publish, or mutate trust.
+It does not connect to a relay, verify Schnorr signatures or attestation artifacts/verifier identities, post to Buzz, operate a wallet, pay, deploy, publish, or mutate trust.
+
+It pins its classified kind subset to a reviewed upstream source revision rather than following Buzz `main` implicitly. See [`upstream-provenance.json`](upstream-provenance.json). The default packet is hash-only for workspace metadata as well as content: it never emits raw relay URLs, community references, channel names, repository references, identifiers, or pubkeys. Hash-only output is not a confidentiality boundary: low-entropy workspace references can still be guessed or correlated, so private exports still require authorization and protected storage.
 
 ## Product fit
 
@@ -74,14 +76,13 @@ It then:
 - verifies that `id` matches the canonical NIP-01 serialization;
 - enforces event, content, and tag bounds;
 - classifies common Buzz message, workflow, agent, forum, and Git event kinds;
-- extracts channel, event, pubkey, address, repository, and identifier references;
+- records deterministic hashes for channel, event, pubkey, address, repository, and identifier references;
 - hashes the signature instead of embedding it;
 - hashes content by default;
 - optionally stores bounded, secret-redacted content;
-- accepts explicit external signature-verification evidence;
-- accepts explicit principal-to-agent binding evidence;
-- accepts explicit relay-audit persistence evidence;
-- creates a deterministic bundle root;
+- accepts only typed external attestation references bound to the exact event ID, pubkey, and signature hash;
+- records those claims as unverified references; it never labels a signature, principal binding, or relay persistence as verified without a separate trusted resolver;
+- commits source metadata and every normalized evidence field into a deterministic bundle root;
 - keeps every financial, deployment, publication, memory, and trust authority flag false.
 
 It also defines an unsigned, proposal-only reference that can later link:
@@ -94,6 +95,12 @@ Buzz event
 ```
 
 No Nostr kind is assigned by this adapter. It cannot sign or publish that reference.
+
+## Upstream provenance and compatibility boundary
+
+The current mapping was reviewed against Block/Buzz commit [`f029deafae6ad3b63e13c29104f3be76122cb1df`](https://github.com/block/buzz/tree/f029deafae6ad3b63e13c29104f3be76122cb1df), specifically [`crates/buzz-core/src/kind.rs`](https://github.com/block/buzz/blob/f029deafae6ad3b63e13c29104f3be76122cb1df/crates/buzz-core/src/kind.rs). The NIP-01 wire checks are pinned to [`nostr-protocol/nips` `c53877571f96eb423661fc23c620d629d37b8f19`](https://github.com/nostr-protocol/nips/tree/c53877571f96eb423661fc23c620d629d37b8f19). The provenance record includes source hashes and the exact classified subset.
+
+This is source-review evidence only. It does not establish live relay, CLI, ACP, private-channel, signature-verifier, or audit-export compatibility. Each needs a separately approved no-customer-data canary.
 
 ## Run
 
@@ -132,25 +139,46 @@ const bundle = compileBuzzEvidenceBundle({
   community_ref: 'community:engineering',
 }, {
   content_policy: 'hash_only',
-  signature_verifications: {
+  signature_attestations: {
     [events[0].id]: {
-      signature_valid: true,
+      event_id: events[0].id,
+      pubkey: events[0].pubkey,
+      signature_hash: 'sha256:<hash of this event signature>',
+      verification_result: 'valid',
       verifier: 'your-nostr-verifier',
       verifier_version: '1.0.0',
-      evidence_ref: 'sha256:...'
+      attestation_ref: 'sha256:<external verifier evidence>'
     }
   },
-  principal_bindings: {
-    [events[0].pubkey]: {
+  principal_attestations: {
+    [events[0].id]: {
+      event_id: events[0].id,
+      pubkey: events[0].pubkey,
+      signature_hash: 'sha256:<hash of this event signature>',
       principal_ref: 'principal:org-123',
       agent_ref: 'agent:release-bot',
-      binding_evidence_ref: 'sha256:...'
+      attestation_ref: 'sha256:<principal binding evidence>'
+    }
+  },
+  audit_attestations: {
+    [events[0].id]: {
+      event_id: events[0].id,
+      pubkey: events[0].pubkey,
+      signature_hash: 'sha256:<hash of this event signature>',
+      persistence_status: 'persisted',
+      audit_entry_ref: 'sha256:<audit entry>',
+      audit_head_ref: 'sha256:<audit head>',
+      verifier: 'buzz-audit-export',
+      verifier_version: '1.0.0',
+      attestation_ref: 'sha256:<persistence evidence>'
     }
   }
 });
 ```
 
-Even with signature, principal, and audit evidence, the bundle remains blocked for economic action until an explicit Agoragentic mandate and external enforcement chokepoint exist.
+First create a hash-only packet to obtain the emitted `signature_hash`; an independent verifier or export process can then produce an attestation bound to that exact event. The compiler verifies only that the caller-supplied fields are structurally bound to the event. It does not fetch or authenticate the attestation artifact, validate the verifier identity, or turn a claim into verification. The compiler never accepts a naked `signature_valid`, `persisted`, or principal-binding boolean as verification evidence.
+
+Even with typed signature, principal, and audit attestation references, the bundle remains blocked until an independently verifiable attestation artifact, trusted verifier policy, explicit Agoragentic mandate, and external enforcement chokepoint exist.
 
 ## Audit conclusions
 
@@ -188,7 +216,7 @@ Input:
 Output:
 
 - canonical event-integrity results;
-- actor and principal bindings;
+- typed but unverified actor and principal-binding references;
 - release evidence graph;
 - missing-approval and missing-persistence findings;
 - public-safe evidence bundle;
@@ -214,7 +242,7 @@ After an externally enforced transaction completes, post an owner-authorized, si
 
 1. Local signed-event evidence compiler — this PR.
 2. Exact live Buzz relay and CLI compatibility canary.
-3. Signature verification and relay-audit export adapter.
+3. Signed attestation artifact, trusted verifier policy, signature verification, and relay-audit export adapter.
 4. Buzz ACP/CLI Harness Core bridge.
 5. Signed Release Evidence Compiler free canary.
 6. Agent OS workspace lane with hard external-action chokepoints.
@@ -223,12 +251,12 @@ After an externally enforced transaction completes, post an owner-authorized, si
 
 ## Publication boundary
 
-This package remains private alpha. It does not claim:
+This package remains unpublished alpha. It does not claim:
 
 - a Block or Buzz partnership;
 - live Buzz compatibility;
-- signature verification without supplied verifier evidence;
-- audit persistence without supplied audit evidence;
+- signature verification without independently validated verifier evidence and trust policy;
+- audit persistence without independently validated audit evidence and trust policy;
 - a principal binding merely from a pubkey;
 - an economic mandate from channel membership;
 - MCP v2 compatibility;
@@ -244,8 +272,8 @@ npm test
 npm run pack:dry
 ```
 
-The dedicated workflow runs on Node 20, 22, and 24 with no credentials, network calls, relay writes, or funds.
+The dedicated workflow runs on Node 20, 22, and 24 with no credentials, network calls, relay writes, or funds. It verifies the packed local artifact can install and run the CLI offline, and that it includes this folder's Apache-2.0 [`LICENSE`](LICENSE) and upstream provenance record.
 
 ## License
 
-This adapter is Apache-2.0. Buzz is also Apache-2.0. No Buzz implementation code is copied into this adapter; it consumes the documented NIP-01 event shape and records upstream attribution.
+This adapter is Apache-2.0. Buzz is also Apache-2.0. No Buzz implementation code is copied into this adapter; it consumes the documented NIP-01 event shape and records upstream attribution and source hashes.

--- a/examples/buzz-signed-workspace-evidence/README.md
+++ b/examples/buzz-signed-workspace-evidence/README.md
@@ -1,0 +1,251 @@
+# Buzz Signed Workspace Evidence Bridge
+
+> **Use Buzz as the signed human-agent workspace; use Agoragentic as the economic authority, policy, outcome-proof, and reconciliation layer.**
+
+This experimental adapter normalizes signed [Block Buzz](https://github.com/block/buzz) / Nostr events into bounded Agoragentic evidence.
+
+It does not connect to a relay, verify Schnorr signatures by itself, post to Buzz, operate a wallet, pay, deploy, publish, or mutate trust.
+
+## Product fit
+
+Buzz is unusually valuable to Agoragentic because it already gives humans and agents one shared workspace substrate:
+
+```text
+people + agents + channels + workflows + git + media
+                         ↓
+                 signed Nostr events
+                         ↓
+               one searchable relay log
+```
+
+Agoragentic should not recreate that workspace. The complementary architecture is:
+
+```text
+Buzz signed event / mention / patch / workflow
+                         ↓
+      Agoragentic signed-workspace evidence bridge
+                         ↓
+principal and agent binding → mandate → policy → allow / ask / deny
+                         ↓
+approved external tool, provider, deployment, or payment chokepoint
+                         ↓
+outcome evaluation → Transaction Assurance receipt → reconciliation
+                         ↓
+optional owner-authorized receipt reference posted back to Buzz
+```
+
+The core distinction is:
+
+```text
+Buzz membership
+≠ economic authority
+
+signed workspace event
+≠ payment authorization
+
+relay acceptance
+≠ guaranteed audit persistence
+
+workflow approval
+≠ complete payment mandate
+
+hash-chain audit entry
+≠ payment, delivery, or outcome receipt
+```
+
+## What this adapter does
+
+It accepts ordinary NIP-01-shaped events:
+
+```json
+{
+  "id": "<64 hex>",
+  "pubkey": "<64 hex>",
+  "created_at": 1786000000,
+  "kind": 9,
+  "tags": [["h", "channel-id"]],
+  "content": "Release candidate ready for review.",
+  "sig": "<128 hex>"
+}
+```
+
+It then:
+
+- verifies that `id` matches the canonical NIP-01 serialization;
+- enforces event, content, and tag bounds;
+- classifies common Buzz message, workflow, agent, forum, and Git event kinds;
+- extracts channel, event, pubkey, address, repository, and identifier references;
+- hashes the signature instead of embedding it;
+- hashes content by default;
+- optionally stores bounded, secret-redacted content;
+- accepts explicit external signature-verification evidence;
+- accepts explicit principal-to-agent binding evidence;
+- accepts explicit relay-audit persistence evidence;
+- creates a deterministic bundle root;
+- keeps every financial, deployment, publication, memory, and trust authority flag false.
+
+It also defines an unsigned, proposal-only reference that can later link:
+
+```text
+Buzz event
++ Buzz evidence root
++ Agoragentic mandate
++ Transaction Assurance receipt
+```
+
+No Nostr kind is assigned by this adapter. It cannot sign or publish that reference.
+
+## Run
+
+Prepare a JSON array of Buzz/Nostr events, then:
+
+```bash
+cd examples/buzz-signed-workspace-evidence
+node cli.mjs ./events.json --out ./buzz-evidence.json
+```
+
+By default, event content is hash-only.
+
+For an explicitly local, bounded preview:
+
+```bash
+node cli.mjs ./events.json \
+  --content-policy bounded \
+  --relay-url https://buzz.example.com \
+  --community community:engineering \
+  --out ./buzz-evidence.json
+```
+
+The bounded mode applies basic credential-pattern redaction and caps embedded content. It is not a full data-loss-prevention system.
+
+## JavaScript API
+
+```javascript
+import {
+  compileBuzzEvidenceBundle,
+  buildBuzzTransactionAssuranceReference,
+} from './buzz-event-evidence.mjs';
+
+const bundle = compileBuzzEvidenceBundle({
+  events,
+  relay_url: 'https://buzz.example.com',
+  community_ref: 'community:engineering',
+}, {
+  content_policy: 'hash_only',
+  signature_verifications: {
+    [events[0].id]: {
+      signature_valid: true,
+      verifier: 'your-nostr-verifier',
+      verifier_version: '1.0.0',
+      evidence_ref: 'sha256:...'
+    }
+  },
+  principal_bindings: {
+    [events[0].pubkey]: {
+      principal_ref: 'principal:org-123',
+      agent_ref: 'agent:release-bot',
+      binding_evidence_ref: 'sha256:...'
+    }
+  }
+});
+```
+
+Even with signature, principal, and audit evidence, the bundle remains blocked for economic action until an explicit Agoragentic mandate and external enforcement chokepoint exist.
+
+## Audit conclusions
+
+### What Buzz does particularly well
+
+- Agents are actual workspace members with their own signing keys and audit trails.
+- The CLI is agent-first: JSON on stdout, structured errors on stderr.
+- ACP agents can be connected to the relay through a harness, with owner-only inbound gating by default.
+- Messages, reactions, workflows, Git activity, media, and agent work share one event substrate.
+- The repository is unusually explicit about what works now, what is being wired, and what is still vision.
+- Packaged desktop releases, one-click relay deployment, screenshots, onboarding, and high-volume dogfooding lower adoption friction.
+- The repository demonstrates strong regression, live-receipt, and failure-characterization discipline.
+
+### Boundaries Agoragentic must not blur
+
+- Buzz documents channel membership as the primary access-control mechanism. That is appropriate for workspace participation, but it is not enough for budgets, merchants, payment rails, wallet authority, per-tool authority, or transaction limits.
+- Buzz's shell and file-edit MCP tools run at the operator's trust level. Process, history, and output bounds are valuable, but they are not an OS security sandbox.
+- Buzz's hash-chain audit is tamper-evident, not tamper-resistant against an attacker who can rewrite the database and recompute the chain.
+- The relay event pipeline treats audit and workflow side effects as asynchronous. A successful event acceptance should not be treated as a complete financial receipt without separate persistence evidence.
+- Workflow approvals are not a substitute for a typed principal mandate and payment/outcome reconciliation contract.
+- The repository currently uses `rmcp 1.1.0`; this audit found no source evidence for MCP `2026-07-28`, `Mcp-Method`, or `Mcp-Name` parity. Exact support must be verified before making an MCP v2 claim.
+
+## Commercial opportunities
+
+The candidate products are defined in [`listing-candidates.json`](listing-candidates.json).
+
+### Signed Release Evidence Compiler
+
+Input:
+
+- signed Buzz channel events;
+- patches, repository announcements, workflow events, review messages, and release decisions;
+- optional CI and external verification evidence.
+
+Output:
+
+- canonical event-integrity results;
+- actor and principal bindings;
+- release evidence graph;
+- missing-approval and missing-persistence findings;
+- public-safe evidence bundle;
+- local Agoragentic receipt.
+
+This is more valuable than generic channel export because it answers:
+
+> Which signed people and agents proposed, reviewed, approved, tested, and released this exact change—and what evidence is still missing?
+
+### Incident Memory Evidence
+
+Search and compile signed incident discussions, prior fixes, workflow runs, owners, and relevant evidence into a bounded response with event IDs and source hashes.
+
+### Governed Buzz Agent Workspace
+
+Connect an Agent OS deployment to Buzz through ACP or the JSON CLI while keeping filesystem, network, credentials, payments, deployment, and owner authority outside the model-controlled workspace process.
+
+### Transaction Assurance Reference
+
+After an externally enforced transaction completes, post an owner-authorized, signed reference back to Buzz so the channel can point to the mandate, evidence root, payment/outcome receipt, and reconciliation state without embedding private payment data.
+
+## Recommended implementation order
+
+1. Local signed-event evidence compiler — this PR.
+2. Exact live Buzz relay and CLI compatibility canary.
+3. Signature verification and relay-audit export adapter.
+4. Buzz ACP/CLI Harness Core bridge.
+5. Signed Release Evidence Compiler free canary.
+6. Agent OS workspace lane with hard external-action chokepoints.
+7. Owner-authorized receipt-reference posting.
+8. Only then evaluate a paid marketplace listing.
+
+## Publication boundary
+
+This package remains private alpha. It does not claim:
+
+- a Block or Buzz partnership;
+- live Buzz compatibility;
+- signature verification without supplied verifier evidence;
+- audit persistence without supplied audit evidence;
+- a principal binding merely from a pubkey;
+- an economic mandate from channel membership;
+- MCP v2 compatibility;
+- a live Marketplace listing;
+- x402 support;
+- production dependency or certification.
+
+## Validation
+
+```bash
+npm run check
+npm test
+npm run pack:dry
+```
+
+The dedicated workflow runs on Node 20, 22, and 24 with no credentials, network calls, relay writes, or funds.
+
+## License
+
+This adapter is Apache-2.0. Buzz is also Apache-2.0. No Buzz implementation code is copied into this adapter; it consumes the documented NIP-01 event shape and records upstream attribution.

--- a/examples/buzz-signed-workspace-evidence/README.md
+++ b/examples/buzz-signed-workspace-evidence/README.md
@@ -79,17 +79,18 @@ It then:
 - records deterministic hashes for channel, event, pubkey, address, repository, and identifier references;
 - hashes the signature instead of embedding it;
 - hashes content by default;
-- optionally stores bounded, secret-redacted content;
-- accepts only typed external attestation references bound to the exact event ID, pubkey, and signature hash;
+- optionally stores bounded raw content after best-effort known-pattern redaction, while marking it unsafe for publication;
+- accepts only typed external attestation references bound to the exact event ID, pubkey, and signature hash, with relay-audit claims additionally bound to the exact source relay hash;
 - records those claims as unverified references; it never labels a signature, principal binding, or relay persistence as verified without a separate trusted resolver;
-- commits source metadata and every normalized evidence field into a deterministic bundle root;
+- commits every deterministic security-relevant output field into `bundle_root`, while retaining `event_root` as the subordinate event/source commitment;
+- exposes `verifyBuzzEvidenceBundle()` to recompute both roots and derived policy fields without claiming signature, attestation, or verifier-identity validation;
 - keeps every financial, deployment, publication, memory, and trust authority flag false.
 
 It also defines an unsigned, proposal-only reference that can later link:
 
 ```text
 Buzz event
-+ Buzz evidence root
++ Buzz full bundle root
 + Agoragentic mandate
 + Transaction Assurance receipt
 ```
@@ -123,7 +124,7 @@ node cli.mjs ./events.json \
   --out ./buzz-evidence.json
 ```
 
-The bounded mode applies basic credential-pattern redaction and caps embedded content. It is not a full data-loss-prevention system.
+The bounded mode redacts a limited set of known credential and payment-card patterns before capping embedded content. It still emits raw workspace content, sets `redaction_complete: false` and `safe_for_publication: false`, and requires explicit content authority, private handling, and publication review. It is not a data-loss-prevention system and must not be used to make an untrusted export public-safe.
 
 ## JavaScript API
 
@@ -131,6 +132,7 @@ The bounded mode applies basic credential-pattern redaction and caps embedded co
 import {
   compileBuzzEvidenceBundle,
   buildBuzzTransactionAssuranceReference,
+  verifyBuzzEvidenceBundle,
 } from './buzz-event-evidence.mjs';
 
 const bundle = compileBuzzEvidenceBundle({
@@ -165,6 +167,7 @@ const bundle = compileBuzzEvidenceBundle({
       event_id: events[0].id,
       pubkey: events[0].pubkey,
       signature_hash: 'sha256:<hash of this event signature>',
+      relay_url_hash: 'sha256:<hash of the exact input relay_url>',
       persistence_status: 'persisted',
       audit_entry_ref: 'sha256:<audit entry>',
       audit_head_ref: 'sha256:<audit head>',
@@ -174,9 +177,13 @@ const bundle = compileBuzzEvidenceBundle({
     }
   }
 });
+
+const verification = verifyBuzzEvidenceBundle(bundle);
 ```
 
-First create a hash-only packet to obtain the emitted `signature_hash`; an independent verifier or export process can then produce an attestation bound to that exact event. The compiler verifies only that the caller-supplied fields are structurally bound to the event. It does not fetch or authenticate the attestation artifact, validate the verifier identity, or turn a claim into verification. The compiler never accepts a naked `signature_valid`, `persisted`, or principal-binding boolean as verification evidence.
+First create a hash-only packet with the exact `relay_url` to obtain the emitted `signature_hash` and `source.relay_url_hash`; an independent verifier or export process can then produce attestations bound to that event and relay. The compiler verifies only that the caller-supplied fields are structurally bound to the event and, for persistence claims, the source relay. It does not fetch or authenticate the attestation artifact, validate the verifier identity, or turn a claim into verification. The compiler never accepts a naked `signature_valid`, `persisted`, or principal-binding boolean as verification evidence.
+
+`verifyBuzzEvidenceBundle()` checks internal commitment consistency, derived summaries, privacy posture, readiness, and fixed no-authority fields. Pass a previously trusted `expected_bundle_root` to detect a fully rehashed replacement. It does not verify Nostr signatures, authenticate external attestations, or establish a trusted origin for the root.
 
 Even with typed signature, principal, and audit attestation references, the bundle remains blocked until an independently verifiable attestation artifact, trusted verifier policy, explicit Agoragentic mandate, and external enforcement chokepoint exist.
 
@@ -219,7 +226,7 @@ Output:
 - typed but unverified actor and principal-binding references;
 - release evidence graph;
 - missing-approval and missing-persistence findings;
-- public-safe evidence bundle;
+- bounded evidence bundle with explicit privacy and publication-review flags;
 - local Agoragentic receipt.
 
 This is more valuable than generic channel export because it answers:
@@ -236,7 +243,7 @@ Connect an Agent OS deployment to Buzz through ACP or the JSON CLI while keeping
 
 ### Transaction Assurance Reference
 
-After an externally enforced transaction completes, post an owner-authorized, signed reference back to Buzz so the channel can point to the mandate, evidence root, payment/outcome receipt, and reconciliation state without embedding private payment data.
+After an externally enforced transaction completes, post an owner-authorized, signed reference back to Buzz so the channel can point to the mandate, full bundle root, and payment/outcome receipt without embedding private payment data. The proposal accepts the full commitment only as `evidence_bundle_root`; it rejects the ambiguous subordinate name `evidence_root`. It uses `claimed_states` plus `state_claims_verified: false`; those caller-supplied labels are references for an external verifier, not proof that any Transaction Assurance state is final.
 
 ## Recommended implementation order
 
@@ -272,7 +279,7 @@ npm test
 npm run pack:dry
 ```
 
-The dedicated workflow runs on Node 20, 22, and 24 with no credentials, network calls, relay writes, or funds. It verifies the packed local artifact can install and run the CLI offline, and that it includes this folder's Apache-2.0 [`LICENSE`](LICENSE) and upstream provenance record.
+The test suite also supports direct execution with `node --test test.mjs`; it does not depend on npm-populated environment variables. The dedicated workflow runs on Node 20, 22, and 24 with no credentials, network calls, relay writes, or funds, while the repository's required `validate` job runs the package checks directly. The tests verify the packed local artifact can install and run the CLI offline, and that it includes this folder's Apache-2.0 [`LICENSE`](LICENSE) and upstream provenance record.
 
 ## License
 

--- a/examples/buzz-signed-workspace-evidence/SKILL.md
+++ b/examples/buzz-signed-workspace-evidence/SKILL.md
@@ -21,13 +21,13 @@ node cli.mjs <events.json> --out buzz-evidence.json
 Rules:
 
 1. Verify each canonical NIP-01 event ID with strict lower-case wire fields; reject coercion, an ID/content mismatch, or an out-of-range kind.
-2. Accept signature, principal, and persistence claims only as typed external attestation references bound to the exact event ID, pubkey, and signature hash.
+2. Accept signature, principal, and persistence claims only as typed external attestation references bound to the exact event ID, pubkey, and signature hash; persistence claims must also bind the exact source relay hash.
 3. Treat every caller-supplied attestation reference as unverified until a separate trusted resolver authenticates the artifact and verifier identity; never accept a naked verification, persistence, or principal boolean.
 4. Do not infer a principal or owner from a pubkey alone.
 5. Buzz channel membership and workspace scopes are not economic mandates.
 6. A relay-accepted event is not payment, delivery, outcome, or reconciliation proof. Require separate relay-audit persistence evidence when persistence matters.
 7. Keep event content and source metadata hash-only by default. Hashes can remain correlatable for low-entropy values, so use bounded content only when the principal permits it and protect private exports separately.
-8. Never expose nsec keys, bearer tokens, API keys, private payment data, or raw private workspace exports.
+8. Treat bounded mode as raw workspace content with best-effort known-pattern redaction, never as complete secret scanning or a public-safe export. Require explicit content authority, private handling, and publication review even when no redaction fires.
 9. Do not post a receipt reference to Buzz without explicit principal publication authority and a signing key outside this adapter.
 10. This source pin is review provenance only; it is not live relay, CLI, ACP, signature-verifier, private-channel, or audit-export compatibility evidence.
 11. This skill grants no spend, wallet, deployment, publication, memory-write, or trust authority.
@@ -43,8 +43,11 @@ event-bound but unverified principal-attestation-reference state
 event-bound but unverified relay-audit-reference state
 content policy and redactions
 hash-only source references
-evidence root
+event root and full security-envelope bundle root
+bundle verification result and externally trusted expected root, when available
+raw-content, redaction-assurance, and publication-review state
 Transaction Assurance blockers
+caller-claimed Transaction Assurance states and state_claims_verified: false
 next safe action
 authority granted: false
 ```

--- a/examples/buzz-signed-workspace-evidence/SKILL.md
+++ b/examples/buzz-signed-workspace-evidence/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: agoragentic-buzz-signed-workspace-evidence
+description: Convert exported Block Buzz / Nostr workspace events into bounded Agoragentic evidence. Use for signed release history, incident memory, workflow evidence, or Transaction Assurance preparation without treating channel membership as financial authority.
+license: Apache-2.0
+metadata:
+  upstream: block/buzz
+  status: experimental
+---
+
+# Buzz Signed Workspace Evidence
+
+Run locally:
+
+```bash
+cd examples/buzz-signed-workspace-evidence
+node cli.mjs <events.json> --out buzz-evidence.json
+```
+
+Rules:
+
+1. Verify each canonical NIP-01 event ID; reject an ID/content mismatch.
+2. Do not claim a valid Schnorr signature unless external verifier evidence is supplied.
+3. Do not infer a principal or owner from a pubkey alone.
+4. Buzz channel membership and workspace scopes are not economic mandates.
+5. A relay-accepted event is not payment, delivery, outcome, or reconciliation proof.
+6. Require separate relay-audit persistence evidence when persistence matters.
+7. Keep event content hash-only by default. Use bounded content only when the principal permits it.
+8. Never expose nsec keys, bearer tokens, API keys, private payment data, or raw private workspace exports.
+9. Do not post a receipt reference to Buzz without explicit principal publication authority and a signing key outside this adapter.
+10. This skill grants no spend, wallet, deployment, publication, memory-write, or trust authority.
+
+Report:
+
+```text
+event count and types
+canonical ID integrity
+signature-verification state
+principal-binding state
+relay-audit state
+content policy and redactions
+channel/event/pubkey references
+evidence root
+Transaction Assurance blockers
+next safe action
+authority granted: false
+```

--- a/examples/buzz-signed-workspace-evidence/SKILL.md
+++ b/examples/buzz-signed-workspace-evidence/SKILL.md
@@ -3,7 +3,9 @@ name: agoragentic-buzz-signed-workspace-evidence
 description: Convert exported Block Buzz / Nostr workspace events into bounded Agoragentic evidence. Use for signed release history, incident memory, workflow evidence, or Transaction Assurance preparation without treating channel membership as financial authority.
 license: Apache-2.0
 metadata:
-  upstream: block/buzz
+  upstream: block/buzz@f029deafae6ad3b63e13c29104f3be76122cb1df
+  upstream_provenance: upstream-provenance.json
+  nip01: nostr-protocol/nips@c53877571f96eb423661fc23c620d629d37b8f19
   status: experimental
 ---
 
@@ -18,27 +20,29 @@ node cli.mjs <events.json> --out buzz-evidence.json
 
 Rules:
 
-1. Verify each canonical NIP-01 event ID; reject an ID/content mismatch.
-2. Do not claim a valid Schnorr signature unless external verifier evidence is supplied.
-3. Do not infer a principal or owner from a pubkey alone.
-4. Buzz channel membership and workspace scopes are not economic mandates.
-5. A relay-accepted event is not payment, delivery, outcome, or reconciliation proof.
-6. Require separate relay-audit persistence evidence when persistence matters.
-7. Keep event content hash-only by default. Use bounded content only when the principal permits it.
+1. Verify each canonical NIP-01 event ID with strict lower-case wire fields; reject coercion, an ID/content mismatch, or an out-of-range kind.
+2. Accept signature, principal, and persistence claims only as typed external attestation references bound to the exact event ID, pubkey, and signature hash.
+3. Treat every caller-supplied attestation reference as unverified until a separate trusted resolver authenticates the artifact and verifier identity; never accept a naked verification, persistence, or principal boolean.
+4. Do not infer a principal or owner from a pubkey alone.
+5. Buzz channel membership and workspace scopes are not economic mandates.
+6. A relay-accepted event is not payment, delivery, outcome, or reconciliation proof. Require separate relay-audit persistence evidence when persistence matters.
+7. Keep event content and source metadata hash-only by default. Hashes can remain correlatable for low-entropy values, so use bounded content only when the principal permits it and protect private exports separately.
 8. Never expose nsec keys, bearer tokens, API keys, private payment data, or raw private workspace exports.
 9. Do not post a receipt reference to Buzz without explicit principal publication authority and a signing key outside this adapter.
-10. This skill grants no spend, wallet, deployment, publication, memory-write, or trust authority.
+10. This source pin is review provenance only; it is not live relay, CLI, ACP, signature-verifier, private-channel, or audit-export compatibility evidence.
+11. This skill grants no spend, wallet, deployment, publication, memory-write, or trust authority.
 
 Report:
 
 ```text
 event count and types
+exact upstream and NIP-01 source pin
 canonical ID integrity
-signature-verification state
-principal-binding state
-relay-audit state
+event-bound but unverified signature-attestation-reference state
+event-bound but unverified principal-attestation-reference state
+event-bound but unverified relay-audit-reference state
 content policy and redactions
-channel/event/pubkey references
+hash-only source references
 evidence root
 Transaction Assurance blockers
 next safe action

--- a/examples/buzz-signed-workspace-evidence/buzz-event-evidence.mjs
+++ b/examples/buzz-signed-workspace-evidence/buzz-event-evidence.mjs
@@ -12,6 +12,11 @@ const MAX_TAGS = 256;
 const MAX_TAG_ITEMS = 16;
 const MAX_TAG_ITEM_BYTES = 4_096;
 const MAX_BOUNDED_CONTENT_CHARS = 8_000;
+const BUNDLE_SCHEMA = 'agoragentic.buzz-evidence-bundle.v2';
+const EVENT_ROOT_SCHEMA = 'agoragentic.buzz-evidence-root.v2';
+const BUNDLE_ROOT_SCHEMA = 'agoragentic.buzz-evidence-bundle-root.v1';
+const BUNDLE_VERIFICATION_SCHEMA = 'agoragentic.buzz-evidence-bundle-verification.v1';
+const TRANSACTION_REFERENCE_SCHEMA = 'agoragentic.buzz-transaction-assurance-reference.v1';
 
 // This deliberately contains only the subset this adapter classifies. The
 // commit and source hash make the mapping reviewable without claiming live
@@ -52,7 +57,32 @@ const SECRET_PATTERNS = Object.freeze([
   [/\bamk_[A-Za-z0-9_-]{8,}\b/g, 'amk_[REDACTED]'],
   [/\bnsec1[023456789acdefghjklmnpqrstuvwxyz]{20,}\b/gi, 'nsec1[REDACTED]'],
   [/\b(?:sk|sk-ant|sk-or)-[A-Za-z0-9_-]{12,}\b/g, 'sk-[REDACTED]'],
-  [/\b(?:api[_-]?key|private[_-]?key|password|secret)\s*[:=]\s*[^\s,;]{8,}/gi, '$1=[REDACTED]'],
+  [/\b(?:github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9]{20,})\b/g, '[GITHUB_TOKEN_REDACTED]'],
+  [/\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g, '[AWS_ACCESS_KEY_REDACTED]'],
+  [/\beyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\b/g, '[JWT_REDACTED]'],
+  [
+    /\b([a-z][a-z0-9+.-]*:\/\/)[^/\s:@]+:[^/\s@]+@/gi,
+    (_match, scheme) => `${scheme}[URL_CREDENTIALS_REDACTED]@`,
+  ],
+  [
+    /\b(api[_-]?key|private[_-]?key|password|secret)\s*[:=]\s*[^\s,;]{8,}/gi,
+    (_match, label) => `${label}=[REDACTED]`,
+  ],
+]);
+
+const BUNDLE_FIELDS = Object.freeze([
+  'schema',
+  'bundle_id',
+  'source',
+  'event_root',
+  'event_commitments',
+  'events',
+  'relationships',
+  'summary',
+  'privacy',
+  'transaction_assurance_readiness',
+  'authority',
+  'bundle_root',
 ]);
 
 export class BuzzEvidenceError extends Error {
@@ -215,16 +245,38 @@ function hashedReferences(values) {
   return values.map(value => sha256(value));
 }
 
+function isLuhnValid(value) {
+  const digits = value.replace(/\D/g, '');
+  if (digits.length < 13 || digits.length > 19 || /^(\d)\1+$/.test(digits)) return false;
+  let sum = 0;
+  let doubleDigit = false;
+  for (let index = digits.length - 1; index >= 0; index -= 1) {
+    let digit = Number(digits[index]);
+    if (doubleDigit) {
+      digit *= 2;
+      if (digit > 9) digit -= 9;
+    }
+    sum += digit;
+    doubleDigit = !doubleDigit;
+  }
+  return sum % 10 === 0;
+}
+
 function redactContent(content) {
   let redacted = content;
   let count = 0;
   for (const [pattern, replacement] of SECRET_PATTERNS) {
-    redacted = redacted.replace(pattern, match => {
+    redacted = redacted.replace(pattern, (...args) => {
       count += 1;
-      if (typeof replacement === 'function') return replacement(match);
+      if (typeof replacement === 'function') return replacement(...args);
       return replacement;
     });
   }
+  redacted = redacted.replace(/\b(?:\d[ -]?){12,18}\d\b/g, match => {
+    if (!isLuhnValid(match)) return match;
+    count += 1;
+    return '[PAYMENT_CARD_REDACTED]';
+  });
   return { content: redacted, redaction_count: count };
 }
 
@@ -238,6 +290,11 @@ function contentEvidence(content, policy) {
       bounded_content: null,
       truncated: false,
       redaction_count: 0,
+      raw_content_embedded: false,
+      redaction_scope: 'not_applicable_no_raw_content',
+      redaction_complete: null,
+      safe_for_publication: false,
+      requires_explicit_content_authority: false,
     };
   }
   if (policy !== 'bounded') {
@@ -246,15 +303,20 @@ function contentEvidence(content, policy) {
       'content_policy must be hash_only, none, or bounded.',
     );
   }
-  const bounded = content.slice(0, MAX_BOUNDED_CONTENT_CHARS);
-  const redacted = redactContent(bounded);
+  const redacted = redactContent(content);
+  const bounded = redacted.content.slice(0, MAX_BOUNDED_CONTENT_CHARS);
   return {
-    policy: 'bounded_redacted',
+    policy: 'bounded_best_effort_redaction',
     content_hash: contentHash,
     content_chars: content.length,
-    bounded_content: redacted.content,
-    truncated: bounded.length < content.length,
+    bounded_content: bounded,
+    truncated: content.length > MAX_BOUNDED_CONTENT_CHARS,
     redaction_count: redacted.redaction_count,
+    raw_content_embedded: true,
+    redaction_scope: 'best_effort_known_patterns_only',
+    redaction_complete: false,
+    safe_for_publication: false,
+    requires_explicit_content_authority: true,
   };
 }
 
@@ -381,6 +443,19 @@ function normalizeAuditAttestation(value, context) {
     );
   }
   const binding = normalizeAttestationBinding(value, context, 'relay-audit attestation');
+  if (!context.relay_url_hash) {
+    throw new BuzzEvidenceError(
+      'relay_binding_required',
+      'A relay-audit attestation requires input.relay_url so its claim can bind the exact relay hash.',
+    );
+  }
+  const relayUrlHash = assertShaRef(value.relay_url_hash, 'relay-audit attestation relay_url_hash');
+  if (relayUrlHash !== context.relay_url_hash) {
+    throw new BuzzEvidenceError(
+      'attestation_binding_mismatch',
+      'relay-audit attestation must bind the exact source relay hash.',
+    );
+  }
   if (value.persistence_status !== 'persisted' && value.persistence_status !== 'not_persisted') {
     throw new BuzzEvidenceError('invalid_evidence', 'relay-audit persistence_status must be persisted or not_persisted.');
   }
@@ -407,7 +482,22 @@ function normalizeAuditAttestation(value, context) {
     verifier: requireString(value.verifier, 'relay-audit attestation verifier', 200),
     verifier_version: requireString(value.verifier_version, 'relay-audit attestation verifier_version', 100),
     evidence_ref: assertShaRef(value.attestation_ref, 'relay-audit attestation attestation_ref'),
-    claimed_binding: binding,
+    claimed_binding: {
+      ...binding,
+      relay_url_hash: relayUrlHash,
+    },
+  };
+}
+
+function buildEventAuthority() {
+  return {
+    workspace_membership_is_economic_authority: false,
+    principal_mandate_verified: false,
+    spend_allowed: false,
+    wallet_access_allowed: false,
+    deploy_allowed: false,
+    publish_allowed: false,
+    trust_mutation_allowed: false,
   };
 }
 
@@ -442,6 +532,7 @@ function normalizeEvent(event, index, options) {
     event_id: id,
     pubkey,
     signature_hash: sha256(sig),
+    relay_url_hash: options.relay_url_hash,
   };
   const signature = normalizeSignatureAttestation(options.signature_attestations[id], context);
   const principalBinding = normalizePrincipalAttestation(options.principal_attestations[id], context);
@@ -465,8 +556,8 @@ function normalizeEvent(event, index, options) {
       canonical_event_id_verified: true,
       raw_event_embedded: false,
       raw_signature_embedded: false,
-      raw_workspace_metadata_embedded: false,
-      exact_content_embedded: contentRecord.policy === 'bounded_redacted'
+      raw_workspace_metadata_embedded: contentRecord.raw_content_embedded,
+      exact_content_embedded: contentRecord.policy === 'bounded_best_effort_redaction'
         && contentRecord.redaction_count === 0
         && contentRecord.truncated === false,
     },
@@ -480,15 +571,7 @@ function normalizeEvent(event, index, options) {
     },
     content: contentRecord,
     relay_audit: auditEvidence,
-    authority: {
-      workspace_membership_is_economic_authority: false,
-      principal_mandate_verified: false,
-      spend_allowed: false,
-      wallet_access_allowed: false,
-      deploy_allowed: false,
-      publish_allowed: false,
-      trust_mutation_allowed: false,
-    },
+    authority: buildEventAuthority(),
   };
 }
 
@@ -528,6 +611,45 @@ function buildRelationships(events) {
   };
 }
 
+function buildSummary(events) {
+  return {
+    event_count: events.length,
+    event_types: events.reduce((counts, event) => {
+      counts[event.event_type] = (counts[event.event_type] || 0) + 1;
+      return counts;
+    }, {}),
+    signature_validity_claims_by_unverified_attestation_reference: events.filter(
+      event => event.signature.status === 'validity_claimed_by_unverified_attestation_reference',
+    ).length,
+    signature_invalidity_claims_by_unverified_attestation_reference: events.filter(
+      event => event.signature.status === 'invalidity_claimed_by_unverified_attestation_reference',
+    ).length,
+    principal_binding_claims_by_unverified_attestation_reference: events.filter(
+      event => event.principal_binding.status === 'binding_claimed_by_unverified_attestation_reference',
+    ).length,
+    relay_persistence_claims_by_unverified_attestation_reference: events.filter(
+      event => event.relay_audit.status === 'persistence_claimed_by_unverified_attestation_reference',
+    ).length,
+    redactions: events.reduce((sum, event) => sum + event.content.redaction_count, 0),
+  };
+}
+
+function buildPrivacy(events) {
+  const boundedContentEventCount = events.filter(event => event.content.raw_content_embedded).length;
+  return {
+    raw_content_embedded: boundedContentEventCount > 0,
+    bounded_content_event_count: boundedContentEventCount,
+    redaction_assurance: boundedContentEventCount > 0
+      ? 'best_effort_known_patterns_only'
+      : 'not_applicable_no_raw_content',
+    safe_for_publication: false,
+    publication_review_required: true,
+    blockers: boundedContentEventCount > 0
+      ? ['bounded_content_requires_explicit_authority_private_handling_and_publication_review']
+      : ['hash_references_may_be_correlatable_and_require_protected_handling'],
+  };
+}
+
 function buildBlockers(events) {
   const blockers = ['workspace_membership_is_not_an_economic_mandate'];
   if (events.some(event => event.signature.status === 'not_verified')) {
@@ -548,10 +670,402 @@ function buildBlockers(events) {
   if (events.some(event => event.relay_audit.attestation_reference_verified === false && event.relay_audit.evidence_ref)) {
     blockers.push('relay_audit_attestation_references_not_independently_verified');
   }
+  if (events.some(event => event.content.raw_content_embedded)) {
+    blockers.push('bounded_content_requires_explicit_authority_private_handling_and_publication_review');
+  }
   blockers.push('principal_mandate_required_before_economic_action');
   blockers.push('independent_attestation_verifier_and_trust_policy_required');
   blockers.push('external_tool_and_payment_chokepoint_required');
   return blockers;
+}
+
+function buildTransactionAssuranceReadiness(events) {
+  return {
+    ready_for_economic_action: false,
+    ready_for_payment: false,
+    ready_for_settlement: false,
+    ready_for_reconciliation: false,
+    blockers: buildBlockers(events),
+    next_safe_action: 'Use an independently verified attestation resolver with an explicit trust policy for signature, principal-binding, and relay-persistence evidence, then evaluate an explicit Agoragentic mandate before any external side effect or payment.',
+  };
+}
+
+function buildBundleAuthority() {
+  return {
+    grants_spend: false,
+    grants_wallet_access: false,
+    grants_deployment: false,
+    grants_publication: false,
+    grants_memory_write: false,
+    grants_trust: false,
+    posts_to_buzz: false,
+  };
+}
+
+function buildEventCommitments(events) {
+  return events.map(event => ({
+    event_id: event.event_id,
+    commitment_ref: sha256(stableStringify(event)),
+  }));
+}
+
+function buildEventRoot(source, relationships, eventCommitments) {
+  return sha256(stableStringify({
+    schema: EVENT_ROOT_SCHEMA,
+    source,
+    relationships,
+    event_commitments: eventCommitments,
+  }));
+}
+
+function buildBundleRootEnvelope(bundle) {
+  return {
+    schema: BUNDLE_ROOT_SCHEMA,
+    bundle_schema: bundle.schema,
+    source: bundle.source,
+    event_root: bundle.event_root,
+    event_commitments: bundle.event_commitments,
+    events: bundle.events,
+    relationships: bundle.relationships,
+    summary: bundle.summary,
+    privacy: bundle.privacy,
+    transaction_assurance_readiness: bundle.transaction_assurance_readiness,
+    authority: bundle.authority,
+  };
+}
+
+function stableEqual(left, right) {
+  return stableStringify(left) === stableStringify(right);
+}
+
+function hasExactFields(value, fields) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  return stableEqual(Object.keys(value).sort(), [...fields].sort());
+}
+
+function validateSecurityInvariants(bundle, fail) {
+  const source = bundle.source;
+  if (!source || typeof source !== 'object' || Array.isArray(source)) {
+    fail('invalid_source');
+  } else {
+    const fixedSourcePolicy = {
+      product: 'Block Buzz',
+      repository: BUZZ_UPSTREAM_PROVENANCE.repository,
+      upstream_revision: BUZZ_UPSTREAM_PROVENANCE.commit,
+      kind_registry_ref: BUZZ_UPSTREAM_PROVENANCE.kind_registry_sha256,
+      nip01_revision: BUZZ_UPSTREAM_PROVENANCE.nip01_commit,
+      nip01_ref: BUZZ_UPSTREAM_PROVENANCE.nip01_sha256,
+      provenance_file: BUZZ_UPSTREAM_PROVENANCE.provenance_file,
+      metadata_policy: 'hash_only',
+      raw_source_metadata_embedded: false,
+      partnership_claimed: false,
+      compatibility_verified_against_live_relay: false,
+      attestation_references_independently_verified: false,
+    };
+    if (!hasExactFields(source, [...Object.keys(fixedSourcePolicy), 'relay_url_hash', 'community_ref_hash'])) {
+      fail('invalid_source');
+    }
+    for (const [field, expected] of Object.entries(fixedSourcePolicy)) {
+      if (source[field] !== expected) fail('source_policy_mismatch');
+    }
+    for (const field of ['relay_url_hash', 'community_ref_hash']) {
+      if (source[field] !== null && (typeof source[field] !== 'string' || !SHA256_REF_PATTERN.test(source[field]))) {
+        fail('invalid_source_reference');
+      }
+    }
+  }
+
+  if (!Array.isArray(bundle.events) || bundle.events.length === 0 || bundle.events.length > MAX_EVENTS) {
+    fail('invalid_event_evidence');
+    return;
+  }
+  const eventIds = new Set();
+  let previousEvent = null;
+  for (const event of bundle.events) {
+    if (!event || typeof event !== 'object' || Array.isArray(event)) {
+      fail('invalid_event_evidence');
+      continue;
+    }
+    if (!hasExactFields(event, [
+      'schema',
+      'event_id',
+      'event_hash_ref',
+      'event_type',
+      'kind',
+      'created_at',
+      'author_pubkey_hash',
+      'signature',
+      'principal_binding',
+      'source_integrity',
+      'references',
+      'content',
+      'relay_audit',
+      'authority',
+    ])
+      || event.schema !== 'agoragentic.buzz-event-evidence.v2'
+      || typeof event.event_id !== 'string'
+      || !EVENT_ID_PATTERN.test(event.event_id)
+      || event.event_hash_ref !== `sha256:${event.event_id}`
+      || typeof event.kind !== 'number'
+      || !Number.isInteger(event.kind)
+      || event.kind < 0
+      || event.kind > MAX_NIP01_KIND
+      || event.event_type !== classifyKind(event.kind)
+      || typeof event.created_at !== 'number'
+      || !Number.isSafeInteger(event.created_at)
+      || event.created_at < 0
+      || typeof event.author_pubkey_hash !== 'string'
+      || !SHA256_REF_PATTERN.test(event.author_pubkey_hash)) {
+      fail('invalid_event_evidence');
+    }
+    if (eventIds.has(event.event_id)) fail('duplicate_event_evidence');
+    eventIds.add(event.event_id);
+    if (previousEvent && (
+      previousEvent.created_at > event.created_at
+      || (previousEvent.created_at === event.created_at
+        && previousEvent.event_id.localeCompare(event.event_id) > 0)
+    )) {
+      fail('event_order_mismatch');
+    }
+    previousEvent = event;
+
+    if (!stableEqual(event.authority, buildEventAuthority())) fail('event_authority_mismatch');
+    if (!hasExactFields(event.source_integrity, [
+      'canonical_event_id_verified',
+      'raw_event_embedded',
+      'raw_signature_embedded',
+      'raw_workspace_metadata_embedded',
+      'exact_content_embedded',
+    ])
+      || !event.source_integrity
+      || event.source_integrity.canonical_event_id_verified !== true
+      || event.source_integrity.raw_event_embedded !== false
+      || event.source_integrity.raw_signature_embedded !== false) {
+      fail('event_source_integrity_mismatch');
+    }
+    if (!hasExactFields(event.content, [
+      'policy',
+      'content_hash',
+      'content_chars',
+      'bounded_content',
+      'truncated',
+      'redaction_count',
+      'raw_content_embedded',
+      'redaction_scope',
+      'redaction_complete',
+      'safe_for_publication',
+      'requires_explicit_content_authority',
+    ])
+      || !event.content
+      || typeof event.content.content_hash !== 'string'
+      || !SHA256_REF_PATTERN.test(event.content.content_hash)
+      || typeof event.content.content_chars !== 'number'
+      || !Number.isSafeInteger(event.content.content_chars)
+      || event.content.content_chars < 0
+      || typeof event.content.truncated !== 'boolean'
+      || typeof event.content.redaction_count !== 'number'
+      || !Number.isSafeInteger(event.content.redaction_count)
+      || event.content.redaction_count < 0
+      || event.content.safe_for_publication !== false) {
+      fail('event_privacy_mismatch');
+    } else if (event.content.policy === 'hash_only') {
+      if (event.content.bounded_content !== null
+        || event.content.raw_content_embedded !== false
+        || event.content.redaction_scope !== 'not_applicable_no_raw_content'
+        || event.content.redaction_complete !== null
+        || event.content.requires_explicit_content_authority !== false) {
+        fail('event_privacy_mismatch');
+      }
+    } else if (event.content.policy === 'bounded_best_effort_redaction') {
+      if (typeof event.content.bounded_content !== 'string'
+        || event.content.bounded_content.length > MAX_BOUNDED_CONTENT_CHARS
+        || event.content.raw_content_embedded !== true
+        || event.content.redaction_scope !== 'best_effort_known_patterns_only'
+        || event.content.redaction_complete !== false
+        || event.content.requires_explicit_content_authority !== true) {
+        fail('event_privacy_mismatch');
+      }
+    } else {
+      fail('event_privacy_mismatch');
+    }
+    const referenceFields = [
+      'channel_ref_hashes',
+      'event_ref_hashes',
+      'pubkey_ref_hashes',
+      'address_ref_hashes',
+      'repository_ref_hashes',
+      'identifier_ref_hashes',
+    ];
+    if (!hasExactFields(event.references, referenceFields)
+      || referenceFields.some(field => !Array.isArray(event.references?.[field])
+        || event.references[field].some(reference => (
+          typeof reference !== 'string' || !SHA256_REF_PATTERN.test(reference)
+        )))) {
+      fail('event_reference_privacy_mismatch');
+    }
+    if (event.source_integrity
+      && event.source_integrity.raw_workspace_metadata_embedded !== event.content?.raw_content_embedded) {
+      fail('event_source_integrity_mismatch');
+    }
+    if (event.source_integrity
+      && (typeof event.source_integrity.exact_content_embedded !== 'boolean'
+        || (event.source_integrity.exact_content_embedded
+          && (event.content?.policy !== 'bounded_best_effort_redaction'
+            || event.content?.redaction_count !== 0
+            || event.content?.truncated !== false)))) {
+      fail('event_source_integrity_mismatch');
+    }
+
+    if (!hasExactFields(event.signature, [
+      'signature_hash',
+      'status',
+      'signature_valid',
+      'verification_result_claimed',
+      'attestation_reference_verified',
+      'verifier',
+      'verifier_version',
+      'evidence_ref',
+      'claimed_binding',
+    ])
+      || !event.signature
+      || event.signature.signature_valid !== null
+      || event.signature.attestation_reference_verified !== false
+      || typeof event.signature.signature_hash !== 'string'
+      || !SHA256_REF_PATTERN.test(event.signature.signature_hash)) {
+      fail('signature_evidence_boundary_mismatch');
+    }
+    if (!hasExactFields(event.principal_binding, [
+      'status',
+      'binding_verified',
+      'principal_ref_hash',
+      'agent_ref_hash',
+      'evidence_ref',
+      'claimed_binding',
+    ])
+      || !event.principal_binding
+      || event.principal_binding.binding_verified !== false) {
+      fail('principal_evidence_boundary_mismatch');
+    }
+    if (!hasExactFields(event.relay_audit, [
+      'status',
+      'persistence_status_claimed',
+      'attestation_reference_verified',
+      'audit_entry_ref',
+      'audit_head_ref',
+      'verifier',
+      'verifier_version',
+      'evidence_ref',
+      'claimed_binding',
+    ])
+      || !event.relay_audit
+      || event.relay_audit.attestation_reference_verified !== false) {
+      fail('relay_evidence_boundary_mismatch');
+    }
+
+    const signatureClaimStatuses = new Set([
+      'validity_claimed_by_unverified_attestation_reference',
+      'invalidity_claimed_by_unverified_attestation_reference',
+    ]);
+    if (event.signature?.status !== 'not_verified' && !signatureClaimStatuses.has(event.signature?.status)) {
+      fail('signature_evidence_boundary_mismatch');
+    } else if (signatureClaimStatuses.has(event.signature?.status)) {
+      if (!event.signature.claimed_binding
+        || typeof event.signature.evidence_ref !== 'string'
+        || !SHA256_REF_PATTERN.test(event.signature.evidence_ref)
+        || typeof event.signature.verifier !== 'string'
+        || !event.signature.verifier
+        || typeof event.signature.verifier_version !== 'string'
+        || !event.signature.verifier_version
+        || (event.signature.status === 'validity_claimed_by_unverified_attestation_reference'
+          && event.signature.verification_result_claimed !== 'valid')
+        || (event.signature.status === 'invalidity_claimed_by_unverified_attestation_reference'
+          && event.signature.verification_result_claimed !== 'invalid')) {
+        fail('signature_evidence_boundary_mismatch');
+      }
+    } else if (event.signature?.claimed_binding !== null
+      || event.signature?.evidence_ref !== null
+      || event.signature?.verification_result_claimed !== null
+      || event.signature?.verifier !== null
+      || event.signature?.verifier_version !== null) {
+      fail('signature_evidence_boundary_mismatch');
+    }
+
+    if (event.principal_binding?.status !== 'unbound'
+      && event.principal_binding?.status !== 'binding_claimed_by_unverified_attestation_reference') {
+      fail('principal_evidence_boundary_mismatch');
+    } else if (event.principal_binding?.status === 'binding_claimed_by_unverified_attestation_reference') {
+      if (!event.principal_binding.claimed_binding
+        || typeof event.principal_binding.evidence_ref !== 'string'
+        || !SHA256_REF_PATTERN.test(event.principal_binding.evidence_ref)
+        || typeof event.principal_binding.principal_ref_hash !== 'string'
+        || !SHA256_REF_PATTERN.test(event.principal_binding.principal_ref_hash)
+        || typeof event.principal_binding.agent_ref_hash !== 'string'
+        || !SHA256_REF_PATTERN.test(event.principal_binding.agent_ref_hash)) {
+        fail('principal_evidence_boundary_mismatch');
+      }
+    } else if (event.principal_binding?.claimed_binding !== null
+      || event.principal_binding?.evidence_ref !== null
+      || event.principal_binding?.principal_ref_hash !== null
+      || event.principal_binding?.agent_ref_hash !== null) {
+      fail('principal_evidence_boundary_mismatch');
+    }
+
+    const relayClaimStatuses = new Set([
+      'persistence_claimed_by_unverified_attestation_reference',
+      'non_persistence_claimed_by_unverified_attestation_reference',
+    ]);
+    if (event.relay_audit?.status !== 'not_verified' && !relayClaimStatuses.has(event.relay_audit?.status)) {
+      fail('relay_evidence_boundary_mismatch');
+    } else if (relayClaimStatuses.has(event.relay_audit?.status)) {
+      if (!event.relay_audit.claimed_binding
+        || typeof event.relay_audit.evidence_ref !== 'string'
+        || !SHA256_REF_PATTERN.test(event.relay_audit.evidence_ref)
+        || !source?.relay_url_hash
+        || typeof event.relay_audit.verifier !== 'string'
+        || !event.relay_audit.verifier
+        || typeof event.relay_audit.verifier_version !== 'string'
+        || !event.relay_audit.verifier_version
+        || (event.relay_audit.status === 'persistence_claimed_by_unverified_attestation_reference'
+          && (event.relay_audit.persistence_status_claimed !== 'persisted'
+            || typeof event.relay_audit.audit_entry_ref !== 'string'
+            || !SHA256_REF_PATTERN.test(event.relay_audit.audit_entry_ref)
+            || typeof event.relay_audit.audit_head_ref !== 'string'
+            || !SHA256_REF_PATTERN.test(event.relay_audit.audit_head_ref)))
+        || (event.relay_audit.status === 'non_persistence_claimed_by_unverified_attestation_reference'
+          && event.relay_audit.persistence_status_claimed !== 'not_persisted')) {
+        fail('relay_evidence_boundary_mismatch');
+      }
+    } else if (event.relay_audit?.claimed_binding !== null
+      || event.relay_audit?.evidence_ref !== null
+      || event.relay_audit?.persistence_status_claimed !== null
+      || event.relay_audit?.audit_entry_ref !== null
+      || event.relay_audit?.audit_head_ref !== null
+      || event.relay_audit?.verifier !== null
+      || event.relay_audit?.verifier_version !== null) {
+      fail('relay_evidence_boundary_mismatch');
+    }
+
+    for (const [label, evidence] of [
+      ['signature', event.signature],
+      ['principal', event.principal_binding],
+      ['relay', event.relay_audit],
+    ]) {
+      if (!evidence?.claimed_binding) continue;
+      const bindingFields = label === 'relay'
+        ? ['event_id', 'author_pubkey_hash', 'signature_hash', 'relay_url_hash']
+        : ['event_id', 'author_pubkey_hash', 'signature_hash'];
+      if (!hasExactFields(evidence.claimed_binding, bindingFields)
+        || evidence.claimed_binding.event_id !== event.event_id
+        || evidence.claimed_binding.author_pubkey_hash !== event.author_pubkey_hash
+        || evidence.claimed_binding.signature_hash !== event.signature?.signature_hash) {
+        fail(`${label}_attestation_binding_mismatch`);
+      }
+    }
+    if (event.relay_audit?.claimed_binding
+      && event.relay_audit.claimed_binding.relay_url_hash !== source?.relay_url_hash) {
+      fail('relay_attestation_binding_mismatch');
+    }
+  }
 }
 
 export function compileBuzzEvidenceBundle(input = {}, options = {}) {
@@ -577,11 +1091,13 @@ export function compileBuzzEvidenceBundle(input = {}, options = {}) {
     );
   }
 
+  const source = buildSource(input);
   const normalizedOptions = {
     content_policy: options.content_policy || 'hash_only',
     signature_attestations: normalizeEvidenceMap(options.signature_attestations, 'signature_attestations'),
     principal_attestations: normalizeEvidenceMap(options.principal_attestations, 'principal_attestations'),
     audit_attestations: normalizeEvidenceMap(options.audit_attestations, 'audit_attestations'),
+    relay_url_hash: source.relay_url_hash,
   };
   const normalized = events.map((event, index) => normalizeEvent(event, index, normalizedOptions));
   const ids = normalized.map(event => event.event_id);
@@ -592,70 +1108,129 @@ export function compileBuzzEvidenceBundle(input = {}, options = {}) {
     left.created_at - right.created_at || left.event_id.localeCompare(right.event_id)
   ));
 
-  const source = buildSource(input);
   const relationships = buildRelationships(normalized);
-  const eventCommitments = normalized.map(event => ({
-    event_id: event.event_id,
-    commitment_ref: sha256(stableStringify(event)),
-  }));
-  const evidenceRoot = sha256(stableStringify({
-    schema: 'agoragentic.buzz-evidence-root.v2',
+  const eventCommitments = buildEventCommitments(normalized);
+  const eventRoot = buildEventRoot(source, relationships, eventCommitments);
+  const summary = buildSummary(normalized);
+  const privacy = buildPrivacy(normalized);
+  const transactionAssuranceReadiness = buildTransactionAssuranceReadiness(normalized);
+  const authority = buildBundleAuthority();
+  const committedBundle = {
+    schema: BUNDLE_SCHEMA,
     source,
-    relationships,
-    event_commitments: eventCommitments,
-  }));
-  const blockers = buildBlockers(normalized);
-
-  return {
-    schema: 'agoragentic.buzz-evidence-bundle.v2',
-    bundle_id: `buzz_bundle_${evidenceRoot.slice(7, 19)}`,
-    source,
-    event_root: evidenceRoot,
+    event_root: eventRoot,
     event_commitments: eventCommitments,
     events: normalized,
     relationships,
-    summary: {
-      event_count: normalized.length,
-      event_types: normalized.reduce((counts, event) => {
-        counts[event.event_type] = (counts[event.event_type] || 0) + 1;
-        return counts;
-      }, {}),
-      signature_validity_claims_by_unverified_attestation_reference: normalized.filter(
-        event => event.signature.status === 'validity_claimed_by_unverified_attestation_reference',
-      ).length,
-      signature_invalidity_claims_by_unverified_attestation_reference: normalized.filter(
-        event => event.signature.status === 'invalidity_claimed_by_unverified_attestation_reference',
-      ).length,
-      principal_binding_claims_by_unverified_attestation_reference: normalized.filter(
-        event => event.principal_binding.status === 'binding_claimed_by_unverified_attestation_reference',
-      ).length,
-      relay_persistence_claims_by_unverified_attestation_reference: normalized.filter(
-        event => event.relay_audit.status === 'persistence_claimed_by_unverified_attestation_reference',
-      ).length,
-      redactions: normalized.reduce((sum, event) => sum + event.content.redaction_count, 0),
-    },
-    transaction_assurance_readiness: {
-      ready_for_economic_action: false,
-      ready_for_payment: false,
-      ready_for_settlement: false,
-      ready_for_reconciliation: false,
-      blockers,
-      next_safe_action: 'Use an independently verified attestation resolver with an explicit trust policy for signature, principal-binding, and relay-persistence evidence, then evaluate an explicit Agoragentic mandate before any external side effect or payment.',
-    },
-    authority: {
-      grants_spend: false,
-      grants_wallet_access: false,
-      grants_deployment: false,
-      grants_publication: false,
-      grants_memory_write: false,
-      grants_trust: false,
-      posts_to_buzz: false,
-    },
-    created_at: new Date().toISOString(),
+    summary,
+    privacy,
+    transaction_assurance_readiness: transactionAssuranceReadiness,
+    authority,
+  };
+  const bundleRoot = sha256(stableStringify(buildBundleRootEnvelope(committedBundle)));
+  return {
+    schema: BUNDLE_SCHEMA,
+    bundle_id: `buzz_bundle_${bundleRoot.slice(7, 19)}`,
+    ...committedBundle,
+    bundle_root: bundleRoot,
   };
 }
 
-function normalizeState(value, field, fallback) {
+export function verifyBuzzEvidenceBundle(bundle = {}, options = {}) {
+  const failures = [];
+  let recomputedEventRoot = null;
+  let recomputedBundleRoot = null;
+  const fail = code => {
+    if (!failures.includes(code)) failures.push(code);
+  };
+
+  if (!bundle || typeof bundle !== 'object' || Array.isArray(bundle)) {
+    return {
+      schema: BUNDLE_VERIFICATION_SCHEMA,
+      valid: false,
+      bundle_root: null,
+      recomputed_bundle_root: null,
+      expected_bundle_root: null,
+      failures: ['invalid_bundle'],
+    };
+  }
+  if (!options || typeof options !== 'object' || Array.isArray(options)) {
+    return {
+      schema: BUNDLE_VERIFICATION_SCHEMA,
+      valid: false,
+      bundle_root: typeof bundle.bundle_root === 'string' ? bundle.bundle_root : null,
+      recomputed_bundle_root: null,
+      expected_bundle_root: null,
+      failures: ['invalid_verification_options'],
+    };
+  }
+
+  if (bundle.schema !== BUNDLE_SCHEMA) fail('bundle_schema_mismatch');
+  const suppliedFields = Object.keys(bundle);
+  for (const field of BUNDLE_FIELDS) {
+    if (!hasOwn(bundle, field)) fail(`missing_field:${field}`);
+  }
+  for (const field of suppliedFields) {
+    if (!BUNDLE_FIELDS.includes(field)) fail(`unexpected_field:${field}`);
+  }
+
+  let expectedBundleRoot = null;
+  if (options.expected_bundle_root !== undefined && options.expected_bundle_root !== null) {
+    if (typeof options.expected_bundle_root !== 'string' || !SHA256_REF_PATTERN.test(options.expected_bundle_root)) {
+      fail('invalid_expected_bundle_root');
+    } else {
+      expectedBundleRoot = options.expected_bundle_root;
+      if (bundle.bundle_root !== expectedBundleRoot) fail('expected_bundle_root_mismatch');
+    }
+  }
+
+  try {
+    validateSecurityInvariants(bundle, fail);
+    const derivedEventCommitments = buildEventCommitments(bundle.events);
+    if (!stableEqual(bundle.event_commitments, derivedEventCommitments)) {
+      fail('event_commitments_mismatch');
+    }
+    const derivedRelationships = buildRelationships(bundle.events);
+    if (!stableEqual(bundle.relationships, derivedRelationships)) fail('relationships_mismatch');
+    recomputedEventRoot = buildEventRoot(bundle.source, derivedRelationships, derivedEventCommitments);
+    if (bundle.event_root !== recomputedEventRoot) fail('event_root_mismatch');
+
+    const derivedSummary = buildSummary(bundle.events);
+    if (!stableEqual(bundle.summary, derivedSummary)) fail('summary_mismatch');
+    const derivedPrivacy = buildPrivacy(bundle.events);
+    if (!stableEqual(bundle.privacy, derivedPrivacy)) fail('privacy_mismatch');
+    const derivedReadiness = buildTransactionAssuranceReadiness(bundle.events);
+    if (!stableEqual(bundle.transaction_assurance_readiness, derivedReadiness)) {
+      fail('transaction_assurance_readiness_mismatch');
+    }
+    const derivedAuthority = buildBundleAuthority();
+    if (!stableEqual(bundle.authority, derivedAuthority)) fail('authority_mismatch');
+
+    recomputedBundleRoot = sha256(stableStringify(buildBundleRootEnvelope(bundle)));
+    if (typeof bundle.bundle_root !== 'string' || !SHA256_REF_PATTERN.test(bundle.bundle_root)) {
+      fail('invalid_bundle_root');
+    } else if (bundle.bundle_root !== recomputedBundleRoot) {
+      fail('bundle_root_mismatch');
+    }
+    if (bundle.bundle_id !== `buzz_bundle_${recomputedBundleRoot.slice(7, 19)}`) {
+      fail('bundle_id_mismatch');
+    }
+  } catch {
+    fail('invalid_bundle_structure');
+  }
+
+  return {
+    schema: BUNDLE_VERIFICATION_SCHEMA,
+    valid: failures.length === 0,
+    bundle_root: typeof bundle.bundle_root === 'string' ? bundle.bundle_root : null,
+    recomputed_bundle_root: recomputedBundleRoot,
+    expected_bundle_root: expectedBundleRoot,
+    recomputed_event_root: recomputedEventRoot,
+    failures,
+  };
+}
+
+function normalizeClaimedState(value, field, fallback) {
   if (value === undefined || value === null) return fallback;
   return requireString(value, field, 50);
 }
@@ -664,26 +1239,39 @@ export function buildBuzzTransactionAssuranceReference(input = {}) {
   if (!input || typeof input !== 'object' || Array.isArray(input)) {
     throw new BuzzEvidenceError('invalid_input', 'input must be an object.');
   }
-  const evidenceRoot = assertShaRef(input.evidence_root, 'evidence_root');
+  if (hasOwn(input, 'states')) {
+    throw new BuzzEvidenceError(
+      'deprecated_transaction_state_shape',
+      'states is not accepted because it can imply verification. Use claimed_states instead.',
+    );
+  }
+  if (hasOwn(input, 'evidence_root')) {
+    throw new BuzzEvidenceError(
+      'deprecated_evidence_root_shape',
+      'evidence_root is ambiguous. Use evidence_bundle_root with the compiled bundle_root.',
+    );
+  }
+  const evidenceBundleRoot = assertShaRef(input.evidence_bundle_root, 'evidence_bundle_root');
   const receiptRef = assertShaRef(input.transaction_assurance_receipt_ref, 'transaction_assurance_receipt_ref');
   const mandateRef = assertShaRef(input.mandate_ref, 'mandate_ref');
   const reference = {
-    schema: 'agoragentic.buzz-transaction-assurance-reference.v1',
+    schema: TRANSACTION_REFERENCE_SCHEMA,
     transaction_id: optionalString(input.transaction_id, 'transaction_id', 300),
     buzz_event_id: input.buzz_event_id === undefined || input.buzz_event_id === null
       ? null
       : assertHex(input.buzz_event_id, EVENT_ID_PATTERN, 'buzz_event_id'),
-    evidence_root: evidenceRoot,
+    evidence_bundle_root: evidenceBundleRoot,
     mandate_ref: mandateRef,
     transaction_assurance_receipt_ref: receiptRef,
-    states: {
-      authority: normalizeState(input.states?.authority, 'states.authority', 'unknown'),
-      payment: normalizeState(input.states?.payment, 'states.payment', 'unknown'),
-      execution: normalizeState(input.states?.execution, 'states.execution', 'unknown'),
-      delivery: normalizeState(input.states?.delivery, 'states.delivery', 'unknown'),
-      outcome: normalizeState(input.states?.outcome, 'states.outcome', 'unknown'),
-      reconciliation: normalizeState(input.states?.reconciliation, 'states.reconciliation', 'unknown'),
+    claimed_states: {
+      authority: normalizeClaimedState(input.claimed_states?.authority, 'claimed_states.authority', 'unknown'),
+      payment: normalizeClaimedState(input.claimed_states?.payment, 'claimed_states.payment', 'unknown'),
+      execution: normalizeClaimedState(input.claimed_states?.execution, 'claimed_states.execution', 'unknown'),
+      delivery: normalizeClaimedState(input.claimed_states?.delivery, 'claimed_states.delivery', 'unknown'),
+      outcome: normalizeClaimedState(input.claimed_states?.outcome, 'claimed_states.outcome', 'unknown'),
+      reconciliation: normalizeClaimedState(input.claimed_states?.reconciliation, 'claimed_states.reconciliation', 'unknown'),
     },
+    state_claims_verified: false,
     publication: {
       event_kind_assigned: false,
       signed: false,
@@ -694,6 +1282,7 @@ export function buildBuzzTransactionAssuranceReference(input = {}) {
     non_claims: [
       'This reference does not verify the Buzz event signature.',
       'This reference does not grant payment or publication authority.',
+      'Transaction Assurance state labels are caller-supplied claims and are not independently verified by this adapter.',
       'A Buzz channel membership is not an Agoragentic economic mandate.',
       'A relay event is not by itself proof of payment, delivery, or reconciliation.',
     ],
@@ -719,6 +1308,11 @@ export const BUZZ_EVIDENCE_CONSTANTS = Object.freeze({
   MAX_TAG_ITEMS,
   MAX_TAG_ITEM_BYTES,
   MAX_BOUNDED_CONTENT_CHARS,
+  BUNDLE_SCHEMA,
+  EVENT_ROOT_SCHEMA,
+  BUNDLE_ROOT_SCHEMA,
+  BUNDLE_VERIFICATION_SCHEMA,
+  TRANSACTION_REFERENCE_SCHEMA,
   BUZZ_KINDS,
   BUZZ_UPSTREAM_PROVENANCE,
 });

--- a/examples/buzz-signed-workspace-evidence/buzz-event-evidence.mjs
+++ b/examples/buzz-signed-workspace-evidence/buzz-event-evidence.mjs
@@ -4,6 +4,7 @@ const EVENT_ID_PATTERN = /^[a-f0-9]{64}$/;
 const PUBKEY_PATTERN = /^[a-f0-9]{64}$/;
 const SIGNATURE_PATTERN = /^[a-f0-9]{128}$/;
 const SHA256_REF_PATTERN = /^sha256:[a-f0-9]{64}$/;
+const MAX_NIP01_KIND = 65_535;
 const MAX_EVENTS = 256;
 const MAX_EVENT_WIRE_BYTES = 65_536;
 const MAX_CONTENT_BYTES = 60_000;
@@ -11,6 +12,21 @@ const MAX_TAGS = 256;
 const MAX_TAG_ITEMS = 16;
 const MAX_TAG_ITEM_BYTES = 4_096;
 const MAX_BOUNDED_CONTENT_CHARS = 8_000;
+
+// This deliberately contains only the subset this adapter classifies. The
+// commit and source hash make the mapping reviewable without claiming live
+// relay compatibility or tracking the upstream main branch implicitly.
+export const BUZZ_UPSTREAM_PROVENANCE = Object.freeze({
+  repository: 'https://github.com/block/buzz',
+  commit: 'f029deafae6ad3b63e13c29104f3be76122cb1df',
+  kind_registry_path: 'crates/buzz-core/src/kind.rs',
+  kind_registry_sha256: 'sha256:74533cfc1ac016dcb1a83279c2b06f93807f29489604cdccefc46b645acfce97',
+  nip01_repository: 'https://github.com/nostr-protocol/nips',
+  nip01_commit: 'c53877571f96eb423661fc23c620d629d37b8f19',
+  nip01_path: '01.md',
+  nip01_sha256: 'sha256:afa8a4eeff70d47503f2acab03b29f4bf0ed90ac95a10d3fd07e4fecddc8ae20',
+  provenance_file: 'upstream-provenance.json',
+});
 
 const BUZZ_KINDS = Object.freeze({
   0: 'profile',
@@ -62,34 +78,61 @@ function sha256Hex(value) {
   return sha256(value).slice(7);
 }
 
-function normalizeString(value, fallback = null, maxLength = 2_000) {
-  if (value === undefined || value === null) return fallback;
-  const normalized = String(value).trim();
-  return normalized ? normalized.slice(0, maxLength) : fallback;
+function assertHex(value, pattern, field) {
+  if (typeof value !== 'string' || !pattern.test(value)) {
+    throw new BuzzEvidenceError('invalid_event', `${field} must be lowercase hexadecimal with the required length.`);
+  }
+  return value;
 }
 
-function assertHex(value, pattern, field) {
-  const normalized = String(value || '').toLowerCase();
-  if (!pattern.test(normalized)) {
-    throw new BuzzEvidenceError('invalid_event', `${field} has an invalid shape.`);
+function assertShaRef(value, field) {
+  if (typeof value !== 'string' || !SHA256_REF_PATTERN.test(value)) {
+    throw new BuzzEvidenceError('invalid_reference', `${field} must be a lowercase sha256 reference.`);
+  }
+  return value;
+}
+
+function requireString(value, field, maxLength) {
+  if (typeof value !== 'string') {
+    throw new BuzzEvidenceError('invalid_evidence', `${field} must be a string.`);
+  }
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new BuzzEvidenceError('invalid_evidence', `${field} must not be empty.`);
+  }
+  if (utf8Bytes(normalized) > maxLength) {
+    throw new BuzzEvidenceError('evidence_too_large', `${field} exceeds ${maxLength} bytes.`);
   }
   return normalized;
 }
 
-function normalizeKind(value) {
-  const kind = Number(value);
-  if (!Number.isInteger(kind) || kind < 0 || kind > 0xffffffff) {
-    throw new BuzzEvidenceError('invalid_event', 'kind must be an unsigned 32-bit integer.');
+function optionalString(value, field, maxLength) {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== 'string') {
+    throw new BuzzEvidenceError('invalid_input', `${field} must be a string when supplied.`);
   }
-  return kind;
+  if (!value.trim()) return null;
+  if (utf8Bytes(value) > maxLength) {
+    throw new BuzzEvidenceError('input_too_large', `${field} exceeds ${maxLength} bytes.`);
+  }
+  return value;
+}
+
+function normalizeKind(value) {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0 || value > MAX_NIP01_KIND) {
+    throw new BuzzEvidenceError(
+      'invalid_event',
+      `kind must be an unsigned NIP-01 integer between 0 and ${MAX_NIP01_KIND}.`,
+    );
+  }
+  return value;
 }
 
 function normalizeTimestamp(value) {
-  const timestamp = Number(value);
-  if (!Number.isInteger(timestamp) || timestamp < 0 || timestamp > Number.MAX_SAFE_INTEGER) {
-    throw new BuzzEvidenceError('invalid_event', 'created_at must be a non-negative integer.');
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    throw new BuzzEvidenceError('invalid_event', 'created_at must be a non-negative integer Unix timestamp.');
   }
-  return timestamp;
+  return value;
 }
 
 function normalizeTags(tags) {
@@ -164,6 +207,14 @@ function tagsByName(tags, name, maximum = 100) {
     .slice(0, maximum);
 }
 
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function hashedReferences(values) {
+  return values.map(value => sha256(value));
+}
+
 function redactContent(content) {
   let redacted = content;
   let count = 0;
@@ -207,95 +258,156 @@ function contentEvidence(content, policy) {
   };
 }
 
-function normalizeVerification(value) {
-  if (!value || typeof value !== 'object') {
-    return {
-      status: 'not_verified',
-      signature_valid: null,
-      verifier: null,
-      verifier_version: null,
-      evidence_ref: null,
-    };
+function normalizeEvidenceMap(value, field) {
+  if (value === undefined || value === null) return {};
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new BuzzEvidenceError('invalid_option', `${field} must be an object keyed by event ID.`);
   }
-  if (value.signature_valid !== true && value.signature_valid !== false) {
-    throw new BuzzEvidenceError(
-      'invalid_verification',
-      'signature verification evidence must set signature_valid to true or false.',
-    );
-  }
-  const evidenceRef = value.evidence_ref === undefined || value.evidence_ref === null
-    ? null
-    : String(value.evidence_ref);
-  if (evidenceRef && !SHA256_REF_PATTERN.test(evidenceRef)) {
-    throw new BuzzEvidenceError(
-      'invalid_verification',
-      'signature verification evidence_ref must be a sha256 reference.',
-    );
-  }
-  return {
-    status: value.signature_valid ? 'verified' : 'invalid',
-    signature_valid: value.signature_valid,
-    verifier: normalizeString(value.verifier, null, 200),
-    verifier_version: normalizeString(value.verifier_version, null, 100),
-    evidence_ref: evidenceRef,
-  };
+  return value;
 }
 
-function normalizePrincipalBinding(value, pubkey) {
-  if (!value || typeof value !== 'object') {
-    return {
-      status: 'unbound',
-      principal_ref: null,
-      agent_ref: null,
-      binding_evidence_ref: null,
-    };
-  }
-  const evidenceRef = value.binding_evidence_ref === undefined || value.binding_evidence_ref === null
-    ? null
-    : String(value.binding_evidence_ref);
-  if (evidenceRef && !SHA256_REF_PATTERN.test(evidenceRef)) {
-    throw new BuzzEvidenceError(
-      'invalid_principal_binding',
-      `principal binding evidence for ${pubkey} must be a sha256 reference.`,
-    );
-  }
-  const principalRef = normalizeString(value.principal_ref, null, 300);
-  if (!principalRef) {
-    throw new BuzzEvidenceError(
-      'invalid_principal_binding',
-      `principal binding for ${pubkey} requires principal_ref.`,
-    );
-  }
-  return {
-    status: 'bound_by_external_evidence',
-    principal_ref: principalRef,
-    agent_ref: normalizeString(value.agent_ref, `nostr:${pubkey}`, 300),
-    binding_evidence_ref: evidenceRef,
-  };
-}
-
-function normalizeAuditEvidence(value) {
-  if (!value || typeof value !== 'object') {
-    return {
-      status: 'not_verified',
-      audit_entry_ref: null,
-      audit_head_ref: null,
-      verifier: null,
-    };
-  }
-  for (const field of ['audit_entry_ref', 'audit_head_ref']) {
-    if (value[field] && !SHA256_REF_PATTERN.test(String(value[field]))) {
+function assertNoDeprecatedEvidenceOptions(options) {
+  for (const field of ['signature_verifications', 'principal_bindings', 'audit_evidence']) {
+    if (hasOwn(options, field) && options[field] !== undefined && options[field] !== null) {
       throw new BuzzEvidenceError(
-        'invalid_audit_evidence',
-        `${field} must be a sha256 reference.`,
+        'deprecated_evidence_shape',
+        `${field} is not accepted. Use typed event-bound attestations instead.`,
       );
     }
   }
+}
+
+function hasOwn(value, field) {
+  return Object.prototype.hasOwnProperty.call(value, field);
+}
+
+function normalizeAttestationBinding(value, context, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new BuzzEvidenceError('invalid_evidence', `${label} must be an object.`);
+  }
+  const eventId = assertHex(value.event_id, EVENT_ID_PATTERN, `${label}.event_id`);
+  const pubkey = assertHex(value.pubkey, PUBKEY_PATTERN, `${label}.pubkey`);
+  const signatureHash = assertShaRef(value.signature_hash, `${label}.signature_hash`);
+  if (eventId !== context.event_id || pubkey !== context.pubkey || signatureHash !== context.signature_hash) {
+    throw new BuzzEvidenceError(
+      'attestation_binding_mismatch',
+      `${label} must bind the exact event ID, pubkey, and signature hash.`,
+    );
+  }
   return {
-    status: value.persisted === true ? 'externally_verified' : 'not_verified',
-    audit_entry_ref: value.audit_entry_ref ? String(value.audit_entry_ref) : null,
-    audit_head_ref: value.audit_head_ref ? String(value.audit_head_ref) : null,
-    verifier: normalizeString(value.verifier, null, 200),
+    event_id: eventId,
+    author_pubkey_hash: sha256(pubkey),
+    signature_hash: signatureHash,
+  };
+}
+
+function normalizeSignatureAttestation(value, context) {
+  if (value === undefined || value === null) {
+    return {
+      status: 'not_verified',
+      signature_valid: null,
+      verification_result_claimed: null,
+      attestation_reference_verified: false,
+      verifier: null,
+      verifier_version: null,
+      evidence_ref: null,
+      claimed_binding: null,
+    };
+  }
+  if (hasOwn(value, 'signature_valid')) {
+    throw new BuzzEvidenceError(
+      'invalid_evidence',
+      'signature_valid is not evidence. Supply verification_result in an event-bound attestation.',
+    );
+  }
+  const binding = normalizeAttestationBinding(value, context, 'signature attestation');
+  if (value.verification_result !== 'valid' && value.verification_result !== 'invalid') {
+    throw new BuzzEvidenceError('invalid_evidence', 'signature attestation verification_result must be valid or invalid.');
+  }
+  return {
+    status: value.verification_result === 'valid'
+      ? 'validity_claimed_by_unverified_attestation_reference'
+      : 'invalidity_claimed_by_unverified_attestation_reference',
+    signature_valid: null,
+    verification_result_claimed: value.verification_result,
+    attestation_reference_verified: false,
+    verifier: requireString(value.verifier, 'signature attestation verifier', 200),
+    verifier_version: requireString(value.verifier_version, 'signature attestation verifier_version', 100),
+    evidence_ref: assertShaRef(value.attestation_ref, 'signature attestation attestation_ref'),
+    claimed_binding: binding,
+  };
+}
+
+function normalizePrincipalAttestation(value, context) {
+  if (value === undefined || value === null) {
+    return {
+      status: 'unbound',
+      binding_verified: false,
+      principal_ref_hash: null,
+      agent_ref_hash: null,
+      evidence_ref: null,
+      claimed_binding: null,
+    };
+  }
+  const binding = normalizeAttestationBinding(value, context, 'principal attestation');
+  return {
+    status: 'binding_claimed_by_unverified_attestation_reference',
+    binding_verified: false,
+    principal_ref_hash: sha256(requireString(value.principal_ref, 'principal attestation principal_ref', 300)),
+    agent_ref_hash: sha256(requireString(value.agent_ref, 'principal attestation agent_ref', 300)),
+    evidence_ref: assertShaRef(value.attestation_ref, 'principal attestation attestation_ref'),
+    claimed_binding: binding,
+  };
+}
+
+function normalizeAuditAttestation(value, context) {
+  if (value === undefined || value === null) {
+    return {
+      status: 'not_verified',
+      persistence_status_claimed: null,
+      attestation_reference_verified: false,
+      audit_entry_ref: null,
+      audit_head_ref: null,
+      verifier: null,
+      verifier_version: null,
+      evidence_ref: null,
+      claimed_binding: null,
+    };
+  }
+  if (hasOwn(value, 'persisted')) {
+    throw new BuzzEvidenceError(
+      'invalid_evidence',
+      'persisted is not evidence. Supply persistence_status in an event-bound attestation.',
+    );
+  }
+  const binding = normalizeAttestationBinding(value, context, 'relay-audit attestation');
+  if (value.persistence_status !== 'persisted' && value.persistence_status !== 'not_persisted') {
+    throw new BuzzEvidenceError('invalid_evidence', 'relay-audit persistence_status must be persisted or not_persisted.');
+  }
+  const auditEntryRef = value.audit_entry_ref === undefined || value.audit_entry_ref === null
+    ? null
+    : assertShaRef(value.audit_entry_ref, 'relay-audit attestation audit_entry_ref');
+  const auditHeadRef = value.audit_head_ref === undefined || value.audit_head_ref === null
+    ? null
+    : assertShaRef(value.audit_head_ref, 'relay-audit attestation audit_head_ref');
+  if (value.persistence_status === 'persisted' && (!auditEntryRef || !auditHeadRef)) {
+    throw new BuzzEvidenceError(
+      'invalid_evidence',
+      'a persisted relay-audit attestation requires audit_entry_ref and audit_head_ref.',
+    );
+  }
+  return {
+    status: value.persistence_status === 'persisted'
+      ? 'persistence_claimed_by_unverified_attestation_reference'
+      : 'non_persistence_claimed_by_unverified_attestation_reference',
+    persistence_status_claimed: value.persistence_status,
+    attestation_reference_verified: false,
+    audit_entry_ref: auditEntryRef,
+    audit_head_ref: auditHeadRef,
+    verifier: requireString(value.verifier, 'relay-audit attestation verifier', 200),
+    verifier_version: requireString(value.verifier_version, 'relay-audit attestation verifier_version', 100),
+    evidence_ref: assertShaRef(value.attestation_ref, 'relay-audit attestation attestation_ref'),
+    claimed_binding: binding,
   };
 }
 
@@ -326,40 +438,45 @@ function normalizeEvent(event, index, options) {
     );
   }
 
-  const verification = normalizeVerification(options.signature_verifications?.[id]);
-  const principalBinding = normalizePrincipalBinding(options.principal_bindings?.[pubkey], pubkey);
-  const auditEvidence = normalizeAuditEvidence(options.audit_evidence?.[id]);
+  const context = {
+    event_id: id,
+    pubkey,
+    signature_hash: sha256(sig),
+  };
+  const signature = normalizeSignatureAttestation(options.signature_attestations[id], context);
+  const principalBinding = normalizePrincipalAttestation(options.principal_attestations[id], context);
+  const auditEvidence = normalizeAuditAttestation(options.audit_attestations[id], context);
   const contentRecord = contentEvidence(content, options.content_policy);
-  const channelRefs = tagsByName(tags, 'h');
-  const eventRefs = tagsByName(tags, 'e');
-  const pubkeyRefs = tagsByName(tags, 'p');
 
   return {
-    schema: 'agoragentic.buzz-event-evidence.v1',
+    schema: 'agoragentic.buzz-event-evidence.v2',
     event_id: id,
     event_hash_ref: `sha256:${id}`,
     event_type: classifyKind(kind),
     kind,
     created_at,
-    author_pubkey: pubkey,
+    author_pubkey_hash: sha256(pubkey),
     signature: {
-      signature_hash: sha256(sig),
-      ...verification,
+      signature_hash: context.signature_hash,
+      ...signature,
     },
     principal_binding: principalBinding,
     source_integrity: {
       canonical_event_id_verified: true,
       raw_event_embedded: false,
       raw_signature_embedded: false,
-      exact_content_embedded: contentRecord.policy === 'bounded_redacted' && contentRecord.redaction_count === 0 && contentRecord.truncated === false,
+      raw_workspace_metadata_embedded: false,
+      exact_content_embedded: contentRecord.policy === 'bounded_redacted'
+        && contentRecord.redaction_count === 0
+        && contentRecord.truncated === false,
     },
     references: {
-      channel_refs: channelRefs,
-      event_refs: eventRefs,
-      pubkey_refs: pubkeyRefs,
-      address_refs: tagsByName(tags, 'a'),
-      repository_refs: tagsByName(tags, 'r'),
-      identifier_refs: tagsByName(tags, 'd'),
+      channel_ref_hashes: hashedReferences(tagsByName(tags, 'h')),
+      event_ref_hashes: hashedReferences(tagsByName(tags, 'e')),
+      pubkey_ref_hashes: hashedReferences(tagsByName(tags, 'p')),
+      address_ref_hashes: hashedReferences(tagsByName(tags, 'a')),
+      repository_ref_hashes: hashedReferences(tagsByName(tags, 'r')),
+      identifier_ref_hashes: hashedReferences(tagsByName(tags, 'd')),
     },
     content: contentRecord,
     relay_audit: auditEvidence,
@@ -375,30 +492,76 @@ function normalizeEvent(event, index, options) {
   };
 }
 
-function unique(values) {
-  return [...new Set(values.filter(Boolean))];
+function stableStringify(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(item => stableStringify(item)).join(',')}]`;
+  return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(',')}}`;
+}
+
+function buildSource(input) {
+  const relayUrl = optionalString(input.relay_url, 'relay_url', 2_048);
+  const communityRef = optionalString(input.community_ref, 'community_ref', 300);
+  return {
+    product: 'Block Buzz',
+    repository: BUZZ_UPSTREAM_PROVENANCE.repository,
+    upstream_revision: BUZZ_UPSTREAM_PROVENANCE.commit,
+    kind_registry_ref: BUZZ_UPSTREAM_PROVENANCE.kind_registry_sha256,
+    nip01_revision: BUZZ_UPSTREAM_PROVENANCE.nip01_commit,
+    nip01_ref: BUZZ_UPSTREAM_PROVENANCE.nip01_sha256,
+    provenance_file: BUZZ_UPSTREAM_PROVENANCE.provenance_file,
+    metadata_policy: 'hash_only',
+    relay_url_hash: relayUrl ? sha256(relayUrl) : null,
+    community_ref_hash: communityRef ? sha256(communityRef) : null,
+    raw_source_metadata_embedded: false,
+    partnership_claimed: false,
+    compatibility_verified_against_live_relay: false,
+    attestation_references_independently_verified: false,
+  };
+}
+
+function buildRelationships(events) {
+  return {
+    channel_ref_hashes: unique(events.flatMap(event => event.references.channel_ref_hashes)),
+    event_ref_hashes: unique(events.flatMap(event => event.references.event_ref_hashes)),
+    pubkey_ref_hashes: unique(events.flatMap(event => event.references.pubkey_ref_hashes)),
+    author_pubkey_hashes: unique(events.map(event => event.author_pubkey_hash)),
+  };
 }
 
 function buildBlockers(events) {
   const blockers = ['workspace_membership_is_not_an_economic_mandate'];
   if (events.some(event => event.signature.status === 'not_verified')) {
-    blockers.push('one_or_more_event_signatures_not_verified');
+    blockers.push('one_or_more_event_signatures_not_independently_verified');
   }
-  if (events.some(event => event.signature.status === 'invalid')) {
-    blockers.push('one_or_more_event_signatures_invalid');
+  if (events.some(event => event.signature.attestation_reference_verified === false && event.signature.evidence_ref)) {
+    blockers.push('signature_attestation_references_not_independently_verified');
   }
   if (events.some(event => event.principal_binding.status === 'unbound')) {
-    blockers.push('one_or_more_event_authors_not_bound_to_a_principal');
+    blockers.push('one_or_more_event_authors_not_bound_to_a_principal_by_independent_evidence');
   }
-  if (events.some(event => event.relay_audit.status !== 'externally_verified')) {
-    blockers.push('relay_audit_persistence_not_verified_for_every_event');
+  if (events.some(event => event.principal_binding.binding_verified === false && event.principal_binding.evidence_ref)) {
+    blockers.push('principal_binding_attestation_references_not_independently_verified');
+  }
+  if (events.some(event => event.relay_audit.status === 'not_verified')) {
+    blockers.push('relay_audit_persistence_not_independently_verified_for_every_event');
+  }
+  if (events.some(event => event.relay_audit.attestation_reference_verified === false && event.relay_audit.evidence_ref)) {
+    blockers.push('relay_audit_attestation_references_not_independently_verified');
   }
   blockers.push('principal_mandate_required_before_economic_action');
+  blockers.push('independent_attestation_verifier_and_trust_policy_required');
   blockers.push('external_tool_and_payment_chokepoint_required');
   return blockers;
 }
 
 export function compileBuzzEvidenceBundle(input = {}, options = {}) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new BuzzEvidenceError('invalid_input', 'input must be an object containing events.');
+  }
+  if (!options || typeof options !== 'object' || Array.isArray(options)) {
+    throw new BuzzEvidenceError('invalid_option', 'options must be an object.');
+  }
+  assertNoDeprecatedEvidenceOptions(options);
   const events = Array.isArray(input.events) ? input.events : [];
   const maxEvents = Number.isInteger(options.max_events) ? options.max_events : MAX_EVENTS;
   if (maxEvents < 1 || maxEvents > MAX_EVENTS) {
@@ -416,9 +579,9 @@ export function compileBuzzEvidenceBundle(input = {}, options = {}) {
 
   const normalizedOptions = {
     content_policy: options.content_policy || 'hash_only',
-    signature_verifications: options.signature_verifications || {},
-    principal_bindings: options.principal_bindings || {},
-    audit_evidence: options.audit_evidence || {},
+    signature_attestations: normalizeEvidenceMap(options.signature_attestations, 'signature_attestations'),
+    principal_attestations: normalizeEvidenceMap(options.principal_attestations, 'principal_attestations'),
+    audit_attestations: normalizeEvidenceMap(options.audit_attestations, 'audit_attestations'),
   };
   const normalized = events.map((event, index) => normalizeEvent(event, index, normalizedOptions));
   const ids = normalized.map(event => event.event_id);
@@ -429,44 +592,46 @@ export function compileBuzzEvidenceBundle(input = {}, options = {}) {
     left.created_at - right.created_at || left.event_id.localeCompare(right.event_id)
   ));
 
-  const eventRootInput = normalized.map(event => ({
+  const source = buildSource(input);
+  const relationships = buildRelationships(normalized);
+  const eventCommitments = normalized.map(event => ({
     event_id: event.event_id,
-    signature_status: event.signature.status,
-    content_hash: event.content.content_hash,
-    audit_status: event.relay_audit.status,
+    commitment_ref: sha256(stableStringify(event)),
   }));
-  const evidenceRoot = sha256(JSON.stringify(eventRootInput));
+  const evidenceRoot = sha256(stableStringify({
+    schema: 'agoragentic.buzz-evidence-root.v2',
+    source,
+    relationships,
+    event_commitments: eventCommitments,
+  }));
   const blockers = buildBlockers(normalized);
 
   return {
-    schema: 'agoragentic.buzz-evidence-bundle.v1',
+    schema: 'agoragentic.buzz-evidence-bundle.v2',
     bundle_id: `buzz_bundle_${evidenceRoot.slice(7, 19)}`,
-    source: {
-      product: 'Block Buzz',
-      repository: 'https://github.com/block/buzz',
-      relay_url: normalizeString(input.relay_url, null, 2_048),
-      community_ref: normalizeString(input.community_ref, null, 300),
-      partnership_claimed: false,
-      compatibility_verified_against_live_relay: options.live_compatibility_verified === true,
-    },
+    source,
     event_root: evidenceRoot,
+    event_commitments: eventCommitments,
     events: normalized,
-    relationships: {
-      channel_refs: unique(normalized.flatMap(event => event.references.channel_refs)),
-      event_refs: unique(normalized.flatMap(event => event.references.event_refs)),
-      pubkey_refs: unique(normalized.flatMap(event => event.references.pubkey_refs)),
-      authors: unique(normalized.map(event => event.author_pubkey)),
-    },
+    relationships,
     summary: {
       event_count: normalized.length,
       event_types: normalized.reduce((counts, event) => {
         counts[event.event_type] = (counts[event.event_type] || 0) + 1;
         return counts;
       }, {}),
-      signatures_verified: normalized.filter(event => event.signature.status === 'verified').length,
-      signatures_invalid: normalized.filter(event => event.signature.status === 'invalid').length,
-      principals_bound: normalized.filter(event => event.principal_binding.status !== 'unbound').length,
-      audit_entries_verified: normalized.filter(event => event.relay_audit.status === 'externally_verified').length,
+      signature_validity_claims_by_unverified_attestation_reference: normalized.filter(
+        event => event.signature.status === 'validity_claimed_by_unverified_attestation_reference',
+      ).length,
+      signature_invalidity_claims_by_unverified_attestation_reference: normalized.filter(
+        event => event.signature.status === 'invalidity_claimed_by_unverified_attestation_reference',
+      ).length,
+      principal_binding_claims_by_unverified_attestation_reference: normalized.filter(
+        event => event.principal_binding.status === 'binding_claimed_by_unverified_attestation_reference',
+      ).length,
+      relay_persistence_claims_by_unverified_attestation_reference: normalized.filter(
+        event => event.relay_audit.status === 'persistence_claimed_by_unverified_attestation_reference',
+      ).length,
       redactions: normalized.reduce((sum, event) => sum + event.content.redaction_count, 0),
     },
     transaction_assurance_readiness: {
@@ -475,7 +640,7 @@ export function compileBuzzEvidenceBundle(input = {}, options = {}) {
       ready_for_settlement: false,
       ready_for_reconciliation: false,
       blockers,
-      next_safe_action: 'Verify signatures and relay persistence, bind each agent key to a principal, then evaluate an explicit Agoragentic mandate before any external side effect or payment.',
+      next_safe_action: 'Use an independently verified attestation resolver with an explicit trust policy for signature, principal-binding, and relay-persistence evidence, then evaluate an explicit Agoragentic mandate before any external side effect or payment.',
     },
     authority: {
       grants_spend: false,
@@ -490,33 +655,34 @@ export function compileBuzzEvidenceBundle(input = {}, options = {}) {
   };
 }
 
-function assertShaRef(value, field) {
-  if (!SHA256_REF_PATTERN.test(String(value || ''))) {
-    throw new BuzzEvidenceError('invalid_reference', `${field} must be a sha256 reference.`);
-  }
-  return String(value);
+function normalizeState(value, field, fallback) {
+  if (value === undefined || value === null) return fallback;
+  return requireString(value, field, 50);
 }
 
 export function buildBuzzTransactionAssuranceReference(input = {}) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new BuzzEvidenceError('invalid_input', 'input must be an object.');
+  }
   const evidenceRoot = assertShaRef(input.evidence_root, 'evidence_root');
   const receiptRef = assertShaRef(input.transaction_assurance_receipt_ref, 'transaction_assurance_receipt_ref');
   const mandateRef = assertShaRef(input.mandate_ref, 'mandate_ref');
   const reference = {
     schema: 'agoragentic.buzz-transaction-assurance-reference.v1',
-    transaction_id: normalizeString(input.transaction_id, null, 300),
-    buzz_event_id: input.buzz_event_id
-      ? assertHex(input.buzz_event_id, EVENT_ID_PATTERN, 'buzz_event_id')
-      : null,
+    transaction_id: optionalString(input.transaction_id, 'transaction_id', 300),
+    buzz_event_id: input.buzz_event_id === undefined || input.buzz_event_id === null
+      ? null
+      : assertHex(input.buzz_event_id, EVENT_ID_PATTERN, 'buzz_event_id'),
     evidence_root: evidenceRoot,
     mandate_ref: mandateRef,
     transaction_assurance_receipt_ref: receiptRef,
     states: {
-      authority: normalizeString(input.states?.authority, 'unknown', 50),
-      payment: normalizeString(input.states?.payment, 'unknown', 50),
-      execution: normalizeString(input.states?.execution, 'unknown', 50),
-      delivery: normalizeString(input.states?.delivery, 'unknown', 50),
-      outcome: normalizeString(input.states?.outcome, 'unknown', 50),
-      reconciliation: normalizeString(input.states?.reconciliation, 'unknown', 50),
+      authority: normalizeState(input.states?.authority, 'states.authority', 'unknown'),
+      payment: normalizeState(input.states?.payment, 'states.payment', 'unknown'),
+      execution: normalizeState(input.states?.execution, 'states.execution', 'unknown'),
+      delivery: normalizeState(input.states?.delivery, 'states.delivery', 'unknown'),
+      outcome: normalizeState(input.states?.outcome, 'states.outcome', 'unknown'),
+      reconciliation: normalizeState(input.states?.reconciliation, 'states.reconciliation', 'unknown'),
     },
     publication: {
       event_kind_assigned: false,
@@ -540,11 +706,12 @@ export function buildBuzzTransactionAssuranceReference(input = {}) {
   };
   return {
     ...reference,
-    reference_hash: sha256(JSON.stringify(reference)),
+    reference_hash: sha256(stableStringify(reference)),
   };
 }
 
 export const BUZZ_EVIDENCE_CONSTANTS = Object.freeze({
+  MAX_NIP01_KIND,
   MAX_EVENTS,
   MAX_EVENT_WIRE_BYTES,
   MAX_CONTENT_BYTES,
@@ -553,4 +720,5 @@ export const BUZZ_EVIDENCE_CONSTANTS = Object.freeze({
   MAX_TAG_ITEM_BYTES,
   MAX_BOUNDED_CONTENT_CHARS,
   BUZZ_KINDS,
+  BUZZ_UPSTREAM_PROVENANCE,
 });

--- a/examples/buzz-signed-workspace-evidence/buzz-event-evidence.mjs
+++ b/examples/buzz-signed-workspace-evidence/buzz-event-evidence.mjs
@@ -1,0 +1,556 @@
+import { createHash } from 'node:crypto';
+
+const EVENT_ID_PATTERN = /^[a-f0-9]{64}$/;
+const PUBKEY_PATTERN = /^[a-f0-9]{64}$/;
+const SIGNATURE_PATTERN = /^[a-f0-9]{128}$/;
+const SHA256_REF_PATTERN = /^sha256:[a-f0-9]{64}$/;
+const MAX_EVENTS = 256;
+const MAX_EVENT_WIRE_BYTES = 65_536;
+const MAX_CONTENT_BYTES = 60_000;
+const MAX_TAGS = 256;
+const MAX_TAG_ITEMS = 16;
+const MAX_TAG_ITEM_BYTES = 4_096;
+const MAX_BOUNDED_CONTENT_CHARS = 8_000;
+
+const BUZZ_KINDS = Object.freeze({
+  0: 'profile',
+  1: 'text_note',
+  7: 'reaction',
+  9: 'stream_message',
+  10100: 'agent_profile',
+  30174: 'agent_engram',
+  30175: 'agent_persona',
+  30179: 'private_managed_agent',
+  40002: 'stream_message_v2',
+  40003: 'stream_message_edit',
+  43001: 'agent_job_request',
+  45001: 'forum_post',
+  45003: 'forum_comment',
+  30617: 'git_repository_announcement',
+  1617: 'git_patch',
+  1618: 'git_pull_request',
+});
+
+const SECRET_PATTERNS = Object.freeze([
+  [/\bBearer\s+[A-Za-z0-9._~+\/-]{8,}\b/gi, 'Bearer [REDACTED]'],
+  [/\bamk_[A-Za-z0-9_-]{8,}\b/g, 'amk_[REDACTED]'],
+  [/\bnsec1[023456789acdefghjklmnpqrstuvwxyz]{20,}\b/gi, 'nsec1[REDACTED]'],
+  [/\b(?:sk|sk-ant|sk-or)-[A-Za-z0-9_-]{12,}\b/g, 'sk-[REDACTED]'],
+  [/\b(?:api[_-]?key|private[_-]?key|password|secret)\s*[:=]\s*[^\s,;]{8,}/gi, '$1=[REDACTED]'],
+]);
+
+export class BuzzEvidenceError extends Error {
+  constructor(code, message, options = {}) {
+    super(message, options);
+    this.name = 'BuzzEvidenceError';
+    this.code = code;
+  }
+}
+
+function utf8Bytes(value) {
+  return Buffer.byteLength(String(value), 'utf8');
+}
+
+function sha256(value) {
+  const bytes = Buffer.isBuffer(value) || value instanceof Uint8Array
+    ? Buffer.from(value)
+    : Buffer.from(String(value), 'utf8');
+  return `sha256:${createHash('sha256').update(bytes).digest('hex')}`;
+}
+
+function sha256Hex(value) {
+  return sha256(value).slice(7);
+}
+
+function normalizeString(value, fallback = null, maxLength = 2_000) {
+  if (value === undefined || value === null) return fallback;
+  const normalized = String(value).trim();
+  return normalized ? normalized.slice(0, maxLength) : fallback;
+}
+
+function assertHex(value, pattern, field) {
+  const normalized = String(value || '').toLowerCase();
+  if (!pattern.test(normalized)) {
+    throw new BuzzEvidenceError('invalid_event', `${field} has an invalid shape.`);
+  }
+  return normalized;
+}
+
+function normalizeKind(value) {
+  const kind = Number(value);
+  if (!Number.isInteger(kind) || kind < 0 || kind > 0xffffffff) {
+    throw new BuzzEvidenceError('invalid_event', 'kind must be an unsigned 32-bit integer.');
+  }
+  return kind;
+}
+
+function normalizeTimestamp(value) {
+  const timestamp = Number(value);
+  if (!Number.isInteger(timestamp) || timestamp < 0 || timestamp > Number.MAX_SAFE_INTEGER) {
+    throw new BuzzEvidenceError('invalid_event', 'created_at must be a non-negative integer.');
+  }
+  return timestamp;
+}
+
+function normalizeTags(tags) {
+  if (!Array.isArray(tags)) {
+    throw new BuzzEvidenceError('invalid_event', 'tags must be an array.');
+  }
+  if (tags.length > MAX_TAGS) {
+    throw new BuzzEvidenceError('event_too_large', `tags exceeds the ${MAX_TAGS}-tag limit.`);
+  }
+
+  return tags.map((tag, tagIndex) => {
+    if (!Array.isArray(tag) || tag.length === 0 || tag.length > MAX_TAG_ITEMS) {
+      throw new BuzzEvidenceError(
+        'invalid_event',
+        `tags[${tagIndex}] must contain 1-${MAX_TAG_ITEMS} string items.`,
+      );
+    }
+    return tag.map((item, itemIndex) => {
+      if (typeof item !== 'string') {
+        throw new BuzzEvidenceError(
+          'invalid_event',
+          `tags[${tagIndex}][${itemIndex}] must be a string.`,
+        );
+      }
+      if (utf8Bytes(item) > MAX_TAG_ITEM_BYTES) {
+        throw new BuzzEvidenceError(
+          'event_too_large',
+          `tags[${tagIndex}][${itemIndex}] exceeds ${MAX_TAG_ITEM_BYTES} bytes.`,
+        );
+      }
+      return item;
+    });
+  });
+}
+
+function normalizeContent(value) {
+  if (typeof value !== 'string') {
+    throw new BuzzEvidenceError('invalid_event', 'content must be a string.');
+  }
+  if (utf8Bytes(value) > MAX_CONTENT_BYTES) {
+    throw new BuzzEvidenceError(
+      'event_too_large',
+      `content exceeds the ${MAX_CONTENT_BYTES}-byte evidence limit.`,
+    );
+  }
+  return value;
+}
+
+function eventSerialization({ pubkey, created_at, kind, tags, content }) {
+  return JSON.stringify([0, pubkey, created_at, kind, tags, content]);
+}
+
+export function canonicalBuzzEventId(event = {}) {
+  const pubkey = assertHex(event.pubkey, PUBKEY_PATTERN, 'pubkey');
+  const created_at = normalizeTimestamp(event.created_at);
+  const kind = normalizeKind(event.kind);
+  const tags = normalizeTags(event.tags);
+  const content = normalizeContent(event.content);
+  return sha256Hex(eventSerialization({ pubkey, created_at, kind, tags, content }));
+}
+
+function classifyKind(kind) {
+  if (kind >= 46001 && kind <= 46012) return 'workflow_event';
+  if (kind >= 20000 && kind <= 29999) return 'ephemeral_event';
+  return BUZZ_KINDS[kind] || 'other_event';
+}
+
+function tagsByName(tags, name, maximum = 100) {
+  return tags
+    .filter(tag => tag[0] === name && typeof tag[1] === 'string')
+    .map(tag => tag[1])
+    .slice(0, maximum);
+}
+
+function redactContent(content) {
+  let redacted = content;
+  let count = 0;
+  for (const [pattern, replacement] of SECRET_PATTERNS) {
+    redacted = redacted.replace(pattern, match => {
+      count += 1;
+      if (typeof replacement === 'function') return replacement(match);
+      return replacement;
+    });
+  }
+  return { content: redacted, redaction_count: count };
+}
+
+function contentEvidence(content, policy) {
+  const contentHash = sha256(content);
+  if (policy === 'none' || policy === 'hash_only') {
+    return {
+      policy: 'hash_only',
+      content_hash: contentHash,
+      content_chars: content.length,
+      bounded_content: null,
+      truncated: false,
+      redaction_count: 0,
+    };
+  }
+  if (policy !== 'bounded') {
+    throw new BuzzEvidenceError(
+      'invalid_option',
+      'content_policy must be hash_only, none, or bounded.',
+    );
+  }
+  const bounded = content.slice(0, MAX_BOUNDED_CONTENT_CHARS);
+  const redacted = redactContent(bounded);
+  return {
+    policy: 'bounded_redacted',
+    content_hash: contentHash,
+    content_chars: content.length,
+    bounded_content: redacted.content,
+    truncated: bounded.length < content.length,
+    redaction_count: redacted.redaction_count,
+  };
+}
+
+function normalizeVerification(value) {
+  if (!value || typeof value !== 'object') {
+    return {
+      status: 'not_verified',
+      signature_valid: null,
+      verifier: null,
+      verifier_version: null,
+      evidence_ref: null,
+    };
+  }
+  if (value.signature_valid !== true && value.signature_valid !== false) {
+    throw new BuzzEvidenceError(
+      'invalid_verification',
+      'signature verification evidence must set signature_valid to true or false.',
+    );
+  }
+  const evidenceRef = value.evidence_ref === undefined || value.evidence_ref === null
+    ? null
+    : String(value.evidence_ref);
+  if (evidenceRef && !SHA256_REF_PATTERN.test(evidenceRef)) {
+    throw new BuzzEvidenceError(
+      'invalid_verification',
+      'signature verification evidence_ref must be a sha256 reference.',
+    );
+  }
+  return {
+    status: value.signature_valid ? 'verified' : 'invalid',
+    signature_valid: value.signature_valid,
+    verifier: normalizeString(value.verifier, null, 200),
+    verifier_version: normalizeString(value.verifier_version, null, 100),
+    evidence_ref: evidenceRef,
+  };
+}
+
+function normalizePrincipalBinding(value, pubkey) {
+  if (!value || typeof value !== 'object') {
+    return {
+      status: 'unbound',
+      principal_ref: null,
+      agent_ref: null,
+      binding_evidence_ref: null,
+    };
+  }
+  const evidenceRef = value.binding_evidence_ref === undefined || value.binding_evidence_ref === null
+    ? null
+    : String(value.binding_evidence_ref);
+  if (evidenceRef && !SHA256_REF_PATTERN.test(evidenceRef)) {
+    throw new BuzzEvidenceError(
+      'invalid_principal_binding',
+      `principal binding evidence for ${pubkey} must be a sha256 reference.`,
+    );
+  }
+  const principalRef = normalizeString(value.principal_ref, null, 300);
+  if (!principalRef) {
+    throw new BuzzEvidenceError(
+      'invalid_principal_binding',
+      `principal binding for ${pubkey} requires principal_ref.`,
+    );
+  }
+  return {
+    status: 'bound_by_external_evidence',
+    principal_ref: principalRef,
+    agent_ref: normalizeString(value.agent_ref, `nostr:${pubkey}`, 300),
+    binding_evidence_ref: evidenceRef,
+  };
+}
+
+function normalizeAuditEvidence(value) {
+  if (!value || typeof value !== 'object') {
+    return {
+      status: 'not_verified',
+      audit_entry_ref: null,
+      audit_head_ref: null,
+      verifier: null,
+    };
+  }
+  for (const field of ['audit_entry_ref', 'audit_head_ref']) {
+    if (value[field] && !SHA256_REF_PATTERN.test(String(value[field]))) {
+      throw new BuzzEvidenceError(
+        'invalid_audit_evidence',
+        `${field} must be a sha256 reference.`,
+      );
+    }
+  }
+  return {
+    status: value.persisted === true ? 'externally_verified' : 'not_verified',
+    audit_entry_ref: value.audit_entry_ref ? String(value.audit_entry_ref) : null,
+    audit_head_ref: value.audit_head_ref ? String(value.audit_head_ref) : null,
+    verifier: normalizeString(value.verifier, null, 200),
+  };
+}
+
+function normalizeEvent(event, index, options) {
+  if (!event || typeof event !== 'object' || Array.isArray(event)) {
+    throw new BuzzEvidenceError('invalid_event', `events[${index}] must be an object.`);
+  }
+  const id = assertHex(event.id, EVENT_ID_PATTERN, `events[${index}].id`);
+  const pubkey = assertHex(event.pubkey, PUBKEY_PATTERN, `events[${index}].pubkey`);
+  const sig = assertHex(event.sig, SIGNATURE_PATTERN, `events[${index}].sig`);
+  const kind = normalizeKind(event.kind);
+  const created_at = normalizeTimestamp(event.created_at);
+  const tags = normalizeTags(event.tags);
+  const content = normalizeContent(event.content);
+  const wire = JSON.stringify({ id, pubkey, created_at, kind, tags, content, sig });
+  if (utf8Bytes(wire) > MAX_EVENT_WIRE_BYTES) {
+    throw new BuzzEvidenceError(
+      'event_too_large',
+      `events[${index}] exceeds the ${MAX_EVENT_WIRE_BYTES}-byte evidence limit.`,
+    );
+  }
+
+  const computedId = sha256Hex(eventSerialization({ pubkey, created_at, kind, tags, content }));
+  if (computedId !== id) {
+    throw new BuzzEvidenceError(
+      'event_id_mismatch',
+      `events[${index}].id does not match the canonical NIP-01 event serialization.`,
+    );
+  }
+
+  const verification = normalizeVerification(options.signature_verifications?.[id]);
+  const principalBinding = normalizePrincipalBinding(options.principal_bindings?.[pubkey], pubkey);
+  const auditEvidence = normalizeAuditEvidence(options.audit_evidence?.[id]);
+  const contentRecord = contentEvidence(content, options.content_policy);
+  const channelRefs = tagsByName(tags, 'h');
+  const eventRefs = tagsByName(tags, 'e');
+  const pubkeyRefs = tagsByName(tags, 'p');
+
+  return {
+    schema: 'agoragentic.buzz-event-evidence.v1',
+    event_id: id,
+    event_hash_ref: `sha256:${id}`,
+    event_type: classifyKind(kind),
+    kind,
+    created_at,
+    author_pubkey: pubkey,
+    signature: {
+      signature_hash: sha256(sig),
+      ...verification,
+    },
+    principal_binding: principalBinding,
+    source_integrity: {
+      canonical_event_id_verified: true,
+      raw_event_embedded: false,
+      raw_signature_embedded: false,
+      exact_content_embedded: contentRecord.policy === 'bounded_redacted' && contentRecord.redaction_count === 0 && contentRecord.truncated === false,
+    },
+    references: {
+      channel_refs: channelRefs,
+      event_refs: eventRefs,
+      pubkey_refs: pubkeyRefs,
+      address_refs: tagsByName(tags, 'a'),
+      repository_refs: tagsByName(tags, 'r'),
+      identifier_refs: tagsByName(tags, 'd'),
+    },
+    content: contentRecord,
+    relay_audit: auditEvidence,
+    authority: {
+      workspace_membership_is_economic_authority: false,
+      principal_mandate_verified: false,
+      spend_allowed: false,
+      wallet_access_allowed: false,
+      deploy_allowed: false,
+      publish_allowed: false,
+      trust_mutation_allowed: false,
+    },
+  };
+}
+
+function unique(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function buildBlockers(events) {
+  const blockers = ['workspace_membership_is_not_an_economic_mandate'];
+  if (events.some(event => event.signature.status === 'not_verified')) {
+    blockers.push('one_or_more_event_signatures_not_verified');
+  }
+  if (events.some(event => event.signature.status === 'invalid')) {
+    blockers.push('one_or_more_event_signatures_invalid');
+  }
+  if (events.some(event => event.principal_binding.status === 'unbound')) {
+    blockers.push('one_or_more_event_authors_not_bound_to_a_principal');
+  }
+  if (events.some(event => event.relay_audit.status !== 'externally_verified')) {
+    blockers.push('relay_audit_persistence_not_verified_for_every_event');
+  }
+  blockers.push('principal_mandate_required_before_economic_action');
+  blockers.push('external_tool_and_payment_chokepoint_required');
+  return blockers;
+}
+
+export function compileBuzzEvidenceBundle(input = {}, options = {}) {
+  const events = Array.isArray(input.events) ? input.events : [];
+  const maxEvents = Number.isInteger(options.max_events) ? options.max_events : MAX_EVENTS;
+  if (maxEvents < 1 || maxEvents > MAX_EVENTS) {
+    throw new BuzzEvidenceError('invalid_option', `max_events must be between 1 and ${MAX_EVENTS}.`);
+  }
+  if (events.length === 0) {
+    throw new BuzzEvidenceError('events_required', 'At least one Buzz/Nostr event is required.');
+  }
+  if (events.length > maxEvents) {
+    throw new BuzzEvidenceError(
+      'too_many_events',
+      `The bundle contains ${events.length} events; the limit is ${maxEvents}.`,
+    );
+  }
+
+  const normalizedOptions = {
+    content_policy: options.content_policy || 'hash_only',
+    signature_verifications: options.signature_verifications || {},
+    principal_bindings: options.principal_bindings || {},
+    audit_evidence: options.audit_evidence || {},
+  };
+  const normalized = events.map((event, index) => normalizeEvent(event, index, normalizedOptions));
+  const ids = normalized.map(event => event.event_id);
+  if (new Set(ids).size !== ids.length) {
+    throw new BuzzEvidenceError('duplicate_event', 'The evidence bundle contains duplicate event IDs.');
+  }
+  normalized.sort((left, right) => (
+    left.created_at - right.created_at || left.event_id.localeCompare(right.event_id)
+  ));
+
+  const eventRootInput = normalized.map(event => ({
+    event_id: event.event_id,
+    signature_status: event.signature.status,
+    content_hash: event.content.content_hash,
+    audit_status: event.relay_audit.status,
+  }));
+  const evidenceRoot = sha256(JSON.stringify(eventRootInput));
+  const blockers = buildBlockers(normalized);
+
+  return {
+    schema: 'agoragentic.buzz-evidence-bundle.v1',
+    bundle_id: `buzz_bundle_${evidenceRoot.slice(7, 19)}`,
+    source: {
+      product: 'Block Buzz',
+      repository: 'https://github.com/block/buzz',
+      relay_url: normalizeString(input.relay_url, null, 2_048),
+      community_ref: normalizeString(input.community_ref, null, 300),
+      partnership_claimed: false,
+      compatibility_verified_against_live_relay: options.live_compatibility_verified === true,
+    },
+    event_root: evidenceRoot,
+    events: normalized,
+    relationships: {
+      channel_refs: unique(normalized.flatMap(event => event.references.channel_refs)),
+      event_refs: unique(normalized.flatMap(event => event.references.event_refs)),
+      pubkey_refs: unique(normalized.flatMap(event => event.references.pubkey_refs)),
+      authors: unique(normalized.map(event => event.author_pubkey)),
+    },
+    summary: {
+      event_count: normalized.length,
+      event_types: normalized.reduce((counts, event) => {
+        counts[event.event_type] = (counts[event.event_type] || 0) + 1;
+        return counts;
+      }, {}),
+      signatures_verified: normalized.filter(event => event.signature.status === 'verified').length,
+      signatures_invalid: normalized.filter(event => event.signature.status === 'invalid').length,
+      principals_bound: normalized.filter(event => event.principal_binding.status !== 'unbound').length,
+      audit_entries_verified: normalized.filter(event => event.relay_audit.status === 'externally_verified').length,
+      redactions: normalized.reduce((sum, event) => sum + event.content.redaction_count, 0),
+    },
+    transaction_assurance_readiness: {
+      ready_for_economic_action: false,
+      ready_for_payment: false,
+      ready_for_settlement: false,
+      ready_for_reconciliation: false,
+      blockers,
+      next_safe_action: 'Verify signatures and relay persistence, bind each agent key to a principal, then evaluate an explicit Agoragentic mandate before any external side effect or payment.',
+    },
+    authority: {
+      grants_spend: false,
+      grants_wallet_access: false,
+      grants_deployment: false,
+      grants_publication: false,
+      grants_memory_write: false,
+      grants_trust: false,
+      posts_to_buzz: false,
+    },
+    created_at: new Date().toISOString(),
+  };
+}
+
+function assertShaRef(value, field) {
+  if (!SHA256_REF_PATTERN.test(String(value || ''))) {
+    throw new BuzzEvidenceError('invalid_reference', `${field} must be a sha256 reference.`);
+  }
+  return String(value);
+}
+
+export function buildBuzzTransactionAssuranceReference(input = {}) {
+  const evidenceRoot = assertShaRef(input.evidence_root, 'evidence_root');
+  const receiptRef = assertShaRef(input.transaction_assurance_receipt_ref, 'transaction_assurance_receipt_ref');
+  const mandateRef = assertShaRef(input.mandate_ref, 'mandate_ref');
+  const reference = {
+    schema: 'agoragentic.buzz-transaction-assurance-reference.v1',
+    transaction_id: normalizeString(input.transaction_id, null, 300),
+    buzz_event_id: input.buzz_event_id
+      ? assertHex(input.buzz_event_id, EVENT_ID_PATTERN, 'buzz_event_id')
+      : null,
+    evidence_root: evidenceRoot,
+    mandate_ref: mandateRef,
+    transaction_assurance_receipt_ref: receiptRef,
+    states: {
+      authority: normalizeString(input.states?.authority, 'unknown', 50),
+      payment: normalizeString(input.states?.payment, 'unknown', 50),
+      execution: normalizeString(input.states?.execution, 'unknown', 50),
+      delivery: normalizeString(input.states?.delivery, 'unknown', 50),
+      outcome: normalizeString(input.states?.outcome, 'unknown', 50),
+      reconciliation: normalizeString(input.states?.reconciliation, 'unknown', 50),
+    },
+    publication: {
+      event_kind_assigned: false,
+      signed: false,
+      posted: false,
+      requires_explicit_principal_authority: true,
+      requires_buzz_signing_key_outside_this_adapter: true,
+    },
+    non_claims: [
+      'This reference does not verify the Buzz event signature.',
+      'This reference does not grant payment or publication authority.',
+      'A Buzz channel membership is not an Agoragentic economic mandate.',
+      'A relay event is not by itself proof of payment, delivery, or reconciliation.',
+    ],
+    authority: {
+      grants_spend: false,
+      grants_wallet_access: false,
+      grants_publication: false,
+      grants_trust: false,
+    },
+  };
+  return {
+    ...reference,
+    reference_hash: sha256(JSON.stringify(reference)),
+  };
+}
+
+export const BUZZ_EVIDENCE_CONSTANTS = Object.freeze({
+  MAX_EVENTS,
+  MAX_EVENT_WIRE_BYTES,
+  MAX_CONTENT_BYTES,
+  MAX_TAGS,
+  MAX_TAG_ITEMS,
+  MAX_TAG_ITEM_BYTES,
+  MAX_BOUNDED_CONTENT_CHARS,
+  BUZZ_KINDS,
+});

--- a/examples/buzz-signed-workspace-evidence/cli.mjs
+++ b/examples/buzz-signed-workspace-evidence/cli.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import {
+  BuzzEvidenceError,
+  compileBuzzEvidenceBundle,
+} from './buzz-event-evidence.mjs';
+
+const MAX_INPUT_BYTES = 4 * 1024 * 1024;
+
+function usage() {
+  return `Usage:
+  node cli.mjs <events.json> [--content-policy hash_only|bounded]
+                             [--relay-url <url>]
+                             [--community <ref>]
+                             [--out <bundle.json>]
+
+Input may be a JSON array of Nostr events or an object containing { events }.
+The command performs no relay connection, signature signing, workspace write,
+payment, deployment, publication, or trust mutation.
+`;
+}
+
+function parseArgs(argv) {
+  const args = [...argv];
+  const result = {
+    input: null,
+    out: null,
+    content_policy: 'hash_only',
+    relay_url: null,
+    community_ref: null,
+  };
+  while (args.length > 0) {
+    const value = args.shift();
+    if (value === '--help' || value === '-h') return { help: true };
+    if (value === '--out' || value === '-o') result.out = args.shift() || null;
+    else if (value === '--content-policy') result.content_policy = args.shift() || '';
+    else if (value === '--relay-url') result.relay_url = args.shift() || null;
+    else if (value === '--community') result.community_ref = args.shift() || null;
+    else if (String(value).startsWith('-')) throw new Error(`Unknown option: ${value}`);
+    else if (!result.input) result.input = value;
+    else throw new Error(`Unexpected argument: ${value}`);
+  }
+  if (!result.input) throw new Error('An events JSON file is required.');
+  return result;
+}
+
+try {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    process.stdout.write(usage());
+    process.exit(0);
+  }
+
+  const inputPath = resolve(args.input);
+  const bytes = await readFile(inputPath);
+  if (bytes.byteLength > MAX_INPUT_BYTES) {
+    throw new BuzzEvidenceError(
+      'input_too_large',
+      `Input JSON exceeds the ${MAX_INPUT_BYTES}-byte CLI limit.`,
+    );
+  }
+  const parsed = JSON.parse(bytes.toString('utf8'));
+  const events = Array.isArray(parsed) ? parsed : parsed.events;
+  const bundle = compileBuzzEvidenceBundle({
+    events,
+    relay_url: args.relay_url || parsed.relay_url,
+    community_ref: args.community_ref || parsed.community_ref,
+  }, {
+    content_policy: args.content_policy,
+  });
+  const output = `${JSON.stringify(bundle, null, 2)}\n`;
+  if (args.out) await writeFile(resolve(args.out), output, 'utf8');
+  else process.stdout.write(output);
+} catch (error) {
+  const code = error instanceof BuzzEvidenceError ? error.code : 'cli_error';
+  process.stderr.write(`agoragentic-buzz-evidence: ${code}: ${error.message}\n`);
+  process.exit(code === 'cli_error' ? 2 : 1);
+}

--- a/examples/buzz-signed-workspace-evidence/cli.mjs
+++ b/examples/buzz-signed-workspace-evidence/cli.mjs
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
-import { readFile, writeFile } from 'node:fs/promises';
+import { open, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   BuzzEvidenceError,
   compileBuzzEvidenceBundle,
 } from './buzz-event-evidence.mjs';
 
-const MAX_INPUT_BYTES = 4 * 1024 * 1024;
+export const MAX_INPUT_BYTES = 4 * 1024 * 1024;
 
 function usage() {
   return `Usage:
@@ -21,7 +22,7 @@ payment, deployment, publication, or trust mutation.
 `;
 }
 
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const args = [...argv];
   const result = {
     input: null,
@@ -45,22 +46,46 @@ function parseArgs(argv) {
   return result;
 }
 
-try {
-  const args = parseArgs(process.argv.slice(2));
+export async function readBoundedJsonFile(inputPath) {
+  const handle = await open(inputPath, 'r');
+  try {
+    const before = await handle.stat();
+    if (!before.isFile()) {
+      throw new BuzzEvidenceError('invalid_input', 'Input must be a regular JSON file.');
+    }
+    if (before.size > MAX_INPUT_BYTES) {
+      throw new BuzzEvidenceError(
+        'input_too_large',
+        `Input JSON exceeds the ${MAX_INPUT_BYTES}-byte CLI limit.`,
+      );
+    }
+
+    // Allocate at most the configured bound plus one sentinel byte. A file that
+    // grows while being read is rejected rather than being read without bound.
+    const bytes = Buffer.alloc(before.size + 1);
+    const { bytesRead } = await handle.read(bytes, 0, bytes.length, 0);
+    const after = await handle.stat();
+    if (bytesRead > MAX_INPUT_BYTES || bytesRead > before.size || after.size !== before.size) {
+      throw new BuzzEvidenceError(
+        'input_changed_during_read',
+        'Input changed while being read; retry with a stable file.',
+      );
+    }
+    return JSON.parse(bytes.subarray(0, bytesRead).toString('utf8'));
+  } finally {
+    await handle.close();
+  }
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
   if (args.help) {
     process.stdout.write(usage());
-    process.exit(0);
+    return 0;
   }
 
   const inputPath = resolve(args.input);
-  const bytes = await readFile(inputPath);
-  if (bytes.byteLength > MAX_INPUT_BYTES) {
-    throw new BuzzEvidenceError(
-      'input_too_large',
-      `Input JSON exceeds the ${MAX_INPUT_BYTES}-byte CLI limit.`,
-    );
-  }
-  const parsed = JSON.parse(bytes.toString('utf8'));
+  const parsed = await readBoundedJsonFile(inputPath);
   const events = Array.isArray(parsed) ? parsed : parsed.events;
   const bundle = compileBuzzEvidenceBundle({
     events,
@@ -72,8 +97,13 @@ try {
   const output = `${JSON.stringify(bundle, null, 2)}\n`;
   if (args.out) await writeFile(resolve(args.out), output, 'utf8');
   else process.stdout.write(output);
-} catch (error) {
-  const code = error instanceof BuzzEvidenceError ? error.code : 'cli_error';
-  process.stderr.write(`agoragentic-buzz-evidence: ${code}: ${error.message}\n`);
-  process.exit(code === 'cli_error' ? 2 : 1);
+  return 0;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch(error => {
+    const code = error instanceof BuzzEvidenceError ? error.code : 'cli_error';
+    process.stderr.write(`agoragentic-buzz-evidence: ${code}: ${error.message}\n`);
+    process.exitCode = code === 'cli_error' ? 2 : 1;
+  });
 }

--- a/examples/buzz-signed-workspace-evidence/listing-candidates.json
+++ b/examples/buzz-signed-workspace-evidence/listing-candidates.json
@@ -36,7 +36,7 @@
         "typed but unverified attestation references",
         "release evidence graph",
         "missing authority and persistence blockers",
-        "evidence root",
+        "full security-envelope bundle root",
         "local receipt"
       ],
       "pricing": {
@@ -51,6 +51,7 @@
         "nip01_vector_checked": true,
         "hash_only_metadata_default": true,
         "event_bound_attestations_required": true,
+        "relay_bound_audit_attestations_required": true,
         "independent_attestation_verifier_available": false,
         "live_buzz_export_adapter": false,
         "signature_verifier": false,

--- a/examples/buzz-signed-workspace-evidence/listing-candidates.json
+++ b/examples/buzz-signed-workspace-evidence/listing-candidates.json
@@ -1,10 +1,18 @@
 {
   "schema": "agoragentic.buzz-listing-candidates.v1",
-  "updated_at": "2026-08-07",
+  "updated_at": "2026-08-08",
   "upstream": {
     "name": "Block Buzz",
     "repository": "https://github.com/block/buzz",
     "license": "Apache-2.0",
+    "source_revision": "f029deafae6ad3b63e13c29104f3be76122cb1df",
+    "kind_registry_path": "crates/buzz-core/src/kind.rs",
+    "kind_registry_sha256": "sha256:74533cfc1ac016dcb1a83279c2b06f93807f29489604cdccefc46b645acfce97",
+    "nip01_repository": "https://github.com/nostr-protocol/nips",
+    "nip01_revision": "c53877571f96eb423661fc23c620d629d37b8f19",
+    "nip01_path": "01.md",
+    "nip01_sha256": "sha256:afa8a4eeff70d47503f2acab03b29f4bf0ed90ac95a10d3fd07e4fecddc8ae20",
+    "provenance_file": "upstream-provenance.json",
     "partnership_claimed": false,
     "live_compatibility_verified": false
   },
@@ -18,14 +26,14 @@
       "buyer_pain": "Teams can see that agents discussed and shipped a change, but cannot easily prove which signed actors proposed, reviewed, approved, tested, and released the exact revision or which evidence is missing.",
       "inputs": [
         "exported Buzz/Nostr events",
-        "optional signature-verification evidence",
-        "optional relay-audit evidence",
-        "optional principal bindings",
+        "optional typed signature-verification attestation reference",
+        "optional typed relay-audit persistence attestation reference",
+        "optional typed principal-binding attestation reference",
         "optional repository and CI evidence"
       ],
       "outputs": [
         "canonical event integrity",
-        "signed-actor evidence",
+        "typed but unverified attestation references",
         "release evidence graph",
         "missing authority and persistence blockers",
         "evidence root",
@@ -39,6 +47,11 @@
       },
       "readiness": {
         "local_event_compiler": true,
+        "exact_upstream_source_pinned": true,
+        "nip01_vector_checked": true,
+        "hash_only_metadata_default": true,
+        "event_bound_attestations_required": true,
+        "independent_attestation_verifier_available": false,
         "live_buzz_export_adapter": false,
         "signature_verifier": false,
         "paid_canary_passed": false,
@@ -84,6 +97,7 @@
   "required_gates": [
     "pin and exercise an exact Buzz commit or release",
     "verify NIP-01 signatures with an independent verifier",
+    "verify attestation artifact integrity and trusted verifier identity before treating a claim as evidence",
     "prove principal-to-agent key binding",
     "prove private-channel non-disclosure",
     "verify relay-audit persistence separately from event acceptance",

--- a/examples/buzz-signed-workspace-evidence/listing-candidates.json
+++ b/examples/buzz-signed-workspace-evidence/listing-candidates.json
@@ -1,0 +1,103 @@
+{
+  "schema": "agoragentic.buzz-listing-candidates.v1",
+  "updated_at": "2026-08-07",
+  "upstream": {
+    "name": "Block Buzz",
+    "repository": "https://github.com/block/buzz",
+    "license": "Apache-2.0",
+    "partnership_claimed": false,
+    "live_compatibility_verified": false
+  },
+  "candidates": [
+    {
+      "slug": "buzz-signed-release-evidence",
+      "name": "Buzz Signed Release Evidence Compiler",
+      "status": "experimental_not_published",
+      "category": "software-delivery",
+      "task": "Compile signed Buzz messages, patches, workflow events, review decisions, and external CI evidence into a bounded release-evidence packet and local receipt.",
+      "buyer_pain": "Teams can see that agents discussed and shipped a change, but cannot easily prove which signed actors proposed, reviewed, approved, tested, and released the exact revision or which evidence is missing.",
+      "inputs": [
+        "exported Buzz/Nostr events",
+        "optional signature-verification evidence",
+        "optional relay-audit evidence",
+        "optional principal bindings",
+        "optional repository and CI evidence"
+      ],
+      "outputs": [
+        "canonical event integrity",
+        "signed-actor evidence",
+        "release evidence graph",
+        "missing authority and persistence blockers",
+        "evidence root",
+        "local receipt"
+      ],
+      "pricing": {
+        "status": "unvalidated",
+        "recommended_launch": "free_bounded_canary",
+        "hypothesis_usd_per_bundle": "0.05",
+        "requires_measured_compute_and_demand": true
+      },
+      "readiness": {
+        "local_event_compiler": true,
+        "live_buzz_export_adapter": false,
+        "signature_verifier": false,
+        "paid_canary_passed": false,
+        "listing_published": false,
+        "x402_enabled": false
+      }
+    },
+    {
+      "slug": "buzz-incident-memory-evidence",
+      "name": "Buzz Incident Memory Evidence",
+      "status": "research_not_published",
+      "category": "incident-response",
+      "task": "Return a bounded, source-linked incident history from signed Buzz events, including prior fixes, actors, decisions, and unresolved evidence gaps.",
+      "pricing": {
+        "status": "unvalidated",
+        "recommended_launch": "free_design_partner_canary"
+      },
+      "readiness": {
+        "local_event_compiler": true,
+        "relay_search_adapter": false,
+        "private_channel_authorization_tested": false,
+        "listing_published": false
+      }
+    },
+    {
+      "slug": "governed-buzz-agent-workspace",
+      "name": "Governed Buzz Agent Workspace",
+      "status": "architecture_only_not_published",
+      "category": "agent-runtime",
+      "task": "Run an Agent OS worker inside a Buzz workspace through ACP or the Buzz CLI while enforcing filesystem, network, credentials, deployment, payment, and owner authority outside the model-controlled process.",
+      "pricing": {
+        "status": "not_defined"
+      },
+      "readiness": {
+        "buzz_acp_live_canary": false,
+        "buzz_cli_live_canary": false,
+        "restricted_runtime_lane": false,
+        "owner_stop_revoke_tested": false,
+        "listing_published": false
+      }
+    }
+  ],
+  "required_gates": [
+    "pin and exercise an exact Buzz commit or release",
+    "verify NIP-01 signatures with an independent verifier",
+    "prove principal-to-agent key binding",
+    "prove private-channel non-disclosure",
+    "verify relay-audit persistence separately from event acceptance",
+    "complete MCP and ACP compatibility matrix",
+    "keep shell and file operations behind Agent OS hard sandbox and policy chokepoints",
+    "run free canary before any price or publication claim",
+    "obtain explicit owner publication approval"
+  ],
+  "authority": {
+    "publishes_listing": false,
+    "enables_spend": false,
+    "enables_wallet": false,
+    "enables_x402": false,
+    "posts_to_buzz": false,
+    "mutates_trust": false
+  }
+}

--- a/examples/buzz-signed-workspace-evidence/package.json
+++ b/examples/buzz-signed-workspace-evidence/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@agoragentic/buzz-signed-workspace-evidence",
+  "version": "0.1.0-alpha.0",
+  "description": "Normalize Buzz/Nostr workspace events into bounded evidence without treating workspace membership as economic authority.",
+  "type": "module",
+  "private": true,
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20"
+  },
+  "bin": {
+    "agoragentic-buzz-evidence": "./cli.mjs"
+  },
+  "exports": {
+    ".": "./buzz-event-evidence.mjs"
+  },
+  "files": [
+    "buzz-event-evidence.mjs",
+    "cli.mjs",
+    "README.md",
+    "SKILL.md",
+    "listing-candidates.json",
+    "receipt-reference.schema.json"
+  ],
+  "scripts": {
+    "check": "node --check buzz-event-evidence.mjs && node --check cli.mjs && node --check test.mjs",
+    "test": "node --test test.mjs",
+    "pack:dry": "npm pack --dry-run"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rhein1/agoragentic-integrations.git",
+    "directory": "examples/buzz-signed-workspace-evidence"
+  },
+  "keywords": [
+    "buzz",
+    "nostr",
+    "agents",
+    "workspace",
+    "evidence",
+    "receipts",
+    "transaction-assurance",
+    "audit"
+  ]
+}

--- a/examples/buzz-signed-workspace-evidence/package.json
+++ b/examples/buzz-signed-workspace-evidence/package.json
@@ -15,12 +15,15 @@
     ".": "./buzz-event-evidence.mjs"
   },
   "files": [
+    "LICENSE",
     "buzz-event-evidence.mjs",
     "cli.mjs",
     "README.md",
     "SKILL.md",
     "listing-candidates.json",
-    "receipt-reference.schema.json"
+    "receipt-reference.schema.json",
+    "receipt-reference.example.json",
+    "upstream-provenance.json"
   ],
   "scripts": {
     "check": "node --check buzz-event-evidence.mjs && node --check cli.mjs && node --check test.mjs",

--- a/examples/buzz-signed-workspace-evidence/receipt-reference.example.json
+++ b/examples/buzz-signed-workspace-evidence/receipt-reference.example.json
@@ -1,0 +1,36 @@
+{
+  "schema": "agoragentic.buzz-transaction-assurance-reference.v1",
+  "transaction_id": "txn_example_only",
+  "buzz_event_id": "fbe42b8e93e7acf54b8f8d0f8c30612645503f4ba606789709ec906bc581f33a",
+  "evidence_root": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "mandate_ref": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "transaction_assurance_receipt_ref": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "states": {
+    "authority": "unknown",
+    "payment": "unknown",
+    "execution": "unknown",
+    "delivery": "unknown",
+    "outcome": "unknown",
+    "reconciliation": "unknown"
+  },
+  "publication": {
+    "event_kind_assigned": false,
+    "signed": false,
+    "posted": false,
+    "requires_explicit_principal_authority": true,
+    "requires_buzz_signing_key_outside_this_adapter": true
+  },
+  "non_claims": [
+    "This reference does not verify the Buzz event signature.",
+    "This reference does not grant payment or publication authority.",
+    "A Buzz channel membership is not an Agoragentic economic mandate.",
+    "A relay event is not by itself proof of payment, delivery, or reconciliation."
+  ],
+  "authority": {
+    "grants_spend": false,
+    "grants_wallet_access": false,
+    "grants_publication": false,
+    "grants_trust": false
+  },
+  "reference_hash": "sha256:e2867fe3fe09b8579e4ecd82a917101a206f12c28ec8a4276fe9dcba3ecddcf8"
+}

--- a/examples/buzz-signed-workspace-evidence/receipt-reference.example.json
+++ b/examples/buzz-signed-workspace-evidence/receipt-reference.example.json
@@ -2,10 +2,10 @@
   "schema": "agoragentic.buzz-transaction-assurance-reference.v1",
   "transaction_id": "txn_example_only",
   "buzz_event_id": "fbe42b8e93e7acf54b8f8d0f8c30612645503f4ba606789709ec906bc581f33a",
-  "evidence_root": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "evidence_bundle_root": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
   "mandate_ref": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
   "transaction_assurance_receipt_ref": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
-  "states": {
+  "claimed_states": {
     "authority": "unknown",
     "payment": "unknown",
     "execution": "unknown",
@@ -13,6 +13,7 @@
     "outcome": "unknown",
     "reconciliation": "unknown"
   },
+  "state_claims_verified": false,
   "publication": {
     "event_kind_assigned": false,
     "signed": false,
@@ -23,6 +24,7 @@
   "non_claims": [
     "This reference does not verify the Buzz event signature.",
     "This reference does not grant payment or publication authority.",
+    "Transaction Assurance state labels are caller-supplied claims and are not independently verified by this adapter.",
     "A Buzz channel membership is not an Agoragentic economic mandate.",
     "A relay event is not by itself proof of payment, delivery, or reconciliation."
   ],
@@ -32,5 +34,5 @@
     "grants_publication": false,
     "grants_trust": false
   },
-  "reference_hash": "sha256:e2867fe3fe09b8579e4ecd82a917101a206f12c28ec8a4276fe9dcba3ecddcf8"
+  "reference_hash": "sha256:0adcdd41aa11b5470f3ef350d6e33950362e2e544262327aa661a0fbcb0ace0a"
 }

--- a/examples/buzz-signed-workspace-evidence/receipt-reference.schema.json
+++ b/examples/buzz-signed-workspace-evidence/receipt-reference.schema.json
@@ -2,15 +2,16 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://agoragentic.com/schema/buzz-transaction-assurance-reference.v1.json",
   "title": "Buzz Transaction Assurance Reference",
-  "description": "Unsigned proposal-only reference for linking a Buzz event and evidence bundle to an external Agoragentic mandate and Transaction Assurance receipt. The schema does not assign a Nostr kind, sign, post, pay, settle, or grant authority.",
+  "description": "Unsigned proposal-only reference for linking a Buzz event and evidence bundle to an external Agoragentic mandate and Transaction Assurance receipt. All state labels are unverified caller claims. The schema does not assign a Nostr kind, sign, post, pay, settle, verify state, or grant authority.",
   "type": "object",
   "additionalProperties": false,
   "required": [
     "schema",
-    "evidence_root",
+    "evidence_bundle_root",
     "mandate_ref",
     "transaction_assurance_receipt_ref",
-    "states",
+    "claimed_states",
+    "state_claims_verified",
     "publication",
     "non_claims",
     "authority",
@@ -28,7 +29,7 @@
       "type": ["string", "null"],
       "pattern": "^[a-f0-9]{64}$"
     },
-    "evidence_root": {
+    "evidence_bundle_root": {
       "$ref": "#/$defs/sha256Ref"
     },
     "mandate_ref": {
@@ -37,7 +38,7 @@
     "transaction_assurance_receipt_ref": {
       "$ref": "#/$defs/sha256Ref"
     },
-    "states": {
+    "claimed_states": {
       "type": "object",
       "additionalProperties": false,
       "required": ["authority", "payment", "execution", "delivery", "outcome", "reconciliation"],
@@ -49,6 +50,9 @@
         "outcome": { "type": "string", "maxLength": 50 },
         "reconciliation": { "type": "string", "maxLength": 50 }
       }
+    },
+    "state_claims_verified": {
+      "const": false
     },
     "publication": {
       "type": "object",

--- a/examples/buzz-signed-workspace-evidence/receipt-reference.schema.json
+++ b/examples/buzz-signed-workspace-evidence/receipt-reference.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agoragentic.com/schema/buzz-transaction-assurance-reference.v1.json",
+  "title": "Buzz Transaction Assurance Reference",
+  "description": "Unsigned proposal-only reference for linking a Buzz event and evidence bundle to an external Agoragentic mandate and Transaction Assurance receipt. The schema does not assign a Nostr kind, sign, post, pay, settle, or grant authority.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "evidence_root",
+    "mandate_ref",
+    "transaction_assurance_receipt_ref",
+    "states",
+    "publication",
+    "non_claims",
+    "authority",
+    "reference_hash"
+  ],
+  "properties": {
+    "schema": {
+      "const": "agoragentic.buzz-transaction-assurance-reference.v1"
+    },
+    "transaction_id": {
+      "type": ["string", "null"],
+      "maxLength": 300
+    },
+    "buzz_event_id": {
+      "type": ["string", "null"],
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "evidence_root": {
+      "$ref": "#/$defs/sha256Ref"
+    },
+    "mandate_ref": {
+      "$ref": "#/$defs/sha256Ref"
+    },
+    "transaction_assurance_receipt_ref": {
+      "$ref": "#/$defs/sha256Ref"
+    },
+    "states": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["authority", "payment", "execution", "delivery", "outcome", "reconciliation"],
+      "properties": {
+        "authority": { "type": "string", "maxLength": 50 },
+        "payment": { "type": "string", "maxLength": 50 },
+        "execution": { "type": "string", "maxLength": 50 },
+        "delivery": { "type": "string", "maxLength": 50 },
+        "outcome": { "type": "string", "maxLength": 50 },
+        "reconciliation": { "type": "string", "maxLength": 50 }
+      }
+    },
+    "publication": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event_kind_assigned",
+        "signed",
+        "posted",
+        "requires_explicit_principal_authority",
+        "requires_buzz_signing_key_outside_this_adapter"
+      ],
+      "properties": {
+        "event_kind_assigned": { "const": false },
+        "signed": { "const": false },
+        "posted": { "const": false },
+        "requires_explicit_principal_authority": { "const": true },
+        "requires_buzz_signing_key_outside_this_adapter": { "const": true }
+      }
+    },
+    "non_claims": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["grants_spend", "grants_wallet_access", "grants_publication", "grants_trust"],
+      "properties": {
+        "grants_spend": { "const": false },
+        "grants_wallet_access": { "const": false },
+        "grants_publication": { "const": false },
+        "grants_trust": { "const": false }
+      }
+    },
+    "reference_hash": {
+      "$ref": "#/$defs/sha256Ref"
+    }
+  },
+  "$defs": {
+    "sha256Ref": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    }
+  }
+}

--- a/examples/buzz-signed-workspace-evidence/test.mjs
+++ b/examples/buzz-signed-workspace-evidence/test.mjs
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
 import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { delimiter, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 import {
@@ -12,6 +14,7 @@ import {
   buildBuzzTransactionAssuranceReference,
   canonicalBuzzEventId,
   compileBuzzEvidenceBundle,
+  verifyBuzzEvidenceBundle,
 } from './buzz-event-evidence.mjs';
 import { MAX_INPUT_BYTES } from './cli.mjs';
 
@@ -19,6 +22,7 @@ const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
 const PUBKEY_A = '1'.repeat(64);
 const PUBKEY_B = '2'.repeat(64);
 const SIGNATURE = '3'.repeat(128);
+const RELAY_URL = 'wss://relay.example.test';
 const ref = character => `sha256:${character.repeat(64)}`;
 
 const NIP01_VECTOR = Object.freeze({
@@ -49,8 +53,72 @@ function clone(value) {
   return JSON.parse(JSON.stringify(value));
 }
 
-function typedAttestations(message) {
-  const preliminary = compileBuzzEvidenceBundle({ events: [message] });
+function testStableStringify(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(item => testStableStringify(item)).join(',')}]`;
+  return `{${Object.keys(value).sort().map(key => (
+    `${JSON.stringify(key)}:${testStableStringify(value[key])}`
+  )).join(',')}}`;
+}
+
+function testSha256(value) {
+  return `sha256:${createHash('sha256').update(value, 'utf8').digest('hex')}`;
+}
+
+function rehashBundle(bundle) {
+  bundle.event_commitments = bundle.events.map(value => ({
+    event_id: value.event_id,
+    commitment_ref: testSha256(testStableStringify(value)),
+  }));
+  bundle.event_root = testSha256(testStableStringify({
+    schema: 'agoragentic.buzz-evidence-root.v2',
+    source: bundle.source,
+    relationships: bundle.relationships,
+    event_commitments: bundle.event_commitments,
+  }));
+  bundle.bundle_root = testSha256(testStableStringify({
+    schema: 'agoragentic.buzz-evidence-bundle-root.v1',
+    bundle_schema: bundle.schema,
+    source: bundle.source,
+    event_root: bundle.event_root,
+    event_commitments: bundle.event_commitments,
+    events: bundle.events,
+    relationships: bundle.relationships,
+    summary: bundle.summary,
+    privacy: bundle.privacy,
+    transaction_assurance_readiness: bundle.transaction_assurance_readiness,
+    authority: bundle.authority,
+  }));
+  bundle.bundle_id = `buzz_bundle_${bundle.bundle_root.slice(7, 19)}`;
+  return bundle;
+}
+
+function resolveNpmCli() {
+  const executableDirectory = dirname(process.execPath);
+  const installRoot = dirname(executableDirectory);
+  const candidates = [
+    process.env.npm_execpath,
+    join(executableDirectory, 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+    join(installRoot, 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'),
+  ];
+  for (const pathEntry of (process.env.PATH || '').split(delimiter).filter(Boolean)) {
+    candidates.push(join(pathEntry, 'node_modules', 'npm', 'bin', 'npm-cli.js'));
+    candidates.push(join(dirname(pathEntry), 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js'));
+  }
+  return candidates.find(candidate => candidate && existsSync(candidate)) || null;
+}
+
+function runNpm(args, options) {
+  const npmCli = resolveNpmCli();
+  if (npmCli) return spawnSync(process.execPath, [npmCli, ...args], options);
+  return spawnSync(process.platform === 'win32' ? 'npm.cmd' : 'npm', args, {
+    ...options,
+    shell: process.platform === 'win32',
+  });
+}
+
+function typedAttestations(message, relayUrl = RELAY_URL) {
+  const preliminary = compileBuzzEvidenceBundle({ events: [message], relay_url: relayUrl });
   const signatureHash = preliminary.events[0].signature.signature_hash;
   const binding = {
     event_id: message.id,
@@ -78,6 +146,7 @@ function typedAttestations(message) {
     audit_attestations: {
       [message.id]: {
         ...binding,
+        relay_url_hash: preliminary.source.relay_url_hash,
         persistence_status: 'persisted',
         audit_entry_ref: ref('6'),
         audit_head_ref: ref('7'),
@@ -101,7 +170,7 @@ function assertReceiptReferenceInstance(schema, instance) {
 
   const shaRefPattern = new RegExp(schema.$defs.sha256Ref.pattern);
   assert.equal(instance.schema, schema.properties.schema.const);
-  assert.match(instance.evidence_root, shaRefPattern);
+  assert.match(instance.evidence_bundle_root, shaRefPattern);
   assert.match(instance.mandate_ref, shaRefPattern);
   assert.match(instance.transaction_assurance_receipt_ref, shaRefPattern);
   assert.match(instance.reference_hash, shaRefPattern);
@@ -109,12 +178,13 @@ function assertReceiptReferenceInstance(schema, instance) {
   assert.equal(typeof instance.transaction_id, 'string');
   assert(instance.transaction_id.length <= schema.properties.transaction_id.maxLength);
 
-  const stateSchema = schema.properties.states;
-  assert.deepEqual(Object.keys(instance.states).sort(), stateSchema.required.slice().sort());
-  for (const value of Object.values(instance.states)) {
+  const stateSchema = schema.properties.claimed_states;
+  assert.deepEqual(Object.keys(instance.claimed_states).sort(), stateSchema.required.slice().sort());
+  for (const value of Object.values(instance.claimed_states)) {
     assert.equal(typeof value, 'string');
     assert(value.length <= stateSchema.properties.authority.maxLength);
   }
+  assert.equal(instance.state_claims_verified, schema.properties.state_claims_verified.const);
 
   for (const [field, definition] of Object.entries(schema.properties.publication.properties)) {
     assert.equal(instance.publication[field], definition.const);
@@ -173,10 +243,15 @@ test('compiles canonical Buzz events without emitting raw workspace metadata by 
   assert.equal(bundle.events[0].source_integrity.canonical_event_id_verified, true);
   assert.equal(bundle.events[0].signature.status, 'not_verified');
   assert.equal(bundle.events[0].content.policy, 'hash_only');
+  assert.equal(bundle.events[0].content.raw_content_embedded, false);
+  assert.equal(bundle.events[0].content.safe_for_publication, false);
   assert.equal(bundle.source.metadata_policy, 'hash_only');
   assert.equal(bundle.source.raw_source_metadata_embedded, false);
   assert.equal(bundle.source.compatibility_verified_against_live_relay, false);
   assert.equal(bundle.events[0].author_pubkey, undefined);
+  assert.equal(bundle.privacy.raw_content_embedded, false);
+  assert.equal(bundle.privacy.safe_for_publication, false);
+  assert.equal(bundle.privacy.publication_review_required, true);
   assert.match(bundle.events[0].references.channel_ref_hashes[0], /^sha256:[a-f0-9]{64}$/);
   assert.equal(bundle.transaction_assurance_readiness.ready_for_economic_action, false);
   assert(bundle.transaction_assurance_readiness.blockers.includes('workspace_membership_is_not_an_economic_mandate'));
@@ -185,7 +260,7 @@ test('compiles canonical Buzz events without emitting raw workspace metadata by 
 
 test('records typed, event-bound attestations as unverified claims rather than external verification', () => {
   const message = event();
-  const bundle = compileBuzzEvidenceBundle({ events: [message] }, typedAttestations(message));
+  const bundle = compileBuzzEvidenceBundle({ events: [message], relay_url: RELAY_URL }, typedAttestations(message));
 
   assert.equal(bundle.summary.signature_validity_claims_by_unverified_attestation_reference, 1);
   assert.equal(bundle.summary.principal_binding_claims_by_unverified_attestation_reference, 1);
@@ -197,6 +272,7 @@ test('records typed, event-bound attestations as unverified claims rather than e
   assert.equal(bundle.events[0].principal_binding.binding_verified, false);
   assert.equal(bundle.events[0].relay_audit.status, 'persistence_claimed_by_unverified_attestation_reference');
   assert.equal(bundle.events[0].relay_audit.attestation_reference_verified, false);
+  assert.equal(bundle.events[0].relay_audit.claimed_binding.relay_url_hash, bundle.source.relay_url_hash);
   assert.equal(bundle.events[0].authority.principal_mandate_verified, false);
   assert.equal(bundle.source.attestation_references_independently_verified, false);
   assert.equal(bundle.transaction_assurance_readiness.ready_for_payment, false);
@@ -221,14 +297,17 @@ test('records typed, event-bound attestations as unverified claims rather than e
   const mismatched = typedAttestations(message);
   mismatched.signature_attestations[message.id].pubkey = PUBKEY_B;
   assert.throws(
-    () => compileBuzzEvidenceBundle({ events: [message] }, mismatched),
+    () => compileBuzzEvidenceBundle({ events: [message], relay_url: RELAY_URL }, mismatched),
     error => error instanceof BuzzEvidenceError && error.code === 'attestation_binding_mismatch',
   );
 
   const forgedButWellFormed = typedAttestations(message);
   forgedButWellFormed.signature_attestations[message.id].verifier = 'attacker-supplied-label';
   forgedButWellFormed.signature_attestations[message.id].attestation_ref = ref('f');
-  const forgedBundle = compileBuzzEvidenceBundle({ events: [message] }, forgedButWellFormed);
+  const forgedBundle = compileBuzzEvidenceBundle(
+    { events: [message], relay_url: RELAY_URL },
+    forgedButWellFormed,
+  );
   assert.equal(
     forgedBundle.events[0].signature.status,
     'validity_claimed_by_unverified_attestation_reference',
@@ -237,7 +316,31 @@ test('records typed, event-bound attestations as unverified claims rather than e
   assert.equal(forgedBundle.events[0].signature.attestation_reference_verified, false);
 });
 
-test('commits all material evidence and source metadata into the event root', () => {
+test('requires relay-audit attestations to bind the exact source relay', () => {
+  const message = event();
+  const attestations = typedAttestations(message, RELAY_URL);
+
+  assert.throws(
+    () => compileBuzzEvidenceBundle({ events: [message] }, attestations),
+    error => error instanceof BuzzEvidenceError && error.code === 'relay_binding_required',
+  );
+  assert.throws(
+    () => compileBuzzEvidenceBundle(
+      { events: [message], relay_url: 'wss://other-relay.example.test' },
+      attestations,
+    ),
+    error => error instanceof BuzzEvidenceError && error.code === 'attestation_binding_mismatch',
+  );
+
+  const missingRelayBinding = clone(attestations);
+  delete missingRelayBinding.audit_attestations[message.id].relay_url_hash;
+  assert.throws(
+    () => compileBuzzEvidenceBundle({ events: [message], relay_url: RELAY_URL }, missingRelayBinding),
+    error => error instanceof BuzzEvidenceError && error.code === 'invalid_reference',
+  );
+});
+
+test('commits normalized event evidence and source metadata into the event root', () => {
   const message = event();
   const input = {
     events: [message],
@@ -260,7 +363,10 @@ test('commits all material evidence and source metadata into the event root', ()
   assert.notEqual(compileBuzzEvidenceBundle(input, auditMutation).event_root, baseline);
 
   assert.notEqual(
-    compileBuzzEvidenceBundle({ ...input, relay_url: 'wss://other.example.test' }, options).event_root,
+    compileBuzzEvidenceBundle(
+      { ...input, relay_url: 'wss://other.example.test' },
+      typedAttestations(message, 'wss://other.example.test'),
+    ).event_root,
     baseline,
   );
 
@@ -269,6 +375,58 @@ test('commits all material evidence and source metadata into the event root', ()
     compileBuzzEvidenceBundle({ ...input, events: [signatureMutationEvent] }, typedAttestations(signatureMutationEvent)).event_root,
     baseline,
   );
+});
+
+test('commits and verifies the complete deterministic security envelope', () => {
+  const message = event();
+  const bundle = compileBuzzEvidenceBundle(
+    { events: [message], relay_url: RELAY_URL, community_ref: 'community:test' },
+    typedAttestations(message),
+  );
+  const valid = verifyBuzzEvidenceBundle(bundle, { expected_bundle_root: bundle.bundle_root });
+
+  assert.equal(valid.valid, true);
+  assert.deepEqual(valid.failures, []);
+  assert.equal(valid.recomputed_bundle_root, bundle.bundle_root);
+  assert.equal(valid.recomputed_event_root, bundle.event_root);
+  assert.equal(bundle.bundle_id, `buzz_bundle_${bundle.bundle_root.slice(7, 19)}`);
+
+  const mutations = [
+    ['authority', value => { value.authority.grants_spend = true; }, 'authority_mismatch'],
+    ['readiness', value => { value.transaction_assurance_readiness.ready_for_payment = true; }, 'transaction_assurance_readiness_mismatch'],
+    ['blockers', value => { value.transaction_assurance_readiness.blockers = []; }, 'transaction_assurance_readiness_mismatch'],
+    ['privacy', value => { value.privacy.safe_for_publication = true; }, 'privacy_mismatch'],
+    ['summary', value => { value.summary.event_count = 99; }, 'summary_mismatch'],
+    ['source', value => { value.source.partnership_claimed = true; }, 'source_policy_mismatch'],
+    ['raw source', value => { value.source.relay_url = RELAY_URL; }, 'invalid_source'],
+    ['event', value => { value.events[0].content.content_hash = ref('e'); }, 'event_commitments_mismatch'],
+    ['raw event', value => { value.events[0].raw_event = { content: 'private' }; }, 'invalid_event_evidence'],
+    ['raw reference', value => { value.events[0].references.repository_ref_hashes = ['private-repository']; }, 'event_reference_privacy_mismatch'],
+    ['event authority', value => { value.events[0].authority.spend_allowed = true; }, 'event_authority_mismatch'],
+    ['signature boundary', value => { value.events[0].signature.status = 'verified'; }, 'signature_evidence_boundary_mismatch'],
+    ['relay binding', value => { value.events[0].relay_audit.claimed_binding.relay_url_hash = ref('f'); }, 'relay_attestation_binding_mismatch'],
+  ];
+  for (const [label, mutate, expectedFailure] of mutations) {
+    const tampered = clone(bundle);
+    mutate(tampered);
+    const result = verifyBuzzEvidenceBundle(tampered, { expected_bundle_root: bundle.bundle_root });
+    assert.equal(result.valid, false, `${label} mutation must fail verification`);
+    assert(result.failures.includes(expectedFailure), `${label} mutation must report ${expectedFailure}`);
+    assert(result.failures.includes('bundle_root_mismatch'), `${label} mutation must break the bundle root`);
+  }
+
+  const unexpectedField = { ...clone(bundle), created_at: new Date().toISOString() };
+  const unexpectedResult = verifyBuzzEvidenceBundle(unexpectedField);
+  assert.equal(unexpectedResult.valid, false);
+  assert(unexpectedResult.failures.includes('unexpected_field:created_at'));
+
+  const rehashedPolicyForgery = clone(bundle);
+  rehashedPolicyForgery.events[0].authority.spend_allowed = true;
+  rehashBundle(rehashedPolicyForgery);
+  const rehashedResult = verifyBuzzEvidenceBundle(rehashedPolicyForgery);
+  assert.equal(rehashedResult.valid, false);
+  assert(rehashedResult.failures.includes('event_authority_mismatch'));
+  assert(!rehashedResult.failures.includes('bundle_root_mismatch'));
 });
 
 test('pins the classifier to the reviewed Block/Buzz registry subset', async () => {
@@ -286,18 +444,46 @@ test('pins the classifier to the reviewed Block/Buzz registry subset', async () 
   assert.equal(bundle.events[1].event_type, 'workflow_event');
 });
 
-test('bounded content is redacted and never represented as exact after redaction', () => {
+test('bounded content uses best-effort redaction and is marked raw and unsafe to publish', () => {
   const message = event({
-    content: 'Deploy with Authorization: Bearer abcdefghijklmnop and api_key=secret-value-123.',
+    content: [
+      'Deploy with Authorization: Bearer abcdefghijklmnop and api_key=secret-value-123.',
+      'github_pat_SYNTHETIC0123456789ABCDEFG',
+      'card=4111111111111111',
+      'https://operator:private-password@private.example/path',
+    ].join(' '),
   });
   const bundle = compileBuzzEvidenceBundle({ events: [message] }, {
     content_policy: 'bounded',
   });
   const evidence = bundle.events[0];
 
-  assert.match(evidence.content.bounded_content, /\[REDACTED\]/);
-  assert(evidence.content.redaction_count >= 1);
+  assert.match(evidence.content.bounded_content, /\[REDACTED\]|_REDACTED\]/);
+  assert(evidence.content.redaction_count >= 4);
+  assert.doesNotMatch(evidence.content.bounded_content, /github_pat_|4111111111111111|operator:private-password/);
+  assert.equal(evidence.content.policy, 'bounded_best_effort_redaction');
+  assert.equal(evidence.content.raw_content_embedded, true);
+  assert.equal(evidence.content.redaction_complete, false);
+  assert.equal(evidence.content.safe_for_publication, false);
+  assert.equal(evidence.source_integrity.raw_workspace_metadata_embedded, true);
   assert.equal(evidence.source_integrity.exact_content_embedded, false);
+  assert.equal(bundle.privacy.raw_content_embedded, true);
+  assert.equal(bundle.privacy.redaction_assurance, 'best_effort_known_patterns_only');
+  assert.equal(bundle.privacy.safe_for_publication, false);
+  assert(bundle.transaction_assurance_readiness.blockers.includes(
+    'bounded_content_requires_explicit_authority_private_handling_and_publication_review',
+  ));
+});
+
+test('redacts the complete content before applying the bounded-content limit', () => {
+  const token = 'github_pat_SYNTHETIC0123456789ABCDEFG';
+  const message = event({ content: `${'x'.repeat(7_990)} ${token} suffix` });
+  const bundle = compileBuzzEvidenceBundle({ events: [message] }, { content_policy: 'bounded' });
+  const content = bundle.events[0].content;
+
+  assert.equal(content.truncated, true);
+  assert.equal(content.redaction_complete, false);
+  assert.doesNotMatch(content.bounded_content, /github_pat_|SYNTHETIC0123456789ABCDEFG/);
 });
 
 test('the CLI rejects oversized input before parsing it', async () => {
@@ -335,10 +521,8 @@ test('the packed artifact installs and runs the local CLI without a network acti
     await writeFile(join(installerDirectory, 'package.json'), JSON.stringify({ private: true }), 'utf8');
     await writeFile(inputPath, JSON.stringify([event()]), 'utf8');
 
-    const npmCli = process.env.npm_execpath;
-    assert(npmCli, 'npm_execpath must be available when running the package test script');
     const npmFlags = ['--ignore-scripts', '--offline', '--no-audit', '--no-fund'];
-    const pack = spawnSync(process.execPath, [npmCli, 'pack', MODULE_DIR, ...npmFlags], {
+    const pack = runNpm(['pack', MODULE_DIR, ...npmFlags], {
       cwd: directory,
       encoding: 'utf8',
       timeout: 20_000,
@@ -348,7 +532,7 @@ test('the packed artifact installs and runs the local CLI without a network acti
       .find(file => file.endsWith('.tgz'));
     assert(tarball, 'npm pack did not produce a tarball');
 
-    const install = spawnSync(process.execPath, [npmCli, 'install', join(directory, tarball), ...npmFlags], {
+    const install = runNpm(['install', join(directory, tarball), ...npmFlags], {
       cwd: installerDirectory,
       encoding: 'utf8',
       timeout: 20_000,
@@ -400,10 +584,10 @@ test('builds an unsigned proposal-only Transaction Assurance reference', () => {
   const reference = buildBuzzTransactionAssuranceReference({
     transaction_id: 'txn_123',
     buzz_event_id: event().id,
-    evidence_root: ref('b'),
+    evidence_bundle_root: ref('b'),
     mandate_ref: ref('c'),
     transaction_assurance_receipt_ref: ref('d'),
-    states: {
+    claimed_states: {
       authority: 'verified',
       payment: 'final',
       execution: 'completed',
@@ -417,8 +601,28 @@ test('builds an unsigned proposal-only Transaction Assurance reference', () => {
   assert.equal(reference.publication.event_kind_assigned, false);
   assert.equal(reference.publication.signed, false);
   assert.equal(reference.publication.posted, false);
+  assert.equal(reference.claimed_states.payment, 'final');
+  assert.equal(reference.state_claims_verified, false);
   assert.equal(reference.authority.grants_publication, false);
   assert.match(reference.reference_hash, /^sha256:[a-f0-9]{64}$/);
+
+  assert.throws(
+    () => buildBuzzTransactionAssuranceReference({
+      evidence_bundle_root: ref('b'),
+      mandate_ref: ref('c'),
+      transaction_assurance_receipt_ref: ref('d'),
+      states: { payment: 'final' },
+    }),
+    error => error instanceof BuzzEvidenceError && error.code === 'deprecated_transaction_state_shape',
+  );
+  assert.throws(
+    () => buildBuzzTransactionAssuranceReference({
+      evidence_root: ref('b'),
+      mandate_ref: ref('c'),
+      transaction_assurance_receipt_ref: ref('d'),
+    }),
+    error => error instanceof BuzzEvidenceError && error.code === 'deprecated_evidence_root_shape',
+  );
 });
 
 test('the deterministic proposal-only fixture conforms to its declared schema contract', async () => {
@@ -429,10 +633,10 @@ test('the deterministic proposal-only fixture conforms to its declared schema co
   const regenerated = buildBuzzTransactionAssuranceReference({
     transaction_id: fixture.transaction_id,
     buzz_event_id: fixture.buzz_event_id,
-    evidence_root: fixture.evidence_root,
+    evidence_bundle_root: fixture.evidence_bundle_root,
     mandate_ref: fixture.mandate_ref,
     transaction_assurance_receipt_ref: fixture.transaction_assurance_receipt_ref,
-    states: fixture.states,
+    claimed_states: fixture.claimed_states,
   });
   assert.deepEqual(regenerated, fixture);
 });

--- a/examples/buzz-signed-workspace-evidence/test.mjs
+++ b/examples/buzz-signed-workspace-evidence/test.mjs
@@ -1,0 +1,155 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  BuzzEvidenceError,
+  buildBuzzTransactionAssuranceReference,
+  canonicalBuzzEventId,
+  compileBuzzEvidenceBundle,
+} from './buzz-event-evidence.mjs';
+
+const PUBKEY_A = '1'.repeat(64);
+const PUBKEY_B = '2'.repeat(64);
+const SIGNATURE = '3'.repeat(128);
+
+function event(overrides = {}) {
+  const value = {
+    pubkey: overrides.pubkey || PUBKEY_A,
+    created_at: overrides.created_at ?? 1_786_000_000,
+    kind: overrides.kind ?? 9,
+    tags: overrides.tags || [['h', 'channel-1'], ['p', PUBKEY_B]],
+    content: overrides.content || 'Release candidate is ready for review.',
+    sig: overrides.sig || SIGNATURE,
+  };
+  return {
+    ...value,
+    id: overrides.id || canonicalBuzzEventId(value),
+  };
+}
+
+test('compiles canonical Buzz events without inventing economic authority', () => {
+  const message = event();
+  const bundle = compileBuzzEvidenceBundle({
+    events: [message],
+    relay_url: 'https://buzz.example.test',
+    community_ref: 'community:test',
+  });
+
+  assert.equal(bundle.schema, 'agoragentic.buzz-evidence-bundle.v1');
+  assert.equal(bundle.events.length, 1);
+  assert.equal(bundle.events[0].event_type, 'stream_message');
+  assert.equal(bundle.events[0].source_integrity.canonical_event_id_verified, true);
+  assert.equal(bundle.events[0].signature.status, 'not_verified');
+  assert.equal(bundle.events[0].content.policy, 'hash_only');
+  assert.equal(bundle.events[0].content.bounded_content, null);
+  assert.deepEqual(bundle.relationships.channel_refs, ['channel-1']);
+  assert.equal(bundle.transaction_assurance_readiness.ready_for_economic_action, false);
+  assert(bundle.transaction_assurance_readiness.blockers.includes('workspace_membership_is_not_an_economic_mandate'));
+  assert.equal(bundle.authority.posts_to_buzz, false);
+});
+
+test('bounded content is redacted and never represented as exact after redaction', () => {
+  const message = event({
+    content: 'Deploy with Authorization: Bearer abcdefghijklmnop and api_key=secret-value-123.',
+  });
+  const bundle = compileBuzzEvidenceBundle({ events: [message] }, {
+    content_policy: 'bounded',
+  });
+  const evidence = bundle.events[0];
+
+  assert.match(evidence.content.bounded_content, /\[REDACTED\]/);
+  assert(evidence.content.redaction_count >= 1);
+  assert.equal(evidence.source_integrity.exact_content_embedded, false);
+});
+
+test('external signature, principal, and audit evidence remain scoped', () => {
+  const message = event();
+  const signatureRef = `sha256:${'4'.repeat(64)}`;
+  const bindingRef = `sha256:${'5'.repeat(64)}`;
+  const auditRef = `sha256:${'6'.repeat(64)}`;
+  const bundle = compileBuzzEvidenceBundle({ events: [message] }, {
+    signature_verifications: {
+      [message.id]: {
+        signature_valid: true,
+        verifier: 'nostr-verifier',
+        verifier_version: '1.0.0',
+        evidence_ref: signatureRef,
+      },
+    },
+    principal_bindings: {
+      [message.pubkey]: {
+        principal_ref: 'principal:owner-1',
+        agent_ref: 'agent:buzz-1',
+        binding_evidence_ref: bindingRef,
+      },
+    },
+    audit_evidence: {
+      [message.id]: {
+        persisted: true,
+        audit_entry_ref: auditRef,
+        audit_head_ref: auditRef,
+        verifier: 'buzz-audit-export',
+      },
+    },
+  });
+
+  assert.equal(bundle.summary.signatures_verified, 1);
+  assert.equal(bundle.summary.principals_bound, 1);
+  assert.equal(bundle.summary.audit_entries_verified, 1);
+  assert.equal(bundle.events[0].principal_binding.status, 'bound_by_external_evidence');
+  assert.equal(bundle.events[0].authority.principal_mandate_verified, false);
+  assert.equal(bundle.transaction_assurance_readiness.ready_for_payment, false);
+  assert(bundle.transaction_assurance_readiness.blockers.includes('principal_mandate_required_before_economic_action'));
+});
+
+test('rejects a tampered event ID', () => {
+  const message = event();
+  message.content = 'tampered';
+  assert.throws(
+    () => compileBuzzEvidenceBundle({ events: [message] }),
+    error => error instanceof BuzzEvidenceError && error.code === 'event_id_mismatch',
+  );
+});
+
+test('rejects duplicate event IDs', () => {
+  const message = event();
+  assert.throws(
+    () => compileBuzzEvidenceBundle({ events: [message, message] }),
+    error => error instanceof BuzzEvidenceError && error.code === 'duplicate_event',
+  );
+});
+
+test('classifies workflow and git evidence while preserving order deterministically', () => {
+  const workflow = event({ kind: 46004, created_at: 20, content: 'approval requested' });
+  const patch = event({ kind: 1617, created_at: 10, content: 'patch body' });
+  const bundle = compileBuzzEvidenceBundle({ events: [workflow, patch] });
+
+  assert.equal(bundle.events[0].event_type, 'git_patch');
+  assert.equal(bundle.events[1].event_type, 'workflow_event');
+  assert.equal(bundle.summary.event_types.git_patch, 1);
+  assert.equal(bundle.summary.event_types.workflow_event, 1);
+});
+
+test('builds an unsigned proposal-only Transaction Assurance reference', () => {
+  const reference = buildBuzzTransactionAssuranceReference({
+    transaction_id: 'txn_123',
+    buzz_event_id: event().id,
+    evidence_root: `sha256:${'7'.repeat(64)}`,
+    mandate_ref: `sha256:${'8'.repeat(64)}`,
+    transaction_assurance_receipt_ref: `sha256:${'9'.repeat(64)}`,
+    states: {
+      authority: 'verified',
+      payment: 'final',
+      execution: 'completed',
+      delivery: 'verified',
+      outcome: 'pass',
+      reconciliation: 'complete',
+    },
+  });
+
+  assert.equal(reference.schema, 'agoragentic.buzz-transaction-assurance-reference.v1');
+  assert.equal(reference.publication.event_kind_assigned, false);
+  assert.equal(reference.publication.signed, false);
+  assert.equal(reference.publication.posted, false);
+  assert.equal(reference.authority.grants_publication, false);
+  assert.match(reference.reference_hash, /^sha256:[a-f0-9]{64}$/);
+});

--- a/examples/buzz-signed-workspace-evidence/test.mjs
+++ b/examples/buzz-signed-workspace-evidence/test.mjs
@@ -1,50 +1,289 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 import {
+  BUZZ_EVIDENCE_CONSTANTS,
+  BUZZ_UPSTREAM_PROVENANCE,
   BuzzEvidenceError,
   buildBuzzTransactionAssuranceReference,
   canonicalBuzzEventId,
   compileBuzzEvidenceBundle,
 } from './buzz-event-evidence.mjs';
+import { MAX_INPUT_BYTES } from './cli.mjs';
 
+const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
 const PUBKEY_A = '1'.repeat(64);
 const PUBKEY_B = '2'.repeat(64);
 const SIGNATURE = '3'.repeat(128);
+const ref = character => `sha256:${character.repeat(64)}`;
+
+const NIP01_VECTOR = Object.freeze({
+  pubkey: '79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798',
+  created_at: 1_234_567_890,
+  kind: 1,
+  tags: [],
+  content: 'Hello, world!',
+  id: 'fbe42b8e93e7acf54b8f8d0f8c30612645503f4ba606789709ec906bc581f33a',
+});
 
 function event(overrides = {}) {
   const value = {
-    pubkey: overrides.pubkey || PUBKEY_A,
+    pubkey: overrides.pubkey ?? PUBKEY_A,
     created_at: overrides.created_at ?? 1_786_000_000,
     kind: overrides.kind ?? 9,
-    tags: overrides.tags || [['h', 'channel-1'], ['p', PUBKEY_B]],
-    content: overrides.content || 'Release candidate is ready for review.',
-    sig: overrides.sig || SIGNATURE,
+    tags: overrides.tags ?? [['h', 'channel-1'], ['p', PUBKEY_B]],
+    content: overrides.content ?? 'Release candidate is ready for review.',
+    sig: overrides.sig ?? SIGNATURE,
   };
   return {
     ...value,
-    id: overrides.id || canonicalBuzzEventId(value),
+    id: overrides.id ?? canonicalBuzzEventId(value),
   };
 }
 
-test('compiles canonical Buzz events without inventing economic authority', () => {
-  const message = event();
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function typedAttestations(message) {
+  const preliminary = compileBuzzEvidenceBundle({ events: [message] });
+  const signatureHash = preliminary.events[0].signature.signature_hash;
+  const binding = {
+    event_id: message.id,
+    pubkey: message.pubkey,
+    signature_hash: signatureHash,
+  };
+  return {
+    signature_attestations: {
+      [message.id]: {
+        ...binding,
+        verification_result: 'valid',
+        verifier: 'independent-nostr-verifier',
+        verifier_version: '1.0.0',
+        attestation_ref: ref('4'),
+      },
+    },
+    principal_attestations: {
+      [message.id]: {
+        ...binding,
+        principal_ref: 'principal:owner-1',
+        agent_ref: 'agent:buzz-1',
+        attestation_ref: ref('5'),
+      },
+    },
+    audit_attestations: {
+      [message.id]: {
+        ...binding,
+        persistence_status: 'persisted',
+        audit_entry_ref: ref('6'),
+        audit_head_ref: ref('7'),
+        verifier: 'buzz-audit-export',
+        verifier_version: '1.0.0',
+        attestation_ref: ref('8'),
+      },
+    },
+  };
+}
+
+function assertReceiptReferenceInstance(schema, instance) {
+  assert.equal(schema.type, 'object');
+  const permittedFields = new Set(Object.keys(schema.properties));
+  for (const field of Object.keys(instance)) {
+    assert(permittedFields.has(field), `unexpected receipt-reference field: ${field}`);
+  }
+  for (const field of schema.required) {
+    assert(Object.hasOwn(instance, field), `missing receipt-reference field: ${field}`);
+  }
+
+  const shaRefPattern = new RegExp(schema.$defs.sha256Ref.pattern);
+  assert.equal(instance.schema, schema.properties.schema.const);
+  assert.match(instance.evidence_root, shaRefPattern);
+  assert.match(instance.mandate_ref, shaRefPattern);
+  assert.match(instance.transaction_assurance_receipt_ref, shaRefPattern);
+  assert.match(instance.reference_hash, shaRefPattern);
+  assert.match(instance.buzz_event_id, new RegExp(schema.properties.buzz_event_id.pattern));
+  assert.equal(typeof instance.transaction_id, 'string');
+  assert(instance.transaction_id.length <= schema.properties.transaction_id.maxLength);
+
+  const stateSchema = schema.properties.states;
+  assert.deepEqual(Object.keys(instance.states).sort(), stateSchema.required.slice().sort());
+  for (const value of Object.values(instance.states)) {
+    assert.equal(typeof value, 'string');
+    assert(value.length <= stateSchema.properties.authority.maxLength);
+  }
+
+  for (const [field, definition] of Object.entries(schema.properties.publication.properties)) {
+    assert.equal(instance.publication[field], definition.const);
+  }
+  for (const [field, definition] of Object.entries(schema.properties.authority.properties)) {
+    assert.equal(instance.authority[field], definition.const);
+  }
+  assert(instance.non_claims.length >= schema.properties.non_claims.minItems);
+  for (const claim of instance.non_claims) assert.equal(typeof claim, 'string');
+}
+
+test('matches an independent fixed NIP-01 serialization vector', () => {
+  assert.equal(canonicalBuzzEventId(NIP01_VECTOR), NIP01_VECTOR.id);
+});
+
+test('rejects coercion, uppercase wire fields, and NIP-01 kind overflow', () => {
+  const valid = event();
+  const alphabeticPubkey = event({ pubkey: 'a'.repeat(64) });
+  const alphabeticSignature = event({ sig: 'b'.repeat(128) });
+  const invalidEvents = [
+    { ...valid, id: valid.id.toUpperCase() },
+    { ...alphabeticPubkey, pubkey: alphabeticPubkey.pubkey.toUpperCase() },
+    { ...alphabeticSignature, sig: alphabeticSignature.sig.toUpperCase() },
+    { ...valid, created_at: String(valid.created_at) },
+    { ...valid, kind: String(valid.kind) },
+    { ...valid, kind: 65_536 },
+  ];
+  for (const invalid of invalidEvents) {
+    assert.throws(
+      () => compileBuzzEvidenceBundle({ events: [invalid] }),
+      error => error instanceof BuzzEvidenceError && error.code === 'invalid_event',
+    );
+  }
+});
+
+test('compiles canonical Buzz events without emitting raw workspace metadata by default', () => {
+  const message = event({
+    tags: [
+      ['h', 'channel-private-42'],
+      ['p', PUBKEY_B],
+      ['r', 'https://username:password@private.example/repository'],
+      ['d', 'internal-release-identifier'],
+    ],
+  });
   const bundle = compileBuzzEvidenceBundle({
     events: [message],
-    relay_url: 'https://buzz.example.test',
-    community_ref: 'community:test',
+    relay_url: 'wss://username:password@relay.private.example',
+    community_ref: 'community:private-engineering',
+  }, {
+    compatibility_verified_against_live_relay: true,
   });
+  const serialized = JSON.stringify(bundle);
 
-  assert.equal(bundle.schema, 'agoragentic.buzz-evidence-bundle.v1');
-  assert.equal(bundle.events.length, 1);
+  assert.equal(bundle.schema, 'agoragentic.buzz-evidence-bundle.v2');
   assert.equal(bundle.events[0].event_type, 'stream_message');
   assert.equal(bundle.events[0].source_integrity.canonical_event_id_verified, true);
   assert.equal(bundle.events[0].signature.status, 'not_verified');
   assert.equal(bundle.events[0].content.policy, 'hash_only');
-  assert.equal(bundle.events[0].content.bounded_content, null);
-  assert.deepEqual(bundle.relationships.channel_refs, ['channel-1']);
+  assert.equal(bundle.source.metadata_policy, 'hash_only');
+  assert.equal(bundle.source.raw_source_metadata_embedded, false);
+  assert.equal(bundle.source.compatibility_verified_against_live_relay, false);
+  assert.equal(bundle.events[0].author_pubkey, undefined);
+  assert.match(bundle.events[0].references.channel_ref_hashes[0], /^sha256:[a-f0-9]{64}$/);
   assert.equal(bundle.transaction_assurance_readiness.ready_for_economic_action, false);
   assert(bundle.transaction_assurance_readiness.blockers.includes('workspace_membership_is_not_an_economic_mandate'));
-  assert.equal(bundle.authority.posts_to_buzz, false);
+  assert.doesNotMatch(serialized, /channel-private-42|private-engineering|username:password|internal-release-identifier/);
+});
+
+test('records typed, event-bound attestations as unverified claims rather than external verification', () => {
+  const message = event();
+  const bundle = compileBuzzEvidenceBundle({ events: [message] }, typedAttestations(message));
+
+  assert.equal(bundle.summary.signature_validity_claims_by_unverified_attestation_reference, 1);
+  assert.equal(bundle.summary.principal_binding_claims_by_unverified_attestation_reference, 1);
+  assert.equal(bundle.summary.relay_persistence_claims_by_unverified_attestation_reference, 1);
+  assert.equal(bundle.events[0].signature.status, 'validity_claimed_by_unverified_attestation_reference');
+  assert.equal(bundle.events[0].signature.signature_valid, null);
+  assert.equal(bundle.events[0].signature.attestation_reference_verified, false);
+  assert.equal(bundle.events[0].principal_binding.status, 'binding_claimed_by_unverified_attestation_reference');
+  assert.equal(bundle.events[0].principal_binding.binding_verified, false);
+  assert.equal(bundle.events[0].relay_audit.status, 'persistence_claimed_by_unverified_attestation_reference');
+  assert.equal(bundle.events[0].relay_audit.attestation_reference_verified, false);
+  assert.equal(bundle.events[0].authority.principal_mandate_verified, false);
+  assert.equal(bundle.source.attestation_references_independently_verified, false);
+  assert.equal(bundle.transaction_assurance_readiness.ready_for_payment, false);
+  assert(bundle.transaction_assurance_readiness.blockers.includes(
+    'signature_attestation_references_not_independently_verified',
+  ));
+  assert(bundle.transaction_assurance_readiness.blockers.includes(
+    'independent_attestation_verifier_and_trust_policy_required',
+  ));
+
+  assert.throws(
+    () => compileBuzzEvidenceBundle({ events: [message] }, {
+      signature_verifications: { [message.id]: { signature_valid: true } },
+    }),
+    error => error instanceof BuzzEvidenceError && error.code === 'deprecated_evidence_shape',
+  );
+  assert.throws(
+    () => compileBuzzEvidenceBundle({ events: [message] }, { signature_verifications: true }),
+    error => error instanceof BuzzEvidenceError && error.code === 'deprecated_evidence_shape',
+  );
+
+  const mismatched = typedAttestations(message);
+  mismatched.signature_attestations[message.id].pubkey = PUBKEY_B;
+  assert.throws(
+    () => compileBuzzEvidenceBundle({ events: [message] }, mismatched),
+    error => error instanceof BuzzEvidenceError && error.code === 'attestation_binding_mismatch',
+  );
+
+  const forgedButWellFormed = typedAttestations(message);
+  forgedButWellFormed.signature_attestations[message.id].verifier = 'attacker-supplied-label';
+  forgedButWellFormed.signature_attestations[message.id].attestation_ref = ref('f');
+  const forgedBundle = compileBuzzEvidenceBundle({ events: [message] }, forgedButWellFormed);
+  assert.equal(
+    forgedBundle.events[0].signature.status,
+    'validity_claimed_by_unverified_attestation_reference',
+  );
+  assert.equal(forgedBundle.events[0].signature.signature_valid, null);
+  assert.equal(forgedBundle.events[0].signature.attestation_reference_verified, false);
+});
+
+test('commits all material evidence and source metadata into the event root', () => {
+  const message = event();
+  const input = {
+    events: [message],
+    relay_url: 'wss://relay.example.test',
+    community_ref: 'community:test',
+  };
+  const options = typedAttestations(message);
+  const baseline = compileBuzzEvidenceBundle(input, options).event_root;
+
+  const signatureMutation = clone(options);
+  signatureMutation.signature_attestations[message.id].attestation_ref = ref('9');
+  assert.notEqual(compileBuzzEvidenceBundle(input, signatureMutation).event_root, baseline);
+
+  const principalMutation = clone(options);
+  principalMutation.principal_attestations[message.id].principal_ref = 'principal:owner-2';
+  assert.notEqual(compileBuzzEvidenceBundle(input, principalMutation).event_root, baseline);
+
+  const auditMutation = clone(options);
+  auditMutation.audit_attestations[message.id].audit_head_ref = ref('a');
+  assert.notEqual(compileBuzzEvidenceBundle(input, auditMutation).event_root, baseline);
+
+  assert.notEqual(
+    compileBuzzEvidenceBundle({ ...input, relay_url: 'wss://other.example.test' }, options).event_root,
+    baseline,
+  );
+
+  const signatureMutationEvent = { ...message, sig: '4'.repeat(128) };
+  assert.notEqual(
+    compileBuzzEvidenceBundle({ ...input, events: [signatureMutationEvent] }, typedAttestations(signatureMutationEvent)).event_root,
+    baseline,
+  );
+});
+
+test('pins the classifier to the reviewed Block/Buzz registry subset', async () => {
+  const provenance = JSON.parse(await readFile(new URL('./upstream-provenance.json', import.meta.url), 'utf8'));
+  assert.equal(BUZZ_UPSTREAM_PROVENANCE.commit, 'f029deafae6ad3b63e13c29104f3be76122cb1df');
+  assert.equal(provenance.block_buzz.commit, BUZZ_UPSTREAM_PROVENANCE.commit);
+  assert.deepEqual(provenance.block_buzz.classified_kind_subset, BUZZ_EVIDENCE_CONSTANTS.BUZZ_KINDS);
+  assert.equal(provenance.block_buzz.kind_registry_sha256, BUZZ_UPSTREAM_PROVENANCE.kind_registry_sha256);
+  assert.equal(provenance.nip_01.commit, BUZZ_UPSTREAM_PROVENANCE.nip01_commit);
+
+  const workflow = event({ kind: 46004, created_at: 20, content: 'approval requested' });
+  const patch = event({ kind: 1617, created_at: 10, content: 'patch body' });
+  const bundle = compileBuzzEvidenceBundle({ events: [workflow, patch] });
+  assert.equal(bundle.events[0].event_type, 'git_patch');
+  assert.equal(bundle.events[1].event_type, 'workflow_event');
 });
 
 test('bounded content is redacted and never represented as exact after redaction', () => {
@@ -61,81 +300,109 @@ test('bounded content is redacted and never represented as exact after redaction
   assert.equal(evidence.source_integrity.exact_content_embedded, false);
 });
 
-test('external signature, principal, and audit evidence remain scoped', () => {
-  const message = event();
-  const signatureRef = `sha256:${'4'.repeat(64)}`;
-  const bindingRef = `sha256:${'5'.repeat(64)}`;
-  const auditRef = `sha256:${'6'.repeat(64)}`;
-  const bundle = compileBuzzEvidenceBundle({ events: [message] }, {
-    signature_verifications: {
-      [message.id]: {
-        signature_valid: true,
-        verifier: 'nostr-verifier',
-        verifier_version: '1.0.0',
-        evidence_ref: signatureRef,
-      },
-    },
-    principal_bindings: {
-      [message.pubkey]: {
-        principal_ref: 'principal:owner-1',
-        agent_ref: 'agent:buzz-1',
-        binding_evidence_ref: bindingRef,
-      },
-    },
-    audit_evidence: {
-      [message.id]: {
-        persisted: true,
-        audit_entry_ref: auditRef,
-        audit_head_ref: auditRef,
-        verifier: 'buzz-audit-export',
-      },
-    },
-  });
-
-  assert.equal(bundle.summary.signatures_verified, 1);
-  assert.equal(bundle.summary.principals_bound, 1);
-  assert.equal(bundle.summary.audit_entries_verified, 1);
-  assert.equal(bundle.events[0].principal_binding.status, 'bound_by_external_evidence');
-  assert.equal(bundle.events[0].authority.principal_mandate_verified, false);
-  assert.equal(bundle.transaction_assurance_readiness.ready_for_payment, false);
-  assert(bundle.transaction_assurance_readiness.blockers.includes('principal_mandate_required_before_economic_action'));
+test('the CLI rejects oversized input before parsing it', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'agoragentic-buzz-evidence-'));
+  try {
+    const inputPath = join(directory, 'oversized.json');
+    await writeFile(inputPath, Buffer.alloc(MAX_INPUT_BYTES + 1, 0x20));
+    const result = spawnSync(process.execPath, ['cli.mjs', inputPath], {
+      cwd: MODULE_DIR,
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /input_too_large/);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
 });
 
-test('rejects a tampered event ID', () => {
-  const message = event();
-  message.content = 'tampered';
-  assert.throws(
-    () => compileBuzzEvidenceBundle({ events: [message] }),
-    error => error instanceof BuzzEvidenceError && error.code === 'event_id_mismatch',
-  );
+test('ships license and provenance in the declared package files', async () => {
+  const packageJson = JSON.parse(await readFile(new URL('./package.json', import.meta.url), 'utf8'));
+  const license = await readFile(new URL('./LICENSE', import.meta.url), 'utf8');
+  assert(packageJson.files.includes('LICENSE'));
+  assert(packageJson.files.includes('upstream-provenance.json'));
+  assert(packageJson.files.includes('receipt-reference.example.json'));
+  assert.match(license, /Apache License/);
 });
 
-test('rejects duplicate event IDs', () => {
-  const message = event();
-  assert.throws(
-    () => compileBuzzEvidenceBundle({ events: [message, message] }),
-    error => error instanceof BuzzEvidenceError && error.code === 'duplicate_event',
-  );
-});
+test('the packed artifact installs and runs the local CLI without a network action', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'agoragentic-buzz-packed-'));
+  try {
+    const installerDirectory = join(directory, 'installer');
+    const inputPath = join(directory, 'events.json');
+    const outputPath = join(directory, 'evidence.json');
+    await mkdir(installerDirectory, { recursive: true });
+    await writeFile(join(installerDirectory, 'package.json'), JSON.stringify({ private: true }), 'utf8');
+    await writeFile(inputPath, JSON.stringify([event()]), 'utf8');
 
-test('classifies workflow and git evidence while preserving order deterministically', () => {
-  const workflow = event({ kind: 46004, created_at: 20, content: 'approval requested' });
-  const patch = event({ kind: 1617, created_at: 10, content: 'patch body' });
-  const bundle = compileBuzzEvidenceBundle({ events: [workflow, patch] });
+    const npmCli = process.env.npm_execpath;
+    assert(npmCli, 'npm_execpath must be available when running the package test script');
+    const npmFlags = ['--ignore-scripts', '--offline', '--no-audit', '--no-fund'];
+    const pack = spawnSync(process.execPath, [npmCli, 'pack', MODULE_DIR, ...npmFlags], {
+      cwd: directory,
+      encoding: 'utf8',
+      timeout: 20_000,
+    });
+    assert.equal(pack.status, 0, pack.error?.message || pack.stderr || pack.stdout);
+    const tarball = (await readdir(directory))
+      .find(file => file.endsWith('.tgz'));
+    assert(tarball, 'npm pack did not produce a tarball');
 
-  assert.equal(bundle.events[0].event_type, 'git_patch');
-  assert.equal(bundle.events[1].event_type, 'workflow_event');
-  assert.equal(bundle.summary.event_types.git_patch, 1);
-  assert.equal(bundle.summary.event_types.workflow_event, 1);
+    const install = spawnSync(process.execPath, [npmCli, 'install', join(directory, tarball), ...npmFlags], {
+      cwd: installerDirectory,
+      encoding: 'utf8',
+      timeout: 20_000,
+    });
+    assert.equal(install.status, 0, install.error?.message || install.stderr || install.stdout);
+
+    const installedCli = join(
+      installerDirectory,
+      'node_modules',
+      '@agoragentic',
+      'buzz-signed-workspace-evidence',
+      'cli.mjs',
+    );
+    const installedPackageDirectory = dirname(installedCli);
+    const installedLicense = await readFile(join(installedPackageDirectory, 'LICENSE'), 'utf8');
+    const installedProvenance = JSON.parse(await readFile(
+      join(installedPackageDirectory, 'upstream-provenance.json'),
+      'utf8',
+    ));
+    const installedReferenceSchema = JSON.parse(await readFile(
+      join(installedPackageDirectory, 'receipt-reference.schema.json'),
+      'utf8',
+    ));
+    const installedReferenceExample = JSON.parse(await readFile(
+      join(installedPackageDirectory, 'receipt-reference.example.json'),
+      'utf8',
+    ));
+    assert.match(installedLicense, /Apache License/);
+    assert.equal(installedProvenance.block_buzz.commit, BUZZ_UPSTREAM_PROVENANCE.commit);
+    assert.equal(installedReferenceSchema.$id, 'https://agoragentic.com/schema/buzz-transaction-assurance-reference.v1.json');
+    assert.equal(installedReferenceExample.schema, installedReferenceSchema.properties.schema.const);
+
+    const run = spawnSync(process.execPath, [installedCli, inputPath, '--out', outputPath], {
+      cwd: installerDirectory,
+      encoding: 'utf8',
+      timeout: 20_000,
+    });
+    assert.equal(run.status, 0, run.stderr || run.stdout);
+    const output = JSON.parse(await readFile(outputPath, 'utf8'));
+    assert.equal(output.schema, 'agoragentic.buzz-evidence-bundle.v2');
+    assert.equal(output.authority.grants_spend, false);
+    assert.equal(output.authority.posts_to_buzz, false);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
 });
 
 test('builds an unsigned proposal-only Transaction Assurance reference', () => {
   const reference = buildBuzzTransactionAssuranceReference({
     transaction_id: 'txn_123',
     buzz_event_id: event().id,
-    evidence_root: `sha256:${'7'.repeat(64)}`,
-    mandate_ref: `sha256:${'8'.repeat(64)}`,
-    transaction_assurance_receipt_ref: `sha256:${'9'.repeat(64)}`,
+    evidence_root: ref('b'),
+    mandate_ref: ref('c'),
+    transaction_assurance_receipt_ref: ref('d'),
     states: {
       authority: 'verified',
       payment: 'final',
@@ -152,4 +419,20 @@ test('builds an unsigned proposal-only Transaction Assurance reference', () => {
   assert.equal(reference.publication.posted, false);
   assert.equal(reference.authority.grants_publication, false);
   assert.match(reference.reference_hash, /^sha256:[a-f0-9]{64}$/);
+});
+
+test('the deterministic proposal-only fixture conforms to its declared schema contract', async () => {
+  const schema = JSON.parse(await readFile(new URL('./receipt-reference.schema.json', import.meta.url), 'utf8'));
+  const fixture = JSON.parse(await readFile(new URL('./receipt-reference.example.json', import.meta.url), 'utf8'));
+  assertReceiptReferenceInstance(schema, fixture);
+
+  const regenerated = buildBuzzTransactionAssuranceReference({
+    transaction_id: fixture.transaction_id,
+    buzz_event_id: fixture.buzz_event_id,
+    evidence_root: fixture.evidence_root,
+    mandate_ref: fixture.mandate_ref,
+    transaction_assurance_receipt_ref: fixture.transaction_assurance_receipt_ref,
+    states: fixture.states,
+  });
+  assert.deepEqual(regenerated, fixture);
 });

--- a/examples/buzz-signed-workspace-evidence/upstream-provenance.json
+++ b/examples/buzz-signed-workspace-evidence/upstream-provenance.json
@@ -1,0 +1,58 @@
+{
+  "schema": "agoragentic.buzz-upstream-provenance.v1",
+  "retrieved_at": "2026-08-08",
+  "block_buzz": {
+    "repository": "https://github.com/block/buzz",
+    "commit": "f029deafae6ad3b63e13c29104f3be76122cb1df",
+    "commit_url": "https://github.com/block/buzz/tree/f029deafae6ad3b63e13c29104f3be76122cb1df",
+    "kind_registry_path": "crates/buzz-core/src/kind.rs",
+    "kind_registry_url": "https://github.com/block/buzz/blob/f029deafae6ad3b63e13c29104f3be76122cb1df/crates/buzz-core/src/kind.rs",
+    "kind_registry_sha256": "sha256:74533cfc1ac016dcb1a83279c2b06f93807f29489604cdccefc46b645acfce97",
+    "classified_kind_subset": {
+      "0": "profile",
+      "1": "text_note",
+      "7": "reaction",
+      "9": "stream_message",
+      "1617": "git_patch",
+      "1618": "git_pull_request",
+      "10100": "agent_profile",
+      "30174": "agent_engram",
+      "30175": "agent_persona",
+      "30179": "private_managed_agent",
+      "30617": "git_repository_announcement",
+      "40002": "stream_message_v2",
+      "40003": "stream_message_edit",
+      "43001": "agent_job_request",
+      "45001": "forum_post",
+      "45003": "forum_comment"
+    }
+  },
+  "nip_01": {
+    "repository": "https://github.com/nostr-protocol/nips",
+    "commit": "c53877571f96eb423661fc23c620d629d37b8f19",
+    "path": "01.md",
+    "source_url": "https://github.com/nostr-protocol/nips/blob/c53877571f96eb423661fc23c620d629d37b8f19/01.md",
+    "sha256": "sha256:afa8a4eeff70d47503f2acab03b29f4bf0ed90ac95a10d3fd07e4fecddc8ae20",
+    "wire_constraints_exercised": [
+      "lowercase 64-character event IDs and pubkeys",
+      "lowercase 128-character signatures",
+      "integer Unix timestamps",
+      "kind range 0 through 65535",
+      "UTF-8 JSON serialization [0,pubkey,created_at,kind,tags,content]"
+    ]
+  },
+  "validation_scope": {
+    "local_compiler_only": true,
+    "relay_connection_performed": false,
+    "signature_or_event_created": false,
+    "event_posted": false,
+    "live_compatibility_claimed": false,
+    "attestation_reference_verified": false
+  },
+  "non_claims": [
+    "The pinned source review does not prove compatibility with a running Buzz relay.",
+    "This adapter does not verify Schnorr signatures itself.",
+    "This adapter does not connect to, sign for, or post to Buzz.",
+    "This adapter does not grant economic, wallet, deployment, publication, or trust authority."
+  ]
+}

--- a/integrations.json
+++ b/integrations.json
@@ -1227,6 +1227,15 @@
       "path": "cline/README.md",
       "install": "npx -y agoragentic-mcp@1.3.6",
       "docs": "cline/README.md"
+    },
+    {
+      "id": "buzz-signed-workspace-evidence",
+      "name": "Buzz Signed Workspace Evidence",
+      "language": "javascript",
+      "status": "experimental",
+      "path": "examples/buzz-signed-workspace-evidence/buzz-event-evidence.mjs",
+      "install": "node examples/buzz-signed-workspace-evidence/cli.mjs <events.json> --out buzz-evidence.json",
+      "docs": "examples/buzz-signed-workspace-evidence/README.md"
     }
   ],
   "specs": [
@@ -1376,6 +1385,8 @@
     "livekit_agents": "livekit-agents/README.md",
     "livekit_agents_adapter": "livekit-agents/agoragentic_livekit.py",
     "pipecat": "pipecat/README.md",
-    "pipecat_adapter": "pipecat/agoragentic_pipecat.py"
+    "pipecat_adapter": "pipecat/agoragentic_pipecat.py",
+    "buzz_signed_workspace_evidence": "examples/buzz-signed-workspace-evidence/README.md",
+    "buzz_signed_workspace_evidence_provenance": "examples/buzz-signed-workspace-evidence/upstream-provenance.json"
   }
 }

--- a/llms.txt
+++ b/llms.txt
@@ -20,7 +20,7 @@
 - Or call agoragentic_register at runtime
 
 ## Integrations
-- Canonical inventory: `integrations.json` (99 indexed surfaces as of 2026-07-28).
+- Canonical inventory: `integrations.json` (100 indexed surfaces as of 2026-08-08).
 - Client-native packages: Cursor (`.cursor-plugin/plugin.json`), Gemini CLI (`gemini-extension.json`), Claude Code (`.claude-plugin/marketplace.json`), and Cline (`llms-install.md`). Package readiness does not imply external marketplace approval.
 - Python frameworks include LangChain, LangGraph, Deep Agents, ClawTeam, CrewAI, AutoGen, OpenAI Agents, Google ADK, Haystack, pydantic-ai, smolagents, Agno, Griptape, LiveKit Agents, Pipecat, LlamaIndex, AgentScope, DSPy, Browser Use, and Langflow.
 - JavaScript/TypeScript frameworks and workflows include MCP, Vercel AI, Cloudflare Agents, Mastra, Bee Agent, ElizaOS, n8n, VoltAgent, Genkit, OpenAI Agents TypeScript, AG-UI, and experimental World AgentKit pre-payment composition.
@@ -33,6 +33,7 @@
 - Micro ECF: https://github.com/rhein1/agoragentic-micro-ecf (canonical local context/policy package); `micro-ecf/` here is a compatibility snapshot
 - Harness Core: harness-core/README.md (local no-spend policy, event ledger, proof, receipt, review, runtime-metadata probe, Agent OS export, and listing-readiness artifacts)
 - Premortem Golden Loop Agent: premortem-golden-loop/README.md and premortem-golden-loop/PROMPT.md (free local six-month failure-frame premortem reports plus OSS agent release premortem, no-spend Golden Loop readiness receipt, and safe self-heal scaffolds)
+- Buzz Signed Workspace Evidence: examples/buzz-signed-workspace-evidence/README.md (experimental local compiler for exported events; exact source pin, hash-only metadata by default, typed but unverified attestation references, and no relay/signing/posting/payment/listing authority)
 
 ## Machine Index
 - integrations.json — structured index of all integrations, tools, packages
@@ -97,6 +98,7 @@
 - griptape/README.md — beta Griptape BaseTool activities for match and execute
 - livekit-agents/README.md — beta LiveKit function tools with off-loop HTTP execution
 - pipecat/README.md — beta Pipecat direct functions for match and execute
+- examples/buzz-signed-workspace-evidence/README.md — experimental Block Buzz/Nostr event evidence compiler; source-review pin only, not live compatibility evidence
 
 ## Live API
 - Manifest: https://agoragentic.com/.well-known/agent-marketplace.json


### PR DESCRIPTION
## Product boundary

Buzz is a signed human-agent workspace. This experimental, unpublished adapter normalizes exported NIP-01-shaped events into deterministic local evidence without treating workspace membership as economic authority.

## What ships

- exact pinned Block/Buzz kind provenance plus an independent fixed NIP-01 event-ID vector;
- strict lower-case wire validation and bounded event/content/tag handling;
- hash-only source and content evidence by default;
- bounded mode explicitly marked raw, best-effort-redacted, and unsafe for publication;
- typed signature, principal, and relay-persistence attestation references bound to the exact event, with relay claims also bound to the exact relay hash;
- explicit `not_verified` semantics because this adapter does not authenticate the attestation artifact or verifier identity;
- a full deterministic `bundle_root` and semantic verifier that rejects policy/privacy/authority forgery even after attacker rehashing;
- an unsigned proposal-only Transaction Assurance reference using `claimed_states` and `state_claims_verified:false`;
- CLI, skill, docs, schemas, provenance, and unpublished listing candidates.

## No-authority boundary

This PR does not connect to a relay, verify Schnorr signatures or attestation identities, read private channels, sign/post events, run ACP agents, grant mandates, move money, publish listings, enable x402, deploy, mutate trust, or claim Block/Buzz partnership or live compatibility.

## Verification

- package syntax checks
- adversarial and packaging tests: 15/15
- offline packed-artifact install and CLI execution
- root machine-surface verifier
- documentation link contract: 207 files
- offline adapter conformance: 100/100
- CI matrix: Node 20, 22, and 24 (current head)