### PR TITLE
chore(n8n): coordinate stable toolchain upgrade

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -59,7 +59,7 @@ npm ci
 npm run check
 ```
 
-The 0.1.3 source candidate uses the stable `@n8n/node-cli` 0.40.3 toolchain and a committed lockfile. It requires Node.js 20.19 or newer. npm still serves 0.1.2 until the candidate is reviewed, merged, tagged exactly as `n8n-v0.1.3`, and published through the trusted-publishing workflow.
+The 0.1.3 source candidate uses the stable `@n8n/node-cli` 0.42.2 toolchain, Prettier 3.9.6, and a committed lockfile. It keeps n8n's compatible ESLint 9 and TypeScript 5 pins, and requires Node.js 20.19 or newer. npm still serves 0.1.2 until the candidate is reviewed, merged, tagged exactly as `n8n-v0.1.3`, and published through the trusted-publishing workflow.
 
 See [Toolchain Audit](TOOLCHAIN_AUDIT.md) for the reproducibility and dependency-advisory record.
 

--- a/n8n/TOOLCHAIN_AUDIT.md
+++ b/n8n/TOOLCHAIN_AUDIT.md
@@ -1,86 +1,94 @@
 # n8n Toolchain Audit
 
-Audit date: 2026-08-05 (supersedes 2026-07-24)
+Audit date: 2026-08-08 (supersedes 2026-08-05)
 
 ## Candidate
 
 - Package: `n8n-nodes-agoragentic@0.1.3`
-- Stable builder: `@n8n/node-cli@0.40.3`
+- Stable builder: `@n8n/node-cli@0.42.2`
+- Formatter: `prettier@3.9.6`
+- Linter: `eslint@9.32.0`
+- Compiler: `typescript@5.9.2`
+- Development host fixture: `n8n-workflow@2.29.3`
 - Release helper: `release-it@21.0.1`
-- Minimum Node.js: 20.19
+- Minimum consumer Node.js: 20.19
 - Install mode: committed lockfile plus `npm ci`
 
-## 2026-08-05 revision
+## Coordinated compatibility decision
 
-Three high advisories entered the development graph and the fail-closed
-`npm run audit:dev` gate correctly rejected them
-(`unexpected audit package set; extra=ip-address,undici`, then
-`unexpected advisory set: ...,GHSA-rgw5-rvv9-x895`).
+The `@n8n/node-cli` npm `stable` tag is `0.42.2`. Its generated community-node
+template still pins ESLint 9.32.0, Prettier 3.6.2, and TypeScript 5.9.2. This
+candidate advances the stable CLI and independently validates the compatible
+Prettier 3.9.6 maintenance update while preserving n8n's linter and compiler
+major lines.
 
-**`ip-address` → 10.4.0.** Lockfile refresh only, satisfies `socks`'
-`^10.1.1`. No manifest change.
+The rejected Dependabot majors are not a coherent toolchain:
 
-**`brace-expansion` → 1.1.18 / 2.1.4 / 5.0.9.** GHSA-rgw5-rvv9-x895 is a
-bypass of the previously accepted GHSA-mh99-v99m-4gvg. The exception recorded
-below is now **stale**: patched releases exist on the 1.x and 2.x lines, so
-the eslint and n8n-cli consumers are fixed in place without being forced onto
-the API-incompatible 5.x line. Both advisories are now resolved rather than
-allowlisted.
+- ESLint 10 fails the current n8n lint rules with
+  `TypeError: context.getFilename is not a function`. The bundled community
+  plugin also declares an exact ESLint 9.29.0 peer.
+- TypeScript 7 fails the current parser stack in `ts-api-utils` while reading
+  `Intrinsic`. The current `typescript-eslint` release supports TypeScript
+  versions below 6.1, not TypeScript 7.
 
-**`undici` → 7.29.0.** Reached through `@n8n/backend-network` (`^7.28.0`,
-satisfied directly) and through `release-it@20.2.1`, which pins `undici`
-to exactly `7.28.0`. Two candidate fixes were rejected:
+The release-contract test pins the complete supported set so a future isolated
+major bump cannot look valid after changing only one manifest line.
 
-- A scoped `overrides` entry — **rejected by lint.** The
-  `@n8n/community-nodes/no-overrides-field` rule forbids the `overrides` field
-  in community node packages outright.
-- Staying on `release-it@20.x` — **no patched release exists.** `20.2.1` is
-  the final 20.x version.
+`n8n-workflow@2.29.3` is an explicit development fixture, not a runtime
+constraint. The published peer remains `n8n-workflow: "*"`, so host n8n
+versions are not narrowed. The fixture keeps clean-install build tests
+deterministic and avoids treating a vulnerable auto-installed peer as shipped
+package code.
 
-`release-it` is therefore bumped to `21.0.1`. Note this changes the
-deliberately locked release pin asserted in `test/release.test.cjs`, updated
-in the same change.
+## Security boundary
 
-`release-it@21` declares `engines.node ^22.21.0 || >=24.0.0`. This does **not**
-change what the published package supports: `engines.node` stays `>=20.19.0`
-for consumers, `release-it` is development-only and is not in the published
-`files` list, and the n8n CI job already runs on Node 22 ("Setup Node 22 for
-n8n toolchain"). Only a maintainer running `npm run release` locally now needs
-Node 22.21 or newer. `release-it` is not used by CI or by
-`publish-n8n.yml`, which publishes via npm trusted publishing.
+The published package audit is clean:
 
-The `uuid` / LangChain moderates described below are unchanged and remain
-accepted under the existing policy. The gate covers high and critical only,
-so those stay visible rather than suppressed.
+```text
+npm audit --omit=dev --audit-level=moderate
+found 0 vulnerabilities
+```
+
+The stable n8n CLI's development-only AI SDK graph currently pins
+`@n8n/utils` to `nanoid@3.3.8`. No stable n8n CLI release contains a patched
+upstream pin, npm proposes an invalid downgrade to node-cli 0.20.0, and the n8n
+community-node lint policy forbids an `overrides` field. The fail-closed
+`npm run audit:dev` gate therefore permits exactly these two advisories and the
+eight affected dependency nodes they currently reach:
+
+- `GHSA-28wg-ghj8-5hjv`
+- `GHSA-2v37-7h3g-55p8`
+
+While high findings remain, a new or missing advisory ID, a severity
+escalation, or an affected-package addition/substitution fails the gate. A
+remediation-driven shrinking subset is intentionally accepted, including an
+ancestor dropping below high severity, so an upstream partial fix does not
+require weakening or rewriting the allowlist.
+Moderate LangChain/uuid findings remain visible. In particular, Dependabot
+alert #8 (`GHSA-w5hq-g745-h8pq`) remains in the CLI's nested LangChain graph:
+the stable CLI pins LangChain releases that require `uuid@^10.0.0`, so the
+patched `uuid@11.1.1` cannot satisfy that range. The explicit host fixture does
+resolve `uuid@11.1.1`; removing the nested finding requires an upstream n8n
+CLI/AI SDK release and must not be forced with the lint-forbidden `overrides`
+field. None of these development dependencies are included in the package
+`files` allowlist or npm tarball. Remove the nanoid exception as soon as stable
+n8n packages consume a patched release.
+
+The prior `brace-expansion`, `ip-address`, and `undici` high findings remain
+resolved in the lockfile. `release-it@21` remains development-only and requires
+Node 22.21 or newer for maintainers running the release helper; trusted npm
+publishing does not use that helper.
 
 ## Validation
 
+- `npm ci`
 - `npm test`
 - `npm run lint`
 - `npm run build`
+- formatter output comparison between Prettier 3.6.2 and 3.9.6
+- `npm audit --omit=dev --audit-level=moderate`
+- `npm run audit:dev`
 - `npm pack --dry-run`
-- `npm audit --omit=dev --audit-level=moderate`: zero production vulnerabilities
-- `npm run audit:dev`: only the documented development advisory is present
 
-Both audit commands run in pull-request validation and again in the trusted-publishing workflow, so the recorded boundary is release-gated rather than advisory-only.
-
-## Transitive Security Policy
-
-The stable n8n node CLI currently brings moderate development-only findings
-through its AI SDK, LangChain, and `uuid` dependency chain. npm offers only an
-invalid downgrade of the builder as an automated fix. The package does not ship
-those development dependencies, and the production dependency audit is clean.
-
-The graph also contains GHSA-mh99-v99m-4gvg through older minimatch consumers.
-The only patched `brace-expansion` release is the API-incompatible 5.0.8 line;
-forcing it into those consumers breaks the n8n lint toolchain. This dependency
-is development-only, receives no untrusted glob input in this package, and is
-not included in the published tarball.
-
-CI and trusted publishing run a fail-closed high/critical audit policy that
-permits only GHSA-mh99-v99m-4gvg in the full development graph while rejecting
-every other high or critical advisory. Moderate development-only findings
-remain visible in npm and Dependabot rather than being hidden.
-
-Recheck this exception when n8n promotes a stable CLI release with an updated
-minimatch dependency tree.
+Pull-request validation and trusted publishing repeat the lint, build, audit,
+and package checks.

--- a/n8n/package-lock.json
+++ b/n8n/package-lock.json
@@ -9,9 +9,10 @@
             "version": "0.1.3",
             "license": "MIT",
             "devDependencies": {
-                "@n8n/node-cli": "0.40.3",
+                "@n8n/node-cli": "0.42.2",
                 "eslint": "9.32.0",
-                "prettier": "3.6.2",
+                "n8n-workflow": "2.29.3",
+                "prettier": "3.9.6",
                 "release-it": "21.0.1",
                 "typescript": "5.9.2"
             },
@@ -28,6 +29,7 @@
             "integrity": "sha512-IjLt0gd3L4jlOfilxVXTifn42FnVffMgDC04RJK1KDZpmkBWLv0XC92MVVmkxrFZNS/7l3xWgP/I3nqtX1sQHw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/node": "^18.11.18",
                 "@types/node-fetch": "^2.6.4",
@@ -39,9 +41,10 @@
             }
         },
         "node_modules/@apm-js-collab/code-transformer": {
-            "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.18.0.tgz",
-            "integrity": "sha512-aN3Oq8r1J3gPJtCwErP664gM0+HhM1I1lujPr9TMTCcEl/joQQbpGpeMdts9B1+W2wHMsvioDMv5F4PvMWE6gw==",
+            "version": "0.18.1",
+            "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.18.1.tgz",
+            "integrity": "sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@types/estree": "^1.0.8",
@@ -56,12 +59,13 @@
             }
         },
         "node_modules/@apm-js-collab/code-transformer-bundler-plugins": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.7.2.tgz",
-            "integrity": "sha512-GvpKWDmzBFzbtVElU+tEDMDYyMY8SnMH4NNwwlUQioNHZvE6sSuHEqNkfU3iYhWL+/XO5Ej+MzhVJoqM10NYCQ==",
+            "version": "0.7.4",
+            "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.7.4.tgz",
+            "integrity": "sha512-nAfOeZPSUAQvJa1iFT/5oCrTm5YQhMMrfCNthNnaXHZiOQhu1KGuLoIx7HtbAi3wfwaBYLaICPIeenIaEwcXIg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@apm-js-collab/code-transformer": "^0.18.0",
+                "@apm-js-collab/code-transformer": "^0.18.1",
                 "es-module-lexer": "^2.1.0",
                 "magic-string": "^0.30.21",
                 "module-details-from-path": "^1.0.4"
@@ -74,6 +78,7 @@
             "version": "0.13.0",
             "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.13.0.tgz",
             "integrity": "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@apm-js-collab/code-transformer": "^0.18.0",
@@ -87,6 +92,7 @@
             "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/Borewit"
@@ -98,6 +104,7 @@
             "integrity": "sha512-mPAuLRU9jWR7o0KJi9+gQnOBDUSIkoKbbFv4HjrA+80qWVcFacrNPlZmf4mguQnfZ0oP2t5c3ws6yuFyAX9vpA==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@types/node": "^18.11.18",
                 "@types/node-fetch": "^2.6.4",
@@ -114,6 +121,7 @@
             "integrity": "sha512-Hi/EzgMFWz+FKyepxHTrqfTPjpsuBS4zRy3e9sbMpBgLPv+9c0R+YZEvS7Bw4mTS66QtvvURRT6zgDGFotthVQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@anthropic-ai/sdk": "^0.27.3",
                 "@browserbasehq/sdk": "^2.0.0",
@@ -134,6 +142,7 @@
             "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "peerDependencies": {
                 "zod": "^3.25.28 || ^4"
             }
@@ -172,6 +181,7 @@
             "version": "6.20.0",
             "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.0.tgz",
             "integrity": "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@codemirror/language": "^6.0.0",
@@ -184,6 +194,7 @@
             "version": "6.12.4",
             "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
             "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@codemirror/state": "^6.0.0",
@@ -198,15 +209,17 @@
             "version": "6.7.1",
             "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
             "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@marijn/find-cluster-break": "^1.0.0"
             }
         },
         "node_modules/@codemirror/view": {
-            "version": "6.43.6",
-            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.6.tgz",
-            "integrity": "sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==",
+            "version": "6.43.8",
+            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.8.tgz",
+            "integrity": "sha512-qtItTDssZ/5GFfi94hrILu9j/VUeFPDPkhovEfmWFj2ipTxnzPB8DdHgfbb8HYTzLTYhrndKmyQxXUz/PDLenw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@codemirror/state": "^6.7.0",
@@ -269,6 +282,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -540,9 +554,9 @@
             }
         },
         "node_modules/@ibm-cloud/watsonx-ai": {
-            "version": "1.7.15",
-            "resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.7.15.tgz",
-            "integrity": "sha512-JUxFuACcKhDC+shavgyLEFjWiSsBjI+tjIBvLrzcHywh0HqTT0m+whe2kL3isPheBzrduSMfovwypbSuKwCp+g==",
+            "version": "1.7.16",
+            "resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.7.16.tgz",
+            "integrity": "sha512-ks7EI3TlrnZ6uKEIGemLHiBqOaqrA2dALNhC9Potl5CeajGNhF0n6eY30cNRvboDbuMRibw1iAtn7vnX4dzlwg==",
             "dev": true,
             "license": "Apache-2.0",
             "peer": true,
@@ -929,6 +943,7 @@
             "version": "1.5.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
             "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@langchain/classic": {
@@ -991,9 +1006,9 @@
             }
         },
         "node_modules/@langchain/classic/node_modules/openai": {
-            "version": "6.48.0",
-            "resolved": "https://registry.npmjs.org/openai/-/openai-6.48.0.tgz",
-            "integrity": "sha512-KhVp+FyV50QrXNextvL9hIU5l6ox5HYuKQjGVk7lIqprgJol90+dQXWONV6S1lRWsKA1bXjrow8RsUT14M1hNA==",
+            "version": "6.49.0",
+            "resolved": "https://registry.npmjs.org/openai/-/openai-6.49.0.tgz",
+            "integrity": "sha512-aYCc0C6L864eR6WSYIwQGyXriw/nIyZx0ObvhzOEVuk0zoBDpynjSbrionWI7q65B5H8jJX0DXR9snEzM6bfPg==",
             "dev": true,
             "license": "Apache-2.0",
             "peerDependencies": {
@@ -1027,7 +1042,6 @@
             "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -1546,9 +1560,9 @@
             }
         },
         "node_modules/@langchain/community/node_modules/@langchain/openai/node_modules/openai": {
-            "version": "6.48.0",
-            "resolved": "https://registry.npmjs.org/openai/-/openai-6.48.0.tgz",
-            "integrity": "sha512-KhVp+FyV50QrXNextvL9hIU5l6ox5HYuKQjGVk7lIqprgJol90+dQXWONV6S1lRWsKA1bXjrow8RsUT14M1hNA==",
+            "version": "6.49.0",
+            "resolved": "https://registry.npmjs.org/openai/-/openai-6.49.0.tgz",
+            "integrity": "sha512-aYCc0C6L864eR6WSYIwQGyXriw/nIyZx0ObvhzOEVuk0zoBDpynjSbrionWI7q65B5H8jJX0DXR9snEzM6bfPg==",
             "dev": true,
             "license": "Apache-2.0",
             "peerDependencies": {
@@ -1582,7 +1596,6 @@
             "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -1593,7 +1606,6 @@
             "integrity": "sha512-nXmyH0FbcsASlRmC9sbqX0gjQdxgB9KcS13vkw9PMaH0zzylwZkGFU9sY0XCPa2/AokmaNTU9DOW3IUDfAtQow==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@cfworker/json-schema": "^4.0.2",
                 "@standard-schema/spec": "^1.1.0",
@@ -1618,14 +1630,14 @@
             }
         },
         "node_modules/@langchain/langgraph": {
-            "version": "1.4.8",
-            "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.8.tgz",
-            "integrity": "sha512-DN1Np1XefdBEbp1qBKlt39cwoL743AAGpR5Ipja0gY2YbWvsoQnOTIrjnj/orSAhaUYsdTKS8VSWdFzsHZo6Ig==",
+            "version": "1.4.9",
+            "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.9.tgz",
+            "integrity": "sha512-EvD9rS66Cya09y6rbMgD3Ir8miAkJQFo7FyJOPRPO736Kz3y5TeyeBDOS8ctff/jRc788bPijHx2NVFM79Qqig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@langchain/langgraph-checkpoint": "^1.1.3",
-                "@langchain/langgraph-sdk": "~1.9.26",
+                "@langchain/langgraph-sdk": "~1.9.28",
                 "@langchain/protocol": "^0.0.18",
                 "@standard-schema/spec": "1.1.0"
             },
@@ -1740,9 +1752,9 @@
             }
         },
         "node_modules/@langchain/openai/node_modules/openai": {
-            "version": "6.48.0",
-            "resolved": "https://registry.npmjs.org/openai/-/openai-6.48.0.tgz",
-            "integrity": "sha512-KhVp+FyV50QrXNextvL9hIU5l6ox5HYuKQjGVk7lIqprgJol90+dQXWONV6S1lRWsKA1bXjrow8RsUT14M1hNA==",
+            "version": "6.49.0",
+            "resolved": "https://registry.npmjs.org/openai/-/openai-6.49.0.tgz",
+            "integrity": "sha512-aYCc0C6L864eR6WSYIwQGyXriw/nIyZx0ObvhzOEVuk0zoBDpynjSbrionWI7q65B5H8jJX0DXR9snEzM6bfPg==",
             "dev": true,
             "license": "Apache-2.0",
             "peerDependencies": {
@@ -1776,7 +1788,6 @@
             "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }
@@ -1808,12 +1819,14 @@
             "version": "1.5.2",
             "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
             "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@lezer/highlight": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
             "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@lezer/common": "^1.3.0"
@@ -1823,6 +1836,7 @@
             "version": "1.4.10",
             "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
             "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@lezer/common": "^1.0.0"
@@ -1832,6 +1846,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
             "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@n8n_io/ai-assistant-sdk": {
@@ -1846,19 +1861,19 @@
             }
         },
         "node_modules/@n8n/ai-node-sdk": {
-            "version": "0.21.3",
-            "resolved": "https://registry.npmjs.org/@n8n/ai-node-sdk/-/ai-node-sdk-0.21.3.tgz",
-            "integrity": "sha512-Pi9G344pW1oQoSCm+ghrGje8zAuTm1mVAjKct6gZVEyHA00zEa2VQGTAdOtoTpERRqV+eY2P1+k7GtU7jSh3PA==",
+            "version": "0.23.2",
+            "resolved": "https://registry.npmjs.org/@n8n/ai-node-sdk/-/ai-node-sdk-0.23.2.tgz",
+            "integrity": "sha512-1k8XPLs2IELbtwMwu1vPX1L50pAvCuCmBZknZ8YxiJj2sd+Gr51t3KMZEQZdAP6U6rYV2wMIekQ6mW61G9taCg==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
-                "@n8n/ai-utilities": "0.24.3"
+                "@n8n/ai-utilities": "0.26.2"
             }
         },
         "node_modules/@n8n/ai-utilities": {
-            "version": "0.24.3",
-            "resolved": "https://registry.npmjs.org/@n8n/ai-utilities/-/ai-utilities-0.24.3.tgz",
-            "integrity": "sha512-onx3ABLbKL8z7W6NuGyKqvSzGpE7XFe5xt4ujYdaXdivqx2rMrjLNWWf5WaOMjfqzA/HjUii1RmozOkT6ADO1g==",
+            "version": "0.26.2",
+            "resolved": "https://registry.npmjs.org/@n8n/ai-utilities/-/ai-utilities-0.26.2.tgz",
+            "integrity": "sha512-NQODtHVAs4INfJjgpQMbn7zx+8IQa/jSHl7L+DQfwm+GGF4IDm41i9QSnmuJYzjmdmdBvEE1VDFPTGeigPtK3Q==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
@@ -1867,55 +1882,245 @@
                 "@langchain/core": "1.2.0",
                 "@langchain/openai": "1.4.4",
                 "@langchain/textsplitters": "1.0.1",
-                "@n8n/api-types": "1.31.3",
-                "@n8n/backend-network": "1.5.3",
-                "@n8n/config": "2.29.1",
+                "@n8n/api-types": "1.33.2",
+                "@n8n/backend-network": "1.7.2",
+                "@n8n/config": "2.31.1",
                 "@n8n/typescript-config": "1.9.0",
-                "@n8n/utils": "1.39.0",
+                "@n8n/utils": "1.41.0",
                 "@thednp/dommatrix": "^2.0.12",
                 "js-tiktoken": "1.0.21",
                 "langchain": "1.2.30",
                 "lodash": "4.18.1",
-                "n8n-workflow": "2.31.3",
+                "n8n-workflow": "2.33.2",
                 "pdf-parse": "2.4.5",
                 "tmp-promise": "3.0.3",
-                "undici": "^6.24.0",
+                "undici": "^6.27.0",
                 "zod": "3.25.67",
                 "zod-to-json-schema": "3.23.3"
             }
         },
+        "node_modules/@n8n/ai-utilities/node_modules/@n8n/errors": {
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.13.0.tgz",
+            "integrity": "sha512-hUZ+ePKp2BzJL40OK1+wTVefJkKLy+mjiBT6KsejkXi1HboYoqHruFqeQZivm5PHhX3CZsHa9ZJy2LGHZrpKCQ==",
+            "dev": true,
+            "license": "SEE LICENSE IN LICENSE.md",
+            "dependencies": {
+                "callsites": "3.1.0"
+            }
+        },
+        "node_modules/@n8n/ai-utilities/node_modules/@n8n/expression-runtime": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.24.0.tgz",
+            "integrity": "sha512-ATII3IU1yAb29oFdGviJuMuL+31oSvTr31FIdVpASDyfHDGPFAbsAC0t/Gpa/RorGvjvmzu6fXow7XA0Xj5jdQ==",
+            "dev": true,
+            "license": "SEE LICENSE IN LICENSE.md",
+            "dependencies": {
+                "@n8n/errors": "0.13.0",
+                "@n8n/tournament": "1.9.0",
+                "isolated-vm": "^6.1.2",
+                "jmespath": "0.16.0",
+                "js-base64": "3.7.8",
+                "jssha": "3.3.1",
+                "lodash": "4.18.1",
+                "luxon": "3.7.2",
+                "md5": "2.3.0",
+                "title-case": "3.0.3",
+                "transliteration": "2.3.5",
+                "zod": "3.25.67"
+            }
+        },
+        "node_modules/@n8n/ai-utilities/node_modules/@n8n/tournament": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.9.0.tgz",
+            "integrity": "sha512-XB88QlKuD5QO1ERrfVbb2BC2uJrHqHsbmK5FlV+hY7W6IZO4BQtGCTJmHKgwCm+mKsVwBUz3edO8rUadNX6sxg==",
+            "dev": true,
+            "license": "SEE LICENSE IN LICENSE.md",
+            "dependencies": {
+                "ast-types": "^0.16.1",
+                "esprima-next": "^5.8.4",
+                "recast": "^0.22.0"
+            }
+        },
+        "node_modules/@n8n/ai-utilities/node_modules/n8n-workflow": {
+            "version": "2.33.2",
+            "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.33.2.tgz",
+            "integrity": "sha512-dGbWefR1opE5fIXKT0AQKDVxXD0LmLX4r84PGl5cGmYzqJhBS/FucRpm+nVo5EBA/fUop5qpGPGcU9BoQUb0aQ==",
+            "dev": true,
+            "license": "SEE LICENSE IN LICENSE.md",
+            "dependencies": {
+                "@codemirror/autocomplete": "6.20.0",
+                "@n8n/errors": "0.13.0",
+                "@n8n/expression-runtime": "0.24.0",
+                "@n8n/tournament": "1.9.0",
+                "@n8n/utils": "1.41.0",
+                "@sentry/core": "^10.55.0",
+                "@sentry/node": "^10.55.0",
+                "ast-types": "0.16.1",
+                "axios": "1.18.0",
+                "callsites": "3.1.0",
+                "esprima-next": "5.8.4",
+                "form-data": "4.0.6",
+                "jmespath": "0.16.0",
+                "js-base64": "3.7.8",
+                "json-schema": "0.4.0",
+                "jsonrepair": "3.13.2",
+                "jssha": "3.3.1",
+                "lodash": "4.18.1",
+                "luxon": "3.7.2",
+                "md5": "2.3.0",
+                "recast": "0.22.0",
+                "ssh2": "1.15.0",
+                "title-case": "3.0.3",
+                "transliteration": "2.3.5",
+                "uuid": "11.1.1",
+                "xml2js": "0.6.2"
+            },
+            "peerDependencies": {
+                "zod": "3.25.67"
+            }
+        },
+        "node_modules/@n8n/ai-utilities/node_modules/uuid": {
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/esm/bin/uuid"
+            }
+        },
         "node_modules/@n8n/api-types": {
-            "version": "1.31.3",
-            "resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-1.31.3.tgz",
-            "integrity": "sha512-iuZBUtom/pf9TmktRND7Q+TzvUr8yp7BY+nHdooi7xU29asxEn4auSVJQtn4pkr26r8h6CtlYgh04inUfQ7N4A==",
+            "version": "1.33.2",
+            "resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-1.33.2.tgz",
+            "integrity": "sha512-A99ssvyUXqH8tdbL2IDbK5Vj+85QLUhkS4Ukk7mH+vx+qt1/i3Lo96RI7lM6U7VJLIroZgfr7J/8JHPR112K0Q==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@n8n_io/ai-assistant-sdk": "1.25.0",
-                "@n8n/permissions": "0.68.0",
-                "n8n-workflow": "2.31.3",
+                "@n8n/permissions": "0.70.0",
+                "n8n-workflow": "2.33.2",
                 "xss": "1.0.15"
             },
             "peerDependencies": {
                 "zod": "3.25.67"
             }
         },
-        "node_modules/@n8n/backend-common": {
-            "version": "1.31.3",
-            "resolved": "https://registry.npmjs.org/@n8n/backend-common/-/backend-common-1.31.3.tgz",
-            "integrity": "sha512-a0S1E00wtaiHwQCDdIJK1WovInQjWD06wymCA4QeuSZdL0vzL0JCuRd7BP6ijAJwItTdwebFdHq7yt0ZID+ZEQ==",
+        "node_modules/@n8n/api-types/node_modules/@n8n/errors": {
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.13.0.tgz",
+            "integrity": "sha512-hUZ+ePKp2BzJL40OK1+wTVefJkKLy+mjiBT6KsejkXi1HboYoqHruFqeQZivm5PHhX3CZsHa9ZJy2LGHZrpKCQ==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
-                "@n8n/config": "2.29.1",
-                "@n8n/constants": "0.31.0",
-                "@n8n/decorators": "1.31.3",
-                "@n8n/di": "0.15.0",
-                "@n8n/utils": "1.39.0",
+                "callsites": "3.1.0"
+            }
+        },
+        "node_modules/@n8n/api-types/node_modules/@n8n/expression-runtime": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.24.0.tgz",
+            "integrity": "sha512-ATII3IU1yAb29oFdGviJuMuL+31oSvTr31FIdVpASDyfHDGPFAbsAC0t/Gpa/RorGvjvmzu6fXow7XA0Xj5jdQ==",
+            "dev": true,
+            "license": "SEE LICENSE IN LICENSE.md",
+            "dependencies": {
+                "@n8n/errors": "0.13.0",
+                "@n8n/tournament": "1.9.0",
+                "isolated-vm": "^6.1.2",
+                "jmespath": "0.16.0",
+                "js-base64": "3.7.8",
+                "jssha": "3.3.1",
+                "lodash": "4.18.1",
+                "luxon": "3.7.2",
+                "md5": "2.3.0",
+                "title-case": "3.0.3",
+                "transliteration": "2.3.5",
+                "zod": "3.25.67"
+            }
+        },
+        "node_modules/@n8n/api-types/node_modules/@n8n/tournament": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.9.0.tgz",
+            "integrity": "sha512-XB88QlKuD5QO1ERrfVbb2BC2uJrHqHsbmK5FlV+hY7W6IZO4BQtGCTJmHKgwCm+mKsVwBUz3edO8rUadNX6sxg==",
+            "dev": true,
+            "license": "SEE LICENSE IN LICENSE.md",
+            "dependencies": {
+                "ast-types": "^0.16.1",
+                "esprima-next": "^5.8.4",
+                "recast": "^0.22.0"
+            }
+        },
+        "node_modules/@n8n/api-types/node_modules/n8n-workflow": {
+            "version": "2.33.2",
+            "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.33.2.tgz",
+            "integrity": "sha512-dGbWefR1opE5fIXKT0AQKDVxXD0LmLX4r84PGl5cGmYzqJhBS/FucRpm+nVo5EBA/fUop5qpGPGcU9BoQUb0aQ==",
+            "dev": true,
+            "license": "SEE LICENSE IN LICENSE.md",
+            "dependencies": {
+                "@codemirror/autocomplete": "6.20.0",
+                "@n8n/errors": "0.13.0",
+                "@n8n/expression-runtime": "0.24.0",
+                "@n8n/tournament": "1.9.0",
+                "@n8n/utils": "1.41.0",
+                "@sentry/core": "^10.55.0",
+                "@sentry/node": "^10.55.0",
+                "ast-types": "0.16.1",
+                "axios": "1.18.0",
+                "callsites": "3.1.0",
+                "esprima-next": "5.8.4",
+                "form-data": "4.0.6",
+                "jmespath": "0.16.0",
+                "js-base64": "3.7.8",
+                "json-schema": "0.4.0",
+                "jsonrepair": "3.13.2",
+                "jssha": "3.3.1",
+                "lodash": "4.18.1",
+                "luxon": "3.7.2",
+                "md5": "2.3.0",
+                "recast": "0.22.0",
+                "ssh2": "1.15.0",
+                "title-case": "3.0.3",
+                "transliteration": "2.3.5",
+                "uuid": "11.1.1",
+                "xml2js": "0.6.2"
+            },
+            "peerDependencies": {
+                "zod": "3.25.67"
+            }
+        },
+        "node_modules/@n8n/api-types/node_modules/uuid": {
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/esm/bin/uuid"
+            }
+        },
+        "node_modules/@n8n/backend-common": {
+            "version": "1.33.2",
+            "resolved": "https://registry.npmjs.org/@n8n/backend-common/-/backend-common-1.33.2.tgz",
+            "integrity": "sha512-0y8a21131PWxUiDxR7TQeSvqSCwqxwrj8/aQwiBehuznPnthhykhpyTqsizrmEQdCcalTX3e5O+o/CWtxR2m/g==",
+            "dev": true,
+            "license": "SEE LICENSE IN LICENSE.md",
+            "dependencies": {
+                "@n8n/config": "2.31.1",
+                "@n8n/constants": "0.32.0",
+                "@n8n/decorators": "1.33.2",
+                "@n8n/di": "0.16.0",
+                "@n8n/utils": "1.41.0",
                 "callsites": "3.1.0",
                 "flatted": "3.4.2",
                 "logform": "2.6.1",
-                "n8n-workflow": "2.31.3",
+                "n8n-workflow": "2.33.2",
                 "picocolors": "1.0.1",
                 "reflect-metadata": "0.2.2",
                 "stream-json": "1.9.1",
@@ -1923,29 +2128,205 @@
                 "yargs-parser": "21.1.1"
             }
         },
-        "node_modules/@n8n/backend-network": {
-            "version": "1.5.3",
-            "resolved": "https://registry.npmjs.org/@n8n/backend-network/-/backend-network-1.5.3.tgz",
-            "integrity": "sha512-1TL+NYNN3h+inv9lHncEmfC/Eat/l2vtb+WAFdv1JsOYzIgoRYtoBt9FmTnwzxiKn6oQUTviaL87yCFoUDb/2Q==",
+        "node_modules/@n8n/backend-common/node_modules/@n8n/errors": {
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.13.0.tgz",
+            "integrity": "sha512-hUZ+ePKp2BzJL40OK1+wTVefJkKLy+mjiBT6KsejkXi1HboYoqHruFqeQZivm5PHhX3CZsHa9ZJy2LGHZrpKCQ==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
-                "@n8n/backend-common": "1.31.3",
-                "@n8n/config": "2.29.1",
-                "@n8n/constants": "0.31.0",
-                "@n8n/di": "0.15.0",
-                "@n8n/utils": "1.39.0",
+                "callsites": "3.1.0"
+            }
+        },
+        "node_modules/@n8n/backend-common/node_modules/@n8n/expression-runtime": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.24.0.tgz",
+            "integrity": "sha512-ATII3IU1yAb29oFdGviJuMuL+31oSvTr31FIdVpASDyfHDGPFAbsAC0t/Gpa/RorGvjvmzu6fXow7XA0Xj5jdQ==",
+            "dev": true,
+            "license": "SEE LICENSE IN LICENSE.md",
+            "dependencies": {
+                "@n8n/errors": "0.13.0",
+                "@n8n/tournament": "1.9.0",
+                "isolated-vm": "^6.1.2",
+                "jmespath": "0.16.0",
+                "js-base64": "3.7.8",
+                "jssha": "3.3.1",
+                "lodash": "4.18.1",
+                "luxon": "3.7.2",
+                "md5": "2.3.0",
+                "title-case": "3.0.3",
+                "transliteration": "2.3.5",
+                "zod": "3.25.67"
+            }
+        },
+        "node_modules/@n8n/backend-common/node_modules/@n8n/tournament": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.9.0.tgz",
+            "integrity": "sha512-XB88QlKuD5QO1ERrfVbb2BC2uJrHqHsbmK5FlV+hY7W6IZO4BQtGCTJmHKgwCm+mKsVwBUz3edO8rUadNX6sxg==",
+            "dev": true,
+            "license": "SEE LICENSE IN LICENSE.md",
+            "dependencies": {
+                "ast-types": "^0.16.1",
+                "esprima-next": "^5.8.4",
+                "recast": "^0.22.0"
+            }
+        },
+        "node_modules/@n8n/backend-common/node_modules/n8n-workflow": {
+            "version": "2.33.2",
+            "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.33.2.tgz",
+            "integrity": "sha512-dGbWefR1opE5fIXKT0AQKDVxXD0LmLX4r84PGl5cGmYzqJhBS/FucRpm+nVo5EBA/fUop5qpGPGcU9BoQUb0aQ==",
+            "dev": true,
+            "license": "SEE LICENSE IN LICENSE.md",
+            "dependencies": {
+                "@codemirror/autocomplete": "6.20.0",
+                "@n8n/errors": "0.13.0",
+                "@n8n/expression-runtime": "0.24.0",
+                "@n8n/tournament": "1.9.0",
+                "@n8n/utils": "1.41.0",
+                "@sentry/core": "^10.55.0",
+                "@sentry/node": "^10.55.0",
+                "ast-types": "0.16.1",
+                "axios": "1.18.0",
+                "callsites": "3.1.0",
+                "esprima-next": "5.8.4",
+                "form-data": "4.0.6",
+                "jmespath": "0.16.0",
+                "js-base64": "3.7.8",
+                "json-schema": "0.4.0",
+                "jsonrepair": "3.13.2",
+                "jssha": "3.3.1",
+                "lodash": "4.18.1",
+                "luxon": "3.7.2",
+                "md5": "2.3.0",
+                "recast": "0.22.0",
+                "ssh2": "1.15.0",
+                "title-case": "3.0.3",
+                "transliteration": "2.3.5",
+                "uuid": "11.1.1",
+                "xml2js": "0.6.2"
+            },
+            "peerDependencies": {
+                "zod": "3.25.67"
+            }
+        },
+        "node_modules/@n8n/backend-common/node_modules/uuid": {
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/esm/bin/uuid"
+            }
+        },
+        "node_modules/@n8n/backend-network": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@n8n/backend-network/-/backend-network-1.7.2.tgz",
+            "integrity": "sha512-nIa8FZwrJKz11JOVGAlEF1LyR+dfS9KXIFziry+lEljTOh5TJFWGb0m0k24WUzruNTco0bZDfHOsTx1B5fVT0g==",
+            "dev": true,
+            "license": "SEE LICENSE IN LICENSE.md",
+            "dependencies": {
+                "@n8n/backend-common": "1.33.2",
+                "@n8n/config": "2.31.1",
+                "@n8n/constants": "0.32.0",
+                "@n8n/di": "0.16.0",
+                "@n8n/utils": "1.41.0",
                 "axios": "1.18.0",
                 "cache-manager": "5.2.3",
                 "form-data": "4.0.6",
                 "http-proxy-agent": "7.0.2",
                 "https-proxy-agent": "7.0.6",
                 "iconv-lite": "0.6.3",
-                "n8n-workflow": "2.31.3",
+                "n8n-workflow": "2.33.2",
                 "proxy-from-env": "^1.1.0",
                 "qs": "6.15.2",
                 "reflect-metadata": "0.2.2",
                 "undici": "^7.28.0",
+                "zod": "3.25.67"
+            }
+        },
+        "node_modules/@n8n/backend-network/node_modules/@n8n/errors": {
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.13.0.tgz",
+            "integrity": "sha512-hUZ+ePKp2BzJL40OK1+wTVefJkKLy+mjiBT6KsejkXi1HboYoqHruFqeQZivm5PHhX3CZsHa9ZJy2LGHZrpKCQ==",
+            "dev": true,
+            "license": "SEE LICENSE IN LICENSE.md",
+            "dependencies": {
+                "callsites": "3.1.0"
+            }
+        },
+        "node_modules/@n8n/backend-network/node_modules/@n8n/expression-runtime": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.24.0.tgz",
+            "integrity": "sha512-ATII3IU1yAb29oFdGviJuMuL+31oSvTr31FIdVpASDyfHDGPFAbsAC0t/Gpa/RorGvjvmzu6fXow7XA0Xj5jdQ==",
+            "dev": true,
+            "license": "SEE LICENSE IN LICENSE.md",
+            "dependencies": {
+                "@n8n/errors": "0.13.0",
+                "@n8n/tournament": "1.9.0",
+                "isolated-vm": "^6.1.2",
+                "jmespath": "0.16.0",
+                "js-base64": "3.7.8",
+                "jssha": "3.3.1",
+                "lodash": "4.18.1",
+                "luxon": "3.7.2",
+                "md5": "2.3.0",
+                "title-case": "3.0.3",
+                "transliteration": "2.3.5",
+                "zod": "3.25.67"
+            }
+        },
+        "node_modules/@n8n/backend-network/node_modules/@n8n/tournament": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.9.0.tgz",
+            "integrity": "sha512-XB88QlKuD5QO1ERrfVbb2BC2uJrHqHsbmK5FlV+hY7W6IZO4BQtGCTJmHKgwCm+mKsVwBUz3edO8rUadNX6sxg==",
+            "dev": true,
+            "license": "SEE LICENSE IN LICENSE.md",
+            "dependencies": {
+                "ast-types": "^0.16.1",
+                "esprima-next": "^5.8.4",
+                "recast": "^0.22.0"
+            }
+        },
+        "node_modules/@n8n/backend-network/node_modules/n8n-workflow": {
+            "version": "2.33.2",
+            "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.33.2.tgz",
+            "integrity": "sha512-dGbWefR1opE5fIXKT0AQKDVxXD0LmLX4r84PGl5cGmYzqJhBS/FucRpm+nVo5EBA/fUop5qpGPGcU9BoQUb0aQ==",
+            "dev": true,
+            "license": "SEE LICENSE IN LICENSE.md",
+            "dependencies": {
+                "@codemirror/autocomplete": "6.20.0",
+                "@n8n/errors": "0.13.0",
+                "@n8n/expression-runtime": "0.24.0",
+                "@n8n/tournament": "1.9.0",
+                "@n8n/utils": "1.41.0",
+                "@sentry/core": "^10.55.0",
+                "@sentry/node": "^10.55.0",
+                "ast-types": "0.16.1",
+                "axios": "1.18.0",
+                "callsites": "3.1.0",
+                "esprima-next": "5.8.4",
+                "form-data": "4.0.6",
+                "jmespath": "0.16.0",
+                "js-base64": "3.7.8",
+                "json-schema": "0.4.0",
+                "jsonrepair": "3.13.2",
+                "jssha": "3.3.1",
+                "lodash": "4.18.1",
+                "luxon": "3.7.2",
+                "md5": "2.3.0",
+                "recast": "0.22.0",
+                "ssh2": "1.15.0",
+                "title-case": "3.0.3",
+                "transliteration": "2.3.5",
+                "uuid": "11.1.1",
+                "xml2js": "0.6.2"
+            },
+            "peerDependencies": {
                 "zod": "3.25.67"
             }
         },
@@ -1959,44 +2340,154 @@
                 "node": ">=20.18.1"
             }
         },
+        "node_modules/@n8n/backend-network/node_modules/uuid": {
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/esm/bin/uuid"
+            }
+        },
         "node_modules/@n8n/config": {
-            "version": "2.29.1",
-            "resolved": "https://registry.npmjs.org/@n8n/config/-/config-2.29.1.tgz",
-            "integrity": "sha512-ccL6ksRS6HiQkxfNxYEc3db4VS8HCwmMJMqaXu7B4f4e6qm13efj2CUl2W60sATezQ+my1ETysfSgy71PbfvzA==",
+            "version": "2.31.1",
+            "resolved": "https://registry.npmjs.org/@n8n/config/-/config-2.31.1.tgz",
+            "integrity": "sha512-5XLfi6qeL0g7axmU8/Y9S011aj7wNEUjdWtjYb68JUkUnDWMkL/Z5MgZ1PpR/cBxUH+ytUrtGxNursEDmDjgXA==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
-                "@n8n/constants": "0.31.0",
-                "@n8n/di": "0.15.0",
+                "@n8n/constants": "0.32.0",
+                "@n8n/di": "0.16.0",
                 "reflect-metadata": "0.2.2",
                 "zod": "3.25.67"
             }
         },
         "node_modules/@n8n/constants": {
-            "version": "0.31.0",
-            "resolved": "https://registry.npmjs.org/@n8n/constants/-/constants-0.31.0.tgz",
-            "integrity": "sha512-qUffAbe5M5Y6IT4Dbjvts6clFSbZHKlfBDool0q5EYlq6fw5aRvvA9K31gxuySxgGaGLazXiflwDlv7OEcSjEA==",
+            "version": "0.32.0",
+            "resolved": "https://registry.npmjs.org/@n8n/constants/-/constants-0.32.0.tgz",
+            "integrity": "sha512-ewF/bQL2bjmHU9Dv5PnW8uDpYw5GlFJ0/nuAp+RDK9OJXXm19ErHb9itLyANvNTLGPQv8bb0BMvHh2kpWaa/8g==",
+            "dev": true,
             "license": "SEE LICENSE IN LICENSE.md"
         },
         "node_modules/@n8n/decorators": {
-            "version": "1.31.3",
-            "resolved": "https://registry.npmjs.org/@n8n/decorators/-/decorators-1.31.3.tgz",
-            "integrity": "sha512-yDgzDjgsS3DGMsdwySaobme0VBzr9ylyVzUQMiB4sVI0VD5V7SGw2LCo6c8aAGMsD4enFXjeOuG/+sMKsdTUbA==",
+            "version": "1.33.2",
+            "resolved": "https://registry.npmjs.org/@n8n/decorators/-/decorators-1.33.2.tgz",
+            "integrity": "sha512-J+oUnIDlBpjzHJLEgFoTDjXSUL8LCk5GzTnJOol0j6Wb9/iTWBGQv+WOWRoCO+JfOLUxBsSVerLDXnSMZ53zVQ==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
-                "@n8n/api-types": "1.31.3",
-                "@n8n/constants": "0.31.0",
-                "@n8n/di": "0.15.0",
-                "@n8n/permissions": "0.68.0",
+                "@n8n/api-types": "1.33.2",
+                "@n8n/constants": "0.32.0",
+                "@n8n/di": "0.16.0",
+                "@n8n/permissions": "0.70.0",
                 "lodash": "4.18.1",
-                "n8n-workflow": "2.31.3"
+                "n8n-workflow": "2.33.2"
+            }
+        },
+        "node_modules/@n8n/decorators/node_modules/@n8n/errors": {
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.13.0.tgz",
+            "integrity": "sha512-hUZ+ePKp2BzJL40OK1+wTVefJkKLy+mjiBT6KsejkXi1HboYoqHruFqeQZivm5PHhX3CZsHa9ZJy2LGHZrpKCQ==",
+            "dev": true,
+            "license": "SEE LICENSE IN LICENSE.md",
+            "dependencies": {
+                "callsites": "3.1.0"
+            }
+        },
+        "node_modules/@n8n/decorators/node_modules/@n8n/expression-runtime": {
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.24.0.tgz",
+            "integrity": "sha512-ATII3IU1yAb29oFdGviJuMuL+31oSvTr31FIdVpASDyfHDGPFAbsAC0t/Gpa/RorGvjvmzu6fXow7XA0Xj5jdQ==",
+            "dev": true,
+            "license": "SEE LICENSE IN LICENSE.md",
+            "dependencies": {
+                "@n8n/errors": "0.13.0",
+                "@n8n/tournament": "1.9.0",
+                "isolated-vm": "^6.1.2",
+                "jmespath": "0.16.0",
+                "js-base64": "3.7.8",
+                "jssha": "3.3.1",
+                "lodash": "4.18.1",
+                "luxon": "3.7.2",
+                "md5": "2.3.0",
+                "title-case": "3.0.3",
+                "transliteration": "2.3.5",
+                "zod": "3.25.67"
+            }
+        },
+        "node_modules/@n8n/decorators/node_modules/@n8n/tournament": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.9.0.tgz",
+            "integrity": "sha512-XB88QlKuD5QO1ERrfVbb2BC2uJrHqHsbmK5FlV+hY7W6IZO4BQtGCTJmHKgwCm+mKsVwBUz3edO8rUadNX6sxg==",
+            "dev": true,
+            "license": "SEE LICENSE IN LICENSE.md",
+            "dependencies": {
+                "ast-types": "^0.16.1",
+                "esprima-next": "^5.8.4",
+                "recast": "^0.22.0"
+            }
+        },
+        "node_modules/@n8n/decorators/node_modules/n8n-workflow": {
+            "version": "2.33.2",
+            "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.33.2.tgz",
+            "integrity": "sha512-dGbWefR1opE5fIXKT0AQKDVxXD0LmLX4r84PGl5cGmYzqJhBS/FucRpm+nVo5EBA/fUop5qpGPGcU9BoQUb0aQ==",
+            "dev": true,
+            "license": "SEE LICENSE IN LICENSE.md",
+            "dependencies": {
+                "@codemirror/autocomplete": "6.20.0",
+                "@n8n/errors": "0.13.0",
+                "@n8n/expression-runtime": "0.24.0",
+                "@n8n/tournament": "1.9.0",
+                "@n8n/utils": "1.41.0",
+                "@sentry/core": "^10.55.0",
+                "@sentry/node": "^10.55.0",
+                "ast-types": "0.16.1",
+                "axios": "1.18.0",
+                "callsites": "3.1.0",
+                "esprima-next": "5.8.4",
+                "form-data": "4.0.6",
+                "jmespath": "0.16.0",
+                "js-base64": "3.7.8",
+                "json-schema": "0.4.0",
+                "jsonrepair": "3.13.2",
+                "jssha": "3.3.1",
+                "lodash": "4.18.1",
+                "luxon": "3.7.2",
+                "md5": "2.3.0",
+                "recast": "0.22.0",
+                "ssh2": "1.15.0",
+                "title-case": "3.0.3",
+                "transliteration": "2.3.5",
+                "uuid": "11.1.1",
+                "xml2js": "0.6.2"
+            },
+            "peerDependencies": {
+                "zod": "3.25.67"
+            }
+        },
+        "node_modules/@n8n/decorators/node_modules/uuid": {
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/@n8n/di": {
-            "version": "0.15.0",
-            "resolved": "https://registry.npmjs.org/@n8n/di/-/di-0.15.0.tgz",
-            "integrity": "sha512-ZsItCGrn41nTluT9XT/uSomOGt1ini08MesITAdarjOGXKHMoDrEiToNPzeiqtqbRGp12D1DONiwyWkrwxfskQ==",
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/@n8n/di/-/di-0.16.0.tgz",
+            "integrity": "sha512-XYvTNd9J77G2JY1L+3hzJX7bTHLRb0MBXN/gh/80gkmfBdeVBvQCFJvvBIvjbGM3iHvEorEQU+mMLRKKxl0lBw==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
@@ -2004,22 +2495,24 @@
             }
         },
         "node_modules/@n8n/errors": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.12.0.tgz",
-            "integrity": "sha512-McWRCwnUG7vupVRmcvcIfMXVDdN5kF1JZJvfXBRBx80PHPVqGtOHXaavbe7iKdxeS3VnkW/mo5Ig04IqikG6nQ==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.10.0.tgz",
+            "integrity": "sha512-Qle4gCsx7qtDRMdie3YkjuXPuo369PP32cR9Svb+INwcjLMxNzmnbJ66jFnOmLn0ntwBccUw1IecJ6axwyTgBQ==",
+            "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "callsites": "3.1.0"
             }
         },
         "node_modules/@n8n/expression-runtime": {
-            "version": "0.22.1",
-            "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.22.1.tgz",
-            "integrity": "sha512-uXqVqa21eIDwDtz9qH34LstV6UoG4zUgxpYvQSW2VdiUrPxkF7oqzHiJBPOpr9SQVDiXPrxbu9X+CjkGhY6lRA==",
+            "version": "0.20.1",
+            "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.20.1.tgz",
+            "integrity": "sha512-8UaKPCnu1hNdZvrNPRVkERPodZiQONF/BeB4uZdXKd/RsT6zOnAzdDF3I9czDpILzLbi8ViG5FeQz04PREt6dQ==",
+            "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
-                "@n8n/errors": "0.12.0",
-                "@n8n/tournament": "1.7.1",
+                "@n8n/errors": "0.10.0",
+                "@n8n/tournament": "1.5.0",
                 "isolated-vm": "^6.1.2",
                 "jmespath": "0.16.0",
                 "js-base64": "3.7.8",
@@ -2033,16 +2526,16 @@
             }
         },
         "node_modules/@n8n/node-cli": {
-            "version": "0.40.3",
-            "resolved": "https://registry.npmjs.org/@n8n/node-cli/-/node-cli-0.40.3.tgz",
-            "integrity": "sha512-cvbZtZIYHrnqMEaMEKTvdhc5b9d/9sZ5mXXQ8kS4hxktRc++1oWb31axr5lUpCrKGDO0deFmyNXoOtlJlrhnBQ==",
+            "version": "0.42.2",
+            "resolved": "https://registry.npmjs.org/@n8n/node-cli/-/node-cli-0.42.2.tgz",
+            "integrity": "sha512-lWRFQ+nwuKJIU2GJic1rCQdDYE7EyMeVoaJuryrryMXRAAeStdmgHRyws9L91Uaj+HHyj8UHFMzabMSUB5L4eg==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@clack/prompts": "^0.11.0",
                 "@eslint/js": "^9.29.0",
-                "@n8n/ai-node-sdk": "0.21.3",
-                "@n8n/eslint-plugin-community-nodes": "0.25.0",
+                "@n8n/ai-node-sdk": "0.23.2",
+                "@n8n/eslint-plugin-community-nodes": "0.27.0",
                 "@oclif/core": "^4.5.2",
                 "change-case": "^5.4.4",
                 "eslint": "9.29.0",
@@ -2117,9 +2610,9 @@
             }
         },
         "node_modules/@n8n/node-cli/node_modules/@n8n/eslint-plugin-community-nodes": {
-            "version": "0.25.0",
-            "resolved": "https://registry.npmjs.org/@n8n/eslint-plugin-community-nodes/-/eslint-plugin-community-nodes-0.25.0.tgz",
-            "integrity": "sha512-qSOrldDCeZmV1eOds/SWqbS/YMyjZrnRRJI1/VDxBU7aa+Jk2jO4DkKp7R5hvhjRH3CosQ0+hW/4WP1xxxuWPw==",
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/@n8n/eslint-plugin-community-nodes/-/eslint-plugin-community-nodes-0.27.0.tgz",
+            "integrity": "sha512-qTcdOyhCODOJ2VtDBpvkWFE5+gLuwUQ+D4+AnCzCQLs0Ba/scOxRGviYZYdhwY70HfNcLpakN3xKLccwFMP6Dw==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
@@ -2156,7 +2649,6 @@
             "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -2235,10 +2727,26 @@
                 "node": "*"
             }
         },
+        "node_modules/@n8n/node-cli/node_modules/prettier": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+            "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "prettier": "bin/prettier.cjs"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
         "node_modules/@n8n/permissions": {
-            "version": "0.68.0",
-            "resolved": "https://registry.npmjs.org/@n8n/permissions/-/permissions-0.68.0.tgz",
-            "integrity": "sha512-FL3cE0ufOGJznDQjs40L1kjcUsXWByp6kDaj3xlzLPXr95Ql0/HWxN1L94jbgYtx7T6XWPu3USJqT5Iu9WFJTg==",
+            "version": "0.70.0",
+            "resolved": "https://registry.npmjs.org/@n8n/permissions/-/permissions-0.70.0.tgz",
+            "integrity": "sha512-V6egB3bM15Aiu5+124vlX6Uth/9XfveBe0KiujubKr41tMj0YVh78ozuSsQPUpA2OpHGKusdA+Im/EmYjvpPnQ==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
@@ -2246,14 +2754,19 @@
             }
         },
         "node_modules/@n8n/tournament": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.7.1.tgz",
-            "integrity": "sha512-v8X7RGiIyR6i4HgWoQU6MivRlic2l5JTRisUfISAMOGaAdMoZJ10/ob3RCoReRHGNONH4n+v9SOf34o8lVCAPQ==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.5.0.tgz",
+            "integrity": "sha512-trQq+DUm3ICx7HSIf1jF3Nixuo5j5d63rqpeEiVWhaiYzLvaju6gBnenNwyR7BQIFILIa08wGWKVFjr7fRo+3Q==",
+            "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "ast-types": "^0.16.1",
                 "esprima-next": "^5.8.4",
                 "recast": "^0.22.0"
+            },
+            "engines": {
+                "node": ">=20.15",
+                "pnpm": ">=9.5"
             }
         },
         "node_modules/@n8n/typescript-config": {
@@ -2264,12 +2777,13 @@
             "license": "SEE LICENSE IN LICENSE.md"
         },
         "node_modules/@n8n/utils": {
-            "version": "1.39.0",
-            "resolved": "https://registry.npmjs.org/@n8n/utils/-/utils-1.39.0.tgz",
-            "integrity": "sha512-vFlcgSFFqJ6jX5T5fKKqeqXL2tOTt3rH/clvRqiUXhwKUuf3CHBY74p+785/JbH3RdcxcMBi682gHn4enJHijg==",
+            "version": "1.41.0",
+            "resolved": "https://registry.npmjs.org/@n8n/utils/-/utils-1.41.0.tgz",
+            "integrity": "sha512-wjlYqMYRDI8RGNEEBQXA9Pw5FsgdqP+4tvk6HJ9POB5x9yQyF4PhHt45a2RVz0BAoGwZKuxnunR3T+pE/FbjKQ==",
+            "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
-                "@n8n/constants": "0.31.0",
+                "@n8n/constants": "0.32.0",
                 "nanoid": "3.3.8"
             }
         },
@@ -2571,7 +3085,6 @@
             "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@octokit/auth-token": "^6.0.0",
                 "@octokit/graphql": "^9.0.3",
@@ -2727,8 +3240,8 @@
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
             "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+            "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -2737,6 +3250,7 @@
             "version": "0.220.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
             "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/api": "^1.3.0"
@@ -2749,8 +3263,8 @@
             "version": "2.10.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
             "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+            "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@opentelemetry/semantic-conventions": "^1.29.0"
             },
@@ -2765,8 +3279,8 @@
             "version": "0.220.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
             "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
+            "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@opentelemetry/api-logs": "0.220.0",
                 "import-in-the-middle": "^3.0.0",
@@ -2783,6 +3297,7 @@
             "version": "2.10.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
             "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/core": "2.10.0",
@@ -2799,6 +3314,7 @@
             "version": "2.10.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
             "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/core": "2.10.0",
@@ -2816,8 +3332,8 @@
             "version": "2.10.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
             "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
+            "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@opentelemetry/core": "2.10.0",
                 "@opentelemetry/resources": "2.10.0",
@@ -2835,6 +3351,7 @@
             "version": "1.43.0",
             "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
             "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=14"
@@ -2855,35 +3372,37 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.61.1",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-            "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+            "version": "1.62.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+            "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
             "dev": true,
             "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "playwright": "1.61.1"
+                "playwright": "1.62.1"
             },
             "bin": {
                 "playwright": "cli.js"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             }
         },
         "node_modules/@sentry/conventions": {
             "version": "0.16.0",
             "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
             "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=14"
             }
         },
         "node_modules/@sentry/core": {
-            "version": "10.67.0",
-            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.67.0.tgz",
-            "integrity": "sha512-b6U3pJ8AUvN9aouq0vl+VZI8KT8RslBsfGMFuNwRr313zOmdmFJBZqTiUw9VGgJ2jGKxLO9alm9rlxBfX4hf+w==",
+            "version": "10.69.0",
+            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.69.0.tgz",
+            "integrity": "sha512-+uuqVEeiDzYuAKjZLqsROKXvRTbl/QeH0gfGRtpYib1cud4rAFWRIkFmcR7Jb7JGFYwmReyQotiTj/hcDszTZg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@sentry/conventions": "^0.16.0"
@@ -2893,19 +3412,20 @@
             }
         },
         "node_modules/@sentry/node": {
-            "version": "10.67.0",
-            "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.67.0.tgz",
-            "integrity": "sha512-SFKpZGqOCEFSmP93NdDP6ikZp4NS7A/JR8+2ofK3jF6Y9Vyox7pX0pxdOnPLpFcPtMybMahfWqSAWJvsFs4RmA==",
+            "version": "10.69.0",
+            "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.69.0.tgz",
+            "integrity": "sha512-xEXA1YGIiTZbrW6MWV34uS6JGQuQg2ijTI0zed+FsJb9JZKPYel/GZK8Km26vfTVb+yCXFmWZNBesKegNcVdzg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@opentelemetry/api": "^1.9.1",
                 "@opentelemetry/instrumentation": "^0.220.0",
                 "@opentelemetry/sdk-trace-base": "^2.9.0",
                 "@sentry/conventions": "^0.16.0",
-                "@sentry/core": "10.67.0",
-                "@sentry/node-core": "10.67.0",
-                "@sentry/opentelemetry": "10.67.0",
-                "@sentry/server-utils": "10.67.0",
+                "@sentry/core": "10.69.0",
+                "@sentry/node-core": "10.69.0",
+                "@sentry/opentelemetry": "10.69.0",
+                "@sentry/server-utils": "10.69.0",
                 "import-in-the-middle": "^3.0.0"
             },
             "engines": {
@@ -2913,14 +3433,15 @@
             }
         },
         "node_modules/@sentry/node-core": {
-            "version": "10.67.0",
-            "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.67.0.tgz",
-            "integrity": "sha512-dBHHRwZyan1pOnFJ+sNBvR8TkXbZAfZU/jpxmALS3JZ2/8AGR7cQKL+b7SleKuJ7iUDZyklN3Nqi0i5JkcA+HA==",
+            "version": "10.69.0",
+            "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.69.0.tgz",
+            "integrity": "sha512-IgArHczrZJxkgxoffHscj0NxQrG6kCazgmGQnlf3j58J1ec21YaUu8Tu+7G4Lo5tCiW3teQnwlKW1ttMXSqWRw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@sentry/conventions": "^0.16.0",
-                "@sentry/core": "10.67.0",
-                "@sentry/opentelemetry": "10.67.0",
+                "@sentry/core": "10.69.0",
+                "@sentry/opentelemetry": "10.69.0",
                 "import-in-the-middle": "^3.0.0"
             },
             "engines": {
@@ -2952,13 +3473,14 @@
             }
         },
         "node_modules/@sentry/opentelemetry": {
-            "version": "10.67.0",
-            "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.67.0.tgz",
-            "integrity": "sha512-oLTOrAK1rOqmYRktOJZwz37B1seXPx1W2FTMVtzTVNjMFA/LZwGzePeZzhUOgzZgfLHixMd/ceWtGqoxAndcjQ==",
+            "version": "10.69.0",
+            "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.69.0.tgz",
+            "integrity": "sha512-3FyWV6YcEJuvLrlaKGE1dHXCI+1YO0a62w7PkwlRg8yp6K6YXkmdwu9GjqaYD+Ju4tm7uC7mHIsGFQMm0M7pqQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@sentry/conventions": "^0.16.0",
-                "@sentry/core": "10.67.0"
+                "@sentry/core": "10.69.0"
             },
             "engines": {
                 "node": ">=18"
@@ -2970,15 +3492,17 @@
             }
         },
         "node_modules/@sentry/server-utils": {
-            "version": "10.67.0",
-            "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.67.0.tgz",
-            "integrity": "sha512-GQ9t+RSTx5s3b/aZrLFuL4nrwPLMah5NiZk5cjxJmgmOSgm3nMdO8gdqCedDch5B13F3YsxtaQYjSJnzLz8M5A==",
+            "version": "10.69.0",
+            "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.69.0.tgz",
+            "integrity": "sha512-0MwHrA8+nNvMIsqf8m3cXwCBlUjr6AS7N6CZvHJtY1DkqEvQqEbD5VIrhzEyHN/KMZIgQ8XeDCQRhjnXFQGRhg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@apm-js-collab/code-transformer-bundler-plugins": "^0.7.1",
+                "@apm-js-collab/code-transformer-bundler-plugins": "^0.7.3",
                 "@apm-js-collab/tracing-hooks": "^0.13.0",
                 "@sentry/conventions": "^0.16.0",
-                "@sentry/core": "10.67.0"
+                "@sentry/core": "10.69.0",
+                "meriyah": "^6.1.4"
             },
             "engines": {
                 "node": ">=18"
@@ -3019,6 +3543,7 @@
             "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "debug": "^4.4.3",
                 "token-types": "^6.1.1"
@@ -3036,7 +3561,8 @@
             "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
             "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@ts-morph/common": {
             "version": "0.28.1",
@@ -3067,6 +3593,7 @@
             "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/ms": "*"
             }
@@ -3075,6 +3602,7 @@
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
             "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/json-schema": {
@@ -3089,7 +3617,8 @@
             "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
             "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/node": {
             "version": "18.19.130",
@@ -3097,6 +3626,7 @@
             "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -3107,6 +3637,7 @@
             "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "form-data": "^4.0.4"
@@ -3124,7 +3655,8 @@
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
             "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/triple-beam": {
             "version": "1.3.5",
@@ -3168,7 +3700,6 @@
             "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.65.0",
                 "@typescript-eslint/types": "8.65.0",
@@ -3720,6 +4251,7 @@
             "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "event-target-shim": "^5.0.0"
             },
@@ -3733,7 +4265,6 @@
             "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3767,6 +4298,7 @@
             "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "humanize-ms": "^1.2.1"
             },
@@ -3824,6 +4356,7 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
@@ -3856,6 +4389,7 @@
             "version": "0.2.6",
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
             "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": "~2.1.0"
@@ -3865,6 +4399,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
             "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.2",
@@ -3878,6 +4413,7 @@
             "version": "0.16.1",
             "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
             "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.0.1"
@@ -3890,6 +4426,7 @@
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
             "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "astring": "bin/astring"
@@ -3916,12 +4453,14 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/available-typed-arrays": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
             "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "possible-typed-array-names": "^1.0.0"
@@ -3937,8 +4476,8 @@
             "version": "1.18.0",
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
             "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
@@ -3950,6 +4489,7 @@
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
             "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "debug": "4"
@@ -3962,6 +4502,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
             "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "agent-base": "6",
@@ -3975,6 +4516,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
             "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10"
@@ -4025,6 +4567,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+            "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "tweetnacl": "^0.14.3"
@@ -4081,12 +4624,14 @@
             "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
             "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
             "dev": true,
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/buildcheck": {
             "version": "0.0.7",
             "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
             "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+            "dev": true,
             "optional": true,
             "engines": {
                 "node": ">=10.0.0"
@@ -4165,6 +4710,7 @@
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
             "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
@@ -4183,6 +4729,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
             "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -4196,6 +4743,7 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
             "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
@@ -4212,6 +4760,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -4234,6 +4783,7 @@
             "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -4289,6 +4839,7 @@
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
             "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": "*"
@@ -4330,6 +4881,7 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
             "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/clean-stack": {
@@ -4391,6 +4943,7 @@
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
             "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "string-width": "^4.2.0",
@@ -4405,6 +4958,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -4414,6 +4968,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
@@ -4447,6 +5002,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
@@ -4459,6 +5015,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/color-string": {
@@ -4511,6 +5068,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "delayed-stream": "~1.0.0"
@@ -4568,6 +5126,7 @@
             "version": "0.0.10",
             "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
             "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+            "dev": true,
             "hasInstallScript": true,
             "optional": true,
             "dependencies": {
@@ -4582,6 +5141,7 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
             "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/cross-spawn": {
@@ -4603,6 +5163,7 @@
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
             "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": "*"
@@ -4629,6 +5190,7 @@
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
             "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ms": "^2.1.3"
@@ -4694,6 +5256,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
             "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-define-property": "^1.0.0",
@@ -4724,6 +5287,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
             "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "define-data-property": "^1.0.1",
@@ -4779,6 +5343,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
@@ -4809,6 +5374,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
             "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.1",
@@ -4825,6 +5391,7 @@
             "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             }
@@ -4849,6 +5416,7 @@
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/enabled": {
@@ -4862,6 +5430,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
             "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -4871,6 +5440,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -4880,12 +5450,14 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
             "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
             "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0"
@@ -4898,6 +5470,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
             "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -4913,6 +5486,7 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
             "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -5080,7 +5654,6 @@
             "integrity": "sha512-4cdstYkKCyjumM2Q9NSI03K8D2a9F4Ssz33K2lv2hQa4KmR9jPLwk3uWGtNvclfqBrPGfGuMBwsGMbe6dMRbfg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/types": "^8.56.0",
                 "comment-parser": "^1.4.1",
@@ -5239,6 +5812,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true,
             "license": "BSD-2-Clause",
             "bin": {
                 "esparse": "bin/esparse.js",
@@ -5252,6 +5826,7 @@
             "version": "5.8.4",
             "resolved": "https://registry.npmjs.org/esprima-next/-/esprima-next-5.8.4.tgz",
             "integrity": "sha512-8nYVZ4ioIH4Msjb/XmhnBdz5WRRBaYqevKa1cv9nGJdCehMbzZCPNEEnqfLCZVetUVrUPEcb5IYyu1GG4hFqgg==",
+            "dev": true,
             "license": "BSD-2-Clause",
             "bin": {
                 "esparse": "bin/esparse.js",
@@ -5265,6 +5840,7 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
             "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+            "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "estraverse": "^5.1.0"
@@ -5290,6 +5866,7 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=4.0"
@@ -5324,6 +5901,7 @@
             "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -5347,7 +5925,8 @@
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -5473,6 +6052,7 @@
             "integrity": "sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@tokenizer/inflate": "^0.4.1",
                 "strtok3": "^10.3.4",
@@ -5598,6 +6178,7 @@
             "version": "1.16.0",
             "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
             "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+            "dev": true,
             "funding": [
                 {
                     "type": "individual",
@@ -5618,6 +6199,7 @@
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
             "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "is-callable": "^1.2.7"
@@ -5650,6 +6232,7 @@
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
             "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
@@ -5667,7 +6250,8 @@
             "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
             "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/formdata-node": {
             "version": "4.4.1",
@@ -5675,6 +6259,7 @@
             "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "node-domexception": "1.0.0",
                 "web-streams-polyfill": "4.0.0-beta.3"
@@ -5694,6 +6279,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
@@ -5702,6 +6288,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -5711,6 +6298,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
             "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -5720,6 +6308,7 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
@@ -5742,6 +6331,7 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
             "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.2",
@@ -5776,6 +6366,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
             "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "dunder-proto": "^1.0.1",
@@ -5899,6 +6490,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
             "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -5943,6 +6535,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
             "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-define-property": "^1.0.0"
@@ -5955,6 +6548,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -5967,6 +6561,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
             "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "has-symbols": "^1.0.3"
@@ -5982,6 +6577,7 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
             "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -6024,6 +6620,7 @@
             "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ms": "^2.0.0"
             }
@@ -6034,6 +6631,7 @@
             "integrity": "sha512-7balLY8WKk+bOhe5Vgg4zG2X6Z0zhpG/3VtYPC69evj+lVJSId8xYP7ISRzRfoeXAlJfzLNMbi2Na/0IdDiIkQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@types/debug": "4.1.12",
                 "@types/node": "18.19.80",
@@ -6062,6 +6660,7 @@
             "integrity": "sha512-kEWeMwMeIvxYkeg1gTc01awpwLbfMRZXdIhwRcakd/KlK53jmRC26LqcbIt7fnAQTu5GzlnWmzA3H6+l1u6xxQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -6072,6 +6671,7 @@
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -6090,6 +6690,7 @@
             "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -6102,7 +6703,8 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/iconv-lite": {
             "version": "0.6.3",
@@ -6136,7 +6738,8 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/ignore": {
             "version": "7.0.6",
@@ -6144,7 +6747,6 @@
             "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -6167,9 +6769,10 @@
             }
         },
         "node_modules/import-in-the-middle": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.2.tgz",
-            "integrity": "sha512-jTd2FfOgOWOdgjkHuk/1Ms8VKFXkPs15ymYBETw1sAOrO/dY3XeGVRWir9qBbw7pXr0T2eTFwfCZ+N02HmiNGA==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.3.tgz",
+            "integrity": "sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==",
+            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "cjs-module-lexer": "^2.2.0",
@@ -6214,6 +6817,7 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/ip-address": {
@@ -6230,6 +6834,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
             "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -6246,6 +6851,7 @@
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/is-bun-module": {
@@ -6262,6 +6868,7 @@
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
             "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -6300,6 +6907,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -6309,6 +6917,7 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
             "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.4",
@@ -6402,6 +7011,7 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
             "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.0",
@@ -6441,6 +7051,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
             "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -6465,10 +7076,24 @@
                 "protocols": "^2.0.1"
             }
         },
+        "node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-typed-array": {
             "version": "1.1.15",
             "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
             "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "which-typed-array": "^1.1.16"
@@ -6514,9 +7139,10 @@
             "license": "ISC"
         },
         "node_modules/isolated-vm": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-6.1.2.tgz",
-            "integrity": "sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/isolated-vm/-/isolated-vm-6.2.0.tgz",
+            "integrity": "sha512-UuSlxSHWt2QuJ5WvBhzlIJx2VVZN/a44SqBbEZFKNdvuSyhOvhmyDo8SQ+njVbhnh/njoL/aW0bUTiFYlpweGQ==",
+            "dev": true,
             "hasInstallScript": true,
             "license": "ISC",
             "dependencies": {
@@ -6531,7 +7157,8 @@
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/issue-parser": {
             "version": "7.0.2",
@@ -6597,7 +7224,6 @@
             "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
             }
@@ -6606,6 +7232,7 @@
             "version": "0.16.0",
             "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
             "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": ">= 0.6.0"
@@ -6615,6 +7242,7 @@
             "version": "3.7.8",
             "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
             "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
+            "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/js-tiktoken": {
@@ -6661,6 +7289,7 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
             "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+            "dev": true,
             "license": "(AFL-2.1 OR BSD-3-Clause)"
         },
         "node_modules/json-schema-traverse": {
@@ -6698,6 +7327,7 @@
             "version": "3.13.2",
             "resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.13.2.tgz",
             "integrity": "sha512-Leuly0nbM4R+S5SVJk3VHfw1oxnlEK9KygdZvfUtEtTawNDyzB4qa1xWTmFt1aeoA7sXZkVTRuIixJ8bAvqVUg==",
+            "dev": true,
             "license": "ISC",
             "bin": {
                 "jsonrepair": "bin/cli.js"
@@ -6709,6 +7339,7 @@
             "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "jws": "^4.0.1",
                 "lodash.includes": "^4.3.0",
@@ -6730,6 +7361,7 @@
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/jssha/-/jssha-3.3.1.tgz",
             "integrity": "sha512-VCMZj12FCFMQYcFLPRm/0lOBbLi8uM2BhXPTqw3U4YAfs4AZfiApOoBLoN8cQE60Z50m1MYMTQVCfgF/KaCVhQ==",
+            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": "*"
@@ -6741,6 +7373,7 @@
             "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "buffer-equal-constant-time": "^1.0.1",
                 "ecdsa-sig-formatter": "1.0.11",
@@ -6753,6 +7386,7 @@
             "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "jwa": "^2.0.1",
                 "safe-buffer": "^5.0.1"
@@ -6830,9 +7464,9 @@
             }
         },
         "node_modules/langsmith": {
-            "version": "0.8.4",
-            "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.8.4.tgz",
-            "integrity": "sha512-e2zdhPUV/mLwVv+Gde/0gLGnCOE/zvZ3gGNh/rvkzrxsDz7qgUT4CJVUmJE2GwQ1A3FPtWKzy08oo//VV1nBFA==",
+            "version": "0.8.9",
+            "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.8.9.tgz",
+            "integrity": "sha512-6ikTB5SO+3SlBQ/+oH8K/JzhglxB8AM4RAe5bHzgWSEIHTgTe+b71bSjf1fDvlYuEXoiPn6uP10BbczrbznUnA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6906,6 +7540,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=13.2.0"
             }
@@ -6930,8 +7565,8 @@
             "version": "4.18.1",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
             "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-            "license": "MIT",
-            "peer": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/lodash.capitalize": {
             "version": "4.2.1",
@@ -6959,28 +7594,32 @@
             "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
             "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.isboolean": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
             "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.isinteger": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
             "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.isnumber": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
             "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.isplainobject": {
             "version": "4.0.6",
@@ -7008,7 +7647,8 @@
             "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
             "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.uniqby": {
             "version": "4.7.0",
@@ -7076,6 +7716,7 @@
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
             "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -7098,6 +7739,7 @@
             "version": "0.30.21",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
             "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -7114,6 +7756,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -7123,6 +7766,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
             "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+            "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "charenc": "0.0.2",
@@ -7144,6 +7788,7 @@
             "version": "6.1.4",
             "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.1.4.tgz",
             "integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=18.0.0"
@@ -7167,6 +7812,7 @@
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -7176,6 +7822,7 @@
             "version": "2.1.35",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "mime-db": "1.52.0"
@@ -7237,12 +7884,14 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
             "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/mustache": {
@@ -7266,16 +7915,16 @@
             }
         },
         "node_modules/n8n-workflow": {
-            "version": "2.31.3",
-            "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.31.3.tgz",
-            "integrity": "sha512-9ca/sMUsdDu7SsWrj2LEd25O6hehwGgLcO1Z/lZTIFaNlUAJeom1PWvnUUJVgZASAnL6ALcJuP03eoORJzmH8Q==",
+            "version": "2.29.3",
+            "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.29.3.tgz",
+            "integrity": "sha512-jsJOV5o6Zd0mfCHAUthRBAZnxGgvcfjGDWdYcZf14rWxpHe4IHdBYR3eVqo/8AxsblGyDrwTQ3DfULX1d71Xog==",
+            "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@codemirror/autocomplete": "6.20.0",
-                "@n8n/errors": "0.12.0",
-                "@n8n/expression-runtime": "0.22.1",
-                "@n8n/tournament": "1.7.1",
-                "@n8n/utils": "1.39.0",
+                "@n8n/errors": "0.10.0",
+                "@n8n/expression-runtime": "0.20.1",
+                "@n8n/tournament": "1.5.0",
                 "@sentry/core": "^10.55.0",
                 "@sentry/node": "^10.55.0",
                 "ast-types": "0.16.1",
@@ -7306,6 +7955,7 @@
             "version": "11.1.1",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
             "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+            "dev": true,
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"
@@ -7319,6 +7969,7 @@
             "version": "2.28.0",
             "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
             "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+            "dev": true,
             "license": "MIT",
             "optional": true
         },
@@ -7326,6 +7977,7 @@
             "version": "3.3.8",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
             "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -7437,6 +8089,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10.5.0"
             }
@@ -7447,6 +8100,7 @@
             "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },
@@ -7466,6 +8120,7 @@
             "version": "4.8.4",
             "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
             "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "node-gyp-build": "bin.js",
@@ -7490,6 +8145,7 @@
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
             "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.7",
@@ -7506,6 +8162,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
             "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -7515,6 +8172,7 @@
             "version": "4.1.7",
             "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
             "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bind": "^1.0.8",
@@ -8012,7 +8670,6 @@
             "integrity": "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@napi-rs/canvas": "0.1.80",
                 "pdfjs-dist": "5.4.296"
@@ -8081,35 +8738,37 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.61.1",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-            "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+            "version": "1.62.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+            "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
-                "playwright-core": "1.61.1"
+                "playwright-core": "1.62.1"
             },
             "bin": {
                 "playwright": "cli.js"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             },
             "optionalDependencies": {
                 "fsevents": "2.3.2"
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.61.1",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-            "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+            "version": "1.62.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+            "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "playwright-core": "cli.js"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             }
         },
         "node_modules/pluralize": {
@@ -8126,6 +8785,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
             "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -8155,9 +8815,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-            "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+            "version": "3.9.6",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+            "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -8302,6 +8962,7 @@
             "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "punycode": "^2.3.1"
             },
@@ -8340,7 +9001,8 @@
             "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
             "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
@@ -8368,8 +9030,7 @@
             "resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-2.2.0.tgz",
             "integrity": "sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/rc9": {
             "version": "3.0.1",
@@ -8415,6 +9076,7 @@
             "version": "0.22.0",
             "resolved": "https://registry.npmjs.org/recast/-/recast-0.22.0.tgz",
             "integrity": "sha512-5AAx+mujtXijsEavc5lWXBPQqrM4+Dl5qNH96N2aNeuJFUzpiiToKPsxQD/zAIJHspz7zz0maX0PCtCTFVlixQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "assert": "^2.0.0",
@@ -8431,6 +9093,7 @@
             "version": "0.15.2",
             "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.15.2.tgz",
             "integrity": "sha512-c27loCv9QkZinsa5ProX751khO9DJl/AcB5c2KNtA6NRvHKS0PgLfcftz72KVq504vB0Gku5s2kUZzDBvQWvHg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.0.1"
@@ -8534,6 +9197,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -8543,6 +9207,7 @@
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
             "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "debug": "^4.3.5",
@@ -8557,7 +9222,8 @@
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
             "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/resolve-from": {
             "version": "4.0.0",
@@ -8612,6 +9278,7 @@
             "integrity": "sha512-pOLi+Gdll3JekwuFjXO3fTq+L9lzMQGcSq7M5gIjExcl3Gu1hd4XXuf5o3+LuSBsaULQH7DiNbsqPd1chVpQGQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=10.7.0"
             },
@@ -8712,6 +9379,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
             "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -8739,12 +9407,14 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/sax": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-            "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+            "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+            "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=11.0.0"
@@ -8754,6 +9424,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/semifies/-/semifies-1.0.0.tgz",
             "integrity": "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==",
+            "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/semver": {
@@ -8785,6 +9456,7 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
             "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "define-data-property": "^1.1.4",
@@ -8972,6 +9644,7 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -8981,6 +9654,7 @@
             "version": "1.15.0",
             "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.15.0.tgz",
             "integrity": "sha512-C0PHgX4h6lBxYx7hcXwu3QWdh4tg6tZZsTfXcdvc5caW/EMxaB4H9dWsl7qk+F7LAW762hp8VbXOX7x4xUYvEw==",
+            "dev": true,
             "hasInstallScript": true,
             "dependencies": {
                 "asn1": "^0.2.6",
@@ -9058,6 +9732,7 @@
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "emoji-regex": "^8.0.0",
@@ -9072,6 +9747,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -9081,6 +9757,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
@@ -9124,6 +9801,7 @@
             "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@tokenizer/token": "^0.3.0"
             },
@@ -9139,6 +9817,7 @@
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
             "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/supports-color": {
@@ -9205,7 +9884,6 @@
             "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -9217,6 +9895,7 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/title-case/-/title-case-3.0.3.tgz",
             "integrity": "sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.0.3"
@@ -9261,6 +9940,7 @@
             "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@borewit/text-codec": "^0.2.1",
                 "@tokenizer/token": "^0.3.0",
@@ -9280,6 +9960,7 @@
             "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "psl": "^1.1.33",
                 "punycode": "^2.1.1",
@@ -9295,12 +9976,14 @@
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/transliteration": {
             "version": "2.3.5",
             "resolved": "https://registry.npmjs.org/transliteration/-/transliteration-2.3.5.tgz",
             "integrity": "sha512-HAGI4Lq4Q9dZ3Utu2phaWgtm3vB6PkLUFqWAScg/UW+1eZ/Tg6Exo4oC0/3VUol/w4BlefLhUUSVBr/9/ZGQOw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "yargs": "^17.5.1"
@@ -9351,12 +10034,14 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
             "license": "0BSD"
         },
         "node_modules/tweetnacl": {
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
             "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+            "dev": true,
             "license": "Unlicense"
         },
         "node_modules/type-check": {
@@ -9443,6 +10128,7 @@
             "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -9465,7 +10151,8 @@
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
             "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/universal-user-agent": {
             "version": "7.0.3",
@@ -9480,6 +10167,7 @@
             "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 4.0.0"
             }
@@ -9558,6 +10246,7 @@
             "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
@@ -9567,6 +10256,7 @@
             "version": "0.12.5",
             "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
             "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "inherits": "^2.0.3",
@@ -9602,6 +10292,7 @@
             "version": "2.2.8",
             "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
             "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/web-streams-polyfill": {
@@ -9610,6 +10301,7 @@
             "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 14"
             }
@@ -9619,7 +10311,8 @@
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
             "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
             "dev": true,
-            "license": "BSD-2-Clause"
+            "license": "BSD-2-Clause",
+            "peer": true
         },
         "node_modules/whatwg-url": {
             "version": "5.0.0",
@@ -9627,6 +10320,7 @@
             "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
@@ -9652,6 +10346,7 @@
             "version": "1.1.22",
             "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
             "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "available-typed-arrays": "^1.0.7",
@@ -9774,19 +10469,6 @@
                 "node": ">= 12.0.0"
             }
         },
-        "node_modules/winston/node_modules/is-stream": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/word-wrap": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -9808,6 +10490,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.0.0",
@@ -9825,6 +10508,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -9834,6 +10518,7 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ansi-regex": "^5.0.1"
@@ -9843,11 +10528,12 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.21.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
-            "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+            "version": "8.21.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+            "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -9901,6 +10587,7 @@
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
             "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "sax": ">=0.6.0",
@@ -9914,6 +10601,7 @@
             "version": "11.0.1",
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
             "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=4.0"
@@ -9940,6 +10628,7 @@
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
             "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=10"
@@ -9965,6 +10654,7 @@
             "version": "17.7.3",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
             "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cliui": "^8.0.1",
@@ -9983,6 +10673,7 @@
             "version": "21.1.1",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
             "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=12"
@@ -10018,8 +10709,8 @@
             "version": "3.25.67",
             "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
             "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+            "dev": true,
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/n8n/package.json
+++ b/n8n/package.json
@@ -49,9 +49,10 @@
         ]
     },
     "devDependencies": {
-        "@n8n/node-cli": "0.40.3",
+        "@n8n/node-cli": "0.42.2",
         "eslint": "9.32.0",
-        "prettier": "3.6.2",
+        "n8n-workflow": "2.29.3",
+        "prettier": "3.9.6",
         "release-it": "21.0.1",
         "typescript": "5.9.2"
     },

--- a/n8n/scripts/audit-dev-dependencies.cjs
+++ b/n8n/scripts/audit-dev-dependencies.cjs
@@ -2,19 +2,19 @@
 
 const { spawnSync } = require('node:child_process');
 
-const ALLOWED_ADVISORY = 'https://github.com/advisories/GHSA-mh99-v99m-4gvg';
+const ALLOWED_ADVISORIES = new Set([
+	'https://github.com/advisories/GHSA-28wg-ghj8-5hjv',
+	'https://github.com/advisories/GHSA-2v37-7h3g-55p8',
+]);
 const ALLOWED_PACKAGES = new Set([
-	'@eslint/config-array',
-	'@eslint/eslintrc',
-	'@n8n/eslint-plugin-community-nodes',
-	'@n8n/node-cli',
-	'@oclif/core',
-	'brace-expansion',
-	'ejs',
-	'eslint',
-	'filelist',
-	'jake',
-	'minimatch',
+	'@n8n/ai-utilities',
+	'@n8n/api-types',
+	'@n8n/backend-common',
+	'@n8n/backend-network',
+	'@n8n/decorators',
+	'@n8n/utils',
+	'n8n-workflow',
+	'nanoid',
 ]);
 
 function validateAuditReport(report) {
@@ -32,9 +32,7 @@ function validateAuditReport(report) {
 	const names = Object.keys(vulnerabilities);
 	const counts = report.metadata?.vulnerabilities;
 	if (!counts || counts.critical !== 0 || counts.high !== names.length) {
-		throw new Error(
-			`unexpected vulnerability counts: ${JSON.stringify(counts ?? null)}`,
-		);
+		throw new Error(`unexpected vulnerability counts: ${JSON.stringify(counts ?? null)}`);
 	}
 	if (names.length === 0) {
 		return { clean: true, allowed: [] };
@@ -42,9 +40,7 @@ function validateAuditReport(report) {
 
 	const unexpectedPackages = names.filter((name) => !ALLOWED_PACKAGES.has(name));
 	if (unexpectedPackages.length) {
-		throw new Error(
-			`unexpected audit package set; extra=${unexpectedPackages.join(',')}`,
-		);
+		throw new Error(`unexpected audit package set; extra=${unexpectedPackages.join(',')}`);
 	}
 
 	const advisoryUrls = new Set();
@@ -69,12 +65,10 @@ function validateAuditReport(report) {
 	}
 
 	if (
-		advisoryUrls.size !== 1 ||
-		!advisoryUrls.has(ALLOWED_ADVISORY)
+		advisoryUrls.size !== ALLOWED_ADVISORIES.size ||
+		[...ALLOWED_ADVISORIES].some((url) => !advisoryUrls.has(url))
 	) {
-		throw new Error(
-			`unexpected advisory set: ${[...advisoryUrls].sort().join(',') || 'none'}`,
-		);
+		throw new Error(`unexpected advisory set: ${[...advisoryUrls].sort().join(',') || 'none'}`);
 	}
 
 	return { clean: false, allowed: names.sort() };
@@ -91,9 +85,7 @@ function main() {
 	});
 	if (result.error) throw result.error;
 	if (![0, 1].includes(result.status)) {
-		throw new Error(
-			`npm audit failed with status ${result.status}: ${result.stderr.trim()}`,
-		);
+		throw new Error(`npm audit failed with status ${result.status}: ${result.stderr.trim()}`);
 	}
 
 	let report;
@@ -109,7 +101,7 @@ function main() {
 		return;
 	}
 	console.log(
-		`Allowed development-only advisory ${ALLOWED_ADVISORY}; ` +
+		`Allowed ${ALLOWED_ADVISORIES.size} development-only advisories; ` +
 			`${verdict.allowed.length} affected dependency nodes verified.`,
 	);
 }

--- a/n8n/test/audit-policy.test.cjs
+++ b/n8n/test/audit-policy.test.cjs
@@ -3,22 +3,17 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
 
-const {
-	validateAuditReport,
-} = require('../scripts/audit-dev-dependencies.cjs');
+const { validateAuditReport } = require('../scripts/audit-dev-dependencies.cjs');
 
 const allowedPackages = [
-	'@eslint/config-array',
-	'@eslint/eslintrc',
-	'@n8n/eslint-plugin-community-nodes',
-	'@n8n/node-cli',
-	'@oclif/core',
-	'brace-expansion',
-	'ejs',
-	'eslint',
-	'filelist',
-	'jake',
-	'minimatch',
+	'@n8n/ai-utilities',
+	'@n8n/api-types',
+	'@n8n/backend-common',
+	'@n8n/backend-network',
+	'@n8n/decorators',
+	'@n8n/utils',
+	'n8n-workflow',
+	'nanoid',
 ];
 
 function allowedReport() {
@@ -28,14 +23,18 @@ function allowedReport() {
 			{
 				severity: 'high',
 				via:
-					name === 'brace-expansion'
+					name === 'nanoid'
 						? [
 								{
-									url: 'https://github.com/advisories/GHSA-mh99-v99m-4gvg',
+									url: 'https://github.com/advisories/GHSA-28wg-ghj8-5hjv',
+									severity: 'high',
+								},
+								{
+									url: 'https://github.com/advisories/GHSA-2v37-7h3g-55p8',
 									severity: 'high',
 								},
 							]
-						: ['brace-expansion'],
+						: ['nanoid'],
 			},
 		]),
 	);
@@ -80,50 +79,57 @@ test('accepts a fully clean development audit', () => {
 	assert.deepEqual(validateAuditReport(report), { clean: true, allowed: [] });
 });
 
-test('accepts a shrinking subset of the documented advisory graph', () => {
+test('accepts remediation-driven shrinkage of the documented advisory graph', () => {
 	const report = allowedReport();
 	for (const [name, vulnerability] of Object.entries(report.vulnerabilities)) {
-		if (name !== 'brace-expansion') vulnerability.severity = 'moderate';
+		if (name !== 'nanoid') vulnerability.severity = 'moderate';
 	}
 	report.metadata.vulnerabilities.high = 1;
 	report.metadata.vulnerabilities.moderate = allowedPackages.length - 1;
 	assert.deepEqual(validateAuditReport(report), {
 		clean: false,
-		allowed: ['brace-expansion'],
+		allowed: ['nanoid'],
 	});
 });
 
 test('rejects a new advisory even when it affects an allowed package', () => {
 	const report = allowedReport();
-	report.vulnerabilities['brace-expansion'].via.push({
+	report.vulnerabilities.nanoid.via.push({
 		url: 'https://github.com/advisories/GHSA-unexpected',
 		severity: 'high',
 	});
-	assert.throws(
-		() => validateAuditReport(report),
-		/unexpected advisory set/,
-	);
+	assert.throws(() => validateAuditReport(report), /unexpected advisory set/);
+});
+
+test('rejects an incomplete advisory set', () => {
+	const report = allowedReport();
+	report.vulnerabilities.nanoid.via.pop();
+	assert.throws(() => validateAuditReport(report), /unexpected advisory set/);
 });
 
 test('rejects changes to the affected package graph', () => {
 	const report = allowedReport();
 	report.vulnerabilities['new-package'] = {
 		severity: 'high',
-		via: ['brace-expansion'],
+		via: ['nanoid'],
 	};
 	report.metadata.vulnerabilities.high += 1;
 	report.metadata.vulnerabilities.total += 1;
-	assert.throws(
-		() => validateAuditReport(report),
-		/unexpected audit package set/,
-	);
+	assert.throws(() => validateAuditReport(report), /unexpected audit package set/);
+});
+
+test('rejects replacing an allowed affected package', () => {
+	const report = allowedReport();
+	delete report.vulnerabilities['@n8n/api-types'];
+	report.vulnerabilities['replacement-package'] = {
+		severity: 'high',
+		via: ['nanoid'],
+	};
+	assert.throws(() => validateAuditReport(report), /unexpected audit package set/);
 });
 
 test('rejects inconsistent high-severity counts', () => {
 	const report = allowedReport();
 	report.metadata.vulnerabilities.high -= 1;
-	assert.throws(
-		() => validateAuditReport(report),
-		/unexpected vulnerability counts/,
-	);
+	assert.throws(() => validateAuditReport(report), /unexpected vulnerability counts/);
 });

--- a/n8n/test/release.test.cjs
+++ b/n8n/test/release.test.cjs
@@ -6,19 +6,30 @@ const path = require('node:path');
 const test = require('node:test');
 
 const root = path.join(__dirname, '..');
-const readJson = (relativePath) => JSON.parse(fs.readFileSync(path.join(root, relativePath), 'utf8'));
+const readJson = (relativePath) =>
+	JSON.parse(fs.readFileSync(path.join(root, relativePath), 'utf8'));
 
 test('0.1.3 release metadata is locked to the stable n8n toolchain', () => {
 	const pkg = readJson('package.json');
 	const lock = readJson('package-lock.json');
 
 	assert.equal(pkg.version, '0.1.3');
-	assert.equal(pkg.devDependencies['@n8n/node-cli'], '0.40.3');
+	assert.equal(pkg.devDependencies['@n8n/node-cli'], '0.42.2');
+	assert.equal(pkg.devDependencies.eslint, '9.32.0');
+	assert.equal(pkg.devDependencies.prettier, '3.9.6');
+	assert.equal(pkg.devDependencies.typescript, '5.9.2');
+	assert.equal(pkg.devDependencies['n8n-workflow'], '2.29.3');
+	assert.equal(pkg.peerDependencies['n8n-workflow'], '*');
 	assert.equal(pkg.devDependencies['release-it'], '21.0.1');
 	assert.equal(pkg.engines.node, '>=20.19.0');
 	assert.equal(pkg.repository.directory, 'n8n');
 	assert.equal(lock.packages[''].version, pkg.version);
-	assert.equal(lock.packages[''].devDependencies['@n8n/node-cli'], '0.40.3');
+	assert.equal(lock.packages[''].devDependencies['@n8n/node-cli'], '0.42.2');
+	assert.equal(lock.packages[''].devDependencies.eslint, '9.32.0');
+	assert.equal(lock.packages[''].devDependencies.prettier, '3.9.6');
+	assert.equal(lock.packages[''].devDependencies.typescript, '5.9.2');
+	assert.equal(lock.packages[''].devDependencies['n8n-workflow'], '2.29.3');
+	assert.equal(lock.packages[''].peerDependencies['n8n-workflow'], '*');
 });
 
 test('current n8n metadata includes required subtitle and themed icons', () => {


### PR DESCRIPTION
## Summary

- upgrade the stable n8n builder from `@n8n/node-cli@0.40.3` to `0.42.2`
- include the compatible Prettier maintenance upgrade from `3.6.2` to `3.9.6`
- retain ESLint `9.32.0` and TypeScript `5.9.2` because the requested majors are not compatible with the current n8n stack
- pin `n8n-workflow@2.29.3` as a development host fixture while preserving the published `n8n-workflow: "*"` peer contract
- update the fail-closed development audit policy and release-contract tests for the resolved graph

Supersedes #253, #255, #256, and #257.

Signed head: `eb13d812f3cf65fad7a5f4391cd74f30f1afce16`

## Compatibility decision

- `@n8n/node-cli@0.42.2` is the current npm stable release and requires ESLint 9 or newer.
- ESLint 10 fails the bundled n8n rule set with `context.getFilename is not a function`; the bundled community plugin also declares ESLint 9.29.0 exactly.
- TypeScript 7 fails the current parser stack in `ts-api-utils`; current `typescript-eslint` supports TypeScript below 6.1.
- Prettier 3.9.6 is compatible: formatter output is byte-identical to 3.6.2 across 11 n8n source, config, test, and documentation surfaces.

No runtime node or integration-manifest behavior changes.

## Security boundary

- `npm audit --omit=dev --audit-level=moderate`: `found 0 vulnerabilities`
- `npm run audit:dev`: green with exactly two documented development-only nanoid advisories and eight verified affected nodes
- the npm tarball excludes the CLI and all other development dependencies
- Dependabot alert #8 remains visible in the CLI's nested LangChain graph: those exact upstream releases require `uuid@^10.0.0`, so patched `uuid@11.1.1` cannot satisfy the range without an upstream n8n release or the n8n-lint-forbidden `overrides` field. The explicit host fixture itself resolves patched `uuid@11.1.1`.

## Validation

- `npm ci` on Windows and Linux/Node 22
- `npm test` - 10/10
- `npm run lint`
- `npm run build`
- `npm run check`
- Prettier 3.6.2 vs 3.9.6 formatter comparison - 11/11 identical
- `npm audit --omit=dev --audit-level=moderate`
- `npm run audit:dev`
- `npm pack --dry-run` - 16 files, no development dependency payload
- `node scripts/verify-integrations-json.js`
- `ajv validate -s integrations.schema.json -d integrations.json --all-errors --spec=draft2020 -c ajv-formats`
- `git diff --cached --check`



