### PR TITLE
docs(protocols): disambiguate ACP namespaces

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -222,7 +222,7 @@ jobs:
             console.log('✅ All ' + idx.tools.length + ' tool IDs follow naming convention');
           "
 
-      - name: Verify ACP adapter
+      - name: Verify Agent Client Protocol adapter
         run: node scripts/verify-acp.js
 
       - name: Verify Rust framework public sync

--- a/ACP_REGISTRY.md
+++ b/ACP_REGISTRY.md
@@ -1,6 +1,6 @@
-# ACP Registry Positioning
+# Agent Client Protocol (ACP) Registry Positioning
 
-Agoragentic already has an ACP Registry entry. Keep that entry focused on Agent OS.
+Agoragentic already has an Agent Client Protocol Registry entry. Keep that entry focused on Agent OS. This file does not describe the historical Agoragentic commerce draft or any external commerce protocol also named ACP.
 
 ## Current Problem
 
@@ -26,7 +26,7 @@ Description:
 Deploy and operate autonomous agents with runtime policy, marketplace routing, receipts, x402/USDC settlement, and governed Agent OS handoff surfaces.
 ```
 
-Distribution should stay on the ACP adapter package if it remains the active adapter:
+Distribution should stay on the Agent Client Protocol adapter package if it remains the active adapter:
 
 ```json
 {
@@ -37,11 +37,11 @@ Distribution should stay on the ACP adapter package if it remains the active ada
 }
 ```
 
-Pin the version to the published ACP adapter package version, not the Agent OS CLI version.
+Pin the version to the published Agent Client Protocol adapter package version, not the Agent OS CLI version.
 
 ## Micro ECF Boundary
 
-Do not register Micro ECF as a separate ACP agent until it has an ACP-native server mode.
+Do not register Micro ECF as a separate Agent Client Protocol agent until it has an Agent Client Protocol-native server mode.
 
 Micro ECF should be described as:
 
@@ -49,10 +49,10 @@ Micro ECF should be described as:
 Local context and policy artifacts that can prepare an Agent OS harness export.
 ```
 
-ACP Registry entry:
+Agent Client Protocol Registry entry:
 
 ```text
-Agoragentic Agent OS ACP adapter
+Agoragentic Agent OS Agent Client Protocol adapter
 ```
 
 Micro ECF:
@@ -64,7 +64,7 @@ Local install / repo artifacts / optional MCP / Agent OS harness export
 ## Submit Checklist
 
 1. Verify the current published `agoragentic-mcp` version.
-2. Update the ACP registry `agent.json` description to Agent OS language.
+2. Update the Agent Client Protocol registry `agent.json` description to Agent OS language.
 3. Keep the repository URL as `https://github.com/rhein1/agoragentic-integrations`.
-4. Do not claim Micro ECF speaks ACP unless the adapter is implemented.
+4. Do not claim Micro ECF speaks Agent Client Protocol unless the adapter is implemented.
 5. Link Micro ECF from this repo README as the local harness/context handoff path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,14 +26,18 @@ CITATION.cff               ← citation metadata
 glama.json                 ← Glama registry entry
 a2a/agent-card.json        ← A2A protocol card
 acp/agent.json             ← Agent Client Protocol adapter manifest
-specs/ACP-SPEC.md           ← Agent Commerce Protocol spec
+specs/ACP-SPEC.md           ← historical Agoragentic Commerce Draft compatibility path
 <framework>/README.md      ← per-framework install + quickstart
 agent-os/README.md         ← public Agent OS deployment/control-plane examples
 micro-ecf/README.md        ← local policy and Agent OS harness export
 micro-ecf/FRAMEWORKS.md    ← using Micro ECF with existing agent frameworks
 harness-core/README.md     ← local no-spend Harness Core proof/export/listing-readiness CLI
-ACP_REGISTRY.md            ← ACP registry positioning and update checklist
+ACP_REGISTRY.md            ← Agent Client Protocol registry positioning and update checklist
 ```
+
+## ACP Namespace Rule
+
+Always expand ACP on first use. `acp/`, `--acp`, and `ACP_REGISTRY.md` mean **Agent Client Protocol**. `specs/ACP-SPEC.md` is the historical **Agoragentic Commerce Draft 0.1** compatibility path, formerly named Agent Commerce Protocol. External systems such as Virtuals ACP require explicitly named adapters and must not be implied by either surface.
 
 ## How to Use This Repo
 
@@ -44,7 +48,7 @@ ACP_REGISTRY.md            ← ACP registry positioning and update checklist
 3. Set `AGORAGENTIC_API_KEY` env var, or call `agoragentic_register` at runtime as the compatibility helper for `POST /api/quickstart`
 4. Call `agoragentic_execute` to route a task by intent, or `agoragentic_match` to preview providers before spend
 5. Use `agoragentic_search` and `agoragentic_invoke` only when you intentionally need catalog browsing or a direct provider call
-6. Use `npx agoragentic-mcp --acp` when an ACP-compatible client needs the same execute-first Agent OS tool surface through stdio
+6. Use `npx agoragentic-mcp --acp` when an Agent Client Protocol (ACP) client needs the same execute-first Agent OS tool surface through stdio
 
 ### If you are an agent that wants to MODIFY this repo:
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ Agent workflow contracts: [governed agent runs](./docs/agent-workflow-contracts.
 | Offline machine-surface check | `node scripts/verify-integrations-json.js` |
 | Offline adapter conformance | `node scripts/adapter-conformance-agent.mjs` |
 
+## Protocol Names
+
+- **Agent Commerce Interchange** is Agoragentic's native governance and evidence contract at `/api/commerce/interchange/*`.
+- **Agent Client Protocol (ACP)** is the stdio adapter selected by `npx agoragentic-mcp --acp`; it exposes the existing MCP tool surface and is not a commerce network.
+- **Agoragentic Commerce Draft 0.1** is the historical document retained at `specs/ACP-SPEC.md`. Its former Agent Commerce Protocol name and `acp_spec` identifiers are compatibility aliases, not a production conformance claim.
+- **External commerce protocols named ACP**, such as Virtuals ACP, require separately named adapters. This repository does not currently ship an active Virtuals ACP adapter.
+
 ## What Agoragentic Does
 
 - Route tasks to tools with `execute(task, input)` — the router picks the provider
@@ -155,7 +162,7 @@ The hosted Triptych OS (Agent OS) control plane is not a downloadable npm packag
 | **[Python SDK source](./sdk/python/)** | `pip install agoragentic` | Python ≥ 3.8 |
 | **[Agent OS CLI source](./sdk/agent-os-cli/)** | `npx agoragentic-os@latest` | Node ≥ 18 |
 | **MCP Server** | `npx agoragentic-mcp` | Node ≥ 18 |
-| **ACP Adapter** | `npx agoragentic-mcp --acp` | Node ≥ 18 |
+| **Agent Client Protocol (ACP) Adapter** | `npx agoragentic-mcp --acp` | Node ≥ 18 |
 | **Micro ECF** | `npx agoragentic-micro-ecf@latest plan --dir .`, then `npx agoragentic-micro-ecf@latest install --dir . --yes` only after explicit approval | Node ≥ 18 |
 | **Harness Core** | `npx agoragentic-harness-core@latest init` | Node ≥ 18 |
 | **Premortem Golden Loop Agent** | `node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs run --repo .` | Node ≥ 18 |
@@ -314,7 +321,7 @@ export AGORAGENTIC_API_KEY="amk_your_key"  # optional, agent can self-register
 # MCP — Claude Desktop, VS Code, Cursor
 npx agoragentic-mcp
 
-# ACP-compatible clients
+# Agent Client Protocol (ACP) clients
 npx agoragentic-mcp --acp
 ```
 
@@ -452,7 +459,7 @@ Your Agent  →  Integration (tools/MCP)  →  Agent OS + Agoragentic API
 | Community testing and independent evidence | [`docs/COMMUNITY_TESTING.md`](./docs/COMMUNITY_TESTING.md) |
 | Agent instructions | [`AGENTS.md`](./AGENTS.md) |
 | Public SDK package sources | [`sdk/README.md`](./sdk/README.md) |
-| ACP registry positioning | [`ACP_REGISTRY.md`](./ACP_REGISTRY.md) |
+| Agent Client Protocol registry positioning | [`ACP_REGISTRY.md`](./ACP_REGISTRY.md) |
 | Agent Client Protocol adapter | [`acp/agent.json`](./acp/agent.json) |
 | Agent Commerce Interchange builder package | [`interchange/README.md`](./interchange/README.md) |
 | Agent Commerce Interchange spec | [`interchange/SPEC.md`](./interchange/SPEC.md) |
@@ -476,7 +483,7 @@ Your Agent  →  Integration (tools/MCP)  →  Agent OS + Agoragentic API
 | Changelog | [`CHANGELOG.md`](./CHANGELOG.md) |
 | Citation | [`CITATION.cff`](./CITATION.cff) |
 | A2A agent card | [`a2a/agent-card.json`](./a2a/agent-card.json) |
-| ACP spec | [`specs/ACP-SPEC.md`](./specs/ACP-SPEC.md) |
+| Agoragentic Commerce Draft 0.1 (legacy ACP-SPEC path) | [`specs/ACP-SPEC.md`](./specs/ACP-SPEC.md) |
 | Glama registry | [`glama.json`](./glama.json) |
 | AG-UI Protocol Bridge | [`ag-ui/README.md`](./ag-ui/README.md) |
 | AWS Bedrock AgentCore Adapter | [`bedrock-agentcore/README.md`](./bedrock-agentcore/README.md) |

--- a/SKILL.md
+++ b/SKILL.md
@@ -35,7 +35,7 @@ Agoragentic is **Triptych OS (Agent OS) for deployed agents and swarms**.
 
 Micro ECF is the local context wedge for builders. Agent OS is the deployment product. Full ECF is the private enterprise runtime engine. The marketplace is the transaction rail where deployed agents buy, sell, invoke, and settle work.
 
-Downloadable/local integration surfaces are SDKs, MCP/ACP adapters, framework wrappers, Micro ECF tooling, Harness Core no-spend proof/export tooling, examples, and public contracts. The full Triptych OS / Agent OS control plane, Router / Marketplace ranking, x402/USDC settlement, receipts, reconciliation, trust mutation, and Full ECF internals are hosted or private.
+Downloadable/local integration surfaces are SDKs, MCP and Agent Client Protocol (ACP) adapters, framework wrappers, Micro ECF tooling, Harness Core no-spend proof/export tooling, examples, and public contracts. The full Triptych OS / Agent OS control plane, Router / Marketplace ranking, x402/USDC settlement, receipts, reconciliation, trust mutation, and Full ECF internals are hosted or private.
 
 Instead of hardcoding provider IDs, retries, billing logic, and fallback rules, agents can call a task like:
 

--- a/acp/README.md
+++ b/acp/README.md
@@ -1,6 +1,6 @@
 # Agoragentic Agent OS - Agent Client Protocol Adapter
 
-This adapter lets ACP-compatible clients launch the Agoragentic MCP relay through stdio and use the same Agent OS tool surface exposed to MCP clients.
+This adapter lets Agent Client Protocol (ACP) clients launch the Agoragentic MCP relay through stdio and use the same Agent OS tool surface exposed to MCP clients.
 
 Agoragentic is Agent OS for deployed agents and swarms. The default path is `execute(task, input, constraints)`: route work by intent, receive a receipt, and settle paid execution in USDC on Base when a paid provider is used.
 
@@ -28,7 +28,7 @@ Use `intent="seller"` or `intent="both"` when the agent will publish capabilitie
 
 ## Agent Registry File
 
-The ACP registry entry is [`agent.json`](./agent.json). It points ACP clients to:
+The Agent Client Protocol registry entry is [`agent.json`](./agent.json). It points Agent Client Protocol clients to:
 
 ```json
 {
@@ -53,7 +53,7 @@ Use these first:
 | `agoragentic_edge_receipt` | Inspect x402 edge receipt metadata |
 | `agoragentic_x402_test` | Exercise the free x402 pipeline canary |
 
-Compatibility helpers such as `agoragentic_register`, `agoragentic_search`, `agoragentic_invoke`, and `agoragentic_vault` may still exist for older clients. New ACP clients should prefer the execute-first flow.
+Compatibility helpers such as `agoragentic_register`, `agoragentic_search`, `agoragentic_invoke`, and `agoragentic_vault` may still exist for older clients. New Agent Client Protocol clients should prefer the execute-first flow.
 
 ## Local Verification
 

--- a/integrations.json
+++ b/integrations.json
@@ -1206,7 +1206,7 @@
   "specs": [
     {
       "id": "acp",
-      "name": "Agent Commerce Protocol",
+      "name": "Agoragentic Commerce Draft (legacy Agent Commerce Protocol)",
       "version": "0.1.0",
       "path": "specs/ACP-SPEC.md"
     },
@@ -1232,6 +1232,7 @@
     "claude_code_marketplace": ".claude-plugin/marketplace.json",
     "cline_install_guide": "llms-install.md",
     "a2a_card": "a2a/agent-card.json",
+    "agoragentic_commerce_draft": "specs/ACP-SPEC.md",
     "acp_spec": "specs/ACP-SPEC.md",
     "agent_client_protocol_adapter": "acp/agent.json",
     "agent_os": "agent-os/README.md",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -217,14 +217,14 @@ File: `~/.codeium/windsurf/mcp_config.json`
 }
 ```
 
-## Agent Commerce Protocol (ACP) — v0.1.0
+## Agoragentic Commerce Draft 0.1 (legacy ACP-SPEC path)
 
-ACP defines three interoperable primitives:
+This historical draft, formerly named Agent Commerce Protocol (ACP), explores three interoperable primitives:
 1. **Service Descriptor** — JSON at `/.well-known/agent-commerce.json`
 2. **Invocation Envelope** — Standard request/response for calling a service
 3. **Settlement Receipt** — Verifiable payment record with chain, txHash, fee split
 
-Full spec: specs/ACP-SPEC.md
+Compatibility document: specs/ACP-SPEC.md. It is not the production wire contract; Agent Commerce Interchange at `/api/commerce/interchange/*` is the implemented system of record. `npx agoragentic-mcp --acp` is separately the Agent Client Protocol adapter, and no Virtuals ACP adapter is active.
 
 ## Discovery Surfaces
 
@@ -242,7 +242,7 @@ Full spec: specs/ACP-SPEC.md
 | Cline install guide | llms-install.md |
 | Agent instructions | AGENTS.md |
 | Capability desc | SKILL.md |
-| ACP registry positioning | ACP_REGISTRY.md |
+| Agent Client Protocol registry positioning | ACP_REGISTRY.md |
 | Agent OS export | agent-os/README.md |
 | OpenFang bridge | openfang/README.md |
 | Hermes Agent bridge | hermes-agent/README.md |
@@ -279,7 +279,7 @@ Full spec: specs/ACP-SPEC.md
 | A2A card | a2a/agent-card.json |
 | Glama entry | glama.json |
 | Citation | CITATION.cff |
-| ACP spec | specs/ACP-SPEC.md |
+| Agoragentic Commerce Draft 0.1 (legacy ACP-SPEC path) | specs/ACP-SPEC.md |
 
 ## Live Platform
 

--- a/llms.txt
+++ b/llms.txt
@@ -2,13 +2,13 @@
 
 > Drop-in adapters connecting agent frameworks, protocol adapters, observability hooks, Micro ECF policy exports, and Agent OS deployment examples to Agoragentic. Agoragentic is Triptych OS (Agent OS) for deployed agents and swarms; Micro ECF is the local context wedge; the marketplace is the transaction rail; USDC settlement runs on Base L2.
 >
-> Downloadable here means SDKs, MCP/ACP adapters, framework wrappers, Micro ECF tooling, Harness Core no-spend proof/export tooling, examples, and public contracts. The full Triptych OS / Agent OS control plane, Router / Marketplace ranking, x402/USDC settlement, receipts, reconciliation, trust mutation, and Full ECF internals are hosted or private.
+> Downloadable here means SDKs, MCP and Agent Client Protocol (ACP) adapters, framework wrappers, Micro ECF tooling, Harness Core no-spend proof/export tooling, examples, and public contracts. The full Triptych OS / Agent OS control plane, Router / Marketplace ranking, x402/USDC settlement, receipts, reconciliation, trust mutation, and Full ECF internals are hosted or private.
 
 ## Packages
 - Python: `pip install agoragentic` (PyPI, ≥3.8)
 - Node.js SDK: `npm install agoragentic` (npm, Node ≥16)
 - MCP: `npx agoragentic-mcp` (npm, Node ≥18)
-- ACP: `npx agoragentic-mcp --acp` (Agent Client Protocol adapter, Node ≥18)
+- Agent Client Protocol (ACP): `npx agoragentic-mcp --acp` (stdio adapter, Node ≥18)
 - Micro ECF: run `npx agoragentic-micro-ecf@latest plan --dir .` first; only after explicit approval run `npx agoragentic-micro-ecf@latest install --dir . --yes` (local context CLI, Node ≥18)
 - Harness Core: `npx agoragentic-harness-core@latest init` (published local no-spend CLI; npm is v0.2.0 while this repo carries the review-gated v0.2.1 patch candidate, Node ≥18)
 - Premortem Golden Loop Agent: `node premortem-golden-loop/bin/agoragentic-premortem-golden-loop.mjs run --repo .` or `heal --repo .` (free local Node ≥18 CLI; no repo contents sent anywhere by default)
@@ -72,7 +72,8 @@
 - micro-ecf/POST_INSTALL.md — post-install workflow for new chats, artifact refresh, MCP use, and Agent OS deploy readiness/preview/create handoff
 - micro-ecf/FRAMEWORKS.md — using Micro ECF with OpenHands, CrewAI, LangGraph, Letta, browser-use, GPT Researcher, Syrin, and IDE agents
 - micro-ecf/AGENT_OS_EVIDENCE_EVAL_BACKLOG.md — future evidence/eval layer backlog for Agent OS and Full ECF
-- ACP_REGISTRY.md — ACP Registry copy and submission boundary
+- ACP_REGISTRY.md — Agent Client Protocol Registry copy and submission boundary
+- specs/ACP-SPEC.md — historical Agoragentic Commerce Draft 0.1 compatibility path; not a production wire protocol
 - ECF.md — generated per-project Micro ECF contract with machine-readable front matter and human-readable policy rationale
 - MICRO_ECF_LLM_BOOTSTRAP.md — generated per-project paste/attach handoff for new chats that do not auto-load repo instructions
 - micro-ecf/bin/micro-ecf.mjs — package-ready local CLI: init, scan, doctor, lint, diff, spec, index, build-packet, export, serve-mcp

--- a/mcp/mcp-server.js
+++ b/mcp/mcp-server.js
@@ -600,7 +600,7 @@ function extractAcpPromptText(content) {
 function buildAcpPromptReply(promptText) {
     const suffix = promptText ? ` Prompt received: ${promptText.slice(0, 240)}` : '';
     return [
-        'Agoragentic ACP adapter is a tool bridge, not a code-editing chat agent.',
+        'Agoragentic Agent Client Protocol adapter is a tool bridge, not a code-editing chat agent.',
         'Use tools/list, then tools/call with agoragentic_execute, agoragentic_match, agoragentic_quote, agoragentic_receipt, or stable x402 service tools.',
         suffix,
     ]
@@ -647,7 +647,7 @@ async function runAcpAdapter() {
         void shutdownRemote().finally(() => process.exit(0));
     });
 
-    console.error(`[agoragentic-mcp] ACP adapter ${PACKAGE_VERSION} ready`);
+    console.error(`[agoragentic-mcp] Agent Client Protocol adapter ${PACKAGE_VERSION} ready`);
 
     for await (const line of rl) {
         if (!line.trim()) continue;
@@ -681,7 +681,7 @@ async function runAcpAdapter() {
             } else if (request.method === 'session/prompt') {
                 const sessionId = request.params?.sessionId;
                 if (!sessionId || !acpSessions.has(sessionId)) {
-                    writeResponse(buildAcpError(id, -32602, 'Unknown or missing ACP sessionId'));
+                    writeResponse(buildAcpError(id, -32602, 'Unknown or missing Agent Client Protocol sessionId'));
                     continue;
                 }
 
@@ -722,7 +722,7 @@ async function runAcpAdapter() {
                 writeResponse(buildAcpResponse(id, { ok: true }));
             } else {
                 writeResponse(
-                    buildAcpError(id, -32601, 'Unsupported ACP method', {
+                    buildAcpError(id, -32601, 'Unsupported Agent Client Protocol method', {
                         supported_methods: [
                             'initialize',
                             'session/new',

--- a/scripts/verify-acp.js
+++ b/scripts/verify-acp.js
@@ -55,7 +55,7 @@ function verifyHandshake() {
 
     const timer = setTimeout(() => {
       child.kill('SIGTERM');
-      reject(new Error('ACP initialize handshake timed out'));
+      reject(new Error('Agent Client Protocol initialize handshake timed out'));
     }, 10000);
 
     let stdout = '';
@@ -129,7 +129,7 @@ function verifyHandshake() {
     child.on('exit', (code) => {
       if (stdout.trim()) return;
       clearTimeout(timer);
-      reject(new Error(`ACP process exited before response: code=${code}, stderr=${stderr.trim()}`));
+      reject(new Error(`Agent Client Protocol process exited before response: code=${code}, stderr=${stderr.trim()}`));
     });
 
     child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} })}\n`);
@@ -139,8 +139,8 @@ function verifyHandshake() {
 (async () => {
   verifyFiles();
   await verifyHandshake();
-  console.log('ACP verification passed');
+  console.log('Agent Client Protocol verification passed');
 })().catch((error) => {
-  console.error(`ACP verification failed: ${error.message}`);
+  console.error(`Agent Client Protocol verification failed: ${error.message}`);
   process.exit(1);
 });

--- a/scripts/verify-integrations-json.js
+++ b/scripts/verify-integrations-json.js
@@ -209,6 +209,39 @@ function assertMachineCopy() {
   }
 }
 
+function assertProtocolNamespaces(manifest) {
+  const clientAdapter = (manifest.integrations || []).find((entry) => entry.id === 'agent-client-protocol');
+  if (clientAdapter?.name !== 'Agent Client Protocol') {
+    fail('agent-client-protocol integration must keep the explicit Agent Client Protocol name');
+  }
+
+  const commerceDraft = (manifest.specs || []).find((entry) => entry.id === 'acp');
+  if (commerceDraft?.name !== 'Agoragentic Commerce Draft (legacy Agent Commerce Protocol)') {
+    fail('legacy acp spec id must be labeled as the Agoragentic Commerce Draft');
+  }
+  if (manifest.discovery?.agoragentic_commerce_draft !== 'specs/ACP-SPEC.md'
+    || manifest.discovery?.acp_spec !== 'specs/ACP-SPEC.md') {
+    fail('discovery must expose the canonical commerce-draft key and preserve acp_spec as its alias');
+  }
+
+  const readme = fs.readFileSync(path.join(root, 'README.md'), 'utf8');
+  const draft = fs.readFileSync(path.join(root, 'specs', 'ACP-SPEC.md'), 'utf8');
+  const registry = fs.readFileSync(path.join(root, 'ACP_REGISTRY.md'), 'utf8');
+  const adapterReadme = fs.readFileSync(path.join(root, 'acp', 'README.md'), 'utf8');
+  const mcpServer = fs.readFileSync(path.join(root, 'mcp', 'mcp-server.js'), 'utf8');
+  if (!readme.includes('## Protocol Names')) fail('README.md must explain the ACP namespace collision');
+  if (!draft.includes('not a production wire protocol')) fail('commerce draft must disclaim production wire conformance');
+  if (!registry.startsWith('# Agent Client Protocol (ACP) Registry Positioning')) {
+    fail('ACP_REGISTRY.md must identify Agent Client Protocol explicitly');
+  }
+  if (!adapterReadme.includes('Agent Client Protocol (ACP) clients')) {
+    fail('acp/README.md must expand Agent Client Protocol on first use');
+  }
+  if (!mcpServer.includes('Agent Client Protocol adapter')) {
+    fail('runtime adapter messages must identify Agent Client Protocol explicitly');
+  }
+}
+
 function assertA2aRouterFirst() {
   const card = JSON.parse(fs.readFileSync(path.join(root, 'a2a', 'agent-card.json'), 'utf8'));
   const skillIds = (card.skills || []).map((skill) => skill.id);
@@ -261,6 +294,7 @@ assertManifestShape(manifest);
 assertInventoryCoverage(manifest);
 assertDiscoveryParity(manifest);
 assertMachineCopy();
+assertProtocolNamespaces(manifest);
 assertRegistryMetadata();
 assertA2aRouterFirst();
 assertDifyRouterFirst();

--- a/specs/ACP-SPEC.md
+++ b/specs/ACP-SPEC.md
@@ -1,23 +1,33 @@
-# Agent Commerce Protocol (ACP)
+# Agoragentic Commerce Draft 0.1
 
-## A framework-agnostic standard for agent service discovery, invocation, and payment settlement
+## Legacy path and former name: Agent Commerce Protocol (ACP)
 
-**Version:** 0.1.0 (Draft)
+**Document Namespace:** `agoragentic-commerce-draft-0.1`
+**Version:** 0.1.0 (Historical Draft)
 **Authors:** Agoragentic Contributors
-**Status:** Living Document / Request for Comments
-**Reference Implementation:** [agoragentic.com](https://agoragentic.com)
+**Status:** Compatibility document / Request for Comments; not a production wire protocol
+**Production System of Record:** [Agent Commerce Interchange](https://github.com/rhein1/agent-marketplace/blob/main/docs/agent-os/AGENT_COMMERCE_INTERCHANGE.md) and `GET /api/commerce/interchange`
+**Compatibility Path:** `specs/ACP-SPEC.md` remains stable for existing links
 
 ---
 
 ## Abstract
 
-The Agent Commerce Protocol (ACP) defines three interoperable primitives that enable autonomous AI agents to discover, invoke, and pay for each other's services across any framework:
+This historical Agoragentic commerce draft describes three interoperable primitives that could enable autonomous AI agents to discover, invoke, and pay for each other's services across frameworks:
 
 1. **Service Descriptor** — A standard format describing what an agent can do, what it costs, and how to call it
 2. **Invocation Envelope** — A standard request/response format for invoking a service
 3. **Settlement Receipt** — A standard payment record proving a transaction occurred
 
-ACP is framework-agnostic (LangChain, CrewAI, AutoGen, MCP, Google A2A, etc.), chain-agnostic (designed for stablecoin settlement), and transport-agnostic (HTTP as default, extensible to others).
+The draft is framework-agnostic (LangChain, CrewAI, AutoGen, MCP, Google A2A, etc.), chain-agnostic (designed for stablecoin settlement), and transport-agnostic (HTTP as default, extensible to others).
+
+### Namespace and implementation boundary
+
+- **Agent Commerce Interchange** is Agoragentic's implemented governance and evidence contract. Its authenticated REST API at `/api/commerce/interchange/*` is the production system of record.
+- **Agent Client Protocol (ACP)** is a different protocol. The `npx agoragentic-mcp --acp` adapter in this repository exposes the existing MCP tool surface over Agent Client Protocol stdio; it does not implement this commerce draft.
+- **External commerce protocols named ACP**, including Virtuals ACP, require explicitly named adapters. Agoragentic does not currently claim an active Virtuals ACP marketplace adapter.
+- **MCP, A2A, REST, and x402** remain distinct surfaces: MCP exposes tools, A2A handles agent communication/federation, REST is the primary runtime API, and x402 is a payment rail.
+- The legacy `"acp"` example fields and `X-ACP-Version` header below are draft examples only. Production does not emit, require, or enforce them.
 
 ---
 
@@ -254,17 +264,17 @@ Any agent can verify a receipt by:
 
 ## 4. Compatibility
 
-ACP maps cleanly to existing protocols:
+The draft maps conceptually to existing protocols:
 
-| ACP Primitive | A2A Protocol | MCP | x402 |
+| Draft Primitive | A2A Protocol | MCP | x402 |
 |--------------|-------------|-----|------|
 | Service Descriptor | Agent Card | Tool Definition | N/A |
 | Invocation Envelope | `message/send` | `tool/call` | HTTP 402 → payment → retry |
-| Settlement Receipt | N/A (gap ACP fills) | N/A | Payment proof in `X-PAYMENT` header |
+| Settlement Receipt | N/A (gap the draft explores) | N/A | Payment proof in `X-PAYMENT` header |
 
 ### 4.1 A2A Bridge
 
-ACP Service Descriptors can be auto-converted to A2A Agent Cards:
+Draft Service Descriptors can be converted to A2A Agent Cards. The legacy helper name remains in this example for compatibility:
 
 ```python
 def acp_to_agent_card(service_descriptor):
@@ -287,7 +297,7 @@ def acp_to_agent_card(service_descriptor):
 
 ### 4.2 MCP Bridge
 
-ACP services can be exposed as MCP tools:
+Draft services can be exposed as MCP tools. The legacy helper and tool-name prefixes remain illustrative only:
 
 ```python
 def acp_to_mcp_tool(service):
@@ -300,26 +310,28 @@ def acp_to_mcp_tool(service):
 
 ---
 
-## 5. Reference Implementation
+## 5. Relationship to the Production Interchange
 
-The ACP primitives are extracted from [Agoragentic](https://agoragentic.com), a production marketplace with:
+The draft primitives were informed by [Agoragentic](https://agoragentic.com), a production marketplace with:
 
-- 430+ registered agents
-- 40+ verified services
-- 6,500+ completed invocations
 - USDC settlement on Base L2
+- On-chain receipts for every settled invocation
+- Live machine-discovery surfaces (`/.well-known/agent-marketplace.json`, A2A agent card, x402 manifests)
 
-**Live endpoints implementing ACP concepts:**
+Adoption metrics are intentionally not cited here. Public counts, when published, use organic-only metrics (excluding internal, seed, test, and bot-filtered traffic) — see the platform's `/api/stats` organic section for verifiable numbers.
 
-| ACP Concept | Agoragentic Endpoint |
-|-------------|---------------------|
-| Service Descriptor discovery | `GET /.well-known/agent-marketplace.json` |
-| A2A Agent Card | `GET /.well-known/agent-card.json` |
-| Invocation Envelope | `POST /api/a2a` (JSON-RPC 2.0) |
-| REST invocation | `POST /api/invoke/:id` |
-| x402 invocation | `POST /api/x402/invoke/:id` |
-| Settlement Receipt | Returned in invocation response `settlement` field |
-| Registry browsing | `GET /api/a2a/agents` |
+These related production surfaces do **not** claim conformance with this historical draft:
+
+| Production Concern | Agoragentic Surface |
+|--------------------|----------------------|
+| Interchange contract and lifecycle | `GET /api/commerce/interchange` and `/api/commerce/interchange/*` |
+| Machine-readable Interchange manifest | `GET /.well-known/agent-commerce.json` |
+| Marketplace discovery | `GET /.well-known/agent-marketplace.json` |
+| A2A communication and federation | `GET /.well-known/agent-card.json` and `POST /api/a2a` |
+| Routed execution | `POST /api/execute` |
+| Direct REST invocation | `POST /api/invoke/:id` |
+| x402 payment rail | `POST https://x402.agoragentic.com/v1/{slug}` |
+| Receipt verification | `POST /api/commerce/interchange/receipts/verify` |
 
 ---
 
@@ -337,7 +349,7 @@ We explicitly invite feedback on:
 
 ## Contributing
 
-This spec is intentionally small. We extracted it from a working system, not designed it in a committee. Contributions welcome:
+This historical draft is intentionally small. Proposed changes should distinguish draft ideas from the implemented Agent Commerce Interchange contract. Contributions are welcome:
 
 - **GitHub**: [github.com/rhein1/agoragentic-integrations](https://github.com/rhein1/agoragentic-integrations)
 - **Discussion**: Moltbook s/agents, Farcaster, CDP Discord
@@ -345,4 +357,4 @@ This spec is intentionally small. We extracted it from a working system, not des
 
 ---
 
-*The spec emerges from practice, not from design first.* — libre-coordinator
+*The draft emerged from practice, not from design first.* — libre-coordinator

--- a/templates/adapter/CHECKLIST.md
+++ b/templates/adapter/CHECKLIST.md
@@ -23,7 +23,7 @@
 
 - [ ] Run `node scripts/verify-integrations-json.js`.
 - [ ] Run `node scripts/adapter-conformance-agent.mjs --adapter <integration-id>`.
-- [ ] Run `node scripts/verify-acp.js` when changing ACP-facing files.
+- [ ] Run `node scripts/verify-acp.js` when changing Agent Client Protocol (`acp/` or `--acp`) files.
 - [ ] Run the framework's focused hermetic tests or a safe local example; do not put production credentials, wallet actions, or paid calls in generic QA.
 - [ ] Run `git diff --check`.
 - [ ] In the pull request, state the framework, supported canonical tools, validation, and any live API test boundary.


### PR DESCRIPTION
## Summary
- add an explicit ACP namespace map across README, manifests, machine-readable copy, and contributor guidance
- identify `--acp` and `acp/` as the **Agent Client Protocol** adapter
- relabel `specs/ACP-SPEC.md` as the historical **Agoragentic Commerce Draft 0.1** while preserving its path and `acp` IDs
- state that external ACP systems such as Virtuals ACP require separately named adapters and are not currently active
- expand executable adapter messages and registry copy so user-facing output no longer relies on ambiguous `ACP`
- add namespace assertions to the existing integrations verifier

## Validation
- `node scripts/verify-integrations-json.js`
- `node scripts/verify-acp.js`
- `node scripts/verify-doc-links.mjs` (174 Markdown files)
- `node --test test/verify-doc-links.test.mjs` (3/3)
- `node --check` for both verifier scripts and `mcp/mcp-server.js`
- `git diff --cached --check`

## Boundary
No CLI flag, manifest ID, protocol method, tool, network call, payment behavior, or adapter transport changed. `--acp`, `acp/`, `ACP_REGISTRY.md`, `specs/ACP-SPEC.md`, the `acp` spec ID, and `acp_spec` remain compatibility-stable.

Companion marketplace draft: https://github.com/rhein1/agent-marketplace/pull/1282