### PR TITLE
fix(docs): link public Interchange contract

### DIFF
--- a/scripts/verify-integrations-json.js
+++ b/scripts/verify-integrations-json.js
@@ -231,6 +231,12 @@ function assertProtocolNamespaces(manifest) {
   const mcpServer = fs.readFileSync(path.join(root, 'mcp', 'mcp-server.js'), 'utf8');
   if (!readme.includes('## Protocol Names')) fail('README.md must explain the ACP namespace collision');
   if (!draft.includes('not a production wire protocol')) fail('commerce draft must disclaim production wire conformance');
+  if (!draft.includes('[Agent Commerce Interchange](https://agoragentic.com/interchange/)')) {
+    fail('commerce draft must link to the public Interchange system of record');
+  }
+  if (draft.includes('github.com/rhein1/agent-marketplace/blob/main/docs')) {
+    fail('public commerce draft must not link to private marketplace documentation');
+  }
   if (!registry.startsWith('# Agent Client Protocol (ACP) Registry Positioning')) {
     fail('ACP_REGISTRY.md must identify Agent Client Protocol explicitly');
   }

--- a/specs/ACP-SPEC.md
+++ b/specs/ACP-SPEC.md
@@ -6,7 +6,7 @@
 **Version:** 0.1.0 (Historical Draft)
 **Authors:** Agoragentic Contributors
 **Status:** Compatibility document / Request for Comments; not a production wire protocol
-**Production System of Record:** [Agent Commerce Interchange](https://github.com/rhein1/agent-marketplace/blob/main/docs/agent-os/AGENT_COMMERCE_INTERCHANGE.md) and `GET /api/commerce/interchange`
+**Production System of Record:** [Agent Commerce Interchange](https://agoragentic.com/interchange/) and `GET /api/commerce/interchange`
 **Compatibility Path:** `specs/ACP-SPEC.md` remains stable for existing links
 
 ---


### PR DESCRIPTION
## Finding
The post-merge unauthenticated audit found that the public commerce draft linked its production system of record to documentation in the private `agent-marketplace` repository, which returns 404 to public readers.

## Fix
- link the system of record to the live public `/interchange/` page
- add a verifier guard that rejects future private marketplace documentation links

## Validation
- `node scripts/verify-integrations-json.js`
- `node scripts/verify-acp.js`
- `node scripts/verify-doc-links.mjs` (174 Markdown files)
- both replacement URLs return HTTP 200 without authentication
- `git diff --cached --check`

No runtime adapter, protocol, payment, or transport behavior changes.