### PR TITLE
Harden the route-first x402 buyer demo

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -273,8 +273,10 @@ jobs:
         run: node --experimental-strip-types --test test/solana-payment-safety.test.mjs
       - name: Run Solana no-funds demo
         run: node examples/agoragentic-growth/2026-06-21-solana-x402-paid-call-adapter-demo-mjs-c10944a6cc/solana_x402_paid_call_adapter_demo.mjs
-      - name: Test x402 buyer demo preflight behavior
-        run: node --test test/x402-buyer-demo-preflight.test.mjs
+      - name: Test x402 buyer demo behavior
+        run: |
+          node --test x402/buyer-demo.test.mjs
+          node --test test/x402-buyer-demo-preflight.test.mjs
 
   adapter-conformance:
     runs-on: ubuntu-latest

--- a/docs/ADAPTER_CONFORMANCE_AGENT.md
+++ b/docs/ADAPTER_CONFORMANCE_AGENT.md
@@ -30,7 +30,7 @@ The worker does not import or execute adapter code. JavaScript is passed to `nod
 | Repository containment | A primary or documentation path is missing, absolute, traverses outside the repo, or resolves through an escaping symlink. |
 | Syntax | The primary JavaScript, TypeScript, Python, or JSON artifact cannot be parsed offline. Documentation-only entries are `not_applicable`. |
 | Credential literals | A credential-shaped literal is present in the primary artifact or its documentation. Reports include only the rule and file path, never the matched value. |
-| Execute-first signal | An advisory is emitted when neither the primary artifact nor docs expose the current execute-first path. |
+| Execution-flow signal | General integrations must expose the current execute-first path. Integration-specific profiles may require a narrower protocol-native flow instead: `x402` must declare its intentional direct x402 boundary and include both `/api/x402/execute/match` and `/api/x402/execute`. Missing profile signals remain advisory rather than being waived. |
 | Colocated tests | An advisory is emitted when no adapter-local test file is present. This keeps syntax-only evidence from being mistaken for runtime coverage. |
 
 ## Evidence boundary

--- a/scripts/adapter-conformance-lib.mjs
+++ b/scripts/adapter-conformance-lib.mjs
@@ -8,6 +8,17 @@ const PARSER_TIMEOUT_MS = 10_000;
 const TEST_FILE_PATTERN = /(?:^|\/)(?:test|tests)\/|(?:\.test|\.spec)\.[^.]+$/i;
 const SKIP_DIRECTORIES = new Set([".git", "coverage", "dist", "node_modules"]);
 
+const FLOW_EXPECTATIONS_BY_INTEGRATION = Object.freeze({
+  x402: {
+    profile: "direct_x402_route_first",
+    signals: [
+      { id: "route_match", scope: "primary", pattern: /\/api\/x402\/execute\/match\b/ },
+      { id: "route_execute", scope: "primary", pattern: /\/api\/x402\/execute(?!\/match)\b/ },
+      { id: "direct_boundary", scope: "docs", pattern: /\bdirect x402\b/ },
+    ],
+  },
+});
+
 const SECRET_PATTERNS = [
   { code: "pem_private_key", pattern: /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/g },
   { code: "github_token", pattern: /\bgh[pousr]_[A-Za-z0-9]{36,}\b/g },
@@ -211,6 +222,25 @@ function canonicalFlowCheck(integration, files) {
     return makeCheck("execute_first_signal", "not_applicable", "Deprecated entries are not required to advertise the current execute-first flow.");
   }
   const content = files.map((file) => file.text).join("\n").toLowerCase();
+  const expectation = FLOW_EXPECTATIONS_BY_INTEGRATION[integration.id];
+  if (expectation) {
+    const missingSignals = expectation.signals
+      .filter((signal) => {
+        const scopedContent = signal.scope === "primary"
+          ? files.find((file) => file.path === integration.path)?.text || ""
+          : files.find((file) => file.path === integration.docs)?.text || "";
+        return !signal.pattern.test(scopedContent.toLowerCase());
+      })
+      .map((signal) => signal.id);
+    const evidence = {
+      profile: expectation.profile,
+      required_signals: expectation.signals.map((signal) => signal.id),
+      missing_signals: missingSignals,
+    };
+    return missingSignals.length === 0
+      ? makeCheck("execute_first_signal", "pass", "Primary artifact contains the direct x402 routes and docs declare the intentional boundary.", evidence)
+      : makeCheck("execute_first_signal", "advisory", "The x402 integration is missing required direct-route or boundary signals.", evidence);
+  }
   const present = content.includes("agoragentic_execute")
     || content.includes("/api/execute")
     || content.includes("execute(task")

--- a/test/adapter-conformance-agent.test.mjs
+++ b/test/adapter-conformance-agent.test.mjs
@@ -69,6 +69,43 @@ test("syntax proof does not execute adapter top-level code", async () => {
   assert.equal(result.checks.find((check) => check.id === "primary_syntax").state, "pass");
 });
 
+test("x402 uses an integration-specific direct-route flow expectation", async () => {
+  const root = fixtureRoot();
+  write(root, "x402/buyer-demo.js", `
+    const matchPath = "/api/x402/execute/match";
+    const executePath = "/api/x402/execute";
+    module.exports = { matchPath, executePath };
+  `);
+  write(root, "x402/README.md", "# x402\n\nIntentional direct x402 protocol example.\n");
+  write(root, "x402/buyer-demo.test.mjs", "// Hermetic fixture test.\n");
+
+  const x402Result = await validateIntegration(root, entry("x402", "javascript", "x402/buyer-demo.js", "x402/README.md"));
+  const x402Flow = x402Result.checks.find((check) => check.id === "execute_first_signal");
+
+  assert.equal(x402Flow.state, "pass");
+  assert.equal(x402Flow.evidence.profile, "direct_x402_route_first");
+  assert.deepEqual(x402Flow.evidence.missing_signals, []);
+  assert.equal(x402Result.checks.find((check) => check.id === "colocated_tests").state, "pass");
+
+  const genericResult = await validateIntegration(root, entry("demo", "javascript", "x402/buyer-demo.js", "x402/README.md"));
+  assert.equal(genericResult.checks.find((check) => check.id === "execute_first_signal").state, "advisory");
+
+  write(root, "x402/README.md", "# x402\n\nProtocol example without an explicit boundary.\n");
+  const missingBoundary = await validateIntegration(root, entry("x402", "javascript", "x402/buyer-demo.js", "x402/README.md"));
+  assert.deepEqual(
+    missingBoundary.checks.find((check) => check.id === "execute_first_signal").evidence.missing_signals,
+    ["direct_boundary"],
+  );
+
+  write(root, "x402/buyer-demo.js", "module.exports = {};\n");
+  write(root, "x402/README.md", "# x402\n\nIntentional direct x402 flow through /api/x402/execute/match and /api/x402/execute.\n");
+  const docsOnlyRoutes = await validateIntegration(root, entry("x402", "javascript", "x402/buyer-demo.js", "x402/README.md"));
+  assert.deepEqual(
+    docsOnlyRoutes.checks.find((check) => check.id === "execute_first_signal").evidence.missing_signals,
+    ["route_match", "route_execute"],
+  );
+});
+
 test("credential findings identify the rule and path without echoing the value", async () => {
   const root = fixtureRoot();
   const secret = "amk_1234567890abcdefghijklmnopqrstuvwxyz";

--- a/x402/README.md
+++ b/x402/README.md
@@ -2,6 +2,14 @@
 
 Pay-per-request agent-to-agent commerce via HTTP 402 on Base L2.
 
+## Intentional Protocol Boundary
+
+This integration intentionally demonstrates Agoragentic's lower-level, direct x402 HTTP rail. It is route-first inside that rail: discover a quote with `GET /api/x402/execute/match`, then use the returned quote with `POST /api/x402/execute`. It never selects or hardcodes a provider ID.
+
+This is not the default buyer path for general Agent OS integrations. Those integrations should prefer `agoragentic_execute` or `POST /api/execute` for canonical cross-marketplace routing. The x402-specific endpoints remain here because inspecting an HTTP 402 challenge is the purpose of this protocol example.
+
+The CLI performs real HTTP requests to `AGORAGENTIC_URL`. Its default route caps matching at `max_cost=0` and executes only when `quote.payment_required === false`. `--paid-preflight` makes one unsigned request to a quoted paid route and stops at the first valid 402 challenge; it never reads wallet credentials, signs, retries, or spends. The colocated `buyer-demo.test.mjs` test replaces HTTP with in-memory fixtures and performs no network or spend.
+
 ## Quick Start
 
 ```bash
@@ -17,6 +25,8 @@ node x402/buyer-demo.js --verbose
 ```
 
 ## How x402 Works
+
+The sequence below describes the complete protocol. `buyer-demo.js` stops after step 2 for a paid route; it does not perform steps 3-5.
 
 ```
   Buyer Agent                    Agoragentic                     Seller API

--- a/x402/buyer-demo.js
+++ b/x402/buyer-demo.js
@@ -3,11 +3,14 @@
  * Agoragentic x402 Buyer Demo Script
  * ===================================
  * 
- * Self-contained Node.js script demonstrating x402 discovery and preflight:
+ * Self-contained Node.js script demonstrating the direct x402 HTTP rail:
  *   1. Discover available services
- *   2. Get a quote via execute/match
+ *   2. Get a route-first quote via /api/x402/execute/match
  *   3. Free-tier execution (echo test)
  *   4. Optional paid-route preflight that stops at the 402 challenge
+ *
+ * This protocol-focused demo intentionally uses /api/x402/execute rather than
+ * the general Agent OS /api/execute entrypoint. It never selects a provider ID.
  * 
  * Usage:
  *   # Free demo (no wallet needed)
@@ -33,11 +36,11 @@ const http = require('http');
 const BASE_URL = process.env.AGORAGENTIC_URL || 'https://agoragentic.com';
 const isPaidPreflight = process.argv.includes('--paid-preflight');
 const isVerbose = process.argv.includes('--verbose') || process.argv.includes('-v');
-
-if (process.argv.includes('--paid')) {
-    console.error('The old --paid mode never signed a payment. Use --paid-preflight for an honest no-spend 402 challenge check.');
-    process.exit(2);
-}
+const DIRECT_X402_FLOW = Object.freeze({
+    profile: 'direct_x402_route_first',
+    matchPath: '/api/x402/execute/match',
+    executePath: '/api/x402/execute',
+});
 
 // ─── Helpers ────────────────────────────────────────────
 function log(emoji, message, data = null) {
@@ -47,9 +50,9 @@ function log(emoji, message, data = null) {
     }
 }
 
-function request(method, path, body = null) {
+function request(method, path, body = null, baseUrl = BASE_URL) {
     return new Promise((resolve, reject) => {
-        const url = new URL(path, BASE_URL);
+        const url = new URL(path, baseUrl);
         const isSecure = url.protocol === 'https:';
         const transport = isSecure ? https : http;
 
@@ -106,15 +109,15 @@ function request(method, path, body = null) {
 // Free-vs-paid is decided ONLY by payment_required === false. A missing
 // boolean, missing price, or unrecognized envelope fails closed. next_step.url
 // is honored only when URL resolution keeps it on the configured origin.
-function sameOriginExecutePath(candidate) {
-    const fallback = '/api/x402/execute';
+function sameOriginExecutePath(candidate, baseUrl = BASE_URL) {
+    const fallback = DIRECT_X402_FLOW.executePath;
     if (typeof candidate !== 'string' || candidate.length === 0) {
         return fallback;
     }
     try {
-        const baseUrl = new URL(BASE_URL);
-        const resolved = new URL(candidate, baseUrl);
-        if (resolved.origin !== baseUrl.origin) {
+        const configuredBaseUrl = new URL(baseUrl);
+        const resolved = new URL(candidate, configuredBaseUrl);
+        if (resolved.origin !== configuredBaseUrl.origin) {
             return fallback;
         }
         return `${resolved.pathname}${resolved.search}`;
@@ -123,7 +126,7 @@ function sameOriginExecutePath(candidate) {
     }
 }
 
-function parseMatchEnvelope(body) {
+function parseMatchEnvelope(body, baseUrl = BASE_URL) {
     if (!body || typeof body !== 'object') {
         throw new Error('Match response is not a JSON object; refusing to guess payment terms');
     }
@@ -146,7 +149,7 @@ function parseMatchEnvelope(body) {
     if (typeof quote.quote_id !== 'string' || quote.quote_id.length === 0) {
         throw new Error('Quote is missing "quote.quote_id"');
     }
-    const executePath = sameOriginExecutePath(quote.next_step?.url);
+    const executePath = sameOriginExecutePath(quote.next_step?.url, baseUrl);
     return {
         quoteId: quote.quote_id,
         paymentRequired: quote.payment_required,
@@ -157,15 +160,15 @@ function parseMatchEnvelope(body) {
 }
 
 // ─── Step 1: Gateway Info ───────────────────────────────
-async function step1_gatewayInfo() {
-    log('ℹ️', 'Step 1: Checking x402 gateway info...');
-    const res = await request('GET', '/api/x402/info');
+async function step1_gatewayInfo(runtime) {
+    runtime.log('ℹ️', 'Step 1: Checking x402 gateway info...');
+    const res = await runtime.request('GET', '/api/x402/info');
 
     if (res.status !== 200) {
         throw new Error(`Gateway info failed: ${res.status}`);
     }
 
-    log('✅', `Gateway: ${res.body.name || 'Agoragentic x402'}`, {
+    runtime.log('✅', `Gateway: ${res.body.name || 'Agoragentic x402'}`, {
         protocol: res.body.protocol || 'x402',
         network: res.body.network,
         currency: res.body.currency,
@@ -175,45 +178,45 @@ async function step1_gatewayInfo() {
 }
 
 // ─── Step 2: Browse Catalog ─────────────────────────────
-async function step2_browseCatalog() {
-    log('🔍', 'Step 2: Browsing x402 service catalog...');
-    const res = await request('GET', '/api/x402/listings');
+async function step2_browseCatalog(runtime) {
+    runtime.log('🔍', 'Step 2: Browsing x402 service catalog...');
+    const res = await runtime.request('GET', '/api/x402/listings');
 
     if (res.status !== 200) {
         throw new Error(`Catalog fetch failed: ${res.status}`);
     }
 
     const listings = res.body.listings || res.body.capabilities || [];
-    log('📋', `Found ${listings.length} available services`);
+    runtime.log('📋', `Found ${listings.length} available services`);
 
     // Show top 5
     const top5 = listings.slice(0, 5);
     for (const listing of top5) {
         const price = parseFloat(listing.price_usdc || listing.price_per_unit || 0);
         const label = price <= 0 ? 'FREE' : `$${price.toFixed(4)} USDC`;
-        log('   ', `• ${listing.name} — ${label} (${listing.category || 'general'})`);
+        runtime.log('   ', `• ${listing.name} — ${label} (${listing.category || 'general'})`);
     }
 
     return listings;
 }
 
 // ─── Step 3: Match a Service ────────────────────────────
-async function step3_executeMatch(task = 'echo') {
-    log('🎯', `Step 3: Finding best match for "${task}"...`);
-    const res = await request('GET', `/api/x402/execute/match?task=${encodeURIComponent(task)}&max_cost=0`);
+async function step3_executeMatch(runtime, task = 'echo') {
+    runtime.log('🎯', `Step 3: Finding best match for "${task}"...`);
+    const res = await runtime.request('GET', `${DIRECT_X402_FLOW.matchPath}?task=${encodeURIComponent(task)}&max_cost=0`);
 
     if (res.status !== 200) {
-        log('⚠️', `No match found for "${task}" — this is normal if no free listings match`);
+        runtime.log('⚠️', `No match found for "${task}" — this is normal if no free listings match`);
         return null;
     }
 
-    const match = parseMatchEnvelope(res.body);
+    const match = parseMatchEnvelope(res.body, runtime.baseUrl);
     if (!match) {
-        log('⚠️', `No provider matched "${task}" — this is normal if no free listings match`);
+        runtime.log('⚠️', `No provider matched "${task}" — this is normal if no free listings match`);
         return null;
     }
 
-    log('✅', `Best match: "${match.provider?.name || 'unnamed provider'}" — $${match.priceUsdc} USDC (${match.paymentRequired ? 'paid' : 'free'})`, {
+    runtime.log('✅', `Best match: "${match.provider?.name || 'unnamed provider'}" — $${match.priceUsdc} USDC (${match.paymentRequired ? 'paid' : 'free'})`, {
         quote_id: match.quoteId,
         listing_id: match.provider?.id,
     });
@@ -222,27 +225,27 @@ async function step3_executeMatch(task = 'echo') {
 }
 
 // ─── Step 4A: Free Execution ────────────────────────────
-async function step4a_freeExecution(match) {
+async function step4a_freeExecution(runtime, match) {
     if (!match) {
-        log('⚠️', 'Step 4a: Skipping free execution — no quote available');
+        runtime.log('⚠️', 'Step 4a: Skipping free execution — no quote available');
         return null;
     }
     if (match.paymentRequired !== false) {
-        log('⚠️', 'Step 4a: Skipping free execution — the matched quote requires payment');
+        runtime.log('⚠️', 'Step 4a: Skipping free execution — the matched quote requires payment');
         return null;
     }
 
-    log('🚀', `Step 4a: Executing free task (quote: ${match.quoteId})...`);
-    const res = await request('POST', match.executePath, {
+    runtime.log('🚀', `Step 4a: Executing free task (quote: ${match.quoteId})...`);
+    const res = await runtime.request('POST', match.executePath, {
         quote_id: match.quoteId,
         input: {
             text: 'Hello from the x402 buyer demo! This is a test invocation.',
-            timestamp: new Date().toISOString(),
+            timestamp: runtime.now(),
         },
     });
 
     if (res.status === 200 && res.body.success) {
-        log('✅', 'Free execution succeeded!', {
+        runtime.log('✅', 'Free execution succeeded!', {
             method: res.body.payment_method,
             cost: res.body.cost,
             invocation_id: res.body.invocation_id,
@@ -251,59 +254,59 @@ async function step4a_freeExecution(match) {
                 : String(res.body.result || '').slice(0, 200),
         });
     } else {
-        log('❌', `Free execution failed: ${res.body?.error || res.status}`, res.body);
+        runtime.log('❌', `Free execution failed: ${res.body?.error || res.status}`, res.body);
     }
 
     return res.body;
 }
 
 // ─── Step 4B: Test Echo ─────────────────────────────────
-async function step4b_testEcho() {
-    log('🔊', 'Step 4b: Testing x402 echo endpoint (free pipeline validation)...');
-    const res = await request('POST', '/api/x402/test/echo', {
+async function step4b_testEcho(runtime) {
+    runtime.log('🔊', 'Step 4b: Testing x402 echo endpoint (free pipeline validation)...');
+    const res = await runtime.request('POST', '/api/x402/test/echo', {
         message: 'Hello from x402 buyer demo!',
-        timestamp: new Date().toISOString(),
+        timestamp: runtime.now(),
     });
 
     if (res.status === 200) {
-        log('✅', 'Echo test passed!', {
+        runtime.log('✅', 'Echo test passed!', {
             method: res.body.method || 'echo',
             echoed: typeof res.body.echoed === 'object'
                 ? JSON.stringify(res.body.echoed).slice(0, 200)
                 : String(res.body.result || res.body.echoed || '').slice(0, 200),
         });
     } else {
-        log('⚠️', `Echo test returned ${res.status}`, res.body);
+        runtime.log('⚠️', `Echo test returned ${res.status}`, res.body);
     }
 
     return res.body;
 }
 
 // ─── Step 5: Paid-route preflight (no signing or spend) ─
-async function step5_paidPreflight() {
-    log('🧾', 'Step 5: Paid-route preflight (stops before signing)...');
+async function step5_paidPreflight(runtime) {
+    runtime.log('🧾', 'Step 5: Paid-route preflight (stops before signing)...');
 
     // Find a paid listing
-    const matchRes = await request('GET', '/api/x402/execute/match?task=analyze&max_cost=1');
+    const matchRes = await runtime.request('GET', `${DIRECT_X402_FLOW.matchPath}?task=analyze&max_cost=1`);
     if (matchRes.status !== 200) {
-        log('⚠️', 'No paid listing found for "analyze" — skipping paid demo');
+        runtime.log('⚠️', 'No paid listing found for "analyze" — skipping paid demo');
         return null;
     }
 
-    const match = parseMatchEnvelope(matchRes.body);
+    const match = parseMatchEnvelope(matchRes.body, runtime.baseUrl);
     if (!match) {
-        log('⚠️', 'No provider matched "analyze" — skipping paid demo');
+        runtime.log('⚠️', 'No provider matched "analyze" — skipping paid demo');
         return null;
     }
 
     if (match.paymentRequired === false) {
-        log('ℹ️', 'Matched listing is free (payment_required=false) — no payment needed');
+        runtime.log('ℹ️', 'Matched listing is free (payment_required=false) — no payment needed');
         return null;
     }
 
-    log('💳', `Matched paid listing: "${match.provider?.name || 'unnamed provider'}" — $${match.priceUsdc} USDC (payment_required=true)`);
+    runtime.log('💳', `Matched paid listing: "${match.provider?.name || 'unnamed provider'}" — $${match.priceUsdc} USDC (payment_required=true)`);
 
-    const executeRes = await request('POST', match.executePath, {
+    const executeRes = await runtime.request('POST', match.executePath, {
         quote_id: match.quoteId,
         input: { text: 'x402 paid-route preflight test' },
     });
@@ -313,44 +316,91 @@ async function step5_paidPreflight() {
         if (!challenge) {
             throw new Error('Received HTTP 402 without PAYMENT-REQUIRED; refusing to report a successful paid-route preflight');
         }
-        log('✅', '402 Payment Required received (challenge header present); preflight stops here without signing or retrying.', {
+        runtime.log('✅', '402 Payment Required received (challenge header present); preflight stops here without signing or retrying.', {
             price: executeRes.body?.price_usdc,
             how_to_pay: executeRes.body?.how_to_pay ? 'included' : 'missing',
         });
     } else if (executeRes.status === 200 && executeRes.body?.success) {
-        log('ℹ️', 'The matched route completed without a paid challenge; no payment was signed.');
+        runtime.log('ℹ️', 'The matched route completed without a paid challenge; no payment was signed.');
     } else {
-        log('⚠️', `Unexpected preflight response: ${executeRes.status}`, executeRes.body);
+        runtime.log('⚠️', `Unexpected preflight response: ${executeRes.status}`, executeRes.body);
     }
 
     return executeRes.body;
 }
 
 // ─── Step 6: Verify Invocation Proof ────────────────────
-async function step6_verifyProof(invocationId) {
+async function step6_verifyProof(runtime, invocationId) {
     if (!invocationId) {
-        log('ℹ️', 'Step 6: Skipping proof verification — no invocation ID');
+        runtime.log('ℹ️', 'Step 6: Skipping proof verification — no invocation ID');
         return null;
     }
 
-    log('🔗', `Step 6: Checking on-chain invocation proof for ${invocationId}...`);
-    const res = await request('GET', `/api/x402/invocations/${invocationId}/proof`);
+    runtime.log('🔗', `Step 6: Checking on-chain invocation proof for ${invocationId}...`);
+    const res = await runtime.request('GET', `/api/x402/invocations/${invocationId}/proof`);
 
     if (res.status === 200) {
-        log('✅', 'Invocation proof:', {
+        runtime.log('✅', 'Invocation proof:', {
             decision_hash: res.body.decision_hash,
             on_chain_status: res.body.on_chain?.status || 'pending',
             chain: res.body.on_chain?.chain || 'eip155:8453',
         });
     } else {
-        log('⚠️', `Proof check returned ${res.status}`, res.body);
+        runtime.log('⚠️', `Proof check returned ${res.status}`, res.body);
     }
 
     return res.body;
 }
 
+function createRuntime(options = {}) {
+    const baseUrl = options.baseUrl || BASE_URL;
+    return {
+        baseUrl,
+        lineBreak: options.lineBreakFn || (() => console.log()),
+        log: options.logFn || log,
+        now: options.nowFn || (() => new Date().toISOString()),
+        request: options.requestFn || ((method, path, body) => request(method, path, body, baseUrl)),
+    };
+}
+
+async function runDemo(options = {}) {
+    const runtime = createRuntime(options);
+
+    const gateway = await step1_gatewayInfo(runtime);
+    runtime.lineBreak();
+
+    const listings = await step2_browseCatalog(runtime);
+    runtime.lineBreak();
+
+    const match = await step3_executeMatch(runtime, 'echo');
+    runtime.lineBreak();
+
+    const echo = await step4b_testEcho(runtime);
+    runtime.lineBreak();
+
+    const execution = await step4a_freeExecution(runtime, match);
+    runtime.lineBreak();
+
+    let paidPreflight = null;
+    if (options.paidPreflight) {
+        paidPreflight = await step5_paidPreflight(runtime);
+        runtime.lineBreak();
+    }
+
+    const invocationId = execution?.invocation_id;
+    const proof = invocationId ? await step6_verifyProof(runtime, invocationId) : null;
+    if (invocationId) runtime.lineBreak();
+
+    return { gateway, listings, match, echo, execution, paidPreflight, proof };
+}
+
 // ─── Main ───────────────────────────────────────────────
 async function main() {
+    if (process.argv.includes('--paid')) {
+        console.error('The old --paid mode never signed a payment. Use --paid-preflight for an honest no-spend 402 challenge check.');
+        process.exit(2);
+    }
+
     console.log('\n╔══════════════════════════════════════════════════╗');
     console.log('║     Agoragentic x402 Buyer Demo                 ║');
     console.log('║     Agent-to-Agent Commerce on Base L2           ║');
@@ -359,38 +409,7 @@ async function main() {
     console.log(`  Mode:   ${isPaidPreflight ? '🧾 Paid-route preflight (no signing)' : '🆓 Free (no wallet needed)'}\n`);
 
     try {
-        // 1. Gateway info
-        await step1_gatewayInfo();
-        console.log();
-
-        // 2. Browse catalog
-        const listings = await step2_browseCatalog();
-        console.log();
-
-        // 3. Match a service
-        const match = await step3_executeMatch('echo');
-        console.log();
-
-        // 4a. Test echo
-        await step4b_testEcho();
-        console.log();
-
-        // 4b. Free execution
-        const execResult = await step4a_freeExecution(match);
-        console.log();
-
-        // 5. Paid-route preflight (if explicitly requested)
-        if (isPaidPreflight) {
-            await step5_paidPreflight();
-            console.log();
-        }
-
-        // 6. Verify proof (if we got an invocation)
-        const invocationId = execResult?.invocation_id;
-        if (invocationId) {
-            await step6_verifyProof(invocationId);
-            console.log();
-        }
+        await runDemo({ paidPreflight: isPaidPreflight });
 
         // ─── Summary ────────────────────────────────────
         console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n');
@@ -415,4 +434,13 @@ async function main() {
     }
 }
 
-main();
+module.exports = {
+    DIRECT_X402_FLOW,
+    parseMatchEnvelope,
+    runDemo,
+    sameOriginExecutePath,
+};
+
+if (require.main === module) {
+    main();
+}

--- a/x402/buyer-demo.test.mjs
+++ b/x402/buyer-demo.test.mjs
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+
+const require = createRequire(import.meta.url);
+
+function quoteEnvelope({ quoteId, paymentRequired, priceUsdc }) {
+    return {
+        quote: {
+            quote_id: quoteId,
+            quoted_price_usdc: priceUsdc,
+            payment_required: paymentRequired,
+            next_step: {
+                method: 'POST',
+                url: '/api/x402/execute',
+                body: { quote_id: quoteId, input: {} },
+            },
+        },
+        selected_provider: { id: 'fixture-provider', name: 'Fixture Provider' },
+    };
+}
+
+test('direct x402 demo stays route-first, no-network, and no-spend under fixtures', async (t) => {
+    const http = require('node:http');
+    const https = require('node:https');
+    const originalHttpRequest = http.request;
+    const originalHttpsRequest = https.request;
+    let networkAttempts = 0;
+    const rejectNetwork = () => {
+        networkAttempts += 1;
+        throw new Error('network access is forbidden in the hermetic x402 test');
+    };
+    http.request = rejectNetwork;
+    https.request = rejectNetwork;
+    t.after(() => {
+        http.request = originalHttpRequest;
+        https.request = originalHttpsRequest;
+    });
+
+    const demoPath = require.resolve('./buyer-demo.js');
+    delete require.cache[demoPath];
+    const { DIRECT_X402_FLOW, runDemo } = require(demoPath);
+    const calls = [];
+
+    const requestFn = async (method, path, body = null) => {
+        calls.push({ method, path, body });
+        if (method === 'GET' && path === '/api/x402/info') {
+            return { status: 200, headers: {}, body: { name: 'Fixture Gateway', protocol: 'x402' } };
+        }
+        if (method === 'GET' && path === '/api/x402/listings') {
+            return { status: 200, headers: {}, body: { listings: [] } };
+        }
+        if (method === 'GET' && path === '/api/x402/execute/match?task=echo&max_cost=0') {
+            return { status: 200, headers: {}, body: quoteEnvelope({ quoteId: 'quote-free', paymentRequired: false, priceUsdc: 0 }) };
+        }
+        if (method === 'GET' && path === '/api/x402/execute/match?task=analyze&max_cost=1') {
+            return { status: 200, headers: {}, body: quoteEnvelope({ quoteId: 'quote-paid', paymentRequired: true, priceUsdc: 0.05 }) };
+        }
+        if (method === 'POST' && path === '/api/x402/test/echo') {
+            return { status: 200, headers: {}, body: { method: 'echo', echoed: body } };
+        }
+        if (method === 'POST' && path === '/api/x402/execute' && body?.quote_id === 'quote-free') {
+            return { status: 200, headers: {}, body: { success: true, cost: 0, invocation_id: 'invocation-fixture' } };
+        }
+        if (method === 'POST' && path === '/api/x402/execute' && body?.quote_id === 'quote-paid') {
+            return {
+                status: 402,
+                headers: { 'payment-required': 'fixture-challenge' },
+                body: { error: 'payment_required', price_usdc: 0.05 },
+            };
+        }
+        if (method === 'GET' && path === '/api/x402/invocations/invocation-fixture/proof') {
+            return { status: 200, headers: {}, body: { decision_hash: 'fixture-hash', on_chain: { status: 'pending_submission' } } };
+        }
+        throw new Error(`unexpected fixture request: ${method} ${path}`);
+    };
+
+    const result = await runDemo({
+        baseUrl: 'https://fixture.invalid',
+        lineBreakFn: () => {},
+        logFn: () => {},
+        nowFn: () => '2026-01-01T00:00:00.000Z',
+        paidPreflight: true,
+        requestFn,
+    });
+
+    assert.deepEqual(DIRECT_X402_FLOW, {
+        profile: 'direct_x402_route_first',
+        matchPath: '/api/x402/execute/match',
+        executePath: '/api/x402/execute',
+    });
+    assert.equal(result.execution.invocation_id, 'invocation-fixture');
+    assert.equal(result.paidPreflight.error, 'payment_required');
+    assert.equal(networkAttempts, 0);
+    assert.equal(calls.some((call) => call.path === '/api/execute'), false);
+    assert.equal(calls.some((call) => /\/api\/x402\/invoke\//.test(call.path)), false);
+
+    const paidPosts = calls.filter((call) => call.method === 'POST' && call.path === '/api/x402/execute' && call.body?.quote_id === 'quote-paid');
+    assert.equal(paidPosts.length, 1, 'the paid preflight must stop after the first unsigned 402');
+
+    const serializedCalls = JSON.stringify(calls);
+    assert.doesNotMatch(serializedCalls, /provider_id|listing_id|payment-signature|authorization|private[_-]?key|wallet/i);
+});


### PR DESCRIPTION
Closes #217.

## Decision

This remains an intentional lower-level direct x402 integration. It is route-first inside that rail through `/api/x402/execute/match` and `/api/x402/execute`, with no hardcoded provider IDs. General integrations continue to prefer `agoragentic_execute` or `/api/execute`.

## Changes

- makes the demo import-safe and runtime-injectable;
- fails closed on malformed quote payment terms and off-origin next-step URLs;
- documents the real-network and no-spend preflight boundaries;
- adds a hermetic colocated test that disables HTTP/HTTPS and proves one unsigned 402 with no retry, wallet, credential, or provider-ID use;
- adds an explicit x402 conformance profile instead of misleading generic execute-first copy;
- runs the colocated test in required validation.

## Verification

- focused x402 + conformance tests: 9/9
- x402 conformance: 1 passed, 0 failed, 0 advisories
- root machine-surface verifier
- documentation link contract: 204 files

No live network call, signing, wallet action, spend, settlement, production mutation, or outreach is performed by the tests.