### PR TITLE
feat(harness): add quality and security receipt adapters

### DIFF
--- a/.github/workflows/harness-evaluation-adapters.yml
+++ b/.github/workflows/harness-evaluation-adapters.yml
@@ -1,0 +1,58 @@
+name: Harness Evaluation Adapters
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'harness-core/**'
+      - '.github/workflows/harness-evaluation-adapters.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'harness-core/**'
+      - '.github/workflows/harness-evaluation-adapters.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22, 24]
+    env:
+      AGORAGENTIC_NO_SPEND: '1'
+      AGORAGENTIC_ALLOW_REAL_SPEND: '0'
+      AGORAGENTIC_ALLOW_NETWORK_CANARIES: '0'
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+          cache-dependency-path: harness-core/package-lock.json
+      - name: Install Harness Core dependencies
+        working-directory: harness-core
+        run: npm ci
+      - name: Parse evaluation schemas and fixtures
+        working-directory: harness-core
+        run: |
+          node -e "for (const file of [
+            'schema/harness-evaluation.v1.json',
+            'schema/local-receipt.v1.json',
+            'test/fixtures/evaluations/impeccable-pass.json',
+            'test/fixtures/evaluations/impeccable-fail.json',
+            'test/fixtures/evaluations/sarif-review.json'
+          ]) { JSON.parse(require('node:fs').readFileSync(file, 'utf8')); console.log('parsed', file); }"
+      - name: Run full Harness Core suite
+        working-directory: harness-core
+        run: npm test
+      - name: Verify packed artifact
+        working-directory: harness-core
+        run: npm run pack:smoke

--- a/harness-core/EVALUATION_ADAPTERS.md
+++ b/harness-core/EVALUATION_ADAPTERS.md
@@ -1,0 +1,63 @@
+# Quality and security evaluation adapters
+
+Harness Core can normalize external design and security findings into the optional `evaluations` section of an `agoragentic.harness.local-receipt.v1` receipt.
+
+Supported inputs:
+
+- Impeccable `3.5.0` JSON findings at source revision `5d10bc842cbccd2ae7d3a88296d87d3be0b125b3`;
+- SARIF `2.1.0` reports from tools that identify their name and version in `tool.driver`.
+
+The adapter code is original Agoragentic code. It does not copy Impeccable skill text, detector code, or scanner output. Impeccable is Apache-2.0 licensed at the pinned source revision. SARIF is an OASIS standard. No Impeccable, Trail of Bits, scanner-vendor, or OASIS endorsement is claimed.
+
+## Run the external tool separately
+
+The parser never installs or invokes a scanner. Produce the report with the external tool under its own documented policy, then pass the JSON into Harness Core. For the pinned Impeccable CLI shape:
+
+```bash
+npx --package impeccable@3.5.0 impeccable detect --json src > impeccable-findings.json
+```
+
+Impeccable omits inline-ignored findings from its normal JSON output. A wrapper that audits suppressions may provide those original finding records under `suppressed_findings`; Harness retains them with `status: "suppressed"`. It never invents suppressed findings that were not supplied.
+
+## Normalize and attach
+
+```js
+import { readFile } from 'node:fs/promises';
+import {
+  attachEvaluationEvidenceToReceipt,
+  normalizeImpeccableFindings,
+} from 'agoragentic-harness-core/evaluations';
+
+const report = JSON.parse(await readFile('impeccable-findings.json', 'utf8'));
+const receipt = JSON.parse(await readFile('.agoragentic/local-receipt.json', 'utf8'));
+
+const evaluation = normalizeImpeccableFindings(report, {
+  producer_version: '3.5.0',
+  source_revision: '5d10bc842cbccd2ae7d3a88296d87d3be0b125b3',
+  analyzed_revision: '0123456789abcdef0123456789abcdef01234567',
+  source_ref: 'impeccable-findings.json',
+  gate: {
+    block_severities: ['critical', 'high'],
+    review_severities: ['medium'],
+    fail_on_advisory: false,
+  },
+});
+
+const updated = attachEvaluationEvidenceToReceipt(receipt, evaluation);
+```
+
+Use `normalizeSarifReport(report, options)` for SARIF. Unsupported Impeccable revisions and unsupported SARIF versions fail closed.
+
+## Evidence and privacy boundary
+
+The normalized record retains:
+
+- producer and adapter version;
+- analyzed revision;
+- hashes of the source reference and complete input report;
+- finding rule, severity, advisory/suppression state, hashed location reference, and hashed message;
+- configured gate, deterministic result, counts, and evidence hash.
+
+It deliberately excludes raw source paths, messages, snippets, prompts, tool output, credentials, and scanner-private payloads. Suppressed findings remain countable and reviewable through their rule, severity, status, and hashes.
+
+A `pass` means only that the supplied report did not cross the configured gate. It does not mean the scanner ran correctly, the findings are accurate, the analyzed revision is complete, vulnerabilities are absent, or the artifact is certified. A `fail` blocks the local receipt and therefore the existing Harness listing-readiness proposal. It does not deploy, publish, spend, call a provider, mutate trust, or bypass owner review.

--- a/harness-core/README.md
+++ b/harness-core/README.md
@@ -265,6 +265,12 @@ Core run artifacts:
 
 Receipts should retain hashes and references rather than secret-bearing raw payloads. Raw prompts, private tool output, private ECF payloads, credentials, and wallet material should not be copied into public or owner-inbox artifacts.
 
+### Quality and security evaluation evidence
+
+Harness Core includes optional parsers for pinned Impeccable findings and SARIF 2.1.0 reports. They attach a hash-bound `evaluations` section to a local receipt, retain suppressed findings, and apply an explicit severity gate. A configured failure changes the local receipt to `blocked`, so the existing listing-readiness check remains fail-closed.
+
+The parsers do not execute scanners and do not retain raw findings, snippets, messages, absolute paths, prompts, or tool output. Parsing a report does not verify scanner execution, finding accuracy, vulnerability absence, certification, endorsement, deployment safety, or marketplace readiness. See [Quality and security evaluation adapters](EVALUATION_ADAPTERS.md).
+
 ## Runtime probes
 
 Probe a local runtime contract without invoking its business tool:

--- a/harness-core/package.json
+++ b/harness-core/package.json
@@ -13,6 +13,7 @@
     ".": "./src/index.mjs",
     "./adapters": "./src/adapters/index.mjs",
     "./adapters/claude-code": "./src/adapters/claude-code.mjs",
+    "./evaluations": "./src/evaluations/index.mjs",
     "./kernel/events": "./src/kernel/events.mjs",
     "./kernel/loop": "./src/kernel/loop.mjs",
     "./kernel/middleware-registry": "./src/kernel/middleware-registry.mjs",
@@ -27,6 +28,7 @@
     "./schema/harness-approval-request.v1.json": "./schema/harness-approval-request.v1.json",
     "./schema/harness-context-import.v1.json": "./schema/harness-context-import.v1.json",
     "./schema/harness-event.v1.json": "./schema/harness-event.v1.json",
+    "./schema/harness-evaluation.v1.json": "./schema/harness-evaluation.v1.json",
     "./schema/harness-profile.v1.json": "./schema/harness-profile.v1.json",
     "./schema/harness-run.v1.json": "./schema/harness-run.v1.json",
     "./schema/harness-runtime-probe.v1.json": "./schema/harness-runtime-probe.v1.json",
@@ -50,6 +52,7 @@
     "schema/",
     "templates/",
     "CHANGELOG.md",
+    "EVALUATION_ADAPTERS.md",
     "LICENSE",
     "README.md",
     "RELEASE_SCOPE.md",
@@ -59,7 +62,7 @@
     "yaml": "^2.5.0"
   },
   "scripts": {
-    "test": "node --test test/cli.test.cjs",
+    "test": "node --test test/cli.test.cjs test/evaluation-adapters.test.mjs",
     "pack:smoke": "node scripts/pack-smoke.mjs",
     "prepublishOnly": "npm test && npm run pack:smoke"
   },

--- a/harness-core/schema/harness-evaluation.v1.json
+++ b/harness-core/schema/harness-evaluation.v1.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://agoragentic.com/schema/harness-evaluation.v1.json",
+  "title": "Agoragentic Harness Evaluation Evidence v1",
+  "description": "Hash-bound structural evidence derived from an external evaluation report. It is not scanner verification, certification, endorsement, or proof of vulnerability absence.",
+  "type": "object",
+  "required": [
+    "schema",
+    "evaluation_id",
+    "adapter",
+    "source_tools",
+    "source",
+    "configured_gate",
+    "findings",
+    "summary",
+    "result",
+    "evidence_hash",
+    "truth_boundary",
+    "authority_boundary"
+  ],
+  "properties": {
+    "schema": { "const": "agoragentic.harness.evaluation.v1" },
+    "evaluation_id": { "type": "string", "pattern": "^evaluation_[a-f0-9]{24}$" },
+    "adapter": {
+      "type": "object",
+      "required": ["name", "version"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "version": { "type": "string", "minLength": 1, "maxLength": 128 }
+      },
+      "additionalProperties": false
+    },
+    "source_tools": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 20,
+      "items": {
+        "type": "object",
+        "required": ["name", "version", "revision"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1, "maxLength": 128 },
+          "version": { "type": "string", "minLength": 1, "maxLength": 128 },
+          "revision": { "type": ["string", "null"], "maxLength": 128 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "source": {
+      "type": "object",
+      "required": ["analyzed_revision", "source_ref_hash", "input_hash", "source_license", "raw_input_retained"],
+      "properties": {
+        "analyzed_revision": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "source_ref_hash": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+        "input_hash": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+        "source_license": { "type": ["string", "null"], "maxLength": 128 },
+        "raw_input_retained": { "const": false }
+      },
+      "additionalProperties": false
+    },
+    "configured_gate": {
+      "type": "object",
+      "required": ["block_severities", "review_severities", "fail_on_advisory"],
+      "properties": {
+        "block_severities": { "$ref": "#/definitions/severityList" },
+        "review_severities": { "$ref": "#/definitions/severityList" },
+        "fail_on_advisory": { "type": "boolean" }
+      },
+      "additionalProperties": false
+    },
+    "findings": {
+      "type": "array",
+      "maxItems": 1000,
+      "items": { "$ref": "#/definitions/finding" }
+    },
+    "summary": {
+      "type": "object",
+      "required": ["total", "active", "suppressed", "advisory", "by_severity"],
+      "properties": {
+        "total": { "type": "integer", "minimum": 0 },
+        "active": { "type": "integer", "minimum": 0 },
+        "suppressed": { "type": "integer", "minimum": 0 },
+        "advisory": { "type": "integer", "minimum": 0 },
+        "by_severity": {
+          "type": "object",
+          "required": ["critical", "high", "medium", "low", "info"],
+          "properties": {
+            "critical": { "type": "integer", "minimum": 0 },
+            "high": { "type": "integer", "minimum": 0 },
+            "medium": { "type": "integer", "minimum": 0 },
+            "low": { "type": "integer", "minimum": 0 },
+            "info": { "type": "integer", "minimum": 0 }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "result": { "enum": ["pass", "review", "fail"] },
+    "evidence_hash": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+    "truth_boundary": {
+      "type": "object",
+      "required": [
+        "structural_parse_only",
+        "scanner_execution_verified",
+        "finding_accuracy_verified",
+        "vulnerability_absence_claimed",
+        "certification_claimed",
+        "endorsement_claimed"
+      ],
+      "properties": {
+        "structural_parse_only": { "const": true },
+        "scanner_execution_verified": { "const": false },
+        "finding_accuracy_verified": { "const": false },
+        "vulnerability_absence_claimed": { "const": false },
+        "certification_claimed": { "const": false },
+        "endorsement_claimed": { "const": false }
+      },
+      "additionalProperties": false
+    },
+    "authority_boundary": {
+      "type": "object",
+      "required": ["execute_tools", "deploy", "publish", "spend", "mutate_trust", "bypass_owner_review"],
+      "properties": {
+        "execute_tools": { "const": false },
+        "deploy": { "const": false },
+        "publish": { "const": false },
+        "spend": { "const": false },
+        "mutate_trust": { "const": false },
+        "bypass_owner_review": { "const": false }
+      },
+      "additionalProperties": false
+    }
+  },
+  "definitions": {
+    "severity": { "enum": ["critical", "high", "medium", "low", "info"] },
+    "severityList": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": { "$ref": "#/definitions/severity" }
+    },
+    "finding": {
+      "type": "object",
+      "required": [
+        "finding_id",
+        "producer_index",
+        "rule_id",
+        "severity",
+        "category",
+        "advisory",
+        "status",
+        "suppression_kind",
+        "location",
+        "message_hash",
+        "raw_message_retained",
+        "raw_snippet_retained"
+      ],
+      "properties": {
+        "finding_id": { "type": "string", "pattern": "^finding_[a-f0-9]{24}$" },
+        "producer_index": { "type": "integer", "minimum": 0, "maximum": 19 },
+        "rule_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "severity": { "$ref": "#/definitions/severity" },
+        "category": { "type": ["string", "null"], "maxLength": 128 },
+        "advisory": { "type": "boolean" },
+        "status": { "enum": ["active", "suppressed"] },
+        "suppression_kind": { "type": ["string", "null"], "maxLength": 128 },
+        "location": {
+          "type": "object",
+          "required": ["path_ref_hash", "line", "column", "raw_path_retained"],
+          "properties": {
+            "path_ref_hash": { "type": ["string", "null"], "pattern": "^sha256:[a-f0-9]{64}$" },
+            "line": { "type": ["integer", "null"], "minimum": 0 },
+            "column": { "type": ["integer", "null"], "minimum": 0 },
+            "raw_path_retained": { "const": false }
+          },
+          "additionalProperties": false
+        },
+        "message_hash": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+        "raw_message_retained": { "const": false },
+        "raw_snippet_retained": { "const": false }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/harness-core/schema/local-receipt.v1.json
+++ b/harness-core/schema/local-receipt.v1.json
@@ -28,6 +28,34 @@
       "required": ["agent_name", "primary_goal", "proof_status", "local_artifacts"],
       "additionalProperties": true
     },
+    "evaluations": {
+      "type": "array",
+      "items": { "$ref": "https://agoragentic.com/schema/harness-evaluation.v1.json" }
+    },
+    "evaluation_summary": {
+      "type": "object",
+      "required": [
+        "schema",
+        "result",
+        "evaluation_count",
+        "finding_count",
+        "active_finding_count",
+        "suppressed_finding_count",
+        "blocks_listing_readiness",
+        "certification_claimed"
+      ],
+      "properties": {
+        "schema": { "const": "agoragentic.harness.evaluation-summary.v1" },
+        "result": { "enum": ["pass", "review", "fail"] },
+        "evaluation_count": { "type": "integer", "minimum": 1 },
+        "finding_count": { "type": "integer", "minimum": 0 },
+        "active_finding_count": { "type": "integer", "minimum": 0 },
+        "suppressed_finding_count": { "type": "integer", "minimum": 0 },
+        "blocks_listing_readiness": { "type": "boolean" },
+        "certification_claimed": { "const": false }
+      },
+      "additionalProperties": false
+    },
     "receipt_boundary": {
       "type": "object",
       "required": ["router_invocation_created", "x402_payment_attempted", "marketplace_published", "hosted_runtime_provisioned", "memory_written"],

--- a/harness-core/src/evaluations/index.mjs
+++ b/harness-core/src/evaluations/index.mjs
@@ -1,0 +1,537 @@
+import { createHash } from 'node:crypto';
+
+export const HARNESS_EVALUATION_SCHEMA = 'agoragentic.harness.evaluation.v1';
+export const SUPPORTED_IMPECCABLE_VERSION = '3.5.0';
+export const SUPPORTED_IMPECCABLE_REVISION = '5d10bc842cbccd2ae7d3a88296d87d3be0b125b3';
+export const SUPPORTED_SARIF_VERSION = '2.1.0';
+
+const MAX_FINDINGS = 1000;
+const MAX_TOOLS = 20;
+const SEVERITIES = new Set(['critical', 'high', 'medium', 'low', 'info']);
+const IDENTIFIER = /^[A-Za-z0-9][A-Za-z0-9._:/@-]{0,127}$/;
+
+export function normalizeImpeccableFindings(input, options = {}) {
+  const payload = Array.isArray(input) ? { findings: input } : requireObject(input, 'Impeccable payload');
+  const version = requireExact(
+    options.producer_version,
+    SUPPORTED_IMPECCABLE_VERSION,
+    'Unsupported Impeccable version',
+  );
+  const revision = requireExact(
+    options.source_revision,
+    SUPPORTED_IMPECCABLE_REVISION,
+    'Unsupported Impeccable source revision',
+  );
+  const findings = requireArray(payload.findings, 'Impeccable findings');
+  const suppressed = payload.suppressed_findings === undefined
+    ? []
+    : requireArray(payload.suppressed_findings, 'Impeccable suppressed_findings');
+
+  return buildEvaluation({
+    adapter: { name: 'impeccable-findings', version: '1' },
+    source_tools: [{ name: 'impeccable', version, revision }],
+    analyzed_revision: options.analyzed_revision,
+    source_ref: options.source_ref,
+    gate: options.gate,
+    source_payload: payload,
+    findings: [
+      ...findings.map((finding) => normalizeImpeccableFinding(finding, false)),
+      ...suppressed.map((finding) => normalizeImpeccableFinding(finding, true)),
+    ],
+    source_license: 'Apache-2.0',
+  });
+}
+
+export function normalizeSarifReport(input, options = {}) {
+  const report = requireObject(input, 'SARIF report');
+  if (report.version !== SUPPORTED_SARIF_VERSION) {
+    throw new TypeError(`Unsupported SARIF version: ${String(report.version || 'missing')}`);
+  }
+  const runs = requireArray(report.runs, 'SARIF runs');
+  if (runs.length === 0 || runs.length > MAX_TOOLS) {
+    throw new RangeError(`SARIF runs must contain between 1 and ${MAX_TOOLS} entries`);
+  }
+
+  const sourceTools = runs.map((run, index) => {
+    const driver = requireObject(run?.tool?.driver, `SARIF run ${index} tool.driver`);
+    return {
+      name: safeIdentifier(driver.name, `SARIF run ${index} tool name`),
+      version: safeIdentifier(
+        driver.semanticVersion || driver.version || 'unknown',
+        `SARIF run ${index} tool version`,
+      ),
+      revision: safeOptionalIdentifier(driver.dottedQuadFileVersion || null, `SARIF run ${index} tool revision`),
+    };
+  });
+
+  const findings = [];
+  for (let runIndex = 0; runIndex < runs.length; runIndex += 1) {
+    const results = runs[runIndex].results === undefined
+      ? []
+      : requireArray(runs[runIndex].results, `SARIF run ${runIndex} results`);
+    for (const result of results) {
+      findings.push(normalizeSarifFinding(result, runIndex));
+      if (findings.length > MAX_FINDINGS) {
+        throw new RangeError(`Evaluation evidence cannot exceed ${MAX_FINDINGS} findings`);
+      }
+    }
+  }
+
+  return buildEvaluation({
+    adapter: { name: 'sarif', version: SUPPORTED_SARIF_VERSION },
+    source_tools: sourceTools,
+    analyzed_revision: options.analyzed_revision,
+    source_ref: options.source_ref,
+    gate: options.gate,
+    source_payload: report,
+    findings,
+    source_license: options.source_license || null,
+  });
+}
+
+export function attachEvaluationEvidenceToReceipt(receipt, entries) {
+  const source = Array.isArray(entries) ? entries : [entries];
+  if (source.length === 0) throw new TypeError('At least one evaluation entry is required');
+  const attached = structuredClone(requireObject(receipt, 'Harness receipt'));
+  if (attached.schema !== 'agoragentic.harness.local-receipt.v1') {
+    throw new TypeError('Evaluation evidence can only attach to a Harness local receipt');
+  }
+
+  const existing = Array.isArray(attached.evaluations)
+    ? attached.evaluations.map(verifyHarnessEvaluation)
+    : [];
+  attached.evaluations = [...existing, ...source.map(verifyHarnessEvaluation)];
+  attached.evaluation_summary = summarizeHarnessEvaluations(attached.evaluations);
+  attached.evidence = {
+    ...requireObject(attached.evidence, 'Harness receipt evidence'),
+    evaluation_count: attached.evaluations.length,
+    evaluation_evidence_hashes: attached.evaluations.map((entry) => entry.evidence_hash),
+  };
+  if (attached.evaluation_summary.result === 'fail') attached.status = 'blocked';
+  return attached;
+}
+
+export function summarizeHarnessEvaluations(entries = []) {
+  const verified = requireArray(entries, 'Evaluation entries').map(verifyHarnessEvaluation);
+  const result = verified.some((entry) => entry.result === 'fail')
+    ? 'fail'
+    : verified.some((entry) => entry.result === 'review')
+      ? 'review'
+      : 'pass';
+  return {
+    schema: 'agoragentic.harness.evaluation-summary.v1',
+    result,
+    evaluation_count: verified.length,
+    finding_count: verified.reduce((sum, entry) => sum + entry.summary.total, 0),
+    active_finding_count: verified.reduce((sum, entry) => sum + entry.summary.active, 0),
+    suppressed_finding_count: verified.reduce((sum, entry) => sum + entry.summary.suppressed, 0),
+    blocks_listing_readiness: result === 'fail',
+    certification_claimed: false,
+  };
+}
+
+export function computeHarnessEvaluationHash(evaluation) {
+  const clone = structuredClone(requireObject(evaluation, 'Evaluation evidence'));
+  clone.evidence_hash = null;
+  return hashValue(clone);
+}
+
+export function verifyHarnessEvaluation(evaluation) {
+  const entry = requireObject(evaluation, 'Evaluation evidence');
+  if (entry.schema !== HARNESS_EVALUATION_SCHEMA) {
+    throw new TypeError(`Evaluation evidence must use ${HARNESS_EVALUATION_SCHEMA}`);
+  }
+  if (entry.evidence_hash !== computeHarnessEvaluationHash(entry)) {
+    throw new TypeError('Evaluation evidence hash mismatch');
+  }
+  assertExactKeys(entry, [
+    'schema', 'evaluation_id', 'adapter', 'source_tools', 'source', 'configured_gate',
+    'findings', 'summary', 'result', 'evidence_hash', 'truth_boundary', 'authority_boundary',
+  ], 'Evaluation evidence');
+  safeIdentifier(entry.evaluation_id, 'evaluation_id');
+  validateAdapter(entry.adapter);
+  validateSourceTools(entry.source_tools);
+  validateSource(entry.source);
+  const gate = normalizeGate(entry.configured_gate);
+  if (stableStringify(gate) !== stableStringify(entry.configured_gate)) {
+    throw new TypeError('Evaluation gate is not canonical');
+  }
+  const findings = requireArray(entry.findings, 'Evaluation findings');
+  if (findings.length > MAX_FINDINGS) throw new RangeError(`Evaluation evidence cannot exceed ${MAX_FINDINGS} findings`);
+  for (const finding of findings) {
+    if (finding.producer_index >= entry.source_tools.length) {
+      throw new TypeError('finding producer_index exceeds source_tools');
+    }
+    validateCanonicalFinding(finding);
+  }
+  const summary = summarizeFindings(findings);
+  if (stableStringify(summary) !== stableStringify(entry.summary)) {
+    throw new TypeError('Evaluation summary is not canonical');
+  }
+  const expectedResult = decideResult(findings, gate);
+  if (entry.result !== expectedResult) throw new TypeError('Evaluation result does not match configured gate');
+  const expectedId = buildEvaluationId(entry.adapter, entry.source_tools, entry.source, findings, gate);
+  if (entry.evaluation_id !== expectedId) throw new TypeError('evaluation_id is not canonical');
+  validateBoundaries(entry);
+  return structuredClone(entry);
+}
+
+function buildEvaluation({
+  adapter,
+  source_tools,
+  analyzed_revision,
+  source_ref,
+  gate,
+  source_payload,
+  findings,
+  source_license,
+}) {
+  if (findings.length > MAX_FINDINGS) {
+    throw new RangeError(`Evaluation evidence cannot exceed ${MAX_FINDINGS} findings`);
+  }
+  const normalizedGate = normalizeGate(gate);
+  const source = {
+    analyzed_revision: safeIdentifier(analyzed_revision, 'analyzed_revision'),
+    source_ref_hash: hashString(requireString(source_ref, 'source_ref')),
+    input_hash: hashValue(source_payload),
+    source_license: source_license ? safeIdentifier(source_license, 'source_license') : null,
+    raw_input_retained: false,
+  };
+  const summary = summarizeFindings(findings);
+  const record = {
+    schema: HARNESS_EVALUATION_SCHEMA,
+    evaluation_id: buildEvaluationId(adapter, source_tools, source, findings, normalizedGate),
+    adapter,
+    source_tools,
+    source,
+    configured_gate: normalizedGate,
+    findings,
+    summary,
+    result: decideResult(findings, normalizedGate),
+    evidence_hash: null,
+    truth_boundary: {
+      structural_parse_only: true,
+      scanner_execution_verified: false,
+      finding_accuracy_verified: false,
+      vulnerability_absence_claimed: false,
+      certification_claimed: false,
+      endorsement_claimed: false,
+    },
+    authority_boundary: {
+      execute_tools: false,
+      deploy: false,
+      publish: false,
+      spend: false,
+      mutate_trust: false,
+      bypass_owner_review: false,
+    },
+  };
+  record.evidence_hash = computeHarnessEvaluationHash(record);
+  return verifyHarnessEvaluation(record);
+}
+
+function normalizeImpeccableFinding(input, forcedSuppressed) {
+  const finding = requireObject(input, 'Impeccable finding');
+  return createFinding({
+    producer_index: 0,
+    rule_id: finding.antipattern,
+    severity: normalizeSeverity(finding.severity || 'warning'),
+    category: finding.category || null,
+    advisory: finding.advisory === true,
+    suppressed: forcedSuppressed || finding.suppressed === true,
+    suppression_kind: forcedSuppressed || finding.suppressed === true ? 'external_or_inline' : null,
+    location: {
+      path: finding.file,
+      line: finding.line,
+      column: null,
+    },
+    message: [finding.name, finding.description, finding.snippet].filter(Boolean).join('\n'),
+  });
+}
+
+function normalizeSarifFinding(input, producerIndex) {
+  const result = requireObject(input, 'SARIF result');
+  const location = result.locations?.[0]?.physicalLocation || {};
+  const region = location.region || {};
+  const suppressions = Array.isArray(result.suppressions) ? result.suppressions : [];
+  return createFinding({
+    producer_index: producerIndex,
+    rule_id: result.ruleId || `rule-index-${Number.isInteger(result.ruleIndex) ? result.ruleIndex : 'unknown'}`,
+    severity: normalizeSarifSeverity(result.level),
+    category: result.properties?.category || null,
+    advisory: result.properties?.advisory === true || result.level === 'note',
+    suppressed: suppressions.length > 0,
+    suppression_kind: suppressions.length > 0
+      ? safeOptionalIdentifier(suppressions[0].kind || 'external', 'SARIF suppression kind')
+      : null,
+    location: {
+      path: location.artifactLocation?.uri,
+      line: region.startLine,
+      column: region.startColumn,
+    },
+    message: result.message?.text || result.message?.markdown || '',
+  });
+}
+
+function createFinding({
+  producer_index,
+  rule_id,
+  severity,
+  category,
+  advisory,
+  suppressed,
+  suppression_kind,
+  location,
+  message,
+}) {
+  const normalizedRule = safeIdentifier(rule_id, 'finding rule_id');
+  const pathRef = location.path ? hashString(String(location.path)) : null;
+  const messageHash = hashString(String(message || ''));
+  const record = {
+    finding_id: '',
+    producer_index,
+    rule_id: normalizedRule,
+    severity,
+    category: category ? safeIdentifier(category, 'finding category') : null,
+    advisory: Boolean(advisory),
+    status: suppressed ? 'suppressed' : 'active',
+    suppression_kind: suppression_kind || null,
+    location: {
+      path_ref_hash: pathRef,
+      line: boundedInteger(location.line, 'finding line'),
+      column: boundedInteger(location.column, 'finding column'),
+      raw_path_retained: false,
+    },
+    message_hash: messageHash,
+    raw_message_retained: false,
+    raw_snippet_retained: false,
+  };
+  record.finding_id = `finding_${hashValue({ ...record, finding_id: null }).slice(7, 31)}`;
+  return record;
+}
+
+function normalizeGate(input = {}) {
+  const gate = input === undefined ? {} : requireObject(input, 'Evaluation gate');
+  const block = normalizeSeverityList(gate.block_severities ?? ['critical', 'high'], 'block_severities');
+  const review = normalizeSeverityList(gate.review_severities ?? ['medium'], 'review_severities');
+  if (block.some((severity) => review.includes(severity))) {
+    throw new TypeError('block_severities and review_severities must not overlap');
+  }
+  return {
+    block_severities: block,
+    review_severities: review,
+    fail_on_advisory: gate.fail_on_advisory === true,
+  };
+}
+
+function summarizeFindings(findings) {
+  const bySeverity = { critical: 0, high: 0, medium: 0, low: 0, info: 0 };
+  let active = 0;
+  let suppressed = 0;
+  let advisory = 0;
+  for (const finding of findings) {
+    bySeverity[finding.severity] += 1;
+    if (finding.status === 'suppressed') suppressed += 1;
+    else active += 1;
+    if (finding.advisory) advisory += 1;
+  }
+  return {
+    total: findings.length,
+    active,
+    suppressed,
+    advisory,
+    by_severity: bySeverity,
+  };
+}
+
+function decideResult(findings, gate) {
+  const active = findings.filter((finding) => finding.status === 'active');
+  const gateEligible = active.filter((finding) => gate.fail_on_advisory || !finding.advisory);
+  if (gateEligible.some((finding) => gate.block_severities.includes(finding.severity))) return 'fail';
+  if (gateEligible.some((finding) => gate.review_severities.includes(finding.severity))) return 'review';
+  return 'pass';
+}
+
+function validateCanonicalFinding(finding) {
+  const entry = requireObject(finding, 'Evaluation finding');
+  assertExactKeys(entry, [
+    'finding_id', 'producer_index', 'rule_id', 'severity', 'category', 'advisory',
+    'status', 'suppression_kind', 'location', 'message_hash', 'raw_message_retained',
+    'raw_snippet_retained',
+  ], 'Evaluation finding');
+  safeIdentifier(entry.finding_id, 'finding_id');
+  if (!Number.isInteger(entry.producer_index) || entry.producer_index < 0 || entry.producer_index >= MAX_TOOLS) {
+    throw new TypeError('finding producer_index is invalid');
+  }
+  safeIdentifier(entry.rule_id, 'finding rule_id');
+  if (!SEVERITIES.has(entry.severity)) throw new TypeError('finding severity is invalid');
+  if (entry.category !== null) safeIdentifier(entry.category, 'finding category');
+  if (typeof entry.advisory !== 'boolean') throw new TypeError('finding advisory must be boolean');
+  if (!['active', 'suppressed'].includes(entry.status)) throw new TypeError('finding status is invalid');
+  if (entry.status === 'suppressed' && !entry.suppression_kind) throw new TypeError('suppressed finding requires suppression_kind');
+  if (entry.status === 'active' && entry.suppression_kind !== null) throw new TypeError('active finding cannot carry suppression_kind');
+  if (entry.suppression_kind !== null) safeIdentifier(entry.suppression_kind, 'suppression_kind');
+  validateLocation(entry.location);
+  requireSha256(entry.message_hash, 'message_hash');
+  if (entry.raw_message_retained !== false || entry.raw_snippet_retained !== false) {
+    throw new TypeError('raw evaluation details must not be retained');
+  }
+  const expectedId = `finding_${hashValue({ ...entry, finding_id: null }).slice(7, 31)}`;
+  if (entry.finding_id !== expectedId) throw new TypeError('finding_id is not canonical');
+}
+
+function validateAdapter(adapter) {
+  const entry = requireObject(adapter, 'Evaluation adapter');
+  assertExactKeys(entry, ['name', 'version'], 'Evaluation adapter');
+  safeIdentifier(entry.name, 'adapter name');
+  safeIdentifier(entry.version, 'adapter version');
+}
+
+function validateSourceTools(tools) {
+  const entries = requireArray(tools, 'source_tools');
+  if (entries.length === 0 || entries.length > MAX_TOOLS) throw new RangeError(`source_tools must contain 1-${MAX_TOOLS} entries`);
+  for (const tool of entries) {
+    const entry = requireObject(tool, 'source tool');
+    assertExactKeys(entry, ['name', 'version', 'revision'], 'source tool');
+    safeIdentifier(entry.name, 'source tool name');
+    safeIdentifier(entry.version, 'source tool version');
+    if (entry.revision !== null) safeIdentifier(entry.revision, 'source tool revision');
+  }
+}
+
+function validateSource(source) {
+  const entry = requireObject(source, 'Evaluation source');
+  assertExactKeys(entry, [
+    'analyzed_revision', 'source_ref_hash', 'input_hash', 'source_license', 'raw_input_retained',
+  ], 'Evaluation source');
+  safeIdentifier(entry.analyzed_revision, 'analyzed_revision');
+  requireSha256(entry.source_ref_hash, 'source_ref_hash');
+  requireSha256(entry.input_hash, 'input_hash');
+  if (entry.source_license !== null) safeIdentifier(entry.source_license, 'source_license');
+  if (entry.raw_input_retained !== false) throw new TypeError('raw evaluation input must not be retained');
+}
+
+function validateLocation(location) {
+  const entry = requireObject(location, 'finding location');
+  assertExactKeys(entry, ['path_ref_hash', 'line', 'column', 'raw_path_retained'], 'finding location');
+  if (entry.path_ref_hash !== null) requireSha256(entry.path_ref_hash, 'path_ref_hash');
+  boundedInteger(entry.line, 'finding line');
+  boundedInteger(entry.column, 'finding column');
+  if (entry.raw_path_retained !== false) throw new TypeError('raw finding path must not be retained');
+}
+
+function validateBoundaries(entry) {
+  const truth = requireObject(entry.truth_boundary, 'truth_boundary');
+  const authority = requireObject(entry.authority_boundary, 'authority_boundary');
+  assertExactKeys(truth, [
+    'structural_parse_only', 'scanner_execution_verified', 'finding_accuracy_verified',
+    'vulnerability_absence_claimed', 'certification_claimed', 'endorsement_claimed',
+  ], 'truth_boundary');
+  assertExactKeys(authority, [
+    'execute_tools', 'deploy', 'publish', 'spend', 'mutate_trust', 'bypass_owner_review',
+  ], 'authority_boundary');
+  for (const key of [
+    'structural_parse_only', 'scanner_execution_verified', 'finding_accuracy_verified',
+    'vulnerability_absence_claimed', 'certification_claimed', 'endorsement_claimed',
+  ]) {
+    if (typeof truth[key] !== 'boolean') throw new TypeError(`truth_boundary.${key} must be boolean`);
+  }
+  if (truth.structural_parse_only !== true || Object.entries(truth).some(([key, value]) => key !== 'structural_parse_only' && value !== false)) {
+    throw new TypeError('Evaluation truth boundary overclaims verification');
+  }
+  for (const key of ['execute_tools', 'deploy', 'publish', 'spend', 'mutate_trust', 'bypass_owner_review']) {
+    if (authority[key] !== false) throw new TypeError(`authority_boundary.${key} must remain false`);
+  }
+}
+
+function normalizeSeverityList(values, label) {
+  const list = requireArray(values, label).map((value) => normalizeSeverity(value));
+  return [...new Set(list)].sort();
+}
+
+function normalizeSeverity(value) {
+  const normalized = String(value || '').trim().toLowerCase();
+  const mapped = {
+    error: 'high',
+    warning: 'medium',
+    warn: 'medium',
+    note: 'low',
+    none: 'info',
+    informational: 'info',
+  }[normalized] || normalized;
+  if (!SEVERITIES.has(mapped)) throw new TypeError(`Unsupported finding severity: ${normalized || 'missing'}`);
+  return mapped;
+}
+
+function normalizeSarifSeverity(value) {
+  return normalizeSeverity(value || 'warning');
+}
+
+function safeIdentifier(value, label) {
+  const normalized = requireString(value, label).trim();
+  if (!IDENTIFIER.test(normalized)) throw new TypeError(`${label} must be a bounded public-safe identifier`);
+  return normalized;
+}
+
+function safeOptionalIdentifier(value, label) {
+  return value === null || value === undefined || value === '' ? null : safeIdentifier(value, label);
+}
+
+function boundedInteger(value, label) {
+  if (value === null || value === undefined || value === '') return null;
+  const number = Number(value);
+  if (!Number.isInteger(number) || number < 0 || number > 1_000_000_000) {
+    throw new TypeError(`${label} must be a non-negative bounded integer`);
+  }
+  return number;
+}
+
+function requireString(value, label) {
+  if (typeof value !== 'string' || value.length === 0 || value.length > 4096) {
+    throw new TypeError(`${label} must be a non-empty bounded string`);
+  }
+  return value;
+}
+
+function requireObject(value, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new TypeError(`${label} must be an object`);
+  return value;
+}
+
+function requireArray(value, label) {
+  if (!Array.isArray(value)) throw new TypeError(`${label} must be an array`);
+  return value;
+}
+
+function requireExact(value, expected, label) {
+  if (value !== expected) throw new TypeError(`${label}; expected ${expected}`);
+  return value;
+}
+
+function requireSha256(value, label) {
+  if (!/^sha256:[a-f0-9]{64}$/.test(String(value || ''))) throw new TypeError(`${label} must be a sha256 reference`);
+}
+
+function assertExactKeys(value, expected, label) {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (stableStringify(actual) !== stableStringify(wanted)) throw new TypeError(`${label} contains missing or unknown fields`);
+}
+
+function hashString(value) {
+  return `sha256:${createHash('sha256').update(String(value), 'utf8').digest('hex')}`;
+}
+
+function hashValue(value) {
+  return hashString(stableStringify(value));
+}
+
+function buildEvaluationId(adapter, sourceTools, source, findings, gate) {
+  return `evaluation_${hashValue({ adapter, source_tools: sourceTools, source, findings, gate }).slice(7, 31)}`;
+}
+
+function stableStringify(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(',')}}`;
+}

--- a/harness-core/src/index.mjs
+++ b/harness-core/src/index.mjs
@@ -52,6 +52,18 @@ export { decideImprovement, improvementCandidateStatus, listImprovements, ownerI
 export { budgetPolicyStatus, createBudgetLimitMiddleware, evaluateBudgetUsage, initBudgetPolicy } from './middleware/budget-limit.mjs';
 export { createRetryPolicyMiddleware, evaluateRetryPolicy, initRetryPolicy, retryPolicyStatus } from './middleware/retry-policy.mjs';
 export { attachWorktreeSession, detachWorktreeSession, getWorktreeSessionStatus } from './kernel/worktree-session.mjs';
+export {
+  HARNESS_EVALUATION_SCHEMA,
+  SUPPORTED_IMPECCABLE_REVISION,
+  SUPPORTED_IMPECCABLE_VERSION,
+  SUPPORTED_SARIF_VERSION,
+  attachEvaluationEvidenceToReceipt,
+  computeHarnessEvaluationHash,
+  normalizeImpeccableFindings,
+  normalizeSarifReport,
+  summarizeHarnessEvaluations,
+  verifyHarnessEvaluation,
+} from './evaluations/index.mjs';
 
 export async function initProject({ dir = process.cwd(), template = 'codebase_maintenance', force = false } = {}) {
   const target = path.resolve(dir);

--- a/harness-core/test/evaluation-adapters.test.mjs
+++ b/harness-core/test/evaluation-adapters.test.mjs
@@ -1,0 +1,154 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import {
+  SUPPORTED_IMPECCABLE_REVISION,
+  attachEvaluationEvidenceToReceipt,
+  computeHarnessEvaluationHash,
+  normalizeImpeccableFindings,
+  normalizeSarifReport,
+  verifyHarnessEvaluation,
+} from '../src/evaluations/index.mjs';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const fixtures = path.join(root, 'test', 'fixtures', 'evaluations');
+const analyzedRevision = '0123456789abcdef0123456789abcdef01234567';
+
+async function fixture(name) {
+  return JSON.parse(await readFile(path.join(fixtures, name), 'utf8'));
+}
+
+function impeccableOptions(overrides = {}) {
+  return {
+    producer_version: '3.5.0',
+    source_revision: SUPPORTED_IMPECCABLE_REVISION,
+    analyzed_revision: analyzedRevision,
+    source_ref: 'reports/impeccable.json',
+    ...overrides,
+  };
+}
+
+function receipt() {
+  return {
+    schema: 'agoragentic.harness.local-receipt.v1',
+    receipt_id: 'local_receipt_fixture',
+    proof_id: 'proof_fixture',
+    created_at: '2026-08-08T00:00:00.000Z',
+    mode: 'local_no_spend_receipt',
+    status: 'recorded',
+    spend: { amount_usdc: 0, settlement_network: 'none', settlement_status: 'not_applicable' },
+    evidence: {
+      agent_name: 'fixture-agent',
+      primary_goal: 'test evaluation evidence',
+      proof_status: 'passed',
+      local_artifacts: ['agent.yaml'],
+    },
+    receipt_boundary: {
+      router_invocation_created: false,
+      x402_payment_attempted: false,
+      marketplace_published: false,
+      hosted_runtime_provisioned: false,
+      memory_written: false,
+    },
+  };
+}
+
+test('Impeccable advisory-only input deterministically passes without retaining raw details', async () => {
+  const input = await fixture('impeccable-pass.json');
+  const first = normalizeImpeccableFindings(input, impeccableOptions());
+  const second = normalizeImpeccableFindings(input, impeccableOptions());
+  assert.deepEqual(first, second);
+  assert.equal(first.result, 'pass');
+  assert.equal(first.summary.advisory, 1);
+  assert.equal(first.evidence_hash, computeHarnessEvaluationHash(first));
+  assert.deepEqual(verifyHarnessEvaluation(first), first);
+  const serialized = JSON.stringify(first);
+  assert.doesNotMatch(serialized, /private design excerpt/);
+  assert.doesNotMatch(serialized, /src\/page\.css/);
+});
+
+test('configured Impeccable failure blocks the receipt while retaining suppressed evidence', async () => {
+  const input = await fixture('impeccable-fail.json');
+  const evaluation = normalizeImpeccableFindings(input, impeccableOptions());
+  assert.equal(evaluation.result, 'fail');
+  assert.equal(evaluation.summary.active, 1);
+  assert.equal(evaluation.summary.suppressed, 1);
+  assert.equal(evaluation.findings[1].status, 'suppressed');
+  const attached = attachEvaluationEvidenceToReceipt(receipt(), evaluation);
+  assert.equal(attached.status, 'blocked');
+  assert.equal(attached.evaluation_summary.blocks_listing_readiness, true);
+  assert.equal(attached.spend.amount_usdc, 0);
+  assert.equal(attached.evaluations[0].authority_boundary.spend, false);
+  const serialized = JSON.stringify(attached);
+  assert.doesNotMatch(serialized, /API_KEY=must-not-escape/);
+  assert.doesNotMatch(serialized, /C:\/private\/project/);
+  assert.doesNotMatch(serialized, /private suppressed excerpt/);
+});
+
+test('SARIF warning produces review and preserves scanner identity plus suppression state', async () => {
+  const input = await fixture('sarif-review.json');
+  const evaluation = normalizeSarifReport(input, {
+    analyzed_revision: analyzedRevision,
+    source_ref: 'reports/security.sarif',
+  });
+  assert.equal(evaluation.result, 'review');
+  assert.equal(evaluation.source_tools[0].name, 'example-sarif-scanner');
+  assert.equal(evaluation.source_tools[0].version, '1.2.3');
+  assert.equal(evaluation.summary.active, 1);
+  assert.equal(evaluation.summary.suppressed, 1);
+  assert.equal(evaluation.findings[1].status, 'suppressed');
+  const serialized = JSON.stringify(evaluation);
+  assert.doesNotMatch(serialized, /private implementation detail/);
+  assert.doesNotMatch(serialized, /src\/example\.js/);
+});
+
+test('unsupported versions and tampered evidence fail closed', async () => {
+  const input = await fixture('impeccable-pass.json');
+  assert.throws(
+    () => normalizeImpeccableFindings(input, impeccableOptions({ producer_version: '4.0.0' })),
+    /Unsupported Impeccable version/,
+  );
+  const sarif = await fixture('sarif-review.json');
+  sarif.version = '2.2.0';
+  assert.throws(() => normalizeSarifReport(sarif, {
+    analyzed_revision: analyzedRevision,
+    source_ref: 'reports/security.sarif',
+  }), /Unsupported SARIF version/);
+  const evaluation = normalizeImpeccableFindings(input, impeccableOptions());
+  evaluation.result = 'fail';
+  assert.throws(() => verifyHarnessEvaluation(evaluation), /hash mismatch/);
+
+  const rehashed = normalizeImpeccableFindings(input, impeccableOptions());
+  rehashed.source_tools[0].version = '3.5.1';
+  rehashed.evidence_hash = computeHarnessEvaluationHash(rehashed);
+  assert.throws(() => verifyHarnessEvaluation(rehashed), /evaluation_id is not canonical/);
+
+  const invalidProducer = normalizeImpeccableFindings(input, impeccableOptions());
+  invalidProducer.findings[0].producer_index = 1;
+  invalidProducer.evidence_hash = computeHarnessEvaluationHash(invalidProducer);
+  assert.throws(() => verifyHarnessEvaluation(invalidProducer), /producer_index exceeds source_tools/);
+});
+
+test('evaluation and extended receipt schemas accept canonical evidence', async () => {
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const evaluationSchema = JSON.parse(await readFile(path.join(root, 'schema', 'harness-evaluation.v1.json'), 'utf8'));
+  const receiptSchema = JSON.parse(await readFile(path.join(root, 'schema', 'local-receipt.v1.json'), 'utf8'));
+  const evaluation = normalizeImpeccableFindings(await fixture('impeccable-pass.json'), impeccableOptions());
+  const attached = attachEvaluationEvidenceToReceipt(receipt(), evaluation);
+  ajv.addSchema(evaluationSchema);
+  assert.equal(ajv.getSchema(evaluationSchema.$id)(evaluation), true);
+  assert.equal(ajv.compile(receiptSchema)(attached), true);
+});
+
+test('package exports the adapter and schema surfaces', async () => {
+  const pkg = JSON.parse(await readFile(path.join(root, 'package.json'), 'utf8'));
+  assert.equal(pkg.exports['./evaluations'], './src/evaluations/index.mjs');
+  assert.equal(pkg.exports['./schema/harness-evaluation.v1.json'], './schema/harness-evaluation.v1.json');
+  assert.ok(pkg.files.includes('EVALUATION_ADAPTERS.md'));
+  assert.match(pkg.scripts.test, /evaluation-adapters\.test\.mjs/);
+});

--- a/harness-core/test/fixtures/evaluations/impeccable-fail.json
+++ b/harness-core/test/fixtures/evaluations/impeccable-fail.json
@@ -1,0 +1,26 @@
+{
+  "findings": [
+    {
+      "antipattern": "inaccessible-contrast",
+      "name": "Contrast failure",
+      "description": "Objective configured failure",
+      "severity": "error",
+      "category": "accessibility",
+      "file": "C:/private/project/src/page.css",
+      "line": 12,
+      "snippet": "API_KEY=must-not-escape"
+    }
+  ],
+  "suppressed_findings": [
+    {
+      "antipattern": "legacy-spacing",
+      "name": "Suppressed spacing finding",
+      "description": "Visible only as bounded evidence",
+      "severity": "warning",
+      "category": "layout",
+      "file": "src/legacy.css",
+      "line": 4,
+      "snippet": "private suppressed excerpt"
+    }
+  ]
+}

--- a/harness-core/test/fixtures/evaluations/impeccable-pass.json
+++ b/harness-core/test/fixtures/evaluations/impeccable-pass.json
@@ -1,0 +1,15 @@
+{
+  "findings": [
+    {
+      "antipattern": "em-dash-overuse",
+      "name": "Em dash overuse",
+      "description": "Advisory typography note",
+      "severity": "warning",
+      "category": "type",
+      "file": "src/page.css",
+      "line": 8,
+      "snippet": "private design excerpt",
+      "advisory": true
+    }
+  ]
+}

--- a/harness-core/test/fixtures/evaluations/sarif-review.json
+++ b/harness-core/test/fixtures/evaluations/sarif-review.json
@@ -1,0 +1,35 @@
+{
+  "version": "2.1.0",
+  "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "example-sarif-scanner",
+          "semanticVersion": "1.2.3"
+        }
+      },
+      "results": [
+        {
+          "ruleId": "EXAMPLE-1",
+          "level": "warning",
+          "message": { "text": "Review this private implementation detail" },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "src/example.js" },
+                "region": { "startLine": 3, "startColumn": 5 }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "EXAMPLE-2",
+          "level": "error",
+          "message": { "text": "Suppressed private detail" },
+          "suppressions": [{ "kind": "inSource" }]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Closes #233.

## What changed
- adds strict, hash-bound Harness evaluation evidence and receipt attachment
- adds pinned Impeccable 3.5.0 / source-revision normalization without copying upstream code or skill text
- adds generic SARIF 2.1.0 normalization with scanner identity/version
- retains suppression state while excluding raw snippets, messages, paths, prompts, and tool output
- makes configured objective failures block the existing local receipt/listing-readiness path
- adds Node 20/22/24 CI, deterministic pass/fail/review fixtures, schema validation, tamper tests, and packed-artifact coverage

## Truth and authority boundary
These adapters parse supplied reports only. They do not execute scanners, verify scanner execution or finding accuracy, claim vulnerability absence/certification/endorsement, deploy, publish, spend, call providers, mutate trust, or bypass owner review.

## Validation
- npm test in harness-core: 15/15
- npm run pack:smoke
- node scripts/verify-integrations-json.js
- node scripts/verify-doc-links.mjs: 213 files
- node scripts/adapter-conformance-agent.mjs: 101 passed
- git diff --check