### PR TITLE
MCP v2 relay: pin stateless hosted transport

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -33,7 +33,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "agoragentic-mcp@1.3.6"
+        "agoragentic-mcp@2.0.0"
       ]
     }
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Bumped the canonical manifest from upstream `2.36.0` to `2.37.0` with 105 indexed surfaces and explicit HyperFrames provenance at upstream revision `9ec9e3a711531b3d45c30a1e2c3006df97dbe5cb`.
+- Prepared the unpublished `agoragentic-mcp@2.0.0` candidate: its remote leg pins stateless MCP `2026-07-28`, preserves the existing local stdio compatibility projection, sends bearer auth on every hosted request, and adds loopback-only v2 plus packed-install validation. npm publication and public registry promotion remain release-tag and owner-gated.
 - Bumped the canonical manifest from upstream `2.34.0` to `2.35.0` with 104 indexed surfaces and Crawl4AI machine discovery pointers.
 - Bumped the canonical manifest to `2.34.0` with 103 indexed surfaces and explicit gstack artifact-bridge provenance at upstream revision `94993f74012782fd94416dd44b8314f6363a13a4`.
 - Bumped the canonical manifest from upstream `2.32.0` to `2.33.0` with 102 indexed surfaces and explicit unpublished/fixture-only OpenCode package discovery.

--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ The hosted Triptych OS (Agent OS) control plane is not a downloadable npm packag
 | **[Node.js SDK source](./sdk/node/)** | `npm install agoragentic` | Node ≥ 16 |
 | **[Python SDK source](./sdk/python/)** | `pip install agoragentic` | Python ≥ 3.8 |
 | **[Agent OS CLI source](./sdk/agent-os-cli/)** | `npx agoragentic-os@latest` | Node ≥ 18 |
-| **MCP Server** | `npx agoragentic-mcp` | Node ≥ 18 |
-| **Agent Client Protocol (ACP) Adapter** | `npx agoragentic-mcp --acp` | Node ≥ 18 |
+| **MCP Server** | `npx agoragentic-mcp` | Node ≥ 20 |
+| **Agent Client Protocol (ACP) Adapter** | `npx agoragentic-mcp --acp` | Node ≥ 20 |
 | **Micro ECF** | `npx agoragentic-micro-ecf@latest plan --dir .`, then `npx agoragentic-micro-ecf@latest install --dir . --yes` only after explicit approval | Node ≥ 18 |
 | **Harness Core** | `npx agoragentic-harness-core@latest init` | Node ≥ 18 |
 | **OpenCode Harness Plugin** | `cd opencode && npm ci` | Node ≥ 18; exact OpenCode 1.18.15 contract fixture only |
@@ -186,7 +186,7 @@ These packages reuse the published MCP relay and default to no embedded API key.
 | [Cursor](./cursor/README.md) | Clone into `~/.cursor/plugins/local/agoragentic` | Local package ready; publisher submission pending |
 | [Gemini CLI](./gemini-cli/README.md) | `gemini extensions install https://github.com/rhein1/agoragentic-integrations` | Direct install ready; gallery discovery follows the GitHub topic |
 | [Claude Code](./claude-code/README.md) | `/plugin marketplace add rhein1/agoragentic-integrations` | Self-hosted community marketplace ready |
-| [Cline](./cline/README.md) | Add `npx -y agoragentic-mcp@1.3.6` as an MCP server | Submission packet ready; Cline review pending |
+| [Cline](./cline/README.md) | Add `npx -y agoragentic-mcp@2.0.0` as an MCP server | Submission packet ready; Cline review pending |
 
 The canonical descriptions, assets, package coordinate, authority boundary, and per-channel statuses live in [`docs/catalog-profile.json`](./docs/catalog-profile.json). Tool inventory is live and authentication-dependent; directory copy must not publish a static tool count.
 

--- a/claude-code/README.md
+++ b/claude-code/README.md
@@ -12,7 +12,7 @@ Run these commands inside Claude Code:
 /reload-plugins
 ```
 
-The plugin starts `agoragentic-mcp@1.3.6` without embedding an API key and adds the generated Agoragentic Skill Pack v2: one router plus focused execution, governance, proof, deployment, selling, and integration skills. Generated copies live in [`plugin/skills`](./plugin/skills/) and must match the canonical [`skills/`](../skills/) sources.
+The plugin starts `agoragentic-mcp@2.0.0` without embedding an API key and adds the generated Agoragentic Skill Pack v2: one router plus focused execution, governance, proof, deployment, selling, and integration skills. Generated copies live in [`plugin/skills`](./plugin/skills/) and must match the canonical [`skills/`](../skills/) sources.
 
 ## Status
 

--- a/claude-code/plugin/.mcp.json
+++ b/claude-code/plugin/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "agoragentic-mcp@1.3.6"
+        "agoragentic-mcp@2.0.0"
       ]
     }
   }

--- a/cline/README.md
+++ b/cline/README.md
@@ -18,7 +18,7 @@ Add an MCP server in Cline:
   "mcpServers": {
     "agoragentic": {
       "command": "npx",
-      "args": ["-y", "agoragentic-mcp@1.3.6"]
+      "args": ["-y", "agoragentic-mcp@2.0.0"]
     }
   }
 }

--- a/cursor/README.md
+++ b/cursor/README.md
@@ -1,6 +1,6 @@
 # Agoragentic for Cursor
 
-The repository includes a Cursor plugin manifest at [`.cursor-plugin/plugin.json`](../.cursor-plugin/plugin.json). It installs Agoragentic Skill Pack v2 and starts `agoragentic-mcp@1.3.6` over stdio. The host-neutral skills live under [`skills/`](../skills/); deterministic Cursor rule projections live under [`.cursor/rules/`](../.cursor/rules/).
+The repository includes a Cursor plugin manifest at [`.cursor-plugin/plugin.json`](../.cursor-plugin/plugin.json). It installs Agoragentic Skill Pack v2 and starts `agoragentic-mcp@2.0.0` over stdio. The host-neutral skills live under [`skills/`](../skills/); deterministic Cursor rule projections live under [`.cursor/rules/`](../.cursor/rules/).
 
 ## Status
 

--- a/docs/catalog-profile.json
+++ b/docs/catalog-profile.json
@@ -1,7 +1,7 @@
 {
   "schema": "agoragentic.integration-distribution.v1",
-  "version": "1.0.2",
-  "updated_at": "2026-07-28",
+  "version": "1.0.3",
+  "updated_at": "2026-08-09",
   "product": {
     "name": "Agoragentic",
     "display_name": "Agoragentic for Triptych OS",
@@ -20,8 +20,8 @@
   "mcp": {
     "registry_name": "io.github.rhein1/agoragentic",
     "npm_package": "agoragentic-mcp",
-    "package_version": "1.3.6",
-    "command": "npx -y agoragentic-mcp@1.3.6",
+    "package_version": "2.0.0",
+    "command": "npx -y agoragentic-mcp@2.0.0",
     "transport": "stdio-relay",
     "remote_endpoint": "https://agoragentic.com/api/mcp",
     "tool_inventory": "dynamic_and_auth_dependent",

--- a/gemini-cli/README.md
+++ b/gemini-cli/README.md
@@ -1,6 +1,6 @@
 # Agoragentic for Gemini CLI
 
-The root [`gemini-extension.json`](../gemini-extension.json) makes this repository installable as a Gemini CLI extension. It launches `agoragentic-mcp@1.3.6`, loads the generated no-spend router in [`GEMINI.md`](../GEMINI.md), and discovers the focused skills under [`skills/`](../skills/) on demand.
+The root [`gemini-extension.json`](../gemini-extension.json) makes this repository installable as a Gemini CLI extension. It launches `agoragentic-mcp@2.0.0`, loads the generated no-spend router in [`GEMINI.md`](../GEMINI.md), and discovers the focused skills under [`skills/`](../skills/) on demand.
 
 ## Install
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -7,7 +7,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "agoragentic-mcp@1.3.6"
+        "agoragentic-mcp@2.0.0"
       ]
     }
   },

--- a/glama.json
+++ b/glama.json
@@ -8,12 +8,12 @@
     "source": "github"
   },
   "maintainers": ["rhein1"],
-  "version": "1.3.6",
+  "version": "2.0.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "agoragentic-mcp",
-      "version": "1.3.6",
+      "version": "2.0.0",
       "transport": {
         "type": "stdio"
       },

--- a/integrations.json
+++ b/integrations.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.38.0",
+  "version": "2.38.1",
   "updated_at": "2026-08-09",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
@@ -14,7 +14,7 @@
       "name": "agoragentic-mcp",
       "install": "npx agoragentic-mcp",
       "registry": "https://www.npmjs.com/package/agoragentic-mcp",
-      "min_node": "18"
+      "min_node": "20"
     },
     "node_sdk": {
       "name": "agoragentic",
@@ -32,13 +32,13 @@
       "name": "agoragentic-mcp",
       "install": "npx agoragentic-mcp",
       "registry": "https://www.npmjs.com/package/agoragentic-mcp",
-      "min_node": "18"
+      "min_node": "20"
     },
     "agent_client_protocol": {
       "name": "agoragentic-mcp",
       "install": "npx agoragentic-mcp --acp",
       "registry": "https://www.npmjs.com/package/agoragentic-mcp",
-      "min_node": "18"
+      "min_node": "20"
     },
     "micro_ecf": {
       "name": "agoragentic-micro-ecf",
@@ -1301,7 +1301,7 @@
       "language": "json",
       "status": "beta",
       "path": "cline/README.md",
-      "install": "npx -y agoragentic-mcp@1.3.6",
+      "install": "npx -y agoragentic-mcp@2.0.0",
       "docs": "cline/README.md"
     },
     {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9,7 +9,7 @@ This repository contains integration paths connecting agent frameworks, protocol
 The published packages and repo-local CLIs are:
 - **Python SDK**: `pip install agoragentic` (PyPI, Python ≥3.8)
 - **Node.js SDK**: `npm install agoragentic` (npm, Node ≥16)
-- **MCP Server**: `npx agoragentic-mcp` (npm, Node ≥18)
+- **MCP Server**: `npx agoragentic-mcp` (npm, Node ≥20)
 - **Micro ECF**: run `npx agoragentic-micro-ecf@latest plan --dir .` first; only after explicit approval run `npx agoragentic-micro-ecf@latest install --dir . --yes` (npm, Node ≥18)
 - **Harness Core**: `npx agoragentic-harness-core@latest init` (npm currently serves v0.2.0; this repo carries the review-gated v0.2.1 patch candidate, Node ≥18)
 - **OpenCode Harness plugin**: `cd opencode && npm ci` from a source checkout (experimental `@agoragentic/opencode` candidate; exact OpenCode 1.18.15 contract fixture only; not published)
@@ -109,7 +109,7 @@ The canonical inventory is `integrations.json` and contains 105 integration surf
 | Cursor Plugin | .cursor-plugin/plugin.json | clone the repository into Cursor's local plugin directory |
 | Gemini CLI Extension | gemini-extension.json | gemini extensions install https://github.com/rhein1/agoragentic-integrations |
 | Claude Code Plugin | .claude-plugin/marketplace.json | /plugin marketplace add rhein1/agoragentic-integrations |
-| Cline MCP Package | llms-install.md | add npx -y agoragentic-mcp@1.3.6 as an MCP server |
+| Cline MCP Package | llms-install.md | add npx -y agoragentic-mcp@2.0.0 as an MCP server |
 | OpenCode Harness Plugin | opencode/src/server.mjs | cd opencode && npm ci from a source checkout; exact OpenCode 1.18.15 contract fixture only |
 | gstack Harness Bridge | gstack/gstack-harness.mjs | cd gstack && npm install from a source checkout; explicit artifact paths only |
 | HyperFrames Receipt Video Workflow | hyperframes/receipt-video.mjs | cd hyperframes && npm install from a source checkout; local browser and FFmpeg only |

--- a/llms-install.md
+++ b/llms-install.md
@@ -22,7 +22,7 @@ An Agoragentic API key is optional and must not be requested for the first-run p
   "mcpServers": {
     "agoragentic": {
       "command": "npx",
-      "args": ["-y", "agoragentic-mcp@1.3.6"]
+      "args": ["-y", "agoragentic-mcp@2.0.0"]
     }
   }
 }

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,10 +1,16 @@
 # agoragentic-mcp
 
-`agoragentic-mcp` is a local stdio relay for the live Agoragentic MCP server at `https://agoragentic.com/api/mcp`.
+`agoragentic-mcp` is a local stdio relay for the Agoragentic MCP server at `https://agoragentic.com/api/mcp`.
 
 When the remote MCP endpoint is reachable, the package mirrors the same live tool, prompt, and resource surface that Agoragentic serves remotely. If the remote endpoint is unavailable, the package fails open to a small local fallback tool surface so registries such as Glama can still discover the core Router / Marketplace tools instead of seeing `tools: []`.
 
 Use this package when your host is already MCP-native. It does not download the hosted Triptych OS (Agent OS) control plane; it gives local agents a stdio bridge into hosted routing, receipts, stable x402 edge services, and deployment/control-plane checks they are authorized to see.
+
+## Protocol behavior
+
+Version 2.0.0 pins the outbound relay connection to MCP `2026-07-28`. The hosted leg is stateless: the relay uses `server/discover`, lets the official client derive `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name`, and does not create or terminate an `mcp-session-id` upstream.
+
+The local stdio side retains the established `initialize` flow for existing desktop hosts. That compatibility layer is local only; it does not restore a remote MCP session. A remote endpoint that cannot establish the pinned v2 protocol leaves the relay on its bounded local fallback surface instead of silently downgrading the hosted connection.
 
 ## Quick Start
 
@@ -127,8 +133,9 @@ After those checks, add `AGORAGENTIC_API_KEY` only when you need authenticated t
 `AGORAGENTIC_API_KEY`
 
 - Optional.
-- When set, the relay forwards `Authorization: Bearer <key>` to the remote MCP server.
+- When set, the relay forwards `Authorization: Bearer <key>` on every remote MCP request.
 - This unlocks authenticated Agent OS routing, receipt, approval, seller, and legacy vault surfaces when your agent is allowed to see them.
+- `agoragentic_register` may return a new `amk_` key, but the relay never retains, reuses, logs, writes, or adds it to `process.env`. Store it only in your own secret manager, then start a new relay process with `AGORAGENTIC_API_KEY` configured.
 
 `AGORAGENTIC_MCP_URL`
 
@@ -138,7 +145,7 @@ After those checks, add `AGORAGENTIC_API_KEY` only when you need authenticated t
 `AGORAGENTIC_BASE_URL`
 
 - Optional base URL for local fallback tools.
-- Defaults to `https://agoragentic.com`.
+- Defaults to the origin of `AGORAGENTIC_MCP_URL` (`https://agoragentic.com` with the default hosted endpoint), so a custom hosted endpoint never silently forwards its bearer key to a different origin. Set it explicitly only when that separate fallback origin is intended.
 
 ## Live Tool Surface
 
@@ -195,9 +202,7 @@ This preview path does not register an agent, execute a provider, or spend USDC.
 
 ## Release Integrity
 
-The npm release uses trusted publishing and an exact `mcp-v<package-version>` tag gate. CI installs from `package-lock.json`, runs the fallback-preview regression, rejects high or critical production dependency advisories, and inspects the package tarball before publication.
-
-The current MCP SDK dependency still carries an upstream moderate `@hono/node-server` static-file advisory. This stdio relay does not use that static-file server path; the release gate remains fail-closed for high and critical advisories while the upstream dependency range is unresolved.
+The npm release uses trusted publishing and an exact `mcp-v<package-version>` tag gate. CI installs from `package-lock.json`, runs both the fallback and loopback-only v2 relay regressions, rejects high or critical production dependency advisories, and inspects the package tarball before publication.
 
 ## Router Flow
 

--- a/mcp/mcp-server.js
+++ b/mcp/mcp-server.js
@@ -5,8 +5,21 @@ const readline = require('readline');
 const crypto = require('crypto');
 const { version: PACKAGE_VERSION } = require('./package.json');
 
-const REMOTE_MCP_URL = process.env.AGORAGENTIC_MCP_URL || 'https://agoragentic.com/api/mcp';
-const AGORAGENTIC_BASE = process.env.AGORAGENTIC_BASE_URL || 'https://agoragentic.com';
+const DEFAULT_REMOTE_MCP_URL = 'https://agoragentic.com/api/mcp';
+const REMOTE_MCP_URL = process.env.AGORAGENTIC_MCP_URL || DEFAULT_REMOTE_MCP_URL;
+const EXPLICIT_AGORAGENTIC_BASE = process.env.AGORAGENTIC_BASE_URL || '';
+
+function fallbackBaseForRemote(remoteMcpUrl) {
+    if (EXPLICIT_AGORAGENTIC_BASE) return EXPLICIT_AGORAGENTIC_BASE;
+    try {
+        return new URL(remoteMcpUrl).origin;
+    } catch {
+        return '';
+    }
+}
+
+const AGORAGENTIC_BASE = fallbackBaseForRemote(REMOTE_MCP_URL);
+const MCP_V2_PROTOCOL_VERSION = '2026-07-28';
 const RAW_API_KEY = process.env.AGORAGENTIC_API_KEY || '';
 const PLACEHOLDER_API_KEYS = new Set([
     'amk_glama_test_placeholder',
@@ -69,6 +82,14 @@ function buildJsonContent(data) {
 }
 
 async function apiCall(method, path, body) {
+    if (!AGORAGENTIC_BASE) {
+        return {
+            ok: false,
+            error: 'invalid_fallback_base',
+            message: 'Set a valid AGORAGENTIC_MCP_URL or explicit AGORAGENTIC_BASE_URL before using local fallback tools.',
+        };
+    }
+
     const headers = {
         'Content-Type': 'application/json',
         'User-Agent': `agoragentic-mcp/${PACKAGE_VERSION}`,
@@ -108,7 +129,7 @@ function requireApiKey() {
     return buildJsonContent({
         ok: false,
         error: 'missing_api_key',
-        message: 'Set AGORAGENTIC_API_KEY for authenticated Router / Marketplace execution tools. Use agoragentic_register to create a key.',
+        message: 'Set AGORAGENTIC_API_KEY before starting the relay for authenticated Router / Marketplace execution tools. Use agoragentic_register to create a key, then configure it in your own secret store.',
     });
 }
 
@@ -363,26 +384,35 @@ async function executeFallbackTool(name, args = {}) {
     });
 }
 
-function buildRemoteTransport() {
-    const { StreamableHTTPClientTransport } = require('@modelcontextprotocol/sdk/client/streamableHttp.js');
-    const headers = {};
-    if (API_KEY) {
-        headers.Authorization = `Bearer ${API_KEY}`;
-    }
-
-    return new StreamableHTTPClientTransport(new URL(REMOTE_MCP_URL), {
+function buildRemoteTransport(apiKeyRef, remoteUrl = REMOTE_MCP_URL) {
+    const { StreamableHTTPClientTransport } = require('@modelcontextprotocol/client');
+    return new StreamableHTTPClientTransport(new URL(remoteUrl), {
+        // The v2 transport calls this function before every HTTP request. This
+        // is intentionally a process-local credential reference, never a
+        // remote session credential or a mutation of process.env.
+        authProvider: {
+            token: async () => apiKeyRef.value || undefined,
+        },
+        onInsufficientScope: 'throw',
         requestInit: {
-            headers,
+            headers: {
+                'User-Agent': `agoragentic-mcp/${PACKAGE_VERSION}`,
+            },
         },
     });
 }
 
-async function connectRemoteClient() {
-    const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
-    const transport = buildRemoteTransport();
+async function connectRemoteClient({ remoteUrl = REMOTE_MCP_URL, apiKey = API_KEY } = {}) {
+    const { Client } = require('@modelcontextprotocol/client');
+    const apiKeyRef = { value: apiKey };
+    const transport = buildRemoteTransport(apiKeyRef, remoteUrl);
     const client = new Client(
         { name: 'agoragentic-mcp', version: PACKAGE_VERSION },
-        { capabilities: { tools: {}, resources: {}, prompts: {} } }
+        {
+            versionNegotiation: {
+                mode: { pin: MCP_V2_PROTOCOL_VERSION },
+            },
+        }
     );
 
     client.onerror = (error) => {
@@ -391,8 +421,41 @@ async function connectRemoteClient() {
         console.error(`[agoragentic-mcp] remote client error: ${message}`);
     };
 
-    await client.connect(transport);
-    return { client, transport };
+    try {
+        await client.connect(transport);
+        if (
+            client.getProtocolEra() !== 'modern'
+            || client.getNegotiatedProtocolVersion() !== MCP_V2_PROTOCOL_VERSION
+            || transport.sessionId !== undefined
+        ) {
+            throw new Error(`Hosted MCP did not establish a stateless ${MCP_V2_PROTOCOL_VERSION} connection.`);
+        }
+
+        // A successful discovery response alone does not prove that this is a
+        // usable relay target. Verify the first read-only protocol method now
+        // so a malformed or incompatible endpoint selects bounded fallback
+        // before the local host begins sending tool calls.
+        await client.listTools();
+        return { client, transport };
+    } catch (error) {
+        try {
+            await client.close();
+        } catch {
+            // Preserve the original connection failure for the fallback path.
+        }
+        throw error;
+    }
+}
+
+async function closeRemoteSession(remoteSession) {
+    if (!remoteSession) return;
+    try {
+        // A pinned v2 connection is stateless; closing the client tears down
+        // the transport without sending the legacy session DELETE lifecycle.
+        await remoteSession.client.close();
+    } catch {
+        // Ignore remote close failures during local shutdown.
+    }
 }
 
 async function runMcpRelay() {
@@ -498,18 +561,7 @@ async function runMcpRelay() {
 
     const shutdown = async (signal) => {
         console.error(`[agoragentic-mcp] shutting down on ${signal}`);
-        if (remoteSession) {
-            try {
-                await remoteSession.transport.terminateSession();
-            } catch {
-                // Ignore session teardown failures during local shutdown.
-            }
-            try {
-                await remoteSession.transport.close();
-            } catch {
-                // Ignore transport close failures during local shutdown.
-            }
-        }
+        await closeRemoteSession(remoteSession);
         process.exit(0);
     };
 
@@ -627,16 +679,7 @@ async function runAcpAdapter() {
 
     async function shutdownRemote() {
         if (!remoteSession) return;
-        try {
-            await remoteSession.transport.terminateSession();
-        } catch {
-            // Ignore session teardown failures during local shutdown.
-        }
-        try {
-            await remoteSession.transport.close();
-        } catch {
-            // Ignore transport close failures during local shutdown.
-        }
+        await closeRemoteSession(remoteSession);
         remoteSession = null;
     }
 
@@ -714,8 +757,8 @@ async function runAcpAdapter() {
             } else if (request.method === 'tools/list') {
                 writeResponse(buildAcpResponse(id, { tools: ACP_TOOLS }));
             } else if (request.method === 'tools/call') {
-                const { client } = await getRemoteSession();
-                const result = await client.callTool(request.params || {});
+                const session = await getRemoteSession();
+                const result = await session.client.callTool(request.params || {});
                 writeResponse(buildAcpResponse(id, result));
             } else if (request.method === 'shutdown') {
                 await shutdownRemote();
@@ -755,6 +798,9 @@ if (require.main === module) {
 }
 
 module.exports = {
+    MCP_V2_PROTOCOL_VERSION,
     buildFallbackToolList,
+    closeRemoteSession,
+    connectRemoteClient,
     executeFallbackTool,
 };

--- a/mcp/mcp-server.js
+++ b/mcp/mcp-server.js
@@ -299,6 +299,32 @@ function mergeFallbackTools(remoteTools = []) {
     return merged;
 }
 
+function createRemoteToolDirectory(client) {
+    let remoteToolNames = null;
+
+    async function list(params = {}) {
+        const result = await client.listTools(params);
+        const isAggregateRequest = params?.cursor === undefined;
+        if (isAggregateRequest) {
+            remoteToolNames = new Set((result.tools || []).map((tool) => tool.name));
+        }
+        return {
+            ...result,
+            tools: isAggregateRequest ? mergeFallbackTools(result.tools) : result.tools,
+        };
+    }
+
+    async function has(name) {
+        if (!remoteToolNames) {
+            const result = await client.listTools();
+            remoteToolNames = new Set((result.tools || []).map((tool) => tool.name));
+        }
+        return remoteToolNames.has(name);
+    }
+
+    return { has, list };
+}
+
 const FALLBACK_TOOL_NAMES = new Set(buildFallbackToolList().map((tool) => tool.name));
 
 async function executeFallbackTool(name, args = {}) {
@@ -485,31 +511,14 @@ async function runMcpRelay() {
 
     if (remoteSession) {
         const { client } = remoteSession;
-        let remoteToolNames = null;
-
-        async function listRemoteTools(params = {}) {
-            const result = await client.listTools(params);
-            remoteToolNames = new Set((result.tools || []).map((tool) => tool.name));
-            return result;
-        }
-
-        async function hasRemoteTool(name) {
-            if (!remoteToolNames) {
-                await listRemoteTools();
-            }
-            return remoteToolNames.has(name);
-        }
+        const remoteTools = createRemoteToolDirectory(client);
 
         server.setRequestHandler(ListToolsRequestSchema, async (request) => {
-            const result = await listRemoteTools(request.params);
-            return {
-                ...result,
-                tools: mergeFallbackTools(result.tools),
-            };
+            return remoteTools.list(request.params);
         });
 
         server.setRequestHandler(CallToolRequestSchema, async (request) => {
-            if (FALLBACK_TOOL_NAMES.has(request.params.name) && !(await hasRemoteTool(request.params.name))) {
+            if (FALLBACK_TOOL_NAMES.has(request.params.name) && !(await remoteTools.has(request.params.name))) {
                 return executeFallbackTool(request.params.name, request.params.arguments || {});
             }
             return client.callTool(request.params);
@@ -802,5 +811,6 @@ module.exports = {
     buildFallbackToolList,
     closeRemoteSession,
     connectRemoteClient,
+    createRemoteToolDirectory,
     executeFallbackTool,
 };

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,19 +1,22 @@
 {
     "name": "agoragentic-mcp",
-    "version": "1.3.6",
+    "version": "2.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "agoragentic-mcp",
-            "version": "1.3.6",
+            "version": "2.0.0",
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
                 "agoragentic-mcp": "dist/mcp-server.cjs"
             },
             "devDependencies": {
+                "@modelcontextprotocol/client": "2.0.0",
+                "@modelcontextprotocol/node": "2.0.0",
                 "@modelcontextprotocol/sdk": "1.30.0",
+                "@modelcontextprotocol/server": "2.0.0",
                 "esbuild": "0.28.1"
             },
             "engines": {
@@ -475,6 +478,60 @@
                 "hono": "^4"
             }
         },
+        "node_modules/@modelcontextprotocol/client": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+            "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@modelcontextprotocol/core": "2.0.0",
+                "cross-spawn": "^7.0.5",
+                "eventsource": "^3.0.2",
+                "eventsource-parser": "^3.0.0",
+                "jose": "^6.1.3",
+                "pkce-challenge": "^5.0.0",
+                "zod": "^4.2.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@modelcontextprotocol/core": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+            "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "zod": "^4.2.0"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/@modelcontextprotocol/node": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/node/-/node-2.0.0.tgz",
+            "integrity": "sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@hono/node-server": "^1.19.9"
+            },
+            "engines": {
+                "node": ">=20"
+            },
+            "peerDependencies": {
+                "@modelcontextprotocol/server": "^2.0.0",
+                "hono": "^4.11.4"
+            },
+            "peerDependenciesMeta": {
+                "hono": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@modelcontextprotocol/sdk": {
             "version": "1.30.0",
             "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
@@ -514,6 +571,21 @@
                 "zod": {
                     "optional": false
                 }
+            }
+        },
+        "node_modules/@modelcontextprotocol/server": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0.tgz",
+            "integrity": "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@modelcontextprotocol/core": "2.0.0",
+                "zod": "^4.2.0"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/accepts": {
@@ -943,9 +1015,9 @@
             }
         },
         "node_modules/express-rate-limit": {
-            "version": "8.6.0",
-            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
-            "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+            "version": "8.6.2",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+            "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1241,13 +1313,17 @@
             }
         },
         "node_modules/media-typer": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-            "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+            "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/merge-descriptors": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
     "name": "agoragentic-mcp",
-    "version": "1.3.6",
+    "version": "2.0.0",
     "mcpName": "io.github.rhein1/agoragentic",
     "description": "Stdio relay and fallback MCP server for Agoragentic's hosted Triptych OS (Agent OS) Router / Marketplace. Exposes registration, search, provider preview, paid execution, and receipt-backed status tools.",
     "main": "dist/mcp-server.cjs",
@@ -11,7 +11,7 @@
         "start": "node dist/mcp-server.cjs",
         "dev": "node mcp-server.js",
         "build": "node scripts/build.js",
-        "check": "node --check mcp-server.js && node --check scripts/build.js && node --check scripts/verify-packed-install.js && node --check test/fallback-preview.test.js",
+        "check": "node --check mcp-server.js && node --check scripts/build.js && node --check scripts/verify-packed-install.js && node --check test/fallback-preview.test.js && node --check test/v2-remote-relay.test.js",
         "test": "node --test test/*.test.js",
         "verify:packed-install": "node scripts/verify-packed-install.js",
         "prepack": "npm run build",
@@ -50,7 +50,10 @@
         "url": "https://github.com/rhein1/agoragentic-integrations/issues"
     },
     "devDependencies": {
+        "@modelcontextprotocol/client": "2.0.0",
+        "@modelcontextprotocol/node": "2.0.0",
         "@modelcontextprotocol/sdk": "1.30.0",
+        "@modelcontextprotocol/server": "2.0.0",
         "esbuild": "0.28.1"
     },
     "overrides": {

--- a/mcp/scripts/verify-packed-install.js
+++ b/mcp/scripts/verify-packed-install.js
@@ -18,10 +18,18 @@ const MCP_V2_PROTOCOL_VERSION = '2026-07-28';
 const PACKED_FIXTURE_API_KEY = 'amk_packed_fixture_key';
 
 const npmCli = process.env.npm_execpath;
-const npmCommand = npmCli ? process.execPath : process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const npmCommand = npmCli
+    ? process.execPath
+    : process.platform === 'win32'
+        ? process.env.ComSpec || 'cmd.exe'
+        : 'npm';
 
 function runNpm(args, options = {}) {
-    const commandArgs = npmCli ? [npmCli, ...args] : args;
+    const commandArgs = npmCli
+        ? [npmCli, ...args]
+        : process.platform === 'win32'
+            ? ['/d', '/s', '/c', 'npm.cmd', ...args]
+            : args;
     return execFileSync(npmCommand, commandArgs, {
         encoding: 'utf8',
         stdio: options.capture ? ['ignore', 'pipe', 'inherit'] : 'inherit',

--- a/mcp/scripts/verify-packed-install.js
+++ b/mcp/scripts/verify-packed-install.js
@@ -2,10 +2,20 @@
 
 const assert = require('assert');
 const fs = require('fs');
+const http = require('http');
 const os = require('os');
 const path = require('path');
 const readline = require('readline');
 const { execFileSync, spawn } = require('child_process');
+const {
+    McpServer,
+    createMcpHandler,
+    fromJsonSchema,
+} = require('@modelcontextprotocol/server');
+const { toNodeHandler } = require('@modelcontextprotocol/node');
+
+const MCP_V2_PROTOCOL_VERSION = '2026-07-28';
+const PACKED_FIXTURE_API_KEY = 'amk_packed_fixture_key';
 
 const npmCli = process.env.npm_execpath;
 const npmCommand = npmCli ? process.execPath : process.platform === 'win32' ? 'npm.cmd' : 'npm';
@@ -109,6 +119,176 @@ function verifyMcpFallback(entrypoint) {
     });
 }
 
+function createMcpV2Fixture() {
+    const requests = [];
+    const handler = createMcpHandler(async () => {
+        const server = new McpServer({ name: 'agoragentic-mcp-packed-fixture', version: '1.0.0' });
+        server.registerTool('packed_v2_probe', {
+            description: 'Loopback-only packed relay probe.',
+            inputSchema: fromJsonSchema({
+                type: 'object',
+                properties: { value: { type: 'string' } },
+                required: ['value'],
+                additionalProperties: false,
+            }),
+        }, async (args) => ({
+            content: [{ type: 'text', text: JSON.stringify({ ok: true, value: args.value }) }],
+        }));
+        return server;
+    }, {
+        legacy: 'reject',
+        responseMode: 'json',
+    });
+    const nodeHandler = toNodeHandler(handler);
+    const server = http.createServer((req, res) => {
+        const chunks = [];
+        req.on('data', (chunk) => chunks.push(chunk));
+        req.on('end', () => {
+            const raw = Buffer.concat(chunks).toString('utf8');
+            let body;
+            try {
+                body = JSON.parse(raw);
+            } catch {
+                res.statusCode = 400;
+                res.end('invalid JSON');
+                return;
+            }
+            requests.push({ httpMethod: req.method, headers: { ...req.headers }, body });
+            nodeHandler(req, res, body);
+        });
+    });
+
+    return {
+        requests,
+        async listen() {
+            await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+            return `http://127.0.0.1:${server.address().port}`;
+        },
+        async close() {
+            await new Promise((resolve) => server.close(resolve));
+        },
+    };
+}
+
+function verifyPackedMcpV2Relay(entrypoint, remoteUrl) {
+    return new Promise((resolve, reject) => {
+        const child = spawn(process.execPath, [entrypoint], {
+            env: {
+                ...process.env,
+                AGORAGENTIC_MCP_URL: remoteUrl,
+                AGORAGENTIC_API_KEY: PACKED_FIXTURE_API_KEY,
+            },
+            stdio: ['pipe', 'pipe', 'pipe'],
+        });
+
+        let stderr = '';
+        let settled = false;
+        const output = readline.createInterface({ input: child.stdout });
+        const timeout = setTimeout(() => {
+            finish(new Error(`packed MCP v2 relay smoke timed out\n${stderr}`));
+        }, 15000);
+
+        function finish(error) {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            output.close();
+            child.kill();
+            if (error) reject(error);
+            else resolve();
+        }
+
+        child.stderr.on('data', (chunk) => {
+            stderr += chunk.toString();
+        });
+        child.on('error', finish);
+        child.on('exit', (code) => {
+            if (!settled) {
+                finish(new Error(`packed MCP v2 relay exited before tools/call (code ${code})\n${stderr}`));
+            }
+        });
+
+        output.on('line', (line) => {
+            let message;
+            try {
+                message = JSON.parse(line);
+            } catch {
+                return;
+            }
+
+            if (message.id === 1 && message.result) {
+                child.stdin.write(`${JSON.stringify({
+                    jsonrpc: '2.0',
+                    method: 'notifications/initialized',
+                    params: {},
+                })}\n`);
+                child.stdin.write(`${JSON.stringify({
+                    jsonrpc: '2.0',
+                    id: 2,
+                    method: 'tools/list',
+                    params: {},
+                })}\n`);
+                return;
+            }
+
+            if (message.id === 2) {
+                try {
+                    assert((message.result?.tools || []).some((tool) => tool.name === 'packed_v2_probe'));
+                    child.stdin.write(`${JSON.stringify({
+                        jsonrpc: '2.0',
+                        id: 3,
+                        method: 'tools/call',
+                        params: { name: 'packed_v2_probe', arguments: { value: 'packed' } },
+                    })}\n`);
+                } catch (error) {
+                    finish(error);
+                }
+                return;
+            }
+
+            if (message.id === 3) {
+                try {
+                    assert.deepStrictEqual(JSON.parse(message.result?.content?.[0]?.text), { ok: true, value: 'packed' });
+                    finish();
+                } catch (error) {
+                    finish(error);
+                }
+            }
+        });
+
+        child.stdin.write(`${JSON.stringify({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+                protocolVersion: '2025-06-18',
+                capabilities: {},
+                clientInfo: {
+                    name: 'agoragentic-packed-v2-relay-smoke',
+                    version: '1.0.0',
+                },
+            },
+        })}\n`);
+    });
+}
+
+function assertPackedMcpV2Requests(requests) {
+    for (const method of ['server/discover', 'tools/list', 'tools/call']) {
+        assert(requests.some((request) => request.body.method === method), `packed relay must send ${method}`);
+    }
+
+    for (const request of requests) {
+        assert.strictEqual(request.httpMethod, 'POST');
+        assert.strictEqual(request.headers['mcp-protocol-version'], MCP_V2_PROTOCOL_VERSION);
+        assert.strictEqual(request.headers['mcp-method'], request.body.method);
+        assert.strictEqual(request.headers['mcp-session-id'], undefined);
+        assert.strictEqual(request.headers.authorization, `Bearer ${PACKED_FIXTURE_API_KEY}`);
+    }
+
+    const toolCall = requests.find((request) => request.body.method === 'tools/call');
+    assert.strictEqual(toolCall.headers['mcp-name'], 'packed_v2_probe');
+}
+
 async function main() {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agoragentic-mcp-packed-'));
     const packDir = path.join(tempRoot, 'pack');
@@ -140,7 +320,16 @@ async function main() {
         assert(fs.existsSync(entrypoint), 'packed MCP bundle is missing');
         await verifyMcpFallback(entrypoint);
 
-        console.log('packed consumer install verified: zero runtime dependencies, audit clean, MCP fallback ready');
+        const fixture = createMcpV2Fixture();
+        const remoteUrl = await fixture.listen();
+        try {
+            await verifyPackedMcpV2Relay(entrypoint, remoteUrl);
+            assertPackedMcpV2Requests(fixture.requests);
+        } finally {
+            await fixture.close();
+        }
+
+        console.log('packed consumer install verified: zero runtime dependencies, audit clean, legacy fallback and v2 relay ready');
     } finally {
         fs.rmSync(tempRoot, { recursive: true, force: true });
     }

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -8,12 +8,12 @@
         "url": "https://github.com/rhein1/agoragentic-integrations",
         "source": "github"
     },
-    "version": "2.1.5",
+    "version": "2.1.6",
     "packages": [
         {
             "registryType": "npm",
             "identifier": "agoragentic-mcp",
-            "version": "1.3.6",
+            "version": "2.0.0",
             "transport": {
                 "type": "stdio"
             },

--- a/mcp/test/v2-remote-relay.test.js
+++ b/mcp/test/v2-remote-relay.test.js
@@ -1,0 +1,381 @@
+'use strict';
+
+/**
+ * Loopback-only proof for the relay's remote MCP 2026-07-28 leg.
+ *
+ * The fixture never contacts Agoragentic, registers a real agent, invokes a
+ * provider, signs a payment, or uses a wallet. It only records the protocol
+ * headers emitted by the official v2 SDK and exercises the local legacy stdio
+ * projection that current desktop hosts still use.
+ */
+
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const path = require('node:path');
+const readline = require('node:readline');
+const { spawn } = require('node:child_process');
+const { test } = require('node:test');
+const {
+    McpServer,
+    createMcpHandler,
+    fromJsonSchema,
+} = require('@modelcontextprotocol/server');
+const { toNodeHandler } = require('@modelcontextprotocol/node');
+
+const {
+    MCP_V2_PROTOCOL_VERSION,
+    closeRemoteSession,
+    connectRemoteClient,
+} = require('../mcp-server.js');
+
+const PACKAGE_ROOT = path.resolve(__dirname, '..');
+const RELAY_ENTRYPOINT = path.join(PACKAGE_ROOT, 'mcp-server.js');
+const FIXTURE_API_KEY = 'amk_loopback_fixture_key';
+const REGISTERED_FIXTURE_API_KEY = 'amk_loopback_registered_key';
+
+function createFixtureServer() {
+    const requests = [];
+    const handler = createMcpHandler(async () => {
+        const server = new McpServer({ name: 'agoragentic-mcp-loopback', version: '1.0.0' });
+
+        server.registerTool('relay_safe_probe', {
+            description: 'Loopback-only read tool.',
+            inputSchema: fromJsonSchema({
+                type: 'object',
+                properties: {
+                    value: { type: 'string' },
+                },
+                required: ['value'],
+                additionalProperties: false,
+            }),
+        }, async (args) => ({
+            content: [{ type: 'text', text: JSON.stringify({ ok: true, value: args.value }) }],
+        }));
+
+        server.registerTool('agoragentic_register', {
+            description: 'Loopback-only registration-key fixture.',
+            inputSchema: fromJsonSchema({ type: 'object', additionalProperties: false }),
+        }, async () => ({
+            content: [{ type: 'text', text: JSON.stringify({ api_key: REGISTERED_FIXTURE_API_KEY }) }],
+        }));
+
+        server.registerTool('relay_payment_probe', {
+            description: 'Loopback-only payment-required fixture.',
+            inputSchema: fromJsonSchema({ type: 'object', additionalProperties: false }),
+        }, async () => ({
+            isError: true,
+            content: [{
+                type: 'text',
+                text: JSON.stringify({
+                    error: 'payment_required',
+                    legacy_jsonrpc_error_code: -32042,
+                    payment: { protocol: 'x402', challenges: [{ scheme: 'exact', network: 'base' }] },
+                }),
+            }],
+        }));
+
+        server.registerResource('relay-fixture-resource', 'agoragentic://fixture/resource', {
+            title: 'Relay fixture resource',
+            mimeType: 'text/plain',
+        }, async () => ({
+            contents: [{
+                uri: 'agoragentic://fixture/resource',
+                mimeType: 'text/plain',
+                text: 'loopback resource',
+            }],
+        }));
+
+        server.registerPrompt('relay-fixture-prompt', {
+            description: 'Loopback-only prompt fixture.',
+        }, async () => ({
+            messages: [{ role: 'user', content: { type: 'text', text: 'loopback prompt' } }],
+        }));
+
+        return server;
+    }, {
+        legacy: 'reject',
+        responseMode: 'json',
+    });
+    const nodeHandler = toNodeHandler(handler);
+    const server = http.createServer((req, res) => {
+        const chunks = [];
+        req.on('data', (chunk) => chunks.push(chunk));
+        req.on('end', () => {
+            const raw = Buffer.concat(chunks).toString('utf8');
+            const body = JSON.parse(raw);
+            requests.push({ httpMethod: req.method, headers: { ...req.headers }, body });
+            nodeHandler(req, res, body);
+        });
+    });
+
+    return {
+        requests,
+        async listen() {
+            await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+            return `http://127.0.0.1:${server.address().port}`;
+        },
+        async close() {
+            await new Promise((resolve) => server.close(resolve));
+        },
+    };
+}
+
+function assertModernRequest(request, expectedMethod, expectedName) {
+    assert.equal(request.httpMethod, 'POST');
+    assert.equal(request.body.method, expectedMethod);
+    assert.equal(request.headers['mcp-protocol-version'], MCP_V2_PROTOCOL_VERSION);
+    assert.equal(request.headers['mcp-method'], expectedMethod);
+    assert.equal(request.headers['mcp-name'], expectedName);
+    assert.equal(request.headers['mcp-session-id'], undefined);
+    assert.equal(request.body.params._meta['io.modelcontextprotocol/protocolVersion'], MCP_V2_PROTOCOL_VERSION);
+}
+
+function spawnLegacyStdioClient(remoteUrl, apiKey, fallbackBaseUrl = 'http://127.0.0.1:9') {
+    const env = {
+        ...process.env,
+        AGORAGENTIC_MCP_URL: remoteUrl,
+        AGORAGENTIC_API_KEY: apiKey,
+    };
+    if (fallbackBaseUrl === null) {
+        delete env.AGORAGENTIC_BASE_URL;
+    } else {
+        env.AGORAGENTIC_BASE_URL = fallbackBaseUrl;
+    }
+    const child = spawn(process.execPath, [RELAY_ENTRYPOINT], {
+        cwd: PACKAGE_ROOT,
+        env,
+        stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const pending = new Map();
+    const stderr = [];
+    let nextId = 1;
+    const output = readline.createInterface({ input: child.stdout });
+
+    output.on('line', (line) => {
+        let message;
+        try {
+            message = JSON.parse(line);
+        } catch {
+            return;
+        }
+        const pendingRequest = pending.get(message.id);
+        if (!pendingRequest) return;
+        pending.delete(message.id);
+        pendingRequest.resolve(message);
+    });
+    child.stderr.on('data', (chunk) => stderr.push(chunk.toString()));
+
+    function request(method, params = {}) {
+        const id = nextId++;
+        return new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => {
+                pending.delete(id);
+                reject(new Error(`stdio relay timed out waiting for ${method}\n${stderr.join('')}`));
+            }, 15000);
+            pending.set(id, {
+                resolve: (message) => {
+                    clearTimeout(timeout);
+                    resolve(message);
+                },
+            });
+            child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`);
+        });
+    }
+
+    return {
+        child,
+        request,
+        getStderr() {
+            return stderr.join('');
+        },
+        async initialize() {
+            const initialized = await request('initialize', {
+                protocolVersion: '2025-06-18',
+                capabilities: {},
+                clientInfo: { name: 'legacy-stdio-fixture', version: '1.0.0' },
+            });
+            child.stdin.write(`${JSON.stringify({
+                jsonrpc: '2.0',
+                method: 'notifications/initialized',
+                params: {},
+            })}\n`);
+            return initialized;
+        },
+        async close() {
+            output.close();
+            if (!child.killed) child.kill();
+            await new Promise((resolve) => child.once('exit', resolve));
+        },
+    };
+}
+
+function createUnavailableMcpWithFallbackFixture() {
+    const requests = [];
+    const server = http.createServer((req, res) => {
+        requests.push({ url: req.url, headers: { ...req.headers } });
+        if (req.url === '/api/mcp') {
+            res.statusCode = 404;
+            res.end('modern MCP unavailable');
+            return;
+        }
+        if (req.url?.startsWith('/api/capabilities')) {
+            res.setHeader('Content-Type', 'application/json');
+            res.end(JSON.stringify({ capabilities: [] }));
+            return;
+        }
+        res.statusCode = 404;
+        res.end('not found');
+    });
+
+    return {
+        requests,
+        async listen() {
+            await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+            return `http://127.0.0.1:${server.address().port}`;
+        },
+        async close() {
+            await new Promise((resolve) => server.close(resolve));
+        },
+    };
+}
+
+test('pins the remote MCP client to stateless 2026-07-28 and sends bearer auth per request', async () => {
+    const fixture = createFixtureServer();
+    const url = await fixture.listen();
+    const remoteSession = await connectRemoteClient({ remoteUrl: url, apiKey: FIXTURE_API_KEY });
+
+    try {
+        assert.equal(remoteSession.client.getProtocolEra(), 'modern');
+        assert.equal(remoteSession.client.getNegotiatedProtocolVersion(), MCP_V2_PROTOCOL_VERSION);
+        assert.equal(remoteSession.transport.sessionId, undefined);
+        await remoteSession.client.listTools();
+        await remoteSession.client.callTool({
+            name: 'relay_safe_probe',
+            arguments: { value: 'safe' },
+        });
+
+        const discover = fixture.requests.find((request) => request.body.method === 'server/discover');
+        const listed = fixture.requests.find((request) => request.body.method === 'tools/list');
+        const called = fixture.requests.find((request) => request.body.method === 'tools/call');
+        assert.ok(discover);
+        assert.ok(listed);
+        assert.ok(called);
+        assertModernRequest(discover, 'server/discover', undefined);
+        assertModernRequest(listed, 'tools/list', undefined);
+        assertModernRequest(called, 'tools/call', 'relay_safe_probe');
+        for (const request of [discover, listed, called]) {
+            assert.equal(request.headers.authorization, `Bearer ${FIXTURE_API_KEY}`);
+        }
+    } finally {
+        await closeRemoteSession(remoteSession);
+        await fixture.close();
+    }
+});
+
+test('does not retain a registration-returned key for later stateless requests', async () => {
+    const fixture = createFixtureServer();
+    const url = await fixture.listen();
+    const remoteSession = await connectRemoteClient({ remoteUrl: url, apiKey: '' });
+
+    try {
+        const registration = await remoteSession.client.callTool({
+            name: 'agoragentic_register',
+            arguments: {},
+        });
+        assert.equal(registration.isError, undefined);
+        await remoteSession.client.listTools();
+
+        const registerRequest = fixture.requests.find((request) => (
+            request.body.method === 'tools/call'
+            && request.body.params.name === 'agoragentic_register'
+        ));
+        const postRegistrationList = fixture.requests.filter((request) => request.body.method === 'tools/list').at(-1);
+        assert.ok(registerRequest);
+        assert.equal(registerRequest.headers.authorization, undefined);
+        assert.ok(postRegistrationList);
+        assert.equal(postRegistrationList.headers.authorization, undefined);
+    } finally {
+        await closeRemoteSession(remoteSession);
+        await fixture.close();
+    }
+});
+
+test('derives fallback tools from a custom MCP origin instead of forwarding its key elsewhere', async () => {
+    const fixture = createUnavailableMcpWithFallbackFixture();
+    const origin = await fixture.listen();
+    const relay = spawnLegacyStdioClient(`${origin}/api/mcp`, FIXTURE_API_KEY, null);
+
+    try {
+        const initialized = await relay.initialize();
+        assert.equal(initialized.error, undefined);
+
+        const search = await relay.request('tools/call', {
+            name: 'agoragentic_search',
+            arguments: { query: 'safe fallback' },
+        });
+        assert.equal(search.error, undefined, JSON.stringify({
+            search,
+            requests: fixture.requests,
+            stderr: relay.getStderr(),
+        }));
+        assert.deepEqual(JSON.parse(search.result.content[0].text), { capabilities: [] });
+
+        const fallbackRequest = fixture.requests.find((request) => request.url.startsWith('/api/capabilities'));
+        assert.ok(fallbackRequest);
+        assert.equal(fallbackRequest.headers.authorization, `Bearer ${FIXTURE_API_KEY}`);
+    } finally {
+        await relay.close();
+        await fixture.close();
+    }
+});
+
+test('preserves legacy stdio host compatibility while proxying v2 tools, resources, prompts, and tool errors', async () => {
+    const fixture = createFixtureServer();
+    const url = await fixture.listen();
+    const relay = spawnLegacyStdioClient(url, FIXTURE_API_KEY);
+
+    try {
+        const initialized = await relay.initialize();
+        assert.equal(initialized.error, undefined);
+
+        const tools = await relay.request('tools/list');
+        assert.ok(tools.result.tools.some((tool) => tool.name === 'relay_safe_probe'));
+
+        const call = await relay.request('tools/call', {
+            name: 'relay_safe_probe',
+            arguments: { value: 'projected' },
+        });
+        assert.deepEqual(JSON.parse(call.result.content[0].text), { ok: true, value: 'projected' });
+
+        const resources = await relay.request('resources/list');
+        assert.ok(resources.result.resources.some((resource) => resource.uri === 'agoragentic://fixture/resource'));
+        const resource = await relay.request('resources/read', { uri: 'agoragentic://fixture/resource' });
+        assert.equal(resource.result.contents[0].text, 'loopback resource');
+
+        const prompts = await relay.request('prompts/list');
+        assert.ok(prompts.result.prompts.some((prompt) => prompt.name === 'relay-fixture-prompt'));
+        const prompt = await relay.request('prompts/get', { name: 'relay-fixture-prompt' });
+        assert.equal(prompt.result.messages[0].content.text, 'loopback prompt');
+
+        const payment = await relay.request('tools/call', {
+            name: 'relay_payment_probe',
+            arguments: {},
+        });
+        assert.equal(payment.error, undefined, 'payment remains a tool result, never a JSON-RPC transport error');
+        assert.equal(payment.result.isError, true);
+        assert.equal(JSON.parse(payment.result.content[0].text).error, 'payment_required');
+
+        const methods = new Set(fixture.requests.map((request) => request.body.method));
+        for (const method of ['server/discover', 'tools/list', 'tools/call', 'resources/list', 'resources/read', 'prompts/list', 'prompts/get']) {
+            assert.ok(methods.has(method), `expected remote v2 ${method}`);
+        }
+        for (const request of fixture.requests) {
+            assert.equal(request.headers['mcp-protocol-version'], MCP_V2_PROTOCOL_VERSION);
+            assert.equal(request.headers['mcp-session-id'], undefined);
+            assert.equal(request.headers.authorization, `Bearer ${FIXTURE_API_KEY}`);
+        }
+    } finally {
+        await relay.close();
+        await fixture.close();
+    }
+});

--- a/mcp/test/v2-remote-relay.test.js
+++ b/mcp/test/v2-remote-relay.test.js
@@ -26,6 +26,7 @@ const {
     MCP_V2_PROTOCOL_VERSION,
     closeRemoteSession,
     connectRemoteClient,
+    createRemoteToolDirectory,
 } = require('../mcp-server.js');
 
 const PACKAGE_ROOT = path.resolve(__dirname, '..');
@@ -298,6 +299,40 @@ test('does not retain a registration-returned key for later stateless requests',
         await closeRemoteSession(remoteSession);
         await fixture.close();
     }
+});
+
+test('keeps fallback identity separate from explicit remote pagination', async () => {
+    const calls = [];
+    const client = {
+        async listTools(params = {}) {
+            calls.push(params);
+            if (params.cursor === 'page-2') {
+                return { tools: [{ name: 'remote_page_two' }] };
+            }
+            return {
+                tools: [
+                    { name: 'remote_page_one' },
+                    { name: 'agoragentic_register' },
+                    { name: 'remote_page_two' },
+                ],
+            };
+        },
+    };
+    const directory = createRemoteToolDirectory(client);
+
+    const page = await directory.list({ cursor: 'page-2' });
+    assert.deepEqual(page.tools.map((tool) => tool.name), ['remote_page_two']);
+    assert.equal(await directory.has('agoragentic_register'), true);
+    assert.equal(calls.length, 2);
+    assert.deepEqual(calls[1], {});
+
+    await directory.list({ cursor: 'page-2' });
+    assert.equal(await directory.has('agoragentic_register'), true);
+    assert.equal(calls.length, 3);
+
+    const aggregate = await directory.list();
+    assert.ok(aggregate.tools.some((tool) => tool.name === 'agoragentic_search'));
+    assert.equal(aggregate.tools.filter((tool) => tool.name === 'agoragentic_register').length, 1);
 });
 
 test('derives fallback tools from a custom MCP origin instead of forwarding its key elsewhere', async () => {


### PR DESCRIPTION
## Summary
- Move the outbound hosted leg of the `agoragentic-mcp` 2.0.0 candidate to the official MCP client v2, pinned to `2026-07-28`.
- Preserve the established local stdio `initialize` projection while requiring a stateless upstream connection: no upstream session ID, no silent downgrade, and per-request Bearer auth.
- Do not retain or reuse a registration-returned API key. If the hosted v2 endpoint is unavailable, the bounded fallback derives from the configured MCP origin unless an explicit fallback origin is supplied.
- Add loopback-only source and packed-artifact proof for headers, methods, no-session behavior, auth forwarding, fallback isolation, legacy stdio projection, and tool-error forwarding. Synchronize the unpublished release-candidate coordinates and Node 20 floor.

## Validation
- `cd mcp && npm run check`
- `cd mcp && npm test` (7/7)
- `cd mcp && npm run build`
- `cd mcp && npm run verify:packed-install`
- `cd mcp && npm audit --audit-level=moderate`
- `node scripts/verify-integrations-json.js`
- `node scripts/verify-doc-links.mjs`
- `node scripts/verify-client-distribution.mjs`
- `node scripts/generate-skill-pack.mjs --check`
- `node --test test/integration-inventory-holds.test.mjs test/verify-doc-links.test.mjs`
- `node scripts/adapter-conformance-agent.mjs --jobs 4` (104/104 offline static checks)

## Boundaries
Draft only. No npm publish, tag/release, registry submission/promotion, hosted deployment, production MCP request, account registration, wallet, payment, or execution occurred. Public hosted discovery remains non-advertising until the hosted v2 work and this relay have independent release evidence.