### PR TITLE
feat(transaction-assurance): add vendor-neutral conformance suite

### DIFF
--- a/.github/workflows/transaction-assurance-conformance.yml
+++ b/.github/workflows/transaction-assurance-conformance.yml
@@ -1,0 +1,116 @@
+name: Transaction Assurance Conformance
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'transaction-assurance/**'
+      - '.github/workflows/transaction-assurance-conformance.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'transaction-assurance/**'
+      - '.github/workflows/transaction-assurance-conformance.yml'
+  workflow_dispatch:
+  workflow_call:
+    inputs:
+      suite-ref:
+        description: Immutable agoragentic-integrations commit containing the suite
+        required: true
+        type: string
+      target-module:
+        description: Caller-repository path exporting evaluateTransactionAssuranceVector
+        required: true
+        type: string
+      target-name:
+        required: true
+        type: string
+      target-version:
+        required: true
+        type: string
+      target-commit:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  suite:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 22, 24]
+    defaults:
+      run:
+        working-directory: transaction-assurance
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+          cache-dependency-path: transaction-assurance/package-lock.json
+      - run: npm ci --ignore-scripts --no-audit --no-fund
+      - run: npm run check
+      - run: npm test
+      - run: npm run conformance
+      - run: npm run pack:dry
+
+  external-target:
+    if: github.event_name == 'workflow_call'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out caller target
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          path: target
+      - name: Check out pinned suite
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          repository: rhein1/agoragentic-integrations
+          ref: ${{ inputs.suite-ref }}
+          path: suite
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: suite/transaction-assurance/package-lock.json
+      - name: Install locked suite dependencies
+        working-directory: suite/transaction-assurance
+        run: npm ci --ignore-scripts --no-audit --no-fund
+      - name: Validate immutable suite and target paths
+        env:
+          SUITE_REF: ${{ inputs.suite-ref }}
+          TARGET_MODULE: ${{ inputs.target-module }}
+        run: |
+          node -e "const path=require('node:path'); const ref=process.env.SUITE_REF; if(!/^[0-9a-f]{40}$/.test(ref)) throw new Error('suite-ref must be a 40-character commit'); const root=path.resolve('target'); const target=path.resolve(root, process.env.TARGET_MODULE); if(target !== root && !target.startsWith(root + path.sep)) throw new Error('target-module must remain inside the caller checkout');"
+      - name: Run target conformance
+        env:
+          TARGET_MODULE: ${{ inputs.target-module }}
+          TARGET_NAME: ${{ inputs.target-name }}
+          TARGET_VERSION: ${{ inputs.target-version }}
+          TARGET_COMMIT: ${{ inputs.target-commit }}
+        run: |
+          node suite/transaction-assurance/bin/run-conformance.mjs \
+            --target-module "$GITHUB_WORKSPACE/target/$TARGET_MODULE" \
+            --target-name "$TARGET_NAME" \
+            --target-version "$TARGET_VERSION" \
+            --target-commit "$TARGET_COMMIT" \
+            --json artifacts/report.json \
+            --junit artifacts/junit.xml \
+            --receipt artifacts/receipt.json
+          node suite/transaction-assurance/bin/verify-conformance-receipt.mjs \
+            artifacts/report.json artifacts/receipt.json
+      - name: Upload bounded conformance artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: transaction-assurance-conformance
+          path: artifacts/
+          if-no-files-found: error

--- a/integrations.json
+++ b/integrations.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.38.1",
+  "version": "2.39.0",
   "updated_at": "2026-08-09",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
@@ -380,7 +380,7 @@
     {
       "directory": "transaction-assurance",
       "status": "unpublished_alpha",
-      "reason": "Version-pinned protocol adapters and internal conformance vectors are implemented, but the vendor-neutral conformance suite and a real external adopter remain required before public catalog inclusion.",
+      "reason": "The source-only vendor-neutral conformance suite, four version-pinned protocol profiles, deterministic runner, reports, receipt verifier, examples, and reusable workflow are implemented. A real external adopter run is still required before public catalog inclusion or any ecosystem-standard claim.",
       "owner": "repository-maintainers",
       "tracking_ref": "https://github.com/rhein1/agoragentic-integrations/issues/246",
       "review_by": "2026-09-08",

--- a/transaction-assurance/CONFORMANCE.md
+++ b/transaction-assurance/CONFORMANCE.md
@@ -1,0 +1,83 @@
+# Transaction Assurance Conformance Suite
+
+The Transaction Assurance conformance suite is an offline, deterministic test contract for wallets, agents, payment rails, merchants, APIs, MCP servers, and marketplaces. It is source-only alpha infrastructure and does not require an Agoragentic account.
+
+## What it evaluates
+
+The language-neutral vector input records bounded booleans and states for authority, terms, limits, payment identity, settlement, execution, outcome validation, reconciliation, and privacy. It intentionally cannot carry prompts, tool output, credentials, private keys, payment payloads, or private owner data.
+
+The manifest pins four existing protocol adapters:
+
+| Adapter | Version | Source pin |
+| --- | --- | --- |
+| Google AP2 | `v0.2.0` | `b4587ac1d055888a73b4b21750973cffba961793` |
+| Visa Trusted Agent Protocol | `commit-16d59bdf` | `16d59bdf3f8a542bc538d0962edbb80ea30a02af` |
+| official OpenAI/Stripe Agentic Commerce Protocol | `2026-04-17` | `7fdd78df677a94dce04c770644b0fbbb1401272b` |
+| x402 | `2.21.0` | `34cb6bd04c88f4333f56b9c778d3d35df997379c` |
+
+These pins bind conformance vocabulary to the package adapters. The suite does not verify protocol signatures or claim provider endorsement.
+
+## Target module contract
+
+A target module exports one function:
+
+```javascript
+export async function evaluateTransactionAssuranceVector({ vector, input }) {
+  return {
+    decision: 'pass', // pass | deny | review
+    code: 'complete_chain_verified',
+  };
+}
+```
+
+The runner rejects extra result fields. It compares the target's exact decision and code with each vector's expected result. Target code runs in the caller's Node process; the suite does not sandbox it or prove that it avoided network or secret access.
+
+Reference modules are included for:
+
+- an x402 resource server;
+- an MCP paid tool;
+- an agent wallet policy;
+- a marketplace listing.
+
+They demonstrate the interface only. Their passing results are not third-party evidence.
+
+## Reports and receipts
+
+The JSON report contains every bounded result and hashes of the manifest, vector set, and materialized inputs. JUnit output has stable names and zero timing noise. The receipt binds:
+
+- suite and target versions;
+- target commit;
+- manifest and vector-set hashes;
+- report hash;
+- pass/fail counts;
+- profiles and pinned adapters tested;
+- per-test input, expected-result, and actual-result hashes;
+- explicit exclusions and the claim boundary.
+
+The public verifier recomputes the receipt from the local manifest, vectors, and report. It does not call Agoragentic or any protocol provider.
+
+## Reusable GitHub workflow
+
+Pin the workflow to a reviewed commit, never a floating branch:
+
+```yaml
+jobs:
+  transaction-assurance:
+    uses: rhein1/agoragentic-integrations/.github/workflows/transaction-assurance-conformance.yml@<SUITE_COMMIT>
+    with:
+      suite-ref: <SUITE_COMMIT>
+      target-module: path/to/transaction-assurance-target.mjs
+      target-name: my-target
+      target-version: 1.0.0
+      target-commit: ${{ github.sha }}
+```
+
+The called workflow checks out the caller repository and the pinned suite separately, grants only `contents: read`, runs with no secrets, and uploads the JSON, JUnit, and receipt artifacts. A green workflow proves only conformance to the pinned vectors.
+
+## Allowed claim
+
+> Passed Agoragentic Transaction Assurance Conformance Suite `<version>` for profile `<profile>` at commit `<sha>`.
+
+It may not be described as certified safe, universally trusted, fraud-proof, legally comprehensive, endorsed by Agoragentic or a protocol provider, or proof of live settlement or production compatibility.
+
+The suite must not be marketed as an ecosystem standard until an external adopter runs it and reports actionable failures. That external evidence is not present yet.

--- a/transaction-assurance/CONTRIBUTING_CONFORMANCE.md
+++ b/transaction-assurance/CONTRIBUTING_CONFORMANCE.md
@@ -1,0 +1,22 @@
+# Contributing Conformance Fixtures and Adapters
+
+Conformance contributions must remain offline, deterministic, license-compatible, bounded, and reviewable.
+
+## Required evidence
+
+1. Name the upstream protocol and exact public version or immutable revision.
+2. Link the source and record its license compatibility.
+3. Explain the field-to-language-neutral mapping without embedding credentials, signatures, payment payloads, prompts, tool output, or private owner data.
+4. Add at least one positive vector and adversarial negative vectors for every supported state transition.
+5. Add tests showing unsupported versions and unknown states fail closed.
+6. Update the manifest, schemas, documentation, and reusable workflow paths together.
+
+## Review boundary
+
+- Parsing is not signature verification.
+- Merchant-declared fulfillment is not independently verified delivery.
+- Settlement is not outcome validation.
+- A receipt hash is not a signature or provenance proof.
+- A passing vector is not certification, endorsement, legal compliance, or universal production compatibility.
+
+Do not add a protocol adapter based on private or mutable documentation. Do not add live credentials, network canaries, funded tests, or provider calls. External adopters should pin the suite commit and submit only public-safe bounded reports after their own privacy review.

--- a/transaction-assurance/README.md
+++ b/transaction-assurance/README.md
@@ -36,7 +36,7 @@ Wallets, payment protocols, card networks, identity systems, and marketplaces ea
 
 ## Status
 
-This is an unpublished alpha implementation on a review branch.
+This is a source-visible, unpublished alpha implementation.
 
 - package: `@agoragentic/transaction-assurance`
 - version: `0.2.0-alpha.0`
@@ -46,8 +46,50 @@ This is an unpublished alpha implementation on a review branch.
 - external cryptographic verifiers: trusted in-process callback interface implemented; verifier implementations remain external
 - hosted Agoragentic execution changes: none
 - marketplace catalog entry: intentionally deferred
+- vendor-neutral conformance suite: implemented as an offline source-only alpha
+- external adopter evidence: not yet obtained
 
 `package.json` remains `private: true` until review, conformance fixtures, provenance, and release ownership are complete.
+
+## Vendor-neutral conformance suite
+
+The package includes an offline deterministic suite covering eight profiles:
+
+1. authority and identity;
+2. commercial terms and quote binding;
+3. payment identifier and idempotency;
+4. settlement evidence and finality;
+5. execution and delivery evidence;
+6. outcome validation;
+7. refund, dispute, and reconciliation;
+8. privacy and redaction.
+
+Run the bundled reference evaluator:
+
+```bash
+npm run conformance
+```
+
+Run a local target module and write JSON, JUnit, and a bounded receipt:
+
+```bash
+node bin/run-conformance.mjs \
+  --target-module examples/conformance-targets/x402-resource-server.mjs \
+  --target-name my-x402-server \
+  --target-version 1.0.0 \
+  --target-commit abc123 \
+  --json artifacts/report.json \
+  --junit artifacts/junit.xml \
+  --receipt artifacts/receipt.json
+
+node bin/verify-conformance-receipt.mjs \
+  artifacts/report.json \
+  artifacts/receipt.json
+```
+
+The runner itself makes no network calls and grants no authority. A target module is caller-supplied code and runs with the caller's process permissions; review it before execution. The bundled examples are reference contract fixtures, not external adoption evidence.
+
+See [CONFORMANCE.md](CONFORMANCE.md) for the target-module contract, reusable workflow, version-pinned protocol profiles, and exact claim boundary. See [CONTRIBUTING_CONFORMANCE.md](CONTRIBUTING_CONFORMANCE.md) before proposing a fixture or adapter.
 
 ## Five-minute local proof
 

--- a/transaction-assurance/bin/run-conformance.mjs
+++ b/transaction-assurance/bin/run-conformance.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import {
+  buildConformanceReceipt,
+  readJson,
+  renderConformanceJUnit,
+  runConformanceSuite,
+} from '../src/conformance.mjs';
+
+const packageRoot = new URL('../', import.meta.url);
+
+function usage() {
+  console.error('Usage: run-conformance [--target-module <path>] [--target-name <name>] [--target-version <version>] [--target-commit <commit>] [--json <path>] [--junit <path>] [--receipt <path>]');
+}
+
+function args(argv) {
+  const output = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith('--') || value === undefined) throw new TypeError('arguments must be --key value pairs');
+    output[key.slice(2)] = value;
+  }
+  return output;
+}
+
+async function write(pathname, contents) {
+  await mkdir(path.dirname(path.resolve(pathname)), { recursive: true });
+  await writeFile(pathname, contents, 'utf8');
+}
+
+async function main() {
+  const options = args(process.argv.slice(2));
+  const manifest = await readJson(new URL('conformance/manifest.v1.json', packageRoot));
+  const vectorSet = await readJson(new URL('conformance/vectors.v1.json', packageRoot));
+  let evaluate;
+  if (options['target-module']) {
+    const module = await import(pathToFileURL(path.resolve(options['target-module'])).href);
+    evaluate = module.evaluateTransactionAssuranceVector;
+    if (typeof evaluate !== 'function') {
+      throw new TypeError('target module must export evaluateTransactionAssuranceVector');
+    }
+  }
+  const report = await runConformanceSuite({
+    manifest,
+    vectorSet,
+    ...(evaluate ? { evaluate } : {}),
+    target: {
+      name: options['target-name'] || 'agoragentic-reference-evaluator',
+      version: options['target-version'] || manifest.suite_version,
+      commit: options['target-commit'] || 'local-uncommitted',
+    },
+  });
+  const receipt = buildConformanceReceipt({ manifest, vectorSet, report });
+  if (options.json) await write(options.json, `${JSON.stringify(report, null, 2)}\n`);
+  if (options.junit) await write(options.junit, renderConformanceJUnit(report));
+  if (options.receipt) await write(options.receipt, `${JSON.stringify(receipt, null, 2)}\n`);
+  if (!options.json) process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  process.exitCode = report.all_passed ? 0 : 1;
+}
+
+main().catch((error) => {
+  usage();
+  console.error(error.message);
+  process.exitCode = 2;
+});

--- a/transaction-assurance/bin/verify-conformance-receipt.mjs
+++ b/transaction-assurance/bin/verify-conformance-receipt.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+import { readJson, verifyConformanceReceipt } from '../src/conformance.mjs';
+
+const packageRoot = new URL('../', import.meta.url);
+
+async function main() {
+  const [reportPath, receiptPath] = process.argv.slice(2);
+  if (!reportPath || !receiptPath) {
+    throw new TypeError('Usage: verify-conformance-receipt <report.json> <receipt.json>');
+  }
+  const [manifest, vectorSet, report, receipt] = await Promise.all([
+    readJson(new URL('conformance/manifest.v1.json', packageRoot)),
+    readJson(new URL('conformance/vectors.v1.json', packageRoot)),
+    readJson(reportPath),
+    readJson(receiptPath),
+  ]);
+  const result = verifyConformanceReceipt({ manifest, vectorSet, report, receipt });
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+  process.exitCode = result.verified ? 0 : 1;
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 2;
+});

--- a/transaction-assurance/conformance/manifest.v1.json
+++ b/transaction-assurance/conformance/manifest.v1.json
@@ -1,0 +1,54 @@
+{
+  "schema": "agoragentic.transaction-assurance-conformance-manifest.v1",
+  "suite_name": "Agoragentic Transaction Assurance Conformance Suite",
+  "suite_version": "0.1.0-alpha.0",
+  "released_at": "2026-08-09T00:00:00.000Z",
+  "profiles": [
+    "authority_identity",
+    "commercial_terms",
+    "payment_idempotency",
+    "settlement_finality",
+    "execution_delivery",
+    "outcome_validation",
+    "reconciliation",
+    "privacy_redaction"
+  ],
+  "protocol_adapters": [
+    {
+      "id": "google_ap2",
+      "version": "v0.2.0",
+      "revision": "b4587ac1d055888a73b4b21750973cffba961793",
+      "source": "https://github.com/google-agentic-commerce/AP2/tree/v0.2.0"
+    },
+    {
+      "id": "visa_tap",
+      "version": "commit-16d59bdf",
+      "revision": "16d59bdf3f8a542bc538d0962edbb80ea30a02af",
+      "source": "https://github.com/visa/trusted-agent-protocol/tree/16d59bdf3f8a542bc538d0962edbb80ea30a02af"
+    },
+    {
+      "id": "openai_stripe_acp",
+      "version": "2026-04-17",
+      "revision": "7fdd78df677a94dce04c770644b0fbbb1401272b",
+      "source": "https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/tree/7fdd78df677a94dce04c770644b0fbbb1401272b/spec/2026-04-17"
+    },
+    {
+      "id": "x402",
+      "version": "2.21.0",
+      "revision": "34cb6bd04c88f4333f56b9c778d3d35df997379c",
+      "source": "https://github.com/x402-foundation/x402/tree/34cb6bd04c88f4333f56b9c778d3d35df997379c/specs/extensions"
+    }
+  ],
+  "vector_set": "conformance/vectors.v1.json",
+  "claim_boundary": "A pass means only that the named target produced the expected bounded decisions for this suite version and profile. It is not certification, endorsement, legal compliance, fraud prevention, settlement proof, or universal production safety.",
+  "explicit_exclusions": [
+    "certification",
+    "endorsement",
+    "legal_compliance",
+    "live_settlement",
+    "production_compatibility",
+    "universal_safety"
+  ],
+  "network_required": false,
+  "spend_authority": false
+}

--- a/transaction-assurance/conformance/vectors.v1.json
+++ b/transaction-assurance/conformance/vectors.v1.json
@@ -1,0 +1,441 @@
+{
+  "schema": "agoragentic.transaction-assurance-conformance-vectors.v1",
+  "suite_version": "0.1.0-alpha.0",
+  "base_input": {
+    "schema": "agoragentic.transaction-assurance-conformance.v1",
+    "protocol": {
+      "adapter_id": "x402",
+      "source_version": "2.21.0"
+    },
+    "authority": {
+      "verification": "verified",
+      "revocation": "active",
+      "audience_match": true,
+      "agent_match": true,
+      "expired": false
+    },
+    "terms": {
+      "merchant_match": true,
+      "category_match": true,
+      "action_match": true,
+      "rail_match": true,
+      "currency_match": true,
+      "quote_match": true,
+      "terms_match": true
+    },
+    "limits": {
+      "per_action_within_limit": true,
+      "daily_within_limit": true,
+      "total_within_limit": true
+    },
+    "payment": {
+      "identifier_present": true,
+      "identifier_reused": false,
+      "replay_detected": false
+    },
+    "settlement": {
+      "observed": true,
+      "verified": true,
+      "final": true
+    },
+    "execution": {
+      "attempted": true,
+      "succeeded": true,
+      "delivery_observed": true
+    },
+    "outcome": {
+      "validation": "passed"
+    },
+    "reconciliation": {
+      "status": "complete"
+    },
+    "privacy": {
+      "raw_secret_exposed": false,
+      "private_key_exposed": false,
+      "payment_credential_exposed": false,
+      "raw_prompt_exposed": false,
+      "raw_tool_output_exposed": false,
+      "private_owner_data_exposed": false
+    }
+  },
+  "vectors": [
+    {
+      "id": "ap2_complete_chain",
+      "profile": "authority_identity",
+      "adapter_id": "google_ap2",
+      "source_version": "v0.2.0",
+      "description": "Pinned AP2 evidence reaches the complete reference outcome.",
+      "input_patch": {},
+      "expected": { "decision": "pass", "code": "complete_chain_verified" }
+    },
+    {
+      "id": "visa_complete_chain",
+      "profile": "commercial_terms",
+      "adapter_id": "visa_tap",
+      "source_version": "commit-16d59bdf",
+      "description": "Pinned Visa TAP evidence reaches the complete reference outcome.",
+      "input_patch": {},
+      "expected": { "decision": "pass", "code": "complete_chain_verified" }
+    },
+    {
+      "id": "acp_complete_chain",
+      "profile": "execution_delivery",
+      "adapter_id": "openai_stripe_acp",
+      "source_version": "2026-04-17",
+      "description": "Pinned official ACP evidence reaches the complete reference outcome.",
+      "input_patch": {},
+      "expected": { "decision": "pass", "code": "complete_chain_verified" }
+    },
+    {
+      "id": "x402_complete_chain",
+      "profile": "settlement_finality",
+      "adapter_id": "x402",
+      "source_version": "2.21.0",
+      "description": "Pinned x402 evidence reaches the complete reference outcome.",
+      "input_patch": {},
+      "expected": { "decision": "pass", "code": "complete_chain_verified" }
+    },
+    {
+      "id": "authority_unverified",
+      "profile": "authority_identity",
+      "adapter_id": "google_ap2",
+      "source_version": "v0.2.0",
+      "description": "Unverified authority requires review.",
+      "input_patch": { "authority": { "verification": "unverified" } },
+      "expected": { "decision": "review", "code": "authority_unverified" }
+    },
+    {
+      "id": "authority_unknown",
+      "profile": "authority_identity",
+      "adapter_id": "google_ap2",
+      "source_version": "v0.2.0",
+      "description": "Unknown verification state fails closed to review.",
+      "input_patch": { "authority": { "verification": "unknown" } },
+      "expected": { "decision": "review", "code": "authority_verification_unknown" }
+    },
+    {
+      "id": "authority_revoked",
+      "profile": "authority_identity",
+      "adapter_id": "visa_tap",
+      "source_version": "commit-16d59bdf",
+      "description": "Revoked authority is denied.",
+      "input_patch": { "authority": { "revocation": "revoked" } },
+      "expected": { "decision": "deny", "code": "authority_revoked" }
+    },
+    {
+      "id": "authority_expired",
+      "profile": "authority_identity",
+      "adapter_id": "openai_stripe_acp",
+      "source_version": "2026-04-17",
+      "description": "Expired authority is denied.",
+      "input_patch": { "authority": { "expired": true } },
+      "expected": { "decision": "deny", "code": "authority_expired" }
+    },
+    {
+      "id": "authority_wrong_audience",
+      "profile": "authority_identity",
+      "adapter_id": "x402",
+      "source_version": "2.21.0",
+      "description": "Wrong audience is denied.",
+      "input_patch": { "authority": { "audience_match": false } },
+      "expected": { "decision": "deny", "code": "authority_wrong_audience" }
+    },
+    {
+      "id": "authority_wrong_agent",
+      "profile": "authority_identity",
+      "adapter_id": "google_ap2",
+      "source_version": "v0.2.0",
+      "description": "Wrong delegated agent is denied.",
+      "input_patch": { "authority": { "agent_match": false } },
+      "expected": { "decision": "deny", "code": "authority_wrong_agent" }
+    },
+    {
+      "id": "unsupported_protocol_version",
+      "profile": "authority_identity",
+      "adapter_id": "x402",
+      "source_version": "2.20.0",
+      "description": "An unpinned protocol version is denied.",
+      "input_patch": {},
+      "expected": { "decision": "deny", "code": "unsupported_protocol_version" }
+    },
+    {
+      "id": "merchant_mismatch",
+      "profile": "commercial_terms",
+      "adapter_id": "visa_tap",
+      "source_version": "commit-16d59bdf",
+      "description": "Wrong merchant is denied.",
+      "input_patch": { "terms": { "merchant_match": false } },
+      "expected": { "decision": "deny", "code": "merchant_mismatch" }
+    },
+    {
+      "id": "category_mismatch",
+      "profile": "commercial_terms",
+      "adapter_id": "google_ap2",
+      "source_version": "v0.2.0",
+      "description": "Wrong category is denied.",
+      "input_patch": { "terms": { "category_match": false } },
+      "expected": { "decision": "deny", "code": "category_mismatch" }
+    },
+    {
+      "id": "action_mismatch",
+      "profile": "commercial_terms",
+      "adapter_id": "google_ap2",
+      "source_version": "v0.2.0",
+      "description": "Wrong action is denied.",
+      "input_patch": { "terms": { "action_match": false } },
+      "expected": { "decision": "deny", "code": "action_mismatch" }
+    },
+    {
+      "id": "rail_mismatch",
+      "profile": "commercial_terms",
+      "adapter_id": "x402",
+      "source_version": "2.21.0",
+      "description": "Wrong payment rail is denied.",
+      "input_patch": { "terms": { "rail_match": false } },
+      "expected": { "decision": "deny", "code": "rail_mismatch" }
+    },
+    {
+      "id": "currency_mismatch",
+      "profile": "commercial_terms",
+      "adapter_id": "openai_stripe_acp",
+      "source_version": "2026-04-17",
+      "description": "Wrong currency is denied.",
+      "input_patch": { "terms": { "currency_match": false } },
+      "expected": { "decision": "deny", "code": "currency_mismatch" }
+    },
+    {
+      "id": "quote_changed",
+      "profile": "commercial_terms",
+      "adapter_id": "openai_stripe_acp",
+      "source_version": "2026-04-17",
+      "description": "A changed quote is denied.",
+      "input_patch": { "terms": { "quote_match": false } },
+      "expected": { "decision": "deny", "code": "quote_changed" }
+    },
+    {
+      "id": "terms_changed",
+      "profile": "commercial_terms",
+      "adapter_id": "visa_tap",
+      "source_version": "commit-16d59bdf",
+      "description": "Changed commercial terms are denied.",
+      "input_patch": { "terms": { "terms_match": false } },
+      "expected": { "decision": "deny", "code": "terms_changed" }
+    },
+    {
+      "id": "per_action_limit_exceeded",
+      "profile": "commercial_terms",
+      "adapter_id": "google_ap2",
+      "source_version": "v0.2.0",
+      "description": "Per-action budget overflow is denied.",
+      "input_patch": { "limits": { "per_action_within_limit": false } },
+      "expected": { "decision": "deny", "code": "per_action_limit_exceeded" }
+    },
+    {
+      "id": "daily_limit_exceeded",
+      "profile": "commercial_terms",
+      "adapter_id": "x402",
+      "source_version": "2.21.0",
+      "description": "Daily budget overflow is denied.",
+      "input_patch": { "limits": { "daily_within_limit": false } },
+      "expected": { "decision": "deny", "code": "daily_limit_exceeded" }
+    },
+    {
+      "id": "total_limit_exceeded",
+      "profile": "commercial_terms",
+      "adapter_id": "openai_stripe_acp",
+      "source_version": "2026-04-17",
+      "description": "Total budget overflow is denied.",
+      "input_patch": { "limits": { "total_within_limit": false } },
+      "expected": { "decision": "deny", "code": "total_limit_exceeded" }
+    },
+    {
+      "id": "payment_identifier_missing",
+      "profile": "payment_idempotency",
+      "adapter_id": "x402",
+      "source_version": "2.21.0",
+      "description": "A missing payment identifier is denied.",
+      "input_patch": { "payment": { "identifier_present": false } },
+      "expected": { "decision": "deny", "code": "payment_identifier_missing" }
+    },
+    {
+      "id": "payment_identifier_reused",
+      "profile": "payment_idempotency",
+      "adapter_id": "openai_stripe_acp",
+      "source_version": "2026-04-17",
+      "description": "A reused payment identifier is denied.",
+      "input_patch": { "payment": { "identifier_reused": true } },
+      "expected": { "decision": "deny", "code": "payment_identifier_reused" }
+    },
+    {
+      "id": "paid_retry_replay",
+      "profile": "payment_idempotency",
+      "adapter_id": "visa_tap",
+      "source_version": "commit-16d59bdf",
+      "description": "A replayed paid retry is denied.",
+      "input_patch": { "payment": { "replay_detected": true } },
+      "expected": { "decision": "deny", "code": "paid_retry_replay_detected" }
+    },
+    {
+      "id": "payment_not_observed",
+      "profile": "settlement_finality",
+      "adapter_id": "x402",
+      "source_version": "2.21.0",
+      "description": "Missing payment observation requires review.",
+      "input_patch": { "settlement": { "observed": false } },
+      "expected": { "decision": "review", "code": "payment_not_observed" }
+    },
+    {
+      "id": "delivery_with_unverified_payment",
+      "profile": "settlement_finality",
+      "adapter_id": "x402",
+      "source_version": "2.21.0",
+      "description": "Delivery cannot compensate for unverified settlement.",
+      "input_patch": { "settlement": { "verified": false } },
+      "expected": { "decision": "deny", "code": "settlement_unverified" }
+    },
+    {
+      "id": "delivery_with_nonfinal_payment",
+      "profile": "settlement_finality",
+      "adapter_id": "x402",
+      "source_version": "2.21.0",
+      "description": "Delivery with non-final settlement requires review.",
+      "input_patch": { "settlement": { "final": false } },
+      "expected": { "decision": "review", "code": "settlement_not_final" }
+    },
+    {
+      "id": "payment_with_failed_execution",
+      "profile": "execution_delivery",
+      "adapter_id": "openai_stripe_acp",
+      "source_version": "2026-04-17",
+      "description": "A failed execution after payment is denied.",
+      "input_patch": { "execution": { "succeeded": false } },
+      "expected": { "decision": "deny", "code": "execution_failed_after_payment" }
+    },
+    {
+      "id": "payment_without_delivery",
+      "profile": "execution_delivery",
+      "adapter_id": "x402",
+      "source_version": "2.21.0",
+      "description": "Payment without delivery evidence requires review.",
+      "input_patch": { "execution": { "delivery_observed": false } },
+      "expected": { "decision": "review", "code": "delivery_missing_after_payment" }
+    },
+    {
+      "id": "outcome_not_validated",
+      "profile": "outcome_validation",
+      "adapter_id": "openai_stripe_acp",
+      "source_version": "2026-04-17",
+      "description": "An unchecked output requires review.",
+      "input_patch": { "outcome": { "validation": "not_checked" } },
+      "expected": { "decision": "review", "code": "outcome_not_validated" }
+    },
+    {
+      "id": "wrong_output",
+      "profile": "outcome_validation",
+      "adapter_id": "google_ap2",
+      "source_version": "v0.2.0",
+      "description": "Failed output validation is denied.",
+      "input_patch": { "outcome": { "validation": "failed" } },
+      "expected": { "decision": "deny", "code": "outcome_validation_failed" }
+    },
+    {
+      "id": "partial_fulfillment",
+      "profile": "outcome_validation",
+      "adapter_id": "openai_stripe_acp",
+      "source_version": "2026-04-17",
+      "description": "Partial fulfillment requires review.",
+      "input_patch": { "outcome": { "validation": "partial" } },
+      "expected": { "decision": "review", "code": "partial_fulfillment" }
+    },
+    {
+      "id": "refund_pending",
+      "profile": "reconciliation",
+      "adapter_id": "x402",
+      "source_version": "2.21.0",
+      "description": "A pending refund requires review.",
+      "input_patch": { "reconciliation": { "status": "refund_pending" } },
+      "expected": { "decision": "review", "code": "refund_pending" }
+    },
+    {
+      "id": "refund_completed",
+      "profile": "reconciliation",
+      "adapter_id": "x402",
+      "source_version": "2.21.0",
+      "description": "A completed refund is a reconciled terminal outcome.",
+      "input_patch": { "reconciliation": { "status": "refunded" } },
+      "expected": { "decision": "pass", "code": "reconciled_refunded" }
+    },
+    {
+      "id": "dispute_pending",
+      "profile": "reconciliation",
+      "adapter_id": "visa_tap",
+      "source_version": "commit-16d59bdf",
+      "description": "A pending dispute requires review.",
+      "input_patch": { "reconciliation": { "status": "dispute_pending" } },
+      "expected": { "decision": "review", "code": "dispute_pending" }
+    },
+    {
+      "id": "dispute_resolved",
+      "profile": "reconciliation",
+      "adapter_id": "visa_tap",
+      "source_version": "commit-16d59bdf",
+      "description": "A resolved dispute is a reconciled terminal outcome.",
+      "input_patch": { "reconciliation": { "status": "dispute_resolved" } },
+      "expected": { "decision": "pass", "code": "reconciled_dispute_resolved" }
+    },
+    {
+      "id": "raw_secret_leak",
+      "profile": "privacy_redaction",
+      "adapter_id": "google_ap2",
+      "source_version": "v0.2.0",
+      "description": "Raw secret exposure is denied.",
+      "input_patch": { "privacy": { "raw_secret_exposed": true } },
+      "expected": { "decision": "deny", "code": "privacy_raw_secret_exposed" }
+    },
+    {
+      "id": "private_key_leak",
+      "profile": "privacy_redaction",
+      "adapter_id": "visa_tap",
+      "source_version": "commit-16d59bdf",
+      "description": "Private-key exposure is denied.",
+      "input_patch": { "privacy": { "private_key_exposed": true } },
+      "expected": { "decision": "deny", "code": "privacy_private_key_exposed" }
+    },
+    {
+      "id": "payment_credential_leak",
+      "profile": "privacy_redaction",
+      "adapter_id": "openai_stripe_acp",
+      "source_version": "2026-04-17",
+      "description": "Payment-credential exposure is denied.",
+      "input_patch": { "privacy": { "payment_credential_exposed": true } },
+      "expected": { "decision": "deny", "code": "privacy_payment_credential_exposed" }
+    },
+    {
+      "id": "raw_prompt_leak",
+      "profile": "privacy_redaction",
+      "adapter_id": "x402",
+      "source_version": "2.21.0",
+      "description": "Raw prompt exposure is denied.",
+      "input_patch": { "privacy": { "raw_prompt_exposed": true } },
+      "expected": { "decision": "deny", "code": "privacy_raw_prompt_exposed" }
+    },
+    {
+      "id": "raw_tool_output_leak",
+      "profile": "privacy_redaction",
+      "adapter_id": "openai_stripe_acp",
+      "source_version": "2026-04-17",
+      "description": "Raw tool-output exposure is denied.",
+      "input_patch": { "privacy": { "raw_tool_output_exposed": true } },
+      "expected": { "decision": "deny", "code": "privacy_raw_tool_output_exposed" }
+    },
+    {
+      "id": "private_owner_data_leak",
+      "profile": "privacy_redaction",
+      "adapter_id": "google_ap2",
+      "source_version": "v0.2.0",
+      "description": "Private owner-data exposure is denied.",
+      "input_patch": { "privacy": { "private_owner_data_exposed": true } },
+      "expected": { "decision": "deny", "code": "privacy_private_owner_data_exposed" }
+    }
+  ]
+}

--- a/transaction-assurance/examples/conformance-targets/agent-wallet-policy.mjs
+++ b/transaction-assurance/examples/conformance-targets/agent-wallet-policy.mjs
@@ -1,0 +1,5 @@
+import { evaluateReferenceVector } from '../../src/conformance.mjs';
+
+export function evaluateTransactionAssuranceVector({ input }) {
+  return evaluateReferenceVector(input);
+}

--- a/transaction-assurance/examples/conformance-targets/marketplace-listing.mjs
+++ b/transaction-assurance/examples/conformance-targets/marketplace-listing.mjs
@@ -1,0 +1,5 @@
+import { evaluateReferenceVector } from '../../src/conformance.mjs';
+
+export function evaluateTransactionAssuranceVector({ input }) {
+  return evaluateReferenceVector(input);
+}

--- a/transaction-assurance/examples/conformance-targets/mcp-paid-tool.mjs
+++ b/transaction-assurance/examples/conformance-targets/mcp-paid-tool.mjs
@@ -1,0 +1,5 @@
+import { evaluateReferenceVector } from '../../src/conformance.mjs';
+
+export function evaluateTransactionAssuranceVector({ input }) {
+  return evaluateReferenceVector(input);
+}

--- a/transaction-assurance/examples/conformance-targets/x402-resource-server.mjs
+++ b/transaction-assurance/examples/conformance-targets/x402-resource-server.mjs
@@ -1,0 +1,5 @@
+import { evaluateReferenceVector } from '../../src/conformance.mjs';
+
+export function evaluateTransactionAssuranceVector({ input }) {
+  return evaluateReferenceVector(input);
+}

--- a/transaction-assurance/package-lock.json
+++ b/transaction-assurance/package-lock.json
@@ -13,7 +13,9 @@
         "ajv-formats": "3.0.1"
       },
       "bin": {
-        "agora-assure": "bin/agora-assure.mjs"
+        "agora-assure": "bin/agora-assure.mjs",
+        "agora-assure-conformance": "bin/run-conformance.mjs",
+        "agora-verify-conformance": "bin/verify-conformance-receipt.mjs"
       },
       "engines": {
         "node": ">=20"

--- a/transaction-assurance/package.json
+++ b/transaction-assurance/package.json
@@ -9,11 +9,14 @@
     "node": ">=20"
   },
   "bin": {
-    "agora-assure": "./bin/agora-assure.mjs"
+    "agora-assure": "./bin/agora-assure.mjs",
+    "agora-assure-conformance": "./bin/run-conformance.mjs",
+    "agora-verify-conformance": "./bin/verify-conformance-receipt.mjs"
   },
   "exports": {
     ".": "./src/index.mjs",
     "./protocol-adapters": "./src/protocol-adapters.mjs",
+    "./conformance": "./src/conformance.mjs",
     "./evaluation-evidence": "./src/evaluation-evidence.mjs",
     "./toploc-evidence": "./src/toploc-evidence.mjs"
   },
@@ -21,18 +24,22 @@
     "bin/",
     "src/",
     "schema/",
+    "conformance/",
     "vendor/",
     "examples/",
     "SKILL.md",
     "README.md",
+    "CONFORMANCE.md",
+    "CONTRIBUTING_CONFORMANCE.md",
     "EVALUATION_EVIDENCE.md",
     "TOPLOC_EVIDENCE.md",
     "LICENSE"
   ],
   "scripts": {
     "test": "node --test test/*.test.mjs",
-    "check": "node --check src/index.mjs && node --check src/protocol-adapters.mjs && node --check src/evaluation-evidence.mjs && node --check src/toploc-evidence.mjs && node --check bin/agora-assure.mjs && node --check examples/x402-generic-middleware.mjs",
+    "check": "node --check src/index.mjs && node --check src/protocol-adapters.mjs && node --check src/conformance.mjs && node --check src/evaluation-evidence.mjs && node --check src/toploc-evidence.mjs && node --check bin/agora-assure.mjs && node --check bin/run-conformance.mjs && node --check bin/verify-conformance-receipt.mjs && node --check examples/x402-generic-middleware.mjs && node --check examples/conformance-targets/x402-resource-server.mjs && node --check examples/conformance-targets/mcp-paid-tool.mjs && node --check examples/conformance-targets/agent-wallet-policy.mjs && node --check examples/conformance-targets/marketplace-listing.mjs",
     "self-test": "node bin/agora-assure.mjs self-test",
+    "conformance": "node bin/run-conformance.mjs --target-name agoragentic-reference-evaluator --target-version 0.1.0-alpha.0 --target-commit local",
     "pack:dry": "npm pack --dry-run"
   },
   "dependencies": {

--- a/transaction-assurance/schema/transaction-assurance-conformance-input.v1.json
+++ b/transaction-assurance/schema/transaction-assurance-conformance-input.v1.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agoragentic.com/schema/transaction-assurance-conformance-input.v1.json",
+  "title": "Transaction Assurance Conformance Input v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "protocol", "authority", "terms", "limits", "payment", "settlement", "execution", "outcome", "reconciliation", "privacy"],
+  "properties": {
+    "schema": { "const": "agoragentic.transaction-assurance-conformance.v1" },
+    "protocol": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["adapter_id", "source_version"],
+      "properties": {
+        "adapter_id": { "$ref": "#/$defs/token" },
+        "source_version": { "type": "string", "minLength": 1, "maxLength": 128 }
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["verification", "revocation", "audience_match", "agent_match", "expired"],
+      "properties": {
+        "verification": { "enum": ["verified", "unverified", "unknown"] },
+        "revocation": { "enum": ["active", "revoked", "not_checked", "unknown"] },
+        "audience_match": { "type": "boolean" },
+        "agent_match": { "type": "boolean" },
+        "expired": { "type": "boolean" }
+      }
+    },
+    "terms": { "$ref": "#/$defs/terms" },
+    "limits": { "$ref": "#/$defs/limits" },
+    "payment": { "$ref": "#/$defs/payment" },
+    "settlement": { "$ref": "#/$defs/settlement" },
+    "execution": { "$ref": "#/$defs/execution" },
+    "outcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["validation"],
+      "properties": { "validation": { "enum": ["passed", "failed", "partial", "not_checked"] } }
+    },
+    "reconciliation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": { "status": { "enum": ["complete", "refunded", "refund_pending", "dispute_pending", "dispute_resolved", "none"] } }
+    },
+    "privacy": { "$ref": "#/$defs/privacy" }
+  },
+  "$defs": {
+    "token": { "type": "string", "pattern": "^[a-z0-9][a-z0-9._:-]{0,127}$" },
+    "terms": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["merchant_match", "category_match", "action_match", "rail_match", "currency_match", "quote_match", "terms_match"],
+      "properties": {
+        "merchant_match": { "type": "boolean" },
+        "category_match": { "type": "boolean" },
+        "action_match": { "type": "boolean" },
+        "rail_match": { "type": "boolean" },
+        "currency_match": { "type": "boolean" },
+        "quote_match": { "type": "boolean" },
+        "terms_match": { "type": "boolean" }
+      }
+    },
+    "limits": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["per_action_within_limit", "daily_within_limit", "total_within_limit"],
+      "properties": {
+        "per_action_within_limit": { "type": "boolean" },
+        "daily_within_limit": { "type": "boolean" },
+        "total_within_limit": { "type": "boolean" }
+      }
+    },
+    "payment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["identifier_present", "identifier_reused", "replay_detected"],
+      "properties": {
+        "identifier_present": { "type": "boolean" },
+        "identifier_reused": { "type": "boolean" },
+        "replay_detected": { "type": "boolean" }
+      }
+    },
+    "settlement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["observed", "verified", "final"],
+      "properties": {
+        "observed": { "type": "boolean" },
+        "verified": { "type": "boolean" },
+        "final": { "type": "boolean" }
+      }
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["attempted", "succeeded", "delivery_observed"],
+      "properties": {
+        "attempted": { "type": "boolean" },
+        "succeeded": { "type": "boolean" },
+        "delivery_observed": { "type": "boolean" }
+      }
+    },
+    "privacy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["raw_secret_exposed", "private_key_exposed", "payment_credential_exposed", "raw_prompt_exposed", "raw_tool_output_exposed", "private_owner_data_exposed"],
+      "properties": {
+        "raw_secret_exposed": { "type": "boolean" },
+        "private_key_exposed": { "type": "boolean" },
+        "payment_credential_exposed": { "type": "boolean" },
+        "raw_prompt_exposed": { "type": "boolean" },
+        "raw_tool_output_exposed": { "type": "boolean" },
+        "private_owner_data_exposed": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/transaction-assurance/schema/transaction-assurance-conformance-manifest.v1.json
+++ b/transaction-assurance/schema/transaction-assurance-conformance-manifest.v1.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agoragentic.com/schema/transaction-assurance-conformance-manifest.v1.json",
+  "title": "Transaction Assurance Conformance Manifest v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "suite_name", "suite_version", "released_at", "profiles", "protocol_adapters", "vector_set", "claim_boundary", "explicit_exclusions", "network_required", "spend_authority"],
+  "properties": {
+    "schema": { "const": "agoragentic.transaction-assurance-conformance-manifest.v1" },
+    "suite_name": { "type": "string", "minLength": 1, "maxLength": 200 },
+    "suite_version": { "type": "string", "minLength": 1, "maxLength": 64 },
+    "released_at": { "type": "string", "format": "date-time" },
+    "profiles": { "type": "array", "minItems": 8, "uniqueItems": true, "items": { "$ref": "#/$defs/token" } },
+    "protocol_adapters": {
+      "type": "array",
+      "minItems": 4,
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "version", "revision", "source"],
+        "properties": {
+          "id": { "$ref": "#/$defs/token" },
+          "version": { "type": "string", "minLength": 1, "maxLength": 128 },
+          "revision": { "type": "string", "minLength": 1, "maxLength": 128 },
+          "source": { "type": "string", "format": "uri" }
+        }
+      }
+    },
+    "vector_set": { "type": "string", "minLength": 1, "maxLength": 300 },
+    "claim_boundary": { "type": "string", "minLength": 1, "maxLength": 1000 },
+    "explicit_exclusions": { "type": "array", "minItems": 1, "uniqueItems": true, "items": { "$ref": "#/$defs/token" } },
+    "network_required": { "const": false },
+    "spend_authority": { "const": false }
+  },
+  "$defs": { "token": { "type": "string", "pattern": "^[a-z0-9][a-z0-9._:-]{0,127}$" } }
+}

--- a/transaction-assurance/schema/transaction-assurance-conformance-receipt.v1.json
+++ b/transaction-assurance/schema/transaction-assurance-conformance-receipt.v1.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agoragentic.com/schema/transaction-assurance-conformance-receipt.v1.json",
+  "title": "Transaction Assurance Conformance Receipt v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "suite_version", "target", "manifest_hash", "vector_set_hash", "report_hash", "total", "passed", "failed", "all_passed", "profiles_tested", "protocol_adapters_tested", "test_hashes", "explicit_exclusions", "claim_boundary", "network_used_by_suite", "spend_authority_granted", "certification_granted", "receipt_hash"],
+  "properties": {
+    "schema": { "const": "agoragentic.transaction-assurance-conformance-receipt.v1" },
+    "suite_version": { "type": "string", "minLength": 1, "maxLength": 64 },
+    "target": { "$ref": "#/$defs/target" },
+    "manifest_hash": { "$ref": "#/$defs/hash" },
+    "vector_set_hash": { "$ref": "#/$defs/hash" },
+    "report_hash": { "$ref": "#/$defs/hash" },
+    "total": { "type": "integer", "minimum": 0 },
+    "passed": { "type": "integer", "minimum": 0 },
+    "failed": { "type": "integer", "minimum": 0 },
+    "all_passed": { "type": "boolean" },
+    "profiles_tested": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/token" }, "uniqueItems": true },
+    "protocol_adapters_tested": { "type": "array", "minItems": 4, "items": { "$ref": "#/$defs/adapter" } },
+    "test_hashes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "input_hash", "expected_hash", "actual_hash", "passed"],
+        "properties": {
+          "id": { "$ref": "#/$defs/token" },
+          "input_hash": { "$ref": "#/$defs/hash" },
+          "expected_hash": { "$ref": "#/$defs/hash" },
+          "actual_hash": { "$ref": "#/$defs/hash" },
+          "passed": { "type": "boolean" }
+        }
+      }
+    },
+    "explicit_exclusions": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/token" }, "uniqueItems": true },
+    "claim_boundary": { "type": "string", "minLength": 1, "maxLength": 1000 },
+    "network_used_by_suite": { "const": false },
+    "spend_authority_granted": { "const": false },
+    "certification_granted": { "const": false },
+    "receipt_hash": { "$ref": "#/$defs/hash" }
+  },
+  "$defs": {
+    "token": { "type": "string", "pattern": "^[a-z0-9][a-z0-9._:-]{0,127}$" },
+    "hash": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "target": { "type": "object", "additionalProperties": false, "required": ["name", "version", "commit"], "properties": { "name": { "type": "string", "minLength": 1, "maxLength": 200 }, "version": { "type": "string", "minLength": 1, "maxLength": 128 }, "commit": { "type": "string", "minLength": 1, "maxLength": 128 } } },
+    "adapter": { "type": "object", "additionalProperties": false, "required": ["id", "version", "revision"], "properties": { "id": { "$ref": "#/$defs/token" }, "version": { "type": "string", "minLength": 1, "maxLength": 128 }, "revision": { "type": "string", "minLength": 1, "maxLength": 128 } } }
+  }
+}

--- a/transaction-assurance/schema/transaction-assurance-conformance-report.v1.json
+++ b/transaction-assurance/schema/transaction-assurance-conformance-report.v1.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agoragentic.com/schema/transaction-assurance-conformance-report.v1.json",
+  "title": "Transaction Assurance Conformance Report v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "suite_version", "target", "manifest_hash", "vector_set_hash", "total", "passed", "failed", "all_passed", "profiles_tested", "protocol_adapters_tested", "results", "network_used_by_suite", "spend_authority_granted", "report_hash"],
+  "properties": {
+    "schema": { "const": "agoragentic.transaction-assurance-conformance-report.v1" },
+    "suite_version": { "type": "string", "minLength": 1, "maxLength": 64 },
+    "target": { "$ref": "#/$defs/target" },
+    "manifest_hash": { "$ref": "#/$defs/hash" },
+    "vector_set_hash": { "$ref": "#/$defs/hash" },
+    "total": { "type": "integer", "minimum": 0 },
+    "passed": { "type": "integer", "minimum": 0 },
+    "failed": { "type": "integer", "minimum": 0 },
+    "all_passed": { "type": "boolean" },
+    "profiles_tested": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/token" }, "uniqueItems": true },
+    "protocol_adapters_tested": { "type": "array", "minItems": 4, "items": { "$ref": "#/$defs/adapter" } },
+    "results": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "profile", "adapter_id", "source_version", "input_hash", "expected", "actual", "passed"],
+        "properties": {
+          "id": { "$ref": "#/$defs/token" },
+          "profile": { "$ref": "#/$defs/token" },
+          "adapter_id": { "$ref": "#/$defs/token" },
+          "source_version": { "type": "string" },
+          "input_hash": { "$ref": "#/$defs/hash" },
+          "expected": { "$ref": "#/$defs/result" },
+          "actual": { "$ref": "#/$defs/result" },
+          "passed": { "type": "boolean" }
+        }
+      }
+    },
+    "network_used_by_suite": { "const": false },
+    "spend_authority_granted": { "const": false },
+    "report_hash": { "$ref": "#/$defs/hash" }
+  },
+  "$defs": {
+    "token": { "type": "string", "pattern": "^[a-z0-9][a-z0-9._:-]{0,127}$" },
+    "hash": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "target": { "type": "object", "additionalProperties": false, "required": ["name", "version", "commit"], "properties": { "name": { "type": "string", "minLength": 1, "maxLength": 200 }, "version": { "type": "string", "minLength": 1, "maxLength": 128 }, "commit": { "type": "string", "minLength": 1, "maxLength": 128 } } },
+    "adapter": { "type": "object", "additionalProperties": false, "required": ["id", "version", "revision"], "properties": { "id": { "$ref": "#/$defs/token" }, "version": { "type": "string", "minLength": 1, "maxLength": 128 }, "revision": { "type": "string", "minLength": 1, "maxLength": 128 } } },
+    "result": { "type": "object", "additionalProperties": false, "required": ["decision", "code"], "properties": { "decision": { "enum": ["pass", "deny", "review"] }, "code": { "$ref": "#/$defs/token" } } }
+  }
+}

--- a/transaction-assurance/schema/transaction-assurance-conformance-vectors.v1.json
+++ b/transaction-assurance/schema/transaction-assurance-conformance-vectors.v1.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agoragentic.com/schema/transaction-assurance-conformance-vectors.v1.json",
+  "title": "Transaction Assurance Conformance Vectors v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "suite_version", "base_input", "vectors"],
+  "properties": {
+    "schema": { "const": "agoragentic.transaction-assurance-conformance-vectors.v1" },
+    "suite_version": { "type": "string", "minLength": 1, "maxLength": 64 },
+    "base_input": { "$ref": "https://agoragentic.com/schema/transaction-assurance-conformance-input.v1.json" },
+    "vectors": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 128,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "profile", "adapter_id", "source_version", "description", "input_patch", "expected"],
+        "properties": {
+          "id": { "$ref": "#/$defs/token" },
+          "profile": { "$ref": "#/$defs/token" },
+          "adapter_id": { "$ref": "#/$defs/token" },
+          "source_version": { "type": "string", "minLength": 1, "maxLength": 128 },
+          "description": { "type": "string", "minLength": 1, "maxLength": 500 },
+          "input_patch": { "type": "object" },
+          "expected": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["decision", "code"],
+            "properties": {
+              "decision": { "enum": ["pass", "deny", "review"] },
+              "code": { "$ref": "#/$defs/token" }
+            }
+          }
+        }
+      }
+    }
+  },
+  "$defs": { "token": { "type": "string", "pattern": "^[a-z0-9][a-z0-9._:-]{0,127}$" } }
+}

--- a/transaction-assurance/src/conformance.mjs
+++ b/transaction-assurance/src/conformance.mjs
@@ -1,0 +1,564 @@
+import { readFile } from 'node:fs/promises';
+
+import { canonicalize, sha256Ref } from './index.mjs';
+import { PROTOCOL_ADAPTER_PINS } from './protocol-adapters.mjs';
+
+export const CONFORMANCE_SCHEMA = 'agoragentic.transaction-assurance-conformance.v1';
+export const CONFORMANCE_REPORT_SCHEMA = 'agoragentic.transaction-assurance-conformance-report.v1';
+export const CONFORMANCE_RECEIPT_SCHEMA = 'agoragentic.transaction-assurance-conformance-receipt.v1';
+
+const DECISIONS = new Set(['pass', 'deny', 'review']);
+const VERIFICATION_STATES = new Set(['verified', 'unverified', 'unknown']);
+const REVOCATION_STATES = new Set(['active', 'revoked', 'not_checked', 'unknown']);
+const OUTCOME_STATES = new Set(['passed', 'failed', 'partial', 'not_checked']);
+const RECONCILIATION_STATES = new Set([
+  'complete',
+  'refunded',
+  'refund_pending',
+  'dispute_pending',
+  'dispute_resolved',
+  'none',
+]);
+const TOKEN = /^[a-z0-9][a-z0-9._:-]{0,127}$/;
+const HASH = /^sha256:[0-9a-f]{64}$/;
+const MAX_VECTORS = 128;
+
+function isObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function object(value, field) {
+  if (!isObject(value)) throw new TypeError(`${field} must be an object`);
+  return value;
+}
+
+function exactKeys(value, keys, field) {
+  object(value, field);
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  if (canonicalize(actual) !== canonicalize(expected)) {
+    throw new TypeError(`${field} must contain exactly: ${expected.join(', ')}`);
+  }
+  return value;
+}
+
+function text(value, field, { max = 500, token = false } = {}) {
+  if (typeof value !== 'string' || !value.trim() || value.length > max) {
+    throw new TypeError(`${field} must be a non-empty string of at most ${max} characters`);
+  }
+  if (token && !TOKEN.test(value)) throw new TypeError(`${field} must be a bounded token`);
+  return value;
+}
+
+function bool(value, field) {
+  if (typeof value !== 'boolean') throw new TypeError(`${field} must be boolean`);
+  return value;
+}
+
+function integer(value, field) {
+  if (!Number.isSafeInteger(value) || value < 0) throw new TypeError(`${field} must be a non-negative integer`);
+  return value;
+}
+
+function enumeration(value, field, values) {
+  text(value, field, { token: true });
+  if (!values.has(value)) throw new TypeError(`${field} is unsupported`);
+  return value;
+}
+
+function uniqueTokens(value, field, { max = 128 } = {}) {
+  if (!Array.isArray(value) || value.length === 0 || value.length > max) {
+    throw new TypeError(`${field} must contain 1-${max} items`);
+  }
+  const result = value.map((item, index) => text(item, `${field}[${index}]`, { token: true }));
+  if (new Set(result).size !== result.length) throw new TypeError(`${field} must be unique`);
+  return result;
+}
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function merge(base, patch) {
+  if (!isObject(patch)) return clone(patch);
+  const output = isObject(base) ? clone(base) : {};
+  for (const [key, value] of Object.entries(patch)) {
+    output[key] = isObject(value) ? merge(output[key], value) : clone(value);
+  }
+  return output;
+}
+
+function validateBooleanRecord(value, keys, field) {
+  exactKeys(value, keys, field);
+  for (const key of keys) bool(value[key], `${field}.${key}`);
+}
+
+export function validateConformanceInput(input) {
+  exactKeys(input, [
+    'schema',
+    'protocol',
+    'authority',
+    'terms',
+    'limits',
+    'payment',
+    'settlement',
+    'execution',
+    'outcome',
+    'reconciliation',
+    'privacy',
+  ], 'input');
+  if (input.schema !== CONFORMANCE_SCHEMA) throw new TypeError('input.schema is unsupported');
+
+  exactKeys(input.protocol, ['adapter_id', 'source_version'], 'input.protocol');
+  text(input.protocol.adapter_id, 'input.protocol.adapter_id', { token: true });
+  text(input.protocol.source_version, 'input.protocol.source_version', { max: 128 });
+
+  exactKeys(input.authority, [
+    'verification',
+    'revocation',
+    'audience_match',
+    'agent_match',
+    'expired',
+  ], 'input.authority');
+  enumeration(input.authority.verification, 'input.authority.verification', VERIFICATION_STATES);
+  enumeration(input.authority.revocation, 'input.authority.revocation', REVOCATION_STATES);
+  bool(input.authority.audience_match, 'input.authority.audience_match');
+  bool(input.authority.agent_match, 'input.authority.agent_match');
+  bool(input.authority.expired, 'input.authority.expired');
+
+  validateBooleanRecord(input.terms, [
+    'merchant_match',
+    'category_match',
+    'action_match',
+    'rail_match',
+    'currency_match',
+    'quote_match',
+    'terms_match',
+  ], 'input.terms');
+  validateBooleanRecord(input.limits, [
+    'per_action_within_limit',
+    'daily_within_limit',
+    'total_within_limit',
+  ], 'input.limits');
+  validateBooleanRecord(input.payment, [
+    'identifier_present',
+    'identifier_reused',
+    'replay_detected',
+  ], 'input.payment');
+  validateBooleanRecord(input.settlement, ['observed', 'verified', 'final'], 'input.settlement');
+  validateBooleanRecord(input.execution, ['attempted', 'succeeded', 'delivery_observed'], 'input.execution');
+
+  exactKeys(input.outcome, ['validation'], 'input.outcome');
+  enumeration(input.outcome.validation, 'input.outcome.validation', OUTCOME_STATES);
+  exactKeys(input.reconciliation, ['status'], 'input.reconciliation');
+  enumeration(input.reconciliation.status, 'input.reconciliation.status', RECONCILIATION_STATES);
+  validateBooleanRecord(input.privacy, [
+    'raw_secret_exposed',
+    'private_key_exposed',
+    'payment_credential_exposed',
+    'raw_prompt_exposed',
+    'raw_tool_output_exposed',
+    'private_owner_data_exposed',
+  ], 'input.privacy');
+  return input;
+}
+
+export function validateConformanceManifest(manifest) {
+  exactKeys(manifest, [
+    'schema',
+    'suite_name',
+    'suite_version',
+    'released_at',
+    'profiles',
+    'protocol_adapters',
+    'vector_set',
+    'claim_boundary',
+    'explicit_exclusions',
+    'network_required',
+    'spend_authority',
+  ], 'manifest');
+  if (manifest.schema !== 'agoragentic.transaction-assurance-conformance-manifest.v1') {
+    throw new TypeError('manifest.schema is unsupported');
+  }
+  text(manifest.suite_name, 'manifest.suite_name', { max: 200 });
+  text(manifest.suite_version, 'manifest.suite_version', { max: 64 });
+  if (Number.isNaN(Date.parse(manifest.released_at))) throw new TypeError('manifest.released_at must be a date-time');
+  uniqueTokens(manifest.profiles, 'manifest.profiles', { max: 16 });
+  if (!Array.isArray(manifest.protocol_adapters) || manifest.protocol_adapters.length < 4) {
+    throw new TypeError('manifest.protocol_adapters must contain at least four adapters');
+  }
+  const ids = new Set();
+  for (const [index, adapter] of manifest.protocol_adapters.entries()) {
+    exactKeys(adapter, ['id', 'version', 'revision', 'source'], `manifest.protocol_adapters[${index}]`);
+    const id = text(adapter.id, `manifest.protocol_adapters[${index}].id`, { token: true });
+    if (ids.has(id)) throw new TypeError('manifest protocol adapter IDs must be unique');
+    ids.add(id);
+    const pin = PROTOCOL_ADAPTER_PINS[id];
+    if (!pin || adapter.version !== pin.version || adapter.revision !== pin.revision || adapter.source !== pin.source) {
+      throw new TypeError(`manifest protocol adapter ${id} is not pinned to the package source`);
+    }
+  }
+  text(manifest.vector_set, 'manifest.vector_set', { max: 300 });
+  text(manifest.claim_boundary, 'manifest.claim_boundary', { max: 1000 });
+  uniqueTokens(manifest.explicit_exclusions, 'manifest.explicit_exclusions', { max: 32 });
+  if (manifest.network_required !== false || manifest.spend_authority !== false) {
+    throw new TypeError('manifest must remain offline and no-spend');
+  }
+  return manifest;
+}
+
+export function validateConformanceVectorSet(vectorSet, manifest) {
+  validateConformanceManifest(manifest);
+  exactKeys(vectorSet, ['schema', 'suite_version', 'base_input', 'vectors'], 'vector_set');
+  if (vectorSet.schema !== 'agoragentic.transaction-assurance-conformance-vectors.v1') {
+    throw new TypeError('vector_set.schema is unsupported');
+  }
+  if (vectorSet.suite_version !== manifest.suite_version) throw new TypeError('vector suite version mismatch');
+  validateConformanceInput(vectorSet.base_input);
+  if (!Array.isArray(vectorSet.vectors) || vectorSet.vectors.length === 0 || vectorSet.vectors.length > MAX_VECTORS) {
+    throw new TypeError(`vector_set.vectors must contain 1-${MAX_VECTORS} vectors`);
+  }
+  const ids = new Set();
+  const profiles = new Set(manifest.profiles);
+  const adapters = new Set(manifest.protocol_adapters.map((item) => item.id));
+  const coveredProfiles = new Set();
+  const coveredAdapters = new Set();
+  for (const [index, vector] of vectorSet.vectors.entries()) {
+    exactKeys(vector, [
+      'id',
+      'profile',
+      'adapter_id',
+      'source_version',
+      'description',
+      'input_patch',
+      'expected',
+    ], `vector_set.vectors[${index}]`);
+    const id = text(vector.id, `vector_set.vectors[${index}].id`, { token: true });
+    if (ids.has(id)) throw new TypeError('vector IDs must be unique');
+    ids.add(id);
+    if (!profiles.has(vector.profile)) throw new TypeError(`vector ${id} uses an unknown profile`);
+    if (!adapters.has(vector.adapter_id)) throw new TypeError(`vector ${id} uses an unknown adapter`);
+    coveredProfiles.add(vector.profile);
+    coveredAdapters.add(vector.adapter_id);
+    text(vector.source_version, `vector ${id}.source_version`, { max: 128 });
+    text(vector.description, `vector ${id}.description`, { max: 500 });
+    object(vector.input_patch, `vector ${id}.input_patch`);
+    exactKeys(vector.expected, ['decision', 'code'], `vector ${id}.expected`);
+    enumeration(vector.expected.decision, `vector ${id}.expected.decision`, DECISIONS);
+    text(vector.expected.code, `vector ${id}.expected.code`, { token: true });
+    materializeVectorInput(vectorSet.base_input, vector);
+  }
+  if (canonicalize([...coveredProfiles].sort()) !== canonicalize([...profiles].sort())) {
+    throw new TypeError('vector set must cover every declared profile');
+  }
+  if (canonicalize([...coveredAdapters].sort()) !== canonicalize([...adapters].sort())) {
+    throw new TypeError('vector set must cover every pinned adapter');
+  }
+  return vectorSet;
+}
+
+export function materializeVectorInput(baseInput, vector) {
+  const input = merge(baseInput, vector.input_patch);
+  input.protocol = {
+    adapter_id: vector.adapter_id,
+    source_version: vector.source_version,
+  };
+  return validateConformanceInput(input);
+}
+
+function result(decision, code) {
+  return Object.freeze({ decision, code });
+}
+
+export function evaluateReferenceVector(input) {
+  validateConformanceInput(input);
+  const pin = PROTOCOL_ADAPTER_PINS[input.protocol.adapter_id];
+  if (!pin || input.protocol.source_version !== pin.version) return result('deny', 'unsupported_protocol_version');
+
+  if (input.authority.verification === 'unknown') return result('review', 'authority_verification_unknown');
+  if (input.authority.verification !== 'verified') return result('review', 'authority_unverified');
+  if (input.authority.revocation === 'revoked') return result('deny', 'authority_revoked');
+  if (input.authority.revocation !== 'active') return result('review', 'authority_revocation_unknown');
+  if (input.authority.expired) return result('deny', 'authority_expired');
+  if (!input.authority.audience_match) return result('deny', 'authority_wrong_audience');
+  if (!input.authority.agent_match) return result('deny', 'authority_wrong_agent');
+
+  for (const [field, code] of [
+    ['merchant_match', 'merchant_mismatch'],
+    ['category_match', 'category_mismatch'],
+    ['action_match', 'action_mismatch'],
+    ['rail_match', 'rail_mismatch'],
+    ['currency_match', 'currency_mismatch'],
+    ['quote_match', 'quote_changed'],
+    ['terms_match', 'terms_changed'],
+  ]) {
+    if (!input.terms[field]) return result('deny', code);
+  }
+  for (const [field, code] of [
+    ['per_action_within_limit', 'per_action_limit_exceeded'],
+    ['daily_within_limit', 'daily_limit_exceeded'],
+    ['total_within_limit', 'total_limit_exceeded'],
+  ]) {
+    if (!input.limits[field]) return result('deny', code);
+  }
+
+  if (!input.payment.identifier_present) return result('deny', 'payment_identifier_missing');
+  if (input.payment.identifier_reused) return result('deny', 'payment_identifier_reused');
+  if (input.payment.replay_detected) return result('deny', 'paid_retry_replay_detected');
+  if (!input.settlement.observed) return result('review', 'payment_not_observed');
+  if (!input.settlement.verified) return result('deny', 'settlement_unverified');
+  if (!input.settlement.final) return result('review', 'settlement_not_final');
+  if (!input.execution.attempted) return result('review', 'execution_not_observed');
+  if (!input.execution.succeeded) return result('deny', 'execution_failed_after_payment');
+  if (!input.execution.delivery_observed) return result('review', 'delivery_missing_after_payment');
+
+  if (input.outcome.validation === 'not_checked') return result('review', 'outcome_not_validated');
+  if (input.outcome.validation === 'failed') return result('deny', 'outcome_validation_failed');
+  if (input.outcome.validation === 'partial') return result('review', 'partial_fulfillment');
+
+  if (Object.entries(input.privacy).some(([, exposed]) => exposed)) {
+    const field = Object.entries(input.privacy).find(([, exposed]) => exposed)[0];
+    return result('deny', `privacy_${field}`);
+  }
+
+  if (input.reconciliation.status === 'refund_pending') return result('review', 'refund_pending');
+  if (input.reconciliation.status === 'dispute_pending') return result('review', 'dispute_pending');
+  if (input.reconciliation.status === 'none') return result('review', 'reconciliation_incomplete');
+  if (input.reconciliation.status === 'refunded') return result('pass', 'reconciled_refunded');
+  if (input.reconciliation.status === 'dispute_resolved') return result('pass', 'reconciled_dispute_resolved');
+  return result('pass', 'complete_chain_verified');
+}
+
+function validateEvaluatorResult(value, field) {
+  exactKeys(value, ['decision', 'code'], field);
+  enumeration(value.decision, `${field}.decision`, DECISIONS);
+  text(value.code, `${field}.code`, { token: true });
+  return value;
+}
+
+export async function runConformanceSuite({
+  manifest,
+  vectorSet,
+  evaluate = ({ input }) => evaluateReferenceVector(input),
+  target,
+}) {
+  validateConformanceVectorSet(vectorSet, manifest);
+  if (typeof evaluate !== 'function') throw new TypeError('evaluate must be a function');
+  exactKeys(target, ['name', 'version', 'commit'], 'target');
+  text(target.name, 'target.name', { max: 200 });
+  text(target.version, 'target.version', { max: 128 });
+  text(target.commit, 'target.commit', { max: 128 });
+
+  const results = [];
+  for (const vector of vectorSet.vectors) {
+    const input = materializeVectorInput(vectorSet.base_input, vector);
+    const actual = await evaluate(Object.freeze({
+      vector: Object.freeze(clone(vector)),
+      input: Object.freeze(clone(input)),
+    }));
+    validateEvaluatorResult(actual, `result for ${vector.id}`);
+    const passed = actual.decision === vector.expected.decision && actual.code === vector.expected.code;
+    results.push({
+      id: vector.id,
+      profile: vector.profile,
+      adapter_id: vector.adapter_id,
+      source_version: vector.source_version,
+      input_hash: sha256Ref(input),
+      expected: clone(vector.expected),
+      actual: clone(actual),
+      passed,
+    });
+  }
+
+  const passed = results.filter((item) => item.passed).length;
+  const body = {
+    schema: CONFORMANCE_REPORT_SCHEMA,
+    suite_version: manifest.suite_version,
+    target: clone(target),
+    manifest_hash: sha256Ref(manifest),
+    vector_set_hash: sha256Ref(vectorSet),
+    total: results.length,
+    passed,
+    failed: results.length - passed,
+    all_passed: passed === results.length,
+    profiles_tested: [...new Set(results.map((item) => item.profile))].sort(),
+    protocol_adapters_tested: manifest.protocol_adapters.map((adapter) => ({
+      id: adapter.id,
+      version: adapter.version,
+      revision: adapter.revision,
+    })),
+    results,
+    network_used_by_suite: false,
+    spend_authority_granted: false,
+  };
+  return { ...body, report_hash: sha256Ref(body) };
+}
+
+export function validateConformanceReport({ manifest, vectorSet, report }) {
+  validateConformanceVectorSet(vectorSet, manifest);
+  exactKeys(report, [
+    'schema',
+    'suite_version',
+    'target',
+    'manifest_hash',
+    'vector_set_hash',
+    'total',
+    'passed',
+    'failed',
+    'all_passed',
+    'profiles_tested',
+    'protocol_adapters_tested',
+    'results',
+    'network_used_by_suite',
+    'spend_authority_granted',
+    'report_hash',
+  ], 'report');
+  if (report.schema !== CONFORMANCE_REPORT_SCHEMA) throw new TypeError('report.schema is unsupported');
+  if (report.suite_version !== manifest.suite_version) throw new TypeError('report suite version mismatch');
+  exactKeys(report.target, ['name', 'version', 'commit'], 'report.target');
+  text(report.target.name, 'report.target.name', { max: 200 });
+  text(report.target.version, 'report.target.version', { max: 128 });
+  text(report.target.commit, 'report.target.commit', { max: 128 });
+  if (report.manifest_hash !== sha256Ref(manifest) || report.vector_set_hash !== sha256Ref(vectorSet)) {
+    throw new TypeError('report input hash mismatch');
+  }
+  if (!Array.isArray(report.results) || report.results.length !== vectorSet.vectors.length) {
+    throw new TypeError('report must contain exactly one result per vector');
+  }
+  const vectorMap = new Map(vectorSet.vectors.map((vector) => [vector.id, vector]));
+  const resultIds = new Set();
+  for (const [index, item] of report.results.entries()) {
+    exactKeys(item, [
+      'id',
+      'profile',
+      'adapter_id',
+      'source_version',
+      'input_hash',
+      'expected',
+      'actual',
+      'passed',
+    ], `report.results[${index}]`);
+    const vector = vectorMap.get(item.id);
+    if (!vector || resultIds.has(item.id)) throw new TypeError('report result IDs must match vectors exactly once');
+    resultIds.add(item.id);
+    if (item.profile !== vector.profile
+      || item.adapter_id !== vector.adapter_id
+      || item.source_version !== vector.source_version) {
+      throw new TypeError(`report result metadata mismatch for ${item.id}`);
+    }
+    if (item.input_hash !== sha256Ref(materializeVectorInput(vectorSet.base_input, vector))) {
+      throw new TypeError(`report input hash mismatch for ${item.id}`);
+    }
+    if (canonicalize(item.expected) !== canonicalize(vector.expected)) {
+      throw new TypeError(`report expected result mismatch for ${item.id}`);
+    }
+    validateEvaluatorResult(item.actual, `report actual result for ${item.id}`);
+    bool(item.passed, `report passed for ${item.id}`);
+    const shouldPass = item.actual.decision === vector.expected.decision
+      && item.actual.code === vector.expected.code;
+    if (item.passed !== shouldPass) throw new TypeError(`report pass flag mismatch for ${item.id}`);
+  }
+  const expectedProfiles = [...new Set(vectorSet.vectors.map((item) => item.profile))].sort();
+  if (canonicalize(report.profiles_tested) !== canonicalize(expectedProfiles)) {
+    throw new TypeError('report profile coverage mismatch');
+  }
+  const expectedAdapters = manifest.protocol_adapters.map((adapter) => ({
+    id: adapter.id,
+    version: adapter.version,
+    revision: adapter.revision,
+  }));
+  if (canonicalize(report.protocol_adapters_tested) !== canonicalize(expectedAdapters)) {
+    throw new TypeError('report adapter coverage mismatch');
+  }
+  const passed = report.results.filter((item) => item.passed).length;
+  if (integer(report.total, 'report.total') !== report.results.length
+    || integer(report.passed, 'report.passed') !== passed
+    || integer(report.failed, 'report.failed') !== report.results.length - passed
+    || bool(report.all_passed, 'report.all_passed') !== (passed === report.results.length)) {
+    throw new TypeError('report counts are inconsistent');
+  }
+  if (report.network_used_by_suite !== false || report.spend_authority_granted !== false) {
+    throw new TypeError('report authority boundary mismatch');
+  }
+  const body = { ...report };
+  delete body.report_hash;
+  if (!HASH.test(report.report_hash || '') || sha256Ref(body) !== report.report_hash) {
+    throw new TypeError('report hash mismatch');
+  }
+  return report;
+}
+
+export function buildConformanceReceipt({ manifest, vectorSet, report }) {
+  validateConformanceReport({ manifest, vectorSet, report });
+  const body = {
+    schema: CONFORMANCE_RECEIPT_SCHEMA,
+    suite_version: manifest.suite_version,
+    target: clone(report.target),
+    manifest_hash: report.manifest_hash,
+    vector_set_hash: report.vector_set_hash,
+    report_hash: report.report_hash,
+    total: integer(report.total, 'report.total'),
+    passed: integer(report.passed, 'report.passed'),
+    failed: integer(report.failed, 'report.failed'),
+    all_passed: bool(report.all_passed, 'report.all_passed'),
+    profiles_tested: clone(report.profiles_tested),
+    protocol_adapters_tested: clone(report.protocol_adapters_tested),
+    test_hashes: report.results.map((item) => ({
+      id: item.id,
+      input_hash: item.input_hash,
+      expected_hash: sha256Ref(item.expected),
+      actual_hash: sha256Ref(item.actual),
+      passed: item.passed,
+    })),
+    explicit_exclusions: clone(manifest.explicit_exclusions),
+    claim_boundary: manifest.claim_boundary,
+    network_used_by_suite: false,
+    spend_authority_granted: false,
+    certification_granted: false,
+  };
+  return { ...body, receipt_hash: sha256Ref(body) };
+}
+
+export function verifyConformanceReceipt({ manifest, vectorSet, report, receipt }) {
+  try {
+    const expected = buildConformanceReceipt({ manifest, vectorSet, report });
+    return {
+      verified: canonicalize(expected) === canonicalize(receipt),
+      receipt_hash: expected.receipt_hash,
+    };
+  } catch (error) {
+    return { verified: false, error: error.message };
+  }
+}
+
+function xml(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+}
+
+export function renderConformanceJUnit(report) {
+  if (report?.schema !== CONFORMANCE_REPORT_SCHEMA) throw new TypeError('report is required');
+  const cases = report.results.map((item) => {
+    const failure = item.passed
+      ? ''
+      : `<failure message="${xml(`${item.actual.decision}:${item.actual.code}`)}">expected ${xml(`${item.expected.decision}:${item.expected.code}`)}</failure>`;
+    return `  <testcase classname="transaction-assurance.${xml(item.profile)}" name="${xml(item.id)}">${failure}</testcase>`;
+  });
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    `<testsuite name="Agoragentic Transaction Assurance" tests="${report.total}" failures="${report.failed}" errors="0" time="0">`,
+    ...cases,
+    '</testsuite>',
+    '',
+  ].join('\n');
+}
+
+export async function readJson(path) {
+  return JSON.parse(await readFile(path, 'utf8'));
+}

--- a/transaction-assurance/test/conformance.test.mjs
+++ b/transaction-assurance/test/conformance.test.mjs
@@ -1,0 +1,216 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+import test from 'node:test';
+
+import {
+  buildConformanceReceipt,
+  evaluateReferenceVector,
+  readJson,
+  renderConformanceJUnit,
+  runConformanceSuite,
+  validateConformanceInput,
+  validateConformanceManifest,
+  validateConformanceReport,
+  validateConformanceVectorSet,
+  verifyConformanceReceipt,
+} from '../src/conformance.mjs';
+
+const execFileAsync = promisify(execFile);
+const root = new URL('../', import.meta.url);
+const manifest = await readJson(new URL('conformance/manifest.v1.json', root));
+const vectorSet = await readJson(new URL('conformance/vectors.v1.json', root));
+
+test('machine contracts and bundled vectors validate strictly', async () => {
+  const schemaFiles = [
+    'transaction-assurance-conformance-input.v1.json',
+    'transaction-assurance-conformance-manifest.v1.json',
+    'transaction-assurance-conformance-vectors.v1.json',
+    'transaction-assurance-conformance-report.v1.json',
+    'transaction-assurance-conformance-receipt.v1.json',
+  ];
+  const schemas = await Promise.all(schemaFiles.map((file) => readJson(new URL(`schema/${file}`, root))));
+  const ajv = new Ajv2020({ allErrors: true, strict: true });
+  addFormats(ajv);
+  for (const schema of schemas) ajv.addSchema(schema);
+  assert.equal(ajv.validate(schemas[1].$id, manifest), true, JSON.stringify(ajv.errors));
+  assert.equal(ajv.validate(schemas[2].$id, vectorSet), true, JSON.stringify(ajv.errors));
+  const generatedReport = await runConformanceSuite({
+    manifest,
+    vectorSet,
+    target: { name: 'schema-target', version: '1', commit: 'fixture' },
+  });
+  const generatedReceipt = buildConformanceReceipt({ manifest, vectorSet, report: generatedReport });
+  assert.equal(ajv.validate(schemas[3].$id, generatedReport), true, JSON.stringify(ajv.errors));
+  assert.equal(ajv.validate(schemas[4].$id, generatedReceipt), true, JSON.stringify(ajv.errors));
+  assert.doesNotThrow(() => validateConformanceManifest(manifest));
+  assert.doesNotThrow(() => validateConformanceVectorSet(vectorSet, manifest));
+  const poisoned = structuredClone(vectorSet.base_input);
+  poisoned.raw_payload = 'not allowed';
+  assert.throws(() => validateConformanceInput(poisoned), /must contain exactly/);
+});
+
+test('reference suite covers every required profile and negative decision', async () => {
+  const report = await runConformanceSuite({
+    manifest,
+    vectorSet,
+    target: { name: 'reference', version: '1', commit: 'test' },
+  });
+  assert.equal(report.total, vectorSet.vectors.length);
+  assert.equal(report.total >= 40, true);
+  assert.equal(report.passed, report.total);
+  assert.equal(report.failed, 0);
+  assert.equal(report.all_passed, true);
+  assert.deepEqual(report.profiles_tested, [...manifest.profiles].sort());
+  assert.deepEqual(
+    new Set(report.protocol_adapters_tested.map((item) => item.id)),
+    new Set(['google_ap2', 'visa_tap', 'openai_stripe_acp', 'x402']),
+  );
+  const codes = new Set(report.results.map((item) => item.actual.code));
+  for (const code of [
+    'authority_unverified',
+    'authority_expired',
+    'authority_revoked',
+    'authority_wrong_audience',
+    'authority_wrong_agent',
+    'merchant_mismatch',
+    'category_mismatch',
+    'action_mismatch',
+    'rail_mismatch',
+    'currency_mismatch',
+    'quote_changed',
+    'terms_changed',
+    'per_action_limit_exceeded',
+    'daily_limit_exceeded',
+    'total_limit_exceeded',
+    'payment_identifier_missing',
+    'payment_identifier_reused',
+    'paid_retry_replay_detected',
+    'delivery_missing_after_payment',
+    'settlement_unverified',
+    'settlement_not_final',
+    'outcome_validation_failed',
+    'partial_fulfillment',
+    'refund_pending',
+    'reconciled_refunded',
+    'dispute_pending',
+    'reconciled_dispute_resolved',
+    'privacy_raw_secret_exposed',
+    'privacy_private_key_exposed',
+    'privacy_payment_credential_exposed',
+    'privacy_raw_prompt_exposed',
+    'privacy_raw_tool_output_exposed',
+    'privacy_private_owner_data_exposed',
+    'unsupported_protocol_version',
+    'authority_verification_unknown',
+  ]) assert.equal(codes.has(code), true, `missing ${code}`);
+});
+
+test('reports, JUnit, and receipts are deterministic and tamper evident', async () => {
+  const target = { name: 'deterministic-target', version: '1.2.3', commit: 'abc123' };
+  const first = await runConformanceSuite({ manifest, vectorSet, target });
+  const second = await runConformanceSuite({ manifest, vectorSet, target });
+  assert.deepEqual(first, second);
+  const junit = renderConformanceJUnit(first);
+  assert.match(junit, new RegExp(`tests="${first.total}" failures="0"`));
+  const receipt = buildConformanceReceipt({ manifest, vectorSet, report: first });
+  assert.equal(receipt.certification_granted, false);
+  assert.equal(receipt.network_used_by_suite, false);
+  assert.equal(receipt.spend_authority_granted, false);
+  assert.deepEqual(verifyConformanceReceipt({ manifest, vectorSet, report: first, receipt }), {
+    verified: true,
+    receipt_hash: receipt.receipt_hash,
+  });
+  const tampered = structuredClone(receipt);
+  tampered.passed -= 1;
+  assert.equal(verifyConformanceReceipt({ manifest, vectorSet, report: first, receipt: tampered }).verified, false);
+  const forgedReport = structuredClone(first);
+  forgedReport.results[0].expected.code = 'authority_unverified';
+  const forgedBody = { ...forgedReport };
+  delete forgedBody.report_hash;
+  const { sha256Ref } = await import('../src/index.mjs');
+  forgedReport.report_hash = sha256Ref(forgedBody);
+  assert.throws(
+    () => validateConformanceReport({ manifest, vectorSet, report: forgedReport }),
+    /expected result mismatch/,
+  );
+});
+
+test('a nonconforming target produces bounded failures without certification', async () => {
+  const report = await runConformanceSuite({
+    manifest,
+    vectorSet,
+    evaluate: () => ({ decision: 'pass', code: 'complete_chain_verified' }),
+    target: { name: 'unsafe-target', version: '0', commit: 'test' },
+  });
+  assert.equal(report.all_passed, false);
+  assert.equal(report.failed > 0, true);
+  const receipt = buildConformanceReceipt({ manifest, vectorSet, report });
+  assert.equal(receipt.certification_granted, false);
+  assert.equal(verifyConformanceReceipt({ manifest, vectorSet, report, receipt }).verified, true);
+});
+
+test('all four example target modules satisfy the reference contract', async () => {
+  for (const filename of [
+    'x402-resource-server.mjs',
+    'mcp-paid-tool.mjs',
+    'agent-wallet-policy.mjs',
+    'marketplace-listing.mjs',
+  ]) {
+    const module = await import(new URL(`examples/conformance-targets/${filename}`, root));
+    const report = await runConformanceSuite({
+      manifest,
+      vectorSet,
+      evaluate: module.evaluateTransactionAssuranceVector,
+      target: { name: filename, version: 'example', commit: 'fixture' },
+    });
+    assert.equal(report.all_passed, true, filename);
+  }
+});
+
+test('CLI writes JSON, JUnit, and a publicly verifiable receipt', async () => {
+  const temp = await mkdtemp(path.join(os.tmpdir(), 'agora-conformance-'));
+  const reportPath = path.join(temp, 'report.json');
+  const junitPath = path.join(temp, 'report.xml');
+  const receiptPath = path.join(temp, 'receipt.json');
+  const cli = new URL('bin/run-conformance.mjs', root);
+  await execFileAsync(process.execPath, [
+    fileURLToPath(cli),
+    '--target-name', 'cli-test',
+    '--target-version', '1',
+    '--target-commit', 'abc',
+    '--json', reportPath,
+    '--junit', junitPath,
+    '--receipt', receiptPath,
+  ]);
+  const [report, junit, receipt] = await Promise.all([
+    readJson(reportPath),
+    readFile(junitPath, 'utf8'),
+    readJson(receiptPath),
+  ]);
+  assert.equal(report.all_passed, true);
+  assert.match(junit, /<testsuite/);
+  assert.equal(receipt.certification_granted, false);
+  const verifier = new URL('bin/verify-conformance-receipt.mjs', root);
+  const verified = await execFileAsync(process.execPath, [fileURLToPath(verifier), reportPath, receiptPath]);
+  assert.deepEqual(JSON.parse(verified.stdout), {
+    verified: true,
+    receipt_hash: receipt.receipt_hash,
+  });
+});
+
+test('reference evaluator rejects malformed result inputs', () => {
+  const input = structuredClone(vectorSet.base_input);
+  input.protocol = { adapter_id: 'x402', source_version: '2.21.0' };
+  assert.deepEqual(evaluateReferenceVector(input), {
+    decision: 'pass',
+    code: 'complete_chain_verified',
+  });
+});


### PR DESCRIPTION
## Summary
- add an offline, deterministic Transaction Assurance conformance suite covering eight assurance profiles
- pin four existing protocol adapters and ship 42 language-neutral positive/adversarial vectors
- add strict schemas, JSON/JUnit reports, a bounded receipt with public verifier, four reference target modules, and a reusable pinned GitHub workflow
- keep the package source-only, no-network, no-spend, and explicitly non-certifying

## Validation
- `npm run check`
- `npm test` (62/62)
- `npm run conformance` (42/42; eight profiles; four pinned adapters)
- `npm run self-test`
- `npm run pack:dry`
- `node scripts/verify-integrations-json.js`
- `node scripts/verify-doc-links.mjs` (227 files)
- `git diff --check`

## Boundary
This progresses #246 but intentionally does not close it. The issue's external-adopter acceptance criterion remains open; bundled examples are reference fixtures, not third-party evidence, and no ecosystem-standard claim is made.