### PR TITLE
feat(harness): add governed Memory SkillOpt bridge

### DIFF
--- a/harness-core/CHANGELOG.md
+++ b/harness-core/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## 0.2.1 - Unreleased
+## 0.3.0 - Unreleased
 
 - Added the packaged Harness Core hero and installed-package README link verification.
 - Narrowed receipt and adapter claims to the configuration/proposal evidence emitted by the package.
+- Added a review-gated Agoragentic Memory to SkillOpt task-draft bridge and bounded SkillOpt report adapter.
 
 ## 0.2.0 - 2026-07-23
 

--- a/harness-core/EVALUATION_ADAPTERS.md
+++ b/harness-core/EVALUATION_ADAPTERS.md
@@ -5,7 +5,8 @@ Harness Core can normalize external design and security findings into the option
 Supported inputs:
 
 - Impeccable `3.5.0` JSON findings at source revision `5d10bc842cbccd2ae7d3a88296d87d3be0b125b3`;
-- SARIF `2.1.0` reports from tools that identify their name and version in `tool.driver`.
+- SARIF `2.1.0` reports from tools that identify their name and version in `tool.driver`;
+- SkillOpt-Sleep `0.2.0` `--json` CLI summaries at source revision `47fe269d75d3def79ffd90236261d26d84868ae5`.
 
 The adapter code is original Agoragentic code. It does not copy Impeccable skill text, detector code, or scanner output. Impeccable is Apache-2.0 licensed at the pinned source revision. SARIF is an OASIS standard. No Impeccable, Trail of Bits, scanner-vendor, or OASIS endorsement is claimed.
 
@@ -48,6 +49,8 @@ const updated = attachEvaluationEvidenceToReceipt(receipt, evaluation);
 
 Use `normalizeSarifReport(report, options)` for SARIF. Unsupported Impeccable revisions and unsupported SARIF versions fail closed.
 
+Use `normalizeSkillOptSleepReport(report, options)` for a completed SkillOpt-Sleep `--json` CLI summary, not the differently shaped staged dataclass `report.json`. `producer_version` and `source_revision` are required operator assertions and must match the supported pin; the summary does not independently prove them. The adapter fails on unreviewed tasks, observed adoption, non-gated acceptance, inconsistent gate evidence, holdout leakage, insufficient task count, or score regression. The pinned native summary omits holdout-integrity evidence, so it requires review unless separately augmented with that evidence; a rejected candidate also requires review. The adapter hashes but does not retain raw optimizer edits, notes, task-file paths, or staging paths. See [Agoragentic Memory to SkillOpt bridge](MEMORY_SKILLOPT.md) for the review-gated task export.
+
 ## Evidence and privacy boundary
 
 The normalized record retains:
@@ -61,3 +64,5 @@ The normalized record retains:
 It deliberately excludes raw source paths, messages, snippets, prompts, tool output, credentials, and scanner-private payloads. Suppressed findings remain countable and reviewable through their rule, severity, status, and hashes.
 
 A `pass` means only that the supplied report did not cross the configured gate. It does not mean the scanner ran correctly, the findings are accurate, the analyzed revision is complete, vulnerabilities are absent, or the artifact is certified. A `fail` blocks the local receipt and therefore the existing Harness listing-readiness proposal. It does not deploy, publish, spend, call a provider, mutate trust, or bypass owner review.
+
+For SkillOpt, `pass` also does not independently prove the task file was owner-reviewed, the holdout was isolated, or the proposed skill should be adopted. Those claims come from the supplied report and remain subject to separate owner verification.

--- a/harness-core/MEMORY_SKILLOPT.md
+++ b/harness-core/MEMORY_SKILLOPT.md
@@ -1,0 +1,81 @@
+# Agoragentic Memory to SkillOpt bridge
+
+Harness Core can turn an explicit operator-supplied selection of public, evidence-backed Agoragentic Memory claims into an unreviewed SkillOpt task draft. It can also normalize a completed SkillOpt-Sleep `--json` CLI summary into the existing Harness evaluation evidence and attach that evidence to a local receipt.
+
+The bridge is source-only and review-gated. It does not call a model or provider, run SkillOpt, mark tasks reviewed, adopt or publish a skill, mutate Memory, invoke the Router, or spend.
+
+## Pinned compatibility
+
+- Agoragentic Memory `0.1.0-rc.2`, source revision `508ac3667a5ad3f6f5da323d7ddaf5f13384095d`, bounded export schema `agoragentic.memory.export.v1`;
+- Microsoft SkillOpt `0.2.0`, source revision `47fe269d75d3def79ffd90236261d26d84868ae5`, task format `skillopt_sleep.tasks.v1`.
+
+Other versions and source revisions require a reviewed compatibility update. The Memory export does not carry producer version or source revision, so the emitted pin is a declared adapter compatibility boundary, not verified provenance. The generated file always has `reviewed: false`, which means the pinned SkillOpt backend must refuse to use it until a human has reviewed the task text and deliberately changed that field outside this bridge.
+
+## Export a task draft
+
+Create a selection file that names only the public Memory claims you intend to expose. The bridge validates the file but does not authenticate who created it:
+
+```json
+{
+  "schema": "agoragentic.memory-skillopt.selection.v1",
+  "memory_project_id": "agoragentic-public",
+  "skillopt_project": "example-project",
+  "target_skill_path": ".agents/skills/example/SKILL.md",
+  "tasks": [
+    {
+      "memory_id": "mem_11111111111111111111111111111111",
+      "split": "train",
+      "skill_hint": "example-skill"
+    },
+    {
+      "memory_id": "mem_22222222222222222222222222222222",
+      "split": "val",
+      "skill_hint": "example-skill"
+    }
+  ]
+}
+```
+
+Then run:
+
+```bash
+agoragentic-memory-skillopt export-tasks \
+  --memory-export memory-export.json \
+  --selection memory-skillopt-selection.json \
+  --output skillopt-tasks.unreviewed.json
+```
+
+The command fails closed unless all selected claims:
+
+- are present in the named Memory project;
+- have `sensitivity: "public"`;
+- are task-like claims with at least one evidence reference;
+- pass bounded secret-shaped and instruction-shaped text checks;
+- include both a training split and a held-out validation or test split.
+
+The output retains the selected public task text, selected Memory IDs, a deterministic hash of a public-safe projection of only the selected claims, and pinned compatibility metadata. Unselected claims and events do not influence that hash. The output excludes repository IDs, Memory events, evidence bodies, source sessions, raw transcripts, prompts, tool output, and credentials.
+
+## Attach a SkillOpt report
+
+After an owner has separately reviewed the tasks and run the pinned SkillOpt version under its own policy, capture the `--json` CLI summary and attach that summary to a Harness local receipt. The staged SkillOpt dataclass `report.json` has a different field shape and is not this adapter's input:
+
+```bash
+agoragentic-memory-skillopt attach-report \
+  --report skillopt-report.json \
+  --receipt .agoragentic/local-receipt.json \
+  --producer-version 0.2.0 \
+  --source-revision 47fe269d75d3def79ffd90236261d26d84868ae5 \
+  --analyzed-revision 0123456789abcdef0123456789abcdef01234567 \
+  --output .agoragentic/local-receipt.skillopt.json
+```
+
+The adapter hashes the complete summary but does not retain raw edits, notes, staging paths, task-file paths, or optimizer rationale. It fails on an unreviewed task file, observed adoption, non-gated acceptance such as `greedy_applied`, inconsistent gate evidence, holdout leakage, too few tasks, or a regressed candidate score. The pinned native CLI summary currently omits `holdout_leaked`; an unaugmented native summary therefore requires review rather than passing. A rejected candidate also requires review.
+
+The producer version and revision are required operator assertions and must match the supported pin; the report does not prove them itself. The adapter trusts the supplied report only as input evidence. A `pass` does not independently prove that the owner reviewed the tasks, SkillOpt ran correctly, the holdout was isolated, the proposed skill is safe, or the skill should be adopted. Adoption and publication remain separate owner decisions.
+
+## Schemas
+
+- [`schema/memory-skillopt-selection.v1.json`](schema/memory-skillopt-selection.v1.json)
+- [`schema/memory-skillopt-task-draft.v1.json`](schema/memory-skillopt-task-draft.v1.json)
+
+The task-draft schema closes all nested provenance and authority objects. Unknown authority fields are rejected.

--- a/harness-core/README.md
+++ b/harness-core/README.md
@@ -278,6 +278,12 @@ Harness Core includes optional parsers for pinned Impeccable findings and SARIF 
 
 The parsers do not execute scanners and do not retain raw findings, snippets, messages, absolute paths, prompts, or tool output. Parsing a report does not verify scanner execution, finding accuracy, vulnerability absence, certification, endorsement, deployment safety, or marketplace readiness. See [Quality and security evaluation adapters](EVALUATION_ADAPTERS.md).
 
+### Memory to SkillOpt task drafts
+
+Harness Core can convert an explicit operator-supplied selection of public, evidence-backed Agoragentic Memory claims into an unreviewed SkillOpt task draft. It can also normalize a completed pinned SkillOpt-Sleep `--json` CLI summary into the same hash-bound evaluation evidence used by local receipts.
+
+The bridge does not run SkillOpt, call a provider, mark tasks reviewed, adopt or publish a skill, mutate Memory, or spend. Generated tasks always start with `reviewed: false`, and the pinned SkillOpt backend refuses them until a human reviews and deliberately changes that field. See [Agoragentic Memory to SkillOpt bridge](MEMORY_SKILLOPT.md).
+
 ## Runtime probes
 
 Probe a local runtime contract without invoking its business tool:
@@ -456,7 +462,7 @@ Use `--help` on the relevant command for exact options supported by the installe
 
 ## Source development
 
-The source tree declares the review-gated Harness Core `0.2.1` patch candidate. npm `@latest` currently serves `0.2.0`; publication remains a separate reviewed release action.
+The source tree declares the review-gated Harness Core `0.3.0` candidate. npm `@latest` currently serves `0.2.0`; publication remains a separate reviewed release action.
 
 ```bash
 git clone https://github.com/rhein1/agoragentic-integrations.git
@@ -479,6 +485,7 @@ Harness Core is the public package boundary for:
 - readiness and status artifacts;
 - runtime metadata probes;
 - context references;
+- review-gated Memory task export and specialist-engine evaluation evidence;
 - host/framework adapters;
 - Agent OS preview exports.
 

--- a/harness-core/TRUSTED_PUBLISHING.md
+++ b/harness-core/TRUSTED_PUBLISHING.md
@@ -24,7 +24,7 @@ Publish only after:
 
 1. Configure npm Trusted Publishing for the package.
 2. Merge the release-ready PR.
-3. Create a GitHub release with the exact package tag `harness-core-v0.2.1`.
+3. Create a GitHub release with the exact package tag `harness-core-v0.3.0`.
 4. The workflow publishes from `harness-core/`.
 
 Do not add `NPM_TOKEN` for this package unless Trusted Publishing is unavailable and the token has been scoped, rotated, and documented.

--- a/harness-core/bin/agoragentic-memory-skillopt.mjs
+++ b/harness-core/bin/agoragentic-memory-skillopt.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+
+import { link, lstat, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import {
+  attachEvaluationEvidenceToReceipt,
+  normalizeSkillOptSleepReport,
+} from '../src/evaluations/index.mjs';
+import { buildSkillOptTaskDraft } from '../src/memory-skillopt.mjs';
+
+function usage() {
+  console.error([
+    'Usage:',
+    '  agoragentic-memory-skillopt export-tasks --memory-export <path> --selection <path> --output <path>',
+    '  agoragentic-memory-skillopt attach-report --report <path> --receipt <path> --producer-version <version> --source-revision <revision> --analyzed-revision <id> --output <path>',
+  ].join('\n'));
+}
+
+function parseArgs(argv) {
+  const [command, ...rest] = argv;
+  if (!['export-tasks', 'attach-report'].includes(command)) throw new TypeError('unsupported command');
+  if (rest.length % 2 !== 0) throw new TypeError('arguments must be --key value pairs');
+  const options = {};
+  for (let index = 0; index < rest.length; index += 2) {
+    const flag = rest[index];
+    const value = rest[index + 1];
+    if (!flag?.startsWith('--') || !value || value.startsWith('--')) throw new TypeError('arguments must be --key value pairs');
+    const key = flag.slice(2);
+    if (Object.hasOwn(options, key)) throw new TypeError(`duplicate option: --${key}`);
+    options[key] = value;
+  }
+  const allowed = command === 'export-tasks'
+    ? new Set(['memory-export', 'selection', 'output'])
+    : new Set(['report', 'receipt', 'producer-version', 'source-revision', 'analyzed-revision', 'output']);
+  for (const key of Object.keys(options)) if (!allowed.has(key)) throw new TypeError(`unknown option: --${key}`);
+  for (const key of allowed) if (!options[key]) throw new TypeError(`missing option: --${key}`);
+  return { command, options };
+}
+
+async function readJsonFile(filename, maximum = 4 * 1024 * 1024) {
+  const stat = await lstat(filename);
+  if (stat.isSymbolicLink() || !stat.isFile()) throw new TypeError(`${filename} must be a regular non-symlink file`);
+  if (stat.size < 2 || stat.size > maximum) throw new RangeError(`${filename} has an unsupported size`);
+  return JSON.parse(await readFile(filename, 'utf8'));
+}
+
+async function writeJsonExclusive(filename, payload) {
+  const destination = path.resolve(filename);
+  await mkdir(path.dirname(destination), { recursive: true });
+  const temporary = `${destination}.tmp-${process.pid}`;
+  try {
+    await writeFile(temporary, `${JSON.stringify(payload, null, 2)}\n`, { encoding: 'utf8', flag: 'wx', mode: 0o600 });
+    await link(temporary, destination);
+  } catch (error) {
+    await rm(temporary, { force: true });
+    if (error.code === 'EEXIST') throw new Error(`output already exists: ${destination}`);
+    throw error;
+  }
+  await rm(temporary, { force: true });
+  return destination;
+}
+
+async function main() {
+  const { command, options } = parseArgs(process.argv.slice(2));
+  if (command === 'export-tasks') {
+    const [memoryExport, selection] = await Promise.all([
+      readJsonFile(options['memory-export']),
+      readJsonFile(options.selection, 128 * 1024),
+    ]);
+    const draft = buildSkillOptTaskDraft(memoryExport, selection);
+    const output = await writeJsonExclusive(options.output, draft);
+    process.stdout.write(`${JSON.stringify({ ok: true, command, output, task_count: draft.tasks.length, reviewed: false })}\n`);
+    return;
+  }
+
+  const [report, receipt] = await Promise.all([
+    readJsonFile(options.report),
+    readJsonFile(options.receipt),
+  ]);
+  const evaluation = normalizeSkillOptSleepReport(report, {
+    producer_version: options['producer-version'],
+    source_revision: options['source-revision'],
+    analyzed_revision: options['analyzed-revision'],
+    source_ref: path.basename(options.report),
+  });
+  const attached = attachEvaluationEvidenceToReceipt(receipt, evaluation);
+  const output = await writeJsonExclusive(options.output, attached);
+  process.stdout.write(`${JSON.stringify({ ok: true, command, output, result: evaluation.result, receipt_status: attached.status })}\n`);
+}
+
+main().catch((error) => {
+  usage();
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/harness-core/package-lock.json
+++ b/harness-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agoragentic-harness-core",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agoragentic-harness-core",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "yaml": "^2.5.0"
@@ -14,7 +14,8 @@
       "bin": {
         "agora-harness": "bin/agoragentic-harness.mjs",
         "agoragentic-harness": "bin/agoragentic-harness.mjs",
-        "agoragentic-harness-core": "bin/agoragentic-harness.mjs"
+        "agoragentic-harness-core": "bin/agoragentic-harness.mjs",
+        "agoragentic-memory-skillopt": "bin/agoragentic-memory-skillopt.mjs"
       },
       "devDependencies": {
         "ajv": "^8.20.0",

--- a/harness-core/package.json
+++ b/harness-core/package.json
@@ -1,19 +1,21 @@
 {
   "name": "agoragentic-harness-core",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Local no-spend Agent OS Harness Core for Micro ECF policy, first proof, receipts, listing readiness, and Triptych OS preview export.",
   "type": "module",
   "license": "Apache-2.0",
   "bin": {
     "agoragentic-harness": "./bin/agoragentic-harness.mjs",
     "agoragentic-harness-core": "./bin/agoragentic-harness.mjs",
-    "agora-harness": "./bin/agoragentic-harness.mjs"
+    "agora-harness": "./bin/agoragentic-harness.mjs",
+    "agoragentic-memory-skillopt": "./bin/agoragentic-memory-skillopt.mjs"
   },
   "exports": {
     ".": "./src/index.mjs",
     "./adapters": "./src/adapters/index.mjs",
     "./adapters/claude-code": "./src/adapters/claude-code.mjs",
     "./evaluations": "./src/evaluations/index.mjs",
+    "./memory-skillopt": "./src/memory-skillopt.mjs",
     "./kernel/events": "./src/kernel/events.mjs",
     "./kernel/loop": "./src/kernel/loop.mjs",
     "./kernel/middleware-registry": "./src/kernel/middleware-registry.mjs",
@@ -38,6 +40,8 @@
     "./schema/listing-readiness.v1.json": "./schema/listing-readiness.v1.json",
     "./schema/local-proof.v1.json": "./schema/local-proof.v1.json",
     "./schema/local-receipt.v1.json": "./schema/local-receipt.v1.json",
+    "./schema/memory-skillopt-selection.v1.json": "./schema/memory-skillopt-selection.v1.json",
+    "./schema/memory-skillopt-task-draft.v1.json": "./schema/memory-skillopt-task-draft.v1.json",
     "./schema/owner-inbox.v1.json": "./schema/owner-inbox.v1.json",
     "./schema/retry-policy.v1.json": "./schema/retry-policy.v1.json",
     "./schema/review-gates.v1.json": "./schema/review-gates.v1.json",
@@ -54,6 +58,7 @@
     "CHANGELOG.md",
     "EVALUATION_ADAPTERS.md",
     "LICENSE",
+    "MEMORY_SKILLOPT.md",
     "README.md",
     "RELEASE_SCOPE.md",
     "TRUSTED_PUBLISHING.md"
@@ -62,7 +67,7 @@
     "yaml": "^2.5.0"
   },
   "scripts": {
-    "test": "node --test test/cli.test.cjs test/evaluation-adapters.test.mjs",
+    "test": "node --test test/cli.test.cjs test/evaluation-adapters.test.mjs test/memory-skillopt.test.mjs",
     "pack:smoke": "node scripts/pack-smoke.mjs",
     "prepublishOnly": "npm test && npm run pack:smoke"
   },

--- a/harness-core/schema/memory-skillopt-selection.v1.json
+++ b/harness-core/schema/memory-skillopt-selection.v1.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://agoragentic.com/schema/memory-skillopt-selection.v1.json",
+  "title": "Agoragentic Memory to SkillOpt selection v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "memory_project_id", "skillopt_project", "target_skill_path", "tasks"],
+  "properties": {
+    "schema": { "const": "agoragentic.memory-skillopt.selection.v1" },
+    "memory_project_id": { "type": "string", "minLength": 1, "maxLength": 512 },
+    "skillopt_project": { "type": "string", "minLength": 1, "maxLength": 128, "pattern": "^[A-Za-z0-9][A-Za-z0-9._:/@-]{0,127}$" },
+    "target_skill_path": { "type": "string", "minLength": 1, "maxLength": 512, "pattern": "^(?![A-Za-z]:)(?!/)(?!.*(?:^|[\\\\/])\\.\\.(?:[\\\\/]|$)).*SKILL\\.md$" },
+    "tasks": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 50,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["memory_id", "split", "skill_hint"],
+        "properties": {
+          "memory_id": { "type": "string", "pattern": "^mem_[a-f0-9]{32}$" },
+          "split": { "enum": ["train", "val", "test"] },
+          "skill_hint": { "type": "string", "maxLength": 128, "pattern": "^$|^[A-Za-z0-9][A-Za-z0-9._:/@-]{0,127}$" }
+        }
+      }
+    }
+  }
+}

--- a/harness-core/schema/memory-skillopt-task-draft.v1.json
+++ b/harness-core/schema/memory-skillopt-task-draft.v1.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://agoragentic.com/schema/memory-skillopt-task-draft.v1.json",
+  "title": "Agoragentic Memory to SkillOpt unreviewed task draft v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["format", "project", "transcript_source", "n_sessions", "target_skill_path", "reviewed", "tasks", "agoragentic_provenance"],
+  "properties": {
+    "format": { "const": "skillopt_sleep.tasks.v1" },
+    "project": { "type": "string", "minLength": 1, "maxLength": 128, "pattern": "^[A-Za-z0-9][A-Za-z0-9._:/@-]{0,127}$" },
+    "transcript_source": { "const": "agoragentic-memory-export" },
+    "n_sessions": { "const": 0 },
+    "target_skill_path": { "type": "string", "minLength": 1, "maxLength": 512 },
+    "reviewed": { "const": false },
+    "tasks": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 50,
+      "items": { "$ref": "#/definitions/task" }
+    },
+    "agoragentic_provenance": { "$ref": "#/definitions/provenance" }
+  },
+  "definitions": {
+    "hash": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+    "memory_id": { "type": "string", "pattern": "^mem_[a-f0-9]{32}$" },
+    "task": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "project", "intent", "context_excerpt", "system", "attempted_solution", "outcome", "reference_kind", "reference", "judge", "tags", "source_sessions", "split", "origin", "derived_from", "skill_hint"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^memory-[a-f0-9]{32}$" },
+        "project": { "type": "string", "minLength": 1, "maxLength": 128, "pattern": "^[A-Za-z0-9][A-Za-z0-9._:/@-]{0,127}$" },
+        "intent": { "type": "string", "minLength": 1, "maxLength": 4096 },
+        "context_excerpt": { "type": "string", "minLength": 1, "maxLength": 4096 },
+        "system": { "const": "" },
+        "attempted_solution": { "const": "" },
+        "outcome": { "enum": ["success", "fail", "unknown"] },
+        "reference_kind": { "const": "none" },
+        "reference": { "const": "" },
+        "judge": { "type": "object", "maxProperties": 0 },
+        "tags": { "type": "array", "minItems": 2, "maxItems": 2, "items": { "type": "string", "maxLength": 128 } },
+        "source_sessions": { "type": "array", "maxItems": 0 },
+        "split": { "enum": ["train", "val", "test"] },
+        "origin": { "const": "real" },
+        "derived_from": { "const": "" },
+        "skill_hint": { "type": "string", "maxLength": 128, "pattern": "^$|^[A-Za-z0-9][A-Za-z0-9._:/@-]{0,127}$" }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema", "selected_memory_claims_hash", "memory_project_hash", "selected_memory_ids", "compatibility", "truth_boundary", "authority_boundary"],
+      "properties": {
+        "schema": { "const": "agoragentic.memory-skillopt.provenance.v1" },
+        "selected_memory_claims_hash": { "$ref": "#/definitions/hash" },
+        "memory_project_hash": { "$ref": "#/definitions/hash" },
+        "selected_memory_ids": { "type": "array", "minItems": 2, "maxItems": 50, "uniqueItems": true, "items": { "$ref": "#/definitions/memory_id" } },
+        "compatibility": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["agoragentic_memory_version", "agoragentic_memory_revision", "skillopt_version", "skillopt_revision"],
+          "properties": {
+            "agoragentic_memory_version": { "const": "0.1.0-rc.2" },
+            "agoragentic_memory_revision": { "const": "508ac3667a5ad3f6f5da323d7ddaf5f13384095d" },
+            "skillopt_version": { "const": "0.2.0" },
+            "skillopt_revision": { "const": "47fe269d75d3def79ffd90236261d26d84868ae5" }
+          }
+        },
+        "truth_boundary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["memory_export_signature_verified", "source_revision_proven_by_export", "task_text_owner_reviewed", "raw_events_retained", "raw_evidence_retained"],
+          "properties": {
+            "memory_export_signature_verified": { "const": false },
+            "source_revision_proven_by_export": { "const": false },
+            "task_text_owner_reviewed": { "const": false },
+            "raw_events_retained": { "const": false },
+            "raw_evidence_retained": { "const": false }
+          }
+        },
+        "authority_boundary": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["call_provider", "run_optimization", "adopt_skill", "publish_skill", "spend"],
+          "properties": {
+            "call_provider": { "const": false },
+            "run_optimization": { "const": false },
+            "adopt_skill": { "const": false },
+            "publish_skill": { "const": false },
+            "spend": { "const": false }
+          }
+        }
+      }
+    }
+  }
+}

--- a/harness-core/scripts/pack-smoke.mjs
+++ b/harness-core/scripts/pack-smoke.mjs
@@ -71,7 +71,9 @@ try {
   const installedPackageRoot = path.join(consumer, 'node_modules', 'agoragentic-harness-core');
   const installedReadmePath = path.join(installedPackageRoot, 'README.md');
   const installedHeroPath = path.join(installedPackageRoot, 'assets', 'harness-core-product-hero.svg');
+  const installedMemorySkillOptBin = path.join(installedPackageRoot, 'bin', 'agoragentic-memory-skillopt.mjs');
   if (!existsSync(installedHeroPath)) fail('installed package is missing assets/harness-core-product-hero.svg');
+  if (!existsSync(installedMemorySkillOptBin)) fail('installed package is missing the Memory-SkillOpt CLI');
 
   const installedReadme = readFileSync(installedReadmePath, 'utf8');
   const expectedReadmeArtifactTree = [
@@ -117,17 +119,19 @@ try {
       import { createRequire } from 'node:module';
       const runModule = await import('agoragentic-harness-core/kernel/run');
       const registryModule = await import('agoragentic-harness-core/kernel/middleware-registry');
+      const memorySkillOptModule = await import('agoragentic-harness-core/memory-skillopt');
       const require = createRequire(import.meta.url);
       const schemas = ${JSON.stringify(schemaFiles)};
       const resolvedSchemas = schemas.map((schema) => require.resolve('agoragentic-harness-core/schema/' + schema));
       console.log(JSON.stringify({
         run: typeof runModule.executeHarnessRun === 'function',
         registry: typeof registryModule.MiddlewareRegistry === 'function',
+        memorySkillOpt: typeof memorySkillOptModule.buildSkillOptTaskDraft === 'function',
         schemas: resolvedSchemas.length === schemas.length,
       }));
     `,
   ], consumer));
-  if (!importCheck.run || !importCheck.registry || !importCheck.schemas) {
+  if (!importCheck.run || !importCheck.registry || !importCheck.memorySkillOpt || !importCheck.schemas) {
     fail(`installed package subpath import failed: ${JSON.stringify(importCheck)}`);
   }
 

--- a/harness-core/src/evaluations/index.mjs
+++ b/harness-core/src/evaluations/index.mjs
@@ -4,6 +4,11 @@ export const HARNESS_EVALUATION_SCHEMA = 'agoragentic.harness.evaluation.v1';
 export const SUPPORTED_IMPECCABLE_VERSION = '3.5.0';
 export const SUPPORTED_IMPECCABLE_REVISION = '5d10bc842cbccd2ae7d3a88296d87d3be0b125b3';
 export const SUPPORTED_SARIF_VERSION = '2.1.0';
+export const SUPPORTED_SKILLOPT_VERSION = '0.2.0';
+export const SUPPORTED_SKILLOPT_REVISION = '47fe269d75d3def79ffd90236261d26d84868ae5';
+
+const SKILLOPT_ACCEPT_ACTIONS = new Set(['accept', 'accept_new_best']);
+const SKILLOPT_REJECT_ACTIONS = new Set(['reject', 'reject_unverified']);
 
 const MAX_FINDINGS = 1000;
 const MAX_TOOLS = 20;
@@ -86,6 +91,69 @@ export function normalizeSarifReport(input, options = {}) {
     source_payload: report,
     findings,
     source_license: options.source_license || null,
+  });
+}
+
+export function normalizeSkillOptSleepReport(input, options = {}) {
+  const report = requireObject(input, 'SkillOpt-Sleep CLI summary');
+  requireBoundedJson(report, 'SkillOpt-Sleep CLI summary');
+  const version = requireExact(
+    options.producer_version,
+    SUPPORTED_SKILLOPT_VERSION,
+    'Unsupported SkillOpt version',
+  );
+  const revision = requireExact(
+    options.source_revision,
+    SUPPORTED_SKILLOPT_REVISION,
+    'Unsupported SkillOpt source revision',
+  );
+  requireBoundedInteger(report.night, 'SkillOpt night');
+  const taskCount = requireBoundedInteger(report.n_tasks, 'SkillOpt task count');
+  requireBoundedInteger(report.n_sessions, 'SkillOpt session count');
+  const acceptedEditCount = requireBoundedInteger(report.n_accepted_edits, 'SkillOpt accepted edit count');
+  requireBoundedInteger(report.n_rejected_edits, 'SkillOpt rejected edit count');
+  const baseline = requireScore(report.baseline, 'SkillOpt baseline score');
+  const candidate = requireScore(report.candidate, 'SkillOpt candidate score');
+  const accepted = requireBoolean(report.accepted, 'SkillOpt accepted');
+  const adopted = requireBoolean(report.adopted, 'SkillOpt adopted');
+  const tasksReviewed = report.tasks_reviewed === true;
+  if (report.tasks_reviewed !== undefined) requireBoolean(report.tasks_reviewed, 'SkillOpt tasks_reviewed');
+  const holdoutReported = report.holdout_leaked !== undefined;
+  const holdoutLeaked = holdoutReported
+    ? requireBoolean(report.holdout_leaked, 'SkillOpt holdout_leaked')
+    : null;
+  const gateAction = safeIdentifier(report.gate_action, 'SkillOpt gate_action');
+  const tasksFileReported = typeof report.tasks_file === 'string' && report.tasks_file.length > 0;
+
+  const findings = [];
+  if (!tasksReviewed) findings.push(skillOptFinding('tasks_not_owner_reviewed', 'high'));
+  if (tasksReviewed && !tasksFileReported) findings.push(skillOptFinding('reviewed_tasks_file_not_reported', 'high'));
+  if (adopted) findings.push(skillOptFinding('automatic_or_prior_adoption_observed', 'critical'));
+  if (taskCount < 2) findings.push(skillOptFinding('insufficient_task_count', 'high'));
+  if (!holdoutReported) findings.push(skillOptFinding('holdout_integrity_not_reported', 'medium'));
+  if (holdoutLeaked === true) findings.push(skillOptFinding('holdout_integrity_leaked', 'critical'));
+  if (candidate < baseline || (accepted && candidate <= baseline)) {
+    findings.push(skillOptFinding('candidate_score_regressed_or_inconsistent', 'high'));
+  }
+  if (accepted && !SKILLOPT_ACCEPT_ACTIONS.has(gateAction)) {
+    findings.push(skillOptFinding('non_gated_or_inconsistent_acceptance', 'high'));
+  }
+  if (!accepted && !SKILLOPT_REJECT_ACTIONS.has(gateAction)) {
+    findings.push(skillOptFinding('unsupported_rejection_action', 'medium'));
+  }
+  if (!accepted && acceptedEditCount > 0) findings.push(skillOptFinding('rejected_candidate_retained_edits', 'high'));
+  if (!accepted) findings.push(skillOptFinding('candidate_not_accepted', 'medium'));
+  if (accepted && acceptedEditCount === 0) findings.push(skillOptFinding('accepted_without_recorded_edit', 'medium'));
+
+  return buildEvaluation({
+    adapter: { name: 'memory-skillopt-report', version: '1' },
+    source_tools: [{ name: 'skillopt', version, revision }],
+    analyzed_revision: options.analyzed_revision,
+    source_ref: options.source_ref,
+    gate: options.gate,
+    source_payload: report,
+    findings,
+    source_license: 'MIT',
   });
 }
 
@@ -228,6 +296,20 @@ function buildEvaluation({
   };
   record.evidence_hash = computeHarnessEvaluationHash(record);
   return verifyHarnessEvaluation(record);
+}
+
+function skillOptFinding(ruleId, severity) {
+  return createFinding({
+    producer_index: 0,
+    rule_id: `skillopt_${ruleId}`,
+    severity,
+    category: 'skill_optimization',
+    advisory: false,
+    suppressed: false,
+    suppression_kind: null,
+    location: { path: null, line: null, column: null },
+    message: ruleId,
+  });
 }
 
 function normalizeImpeccableFinding(input, forcedSuppressed) {
@@ -484,6 +566,37 @@ function boundedInteger(value, label) {
     throw new TypeError(`${label} must be a non-negative bounded integer`);
   }
   return number;
+}
+
+function requireBoundedInteger(value, label) {
+  const result = boundedInteger(value, label);
+  if (result === null) throw new TypeError(`${label} is required`);
+  return result;
+}
+
+function requireScore(value, label) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0 || value > 1) {
+    throw new TypeError(`${label} must be a finite number from 0 through 1`);
+  }
+  return value;
+}
+
+function requireBoolean(value, label) {
+  if (typeof value !== 'boolean') throw new TypeError(`${label} must be boolean`);
+  return value;
+}
+
+function requireBoundedJson(value, label, maximum = 1024 * 1024) {
+  let serialized;
+  try {
+    serialized = JSON.stringify(value);
+  } catch {
+    throw new TypeError(`${label} must be JSON-serializable`);
+  }
+  if (Buffer.byteLength(serialized, 'utf8') > maximum) {
+    throw new RangeError(`${label} exceeds ${maximum} bytes`);
+  }
+  return value;
 }
 
 function requireString(value, label) {

--- a/harness-core/src/index.mjs
+++ b/harness-core/src/index.mjs
@@ -57,13 +57,23 @@ export {
   SUPPORTED_IMPECCABLE_REVISION,
   SUPPORTED_IMPECCABLE_VERSION,
   SUPPORTED_SARIF_VERSION,
+  SUPPORTED_SKILLOPT_REVISION,
+  SUPPORTED_SKILLOPT_VERSION,
   attachEvaluationEvidenceToReceipt,
   computeHarnessEvaluationHash,
   normalizeImpeccableFindings,
   normalizeSarifReport,
+  normalizeSkillOptSleepReport,
   summarizeHarnessEvaluations,
   verifyHarnessEvaluation,
 } from './evaluations/index.mjs';
+
+export {
+  MEMORY_SKILLOPT_SELECTION_SCHEMA,
+  SKILLOPT_TASK_FORMAT,
+  buildSkillOptTaskDraft,
+  validateMemorySkillOptSelection,
+} from './memory-skillopt.mjs';
 
 export async function initProject({ dir = process.cwd(), template = 'codebase_maintenance', force = false } = {}) {
   const target = path.resolve(dir);
@@ -300,7 +310,7 @@ export function buildAgentOsExport(project, options = {}) {
     generated_at: generatedAt,
     generated_from: {
       source: 'agoragentic-harness-core',
-      package_version: '0.2.1',
+      package_version: '0.3.0',
       local_only: true,
     },
     schema_artifacts: {

--- a/harness-core/src/memory-skillopt.mjs
+++ b/harness-core/src/memory-skillopt.mjs
@@ -1,0 +1,243 @@
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+
+export const MEMORY_SKILLOPT_SELECTION_SCHEMA = 'agoragentic.memory-skillopt.selection.v1';
+export const SKILLOPT_TASK_FORMAT = 'skillopt_sleep.tasks.v1';
+export const MEMORY_EXPORT_SCHEMA = 'agoragentic.memory.export.v1';
+export const SUPPORTED_MEMORY_VERSION = '0.1.0-rc.2';
+export const SUPPORTED_MEMORY_REVISION = '508ac3667a5ad3f6f5da323d7ddaf5f13384095d';
+export const SKILLOPT_COMPATIBILITY_VERSION = '0.2.0';
+export const SKILLOPT_COMPATIBILITY_REVISION = '47fe269d75d3def79ffd90236261d26d84868ae5';
+
+const MEMORY_ID = /^mem_[a-f0-9]{32}$/;
+const SAFE_IDENTIFIER = /^[A-Za-z0-9][A-Za-z0-9._:/@-]{0,127}$/;
+const ALLOWED_TYPES = new Set(['goal', 'intent', 'open_loop', 'validation', 'hypothesis', 'preference']);
+const SPLITS = new Set(['train', 'val', 'test']);
+const SECRET_PATTERNS = [
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----/i,
+  /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/,
+  /\b(?:sk|ghp|github_pat|amk)_[A-Za-z0-9_-]{16,}\b/,
+  /\b(?:database_url|admin_secret|wallet_secret|seed phrase|private key)\b/i,
+  /\b(?:password|passwd|token|secret)\s*[:=]\s*[^\s]{8,}/i,
+  /\bignore (?:all )?(?:previous|prior) instructions\b/i,
+  /\b(?:system prompt|developer message|hidden instructions)\b/i,
+];
+
+export function validateMemorySkillOptSelection(selection) {
+  exactKeys(selection, [
+    'schema',
+    'memory_project_id',
+    'skillopt_project',
+    'target_skill_path',
+    'tasks',
+  ], 'selection');
+  if (selection.schema !== MEMORY_SKILLOPT_SELECTION_SCHEMA) {
+    throw new TypeError('selection.schema is unsupported');
+  }
+  boundedText(selection.memory_project_id, 'selection.memory_project_id', 512);
+  safeIdentifier(selection.skillopt_project, 'selection.skillopt_project');
+  const target = boundedText(selection.target_skill_path, 'selection.target_skill_path', 512);
+  if (path.isAbsolute(target)
+    || /^[A-Za-z]:[\\/]/.test(target)
+    || target.startsWith('\\')
+    || target.split(/[\\/]+/).includes('..')
+    || /[\u0000-\u001f\u007f]/.test(target)
+    || !/SKILL\.md$/i.test(target)) {
+    throw new TypeError('selection.target_skill_path must be a relative SKILL.md path without parent traversal');
+  }
+  if (!Array.isArray(selection.tasks) || selection.tasks.length < 2 || selection.tasks.length > 50) {
+    throw new TypeError('selection.tasks must contain 2-50 entries');
+  }
+  const ids = new Set();
+  const splits = new Set();
+  for (const [index, task] of selection.tasks.entries()) {
+    exactKeys(task, ['memory_id', 'split', 'skill_hint'], `selection.tasks[${index}]`);
+    if (!MEMORY_ID.test(task.memory_id || '') || ids.has(task.memory_id)) {
+      throw new TypeError('selection task memory IDs must be unique canonical memory IDs');
+    }
+    ids.add(task.memory_id);
+    if (!SPLITS.has(task.split)) throw new TypeError(`selection.tasks[${index}].split is unsupported`);
+    splits.add(task.split);
+    if (task.skill_hint !== '') safeIdentifier(task.skill_hint, `selection.tasks[${index}].skill_hint`);
+  }
+  if (!splits.has('train') || (!splits.has('val') && !splits.has('test'))) {
+    throw new TypeError('selection must include train and held-out val or test tasks');
+  }
+  return selection;
+}
+
+export function buildSkillOptTaskDraft(memoryExport, selection) {
+  validateMemoryExport(memoryExport);
+  validateMemorySkillOptSelection(selection);
+  const claims = new Map(memoryExport.claims.map((claim) => [claim.id, claim]));
+  const selectedClaims = [];
+  const tasks = selection.tasks.map((selected) => {
+    const claim = claims.get(selected.memory_id);
+    if (!claim) throw new TypeError(`selected memory ${selected.memory_id} is absent from the export`);
+    validateSelectedClaim(claim, selection.memory_project_id);
+    selectedClaims.push(claim);
+    const intent = claim.next_action || claim.title;
+    const context = claim.summary;
+    assertPublicSafeText(intent, `memory ${claim.id} intent`);
+    assertPublicSafeText(context, `memory ${claim.id} context`);
+    return {
+      id: `memory-${claim.id.slice(4)}`,
+      project: selection.skillopt_project,
+      intent: boundedText(intent, `memory ${claim.id} intent`, 4096),
+      context_excerpt: boundedText(context, `memory ${claim.id} context`, 4096),
+      system: '',
+      attempted_solution: '',
+      outcome: claim.state === 'verified_done' ? 'success' : claim.state === 'blocked' ? 'fail' : 'unknown',
+      reference_kind: 'none',
+      reference: '',
+      judge: {},
+      tags: ['agoragentic-memory', `memory-${claim.type}`],
+      source_sessions: [],
+      split: selected.split,
+      origin: 'real',
+      derived_from: '',
+      skill_hint: selected.skill_hint,
+    };
+  });
+  const selectedIds = selection.tasks.map((item) => item.memory_id);
+  return {
+    format: SKILLOPT_TASK_FORMAT,
+    project: selection.skillopt_project,
+    transcript_source: 'agoragentic-memory-export',
+    n_sessions: 0,
+    target_skill_path: selection.target_skill_path.replaceAll('\\', '/'),
+    reviewed: false,
+    tasks,
+    agoragentic_provenance: {
+      schema: 'agoragentic.memory-skillopt.provenance.v1',
+      selected_memory_claims_hash: hashValue(selectedClaims.map(publicClaimProjection)),
+      memory_project_hash: hashString(selection.memory_project_id),
+      selected_memory_ids: selectedIds,
+      compatibility: {
+        agoragentic_memory_version: SUPPORTED_MEMORY_VERSION,
+        agoragentic_memory_revision: SUPPORTED_MEMORY_REVISION,
+        skillopt_version: SKILLOPT_COMPATIBILITY_VERSION,
+        skillopt_revision: SKILLOPT_COMPATIBILITY_REVISION,
+      },
+      truth_boundary: {
+        memory_export_signature_verified: false,
+        source_revision_proven_by_export: false,
+        task_text_owner_reviewed: false,
+        raw_events_retained: false,
+        raw_evidence_retained: false,
+      },
+      authority_boundary: {
+        call_provider: false,
+        run_optimization: false,
+        adopt_skill: false,
+        publish_skill: false,
+        spend: false,
+      },
+    },
+  };
+}
+
+function publicClaimProjection(claim) {
+  return {
+    id: claim.id,
+    type: claim.type,
+    state: claim.state,
+    title: claim.title,
+    summary: claim.summary,
+    next_action: claim.next_action ?? null,
+    sensitivity: claim.sensitivity,
+    evidence_total: claim.evidence_total,
+    evidence_reference_hashes: claim.evidence.map(hashValue).sort(),
+  };
+}
+
+function validateMemoryExport(value) {
+  requireBoundedJson(value, 'memory export', 4 * 1024 * 1024);
+  exactKeys(value, [
+    'schema', 'generated_at', 'authority', 'scope', 'limits', 'excludes',
+    'truncation_possible', 'repositories', 'claims', 'events',
+  ], 'memory export');
+  if (value.schema !== MEMORY_EXPORT_SCHEMA
+    || value.authority !== 'index_only_verify_sources'
+    || value.scope !== 'bounded_current_state') {
+    throw new TypeError('memory export boundary is unsupported');
+  }
+  if (!Array.isArray(value.claims) || value.claims.length > 2000 || !Array.isArray(value.events)) {
+    throw new TypeError('memory export claims/events are malformed');
+  }
+  const claimIds = new Set();
+  for (const claim of value.claims) {
+    if (!claim || typeof claim !== 'object' || Array.isArray(claim) || !MEMORY_ID.test(claim.id || '')) {
+      throw new TypeError('memory export contains a malformed claim identity');
+    }
+    if (claimIds.has(claim.id)) throw new TypeError(`memory export contains duplicate claim identity ${claim.id}`);
+    claimIds.add(claim.id);
+  }
+}
+
+function validateSelectedClaim(claim, projectId) {
+  if (!claim || typeof claim !== 'object' || Array.isArray(claim)) throw new TypeError('selected claim is malformed');
+  if (!MEMORY_ID.test(claim.id || '') || claim.project_id !== projectId) {
+    throw new TypeError(`selected memory ${String(claim.id || 'unknown')} has the wrong project identity`);
+  }
+  if (claim.sensitivity !== 'public') throw new TypeError(`selected memory ${claim.id} is not public`);
+  if (!ALLOWED_TYPES.has(claim.type)) throw new TypeError(`selected memory ${claim.id} is not a task-like claim`);
+  if (!Number.isInteger(claim.evidence_total) || claim.evidence_total < 1 || !Array.isArray(claim.evidence) || claim.evidence.length < 1) {
+    throw new TypeError(`selected memory ${claim.id} has no evidence reference`);
+  }
+  boundedText(claim.title, `memory ${claim.id} title`, 256);
+  boundedText(claim.summary, `memory ${claim.id} summary`, 16 * 1024);
+  if (claim.next_action !== null && claim.next_action !== undefined && claim.next_action !== '') {
+    boundedText(claim.next_action, `memory ${claim.id} next_action`, 4096);
+  }
+}
+
+function assertPublicSafeText(value, label) {
+  const text = boundedText(value, label, 16 * 1024);
+  if (/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/.test(text)) {
+    throw new TypeError(`${label} contains control characters`);
+  }
+  const match = SECRET_PATTERNS.find((pattern) => pattern.test(text));
+  if (match) throw new TypeError(`${label} contains secret-shaped or instruction-like text`);
+}
+
+function exactKeys(value, expected, label) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new TypeError(`${label} must be an object`);
+  const actual = Object.keys(value).sort();
+  if (stableStringify(actual) !== stableStringify([...expected].sort())) {
+    throw new TypeError(`${label} contains missing or unknown fields`);
+  }
+}
+
+function boundedText(value, label, maximum) {
+  if (typeof value !== 'string' || !value.trim() || value.length > maximum) {
+    throw new TypeError(`${label} must be a non-empty string of at most ${maximum} characters`);
+  }
+  return value;
+}
+
+function safeIdentifier(value, label) {
+  const text = boundedText(value, label, 128);
+  if (!SAFE_IDENTIFIER.test(text)) throw new TypeError(`${label} must be a bounded public-safe identifier`);
+  return text;
+}
+
+function requireBoundedJson(value, label, maximum) {
+  let serialized;
+  try { serialized = JSON.stringify(value); } catch { throw new TypeError(`${label} must be JSON-serializable`); }
+  if (Buffer.byteLength(serialized, 'utf8') > maximum) throw new RangeError(`${label} exceeds ${maximum} bytes`);
+}
+
+function hashString(value) {
+  return `sha256:${createHash('sha256').update(String(value), 'utf8').digest('hex')}`;
+}
+
+function hashValue(value) {
+  return hashString(stableStringify(value));
+}
+
+function stableStringify(value) {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(',')}}`;
+}

--- a/harness-core/test/cli.test.cjs
+++ b/harness-core/test/cli.test.cjs
@@ -57,9 +57,10 @@ function validateSchema(schemaRelPath, payload) {
 test('Harness Core package exposes local no-spend CLI bins', () => {
   const pkg = readJson(path.join(packageRoot, 'package.json'));
   assert.equal(pkg.name, 'agoragentic-harness-core');
-  assert.equal(pkg.version, '0.2.1');
+  assert.equal(pkg.version, '0.3.0');
   assert.equal(pkg.bin['agoragentic-harness'], './bin/agoragentic-harness.mjs');
   assert.equal(pkg.bin['agora-harness'], './bin/agoragentic-harness.mjs');
+  assert.equal(pkg.bin['agoragentic-memory-skillopt'], './bin/agoragentic-memory-skillopt.mjs');
   assert.match(pkg.description, /Local no-spend Agent OS Harness Core/);
   assert.equal(pkg.repository.directory, 'harness-core');
 
@@ -126,7 +127,7 @@ test('export emits a schema-valid Agent OS Harness packet for preview only', () 
   assert.equal(packet.public_boundary.no_spend_export, true);
   assert.equal(packet.public_boundary.hosted_billing, false);
   assert.equal(packet.agent_os_preview_request.deployment_packet.source, 'harness_core_local');
-  assert.equal(packet.generated_from.package_version, '0.2.1');
+  assert.equal(packet.generated_from.package_version, '0.3.0');
   assert.equal(packet.agent_os_export.preview_endpoint, 'POST /api/hosting/agent-os/preview');
   validateSchema('schema/agent-os-harness.v1.json', packet);
 });

--- a/harness-core/test/memory-skillopt.test.mjs
+++ b/harness-core/test/memory-skillopt.test.mjs
@@ -1,0 +1,254 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+import test from 'node:test';
+
+import {
+  SUPPORTED_SKILLOPT_REVISION,
+  SUPPORTED_SKILLOPT_VERSION,
+  attachEvaluationEvidenceToReceipt,
+  normalizeSkillOptSleepReport,
+} from '../src/evaluations/index.mjs';
+import { buildSkillOptTaskDraft } from '../src/memory-skillopt.mjs';
+
+const execFileAsync = promisify(execFile);
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const memoryIds = [
+  'mem_11111111111111111111111111111111',
+  'mem_22222222222222222222222222222222',
+  'mem_33333333333333333333333333333333',
+];
+
+function memoryExport() {
+  const claim = (id, overrides = {}) => ({
+    id,
+    project_id: 'agoragentic-public',
+    repo_id: 'rhein1/example',
+    type: 'open_loop',
+    state: 'open',
+    title: `Task ${id.slice(-2)}`,
+    summary: 'Run a bounded deterministic check and compare the public result.',
+    next_action: 'Execute the local fixture and verify its expected public-safe output.',
+    sensitivity: 'public',
+    evidence: [{ evidence_id: `ev_${id.slice(4)}`, evidence_hash: `sha256:${'a'.repeat(64)}` }],
+    evidence_total: 1,
+    ...overrides,
+  });
+  return {
+    schema: 'agoragentic.memory.export.v1',
+    generated_at: '2026-08-09T00:00:00.000Z',
+    authority: 'index_only_verify_sources',
+    scope: 'bounded_current_state',
+    limits: { claims_per_repository: 100, events_per_repository: 200 },
+    excludes: ['mutation_receipts'],
+    truncation_possible: true,
+    repositories: [{ project_id: 'agoragentic-public', repo_id: 'rhein1/example' }],
+    claims: [
+      claim(memoryIds[0]),
+      claim(memoryIds[1], { type: 'validation', state: 'verified_done' }),
+      claim(memoryIds[2], { sensitivity: 'private', summary: 'must never leave the private ledger' }),
+    ],
+    events: [{ private_event_detail: 'must not be retained' }],
+  };
+}
+
+function selection(ids = memoryIds.slice(0, 2)) {
+  return {
+    schema: 'agoragentic.memory-skillopt.selection.v1',
+    memory_project_id: 'agoragentic-public',
+    skillopt_project: 'agoragentic-fixture',
+    target_skill_path: '.agents/skills/example/SKILL.md',
+    tasks: [
+      { memory_id: ids[0], split: 'train', skill_hint: 'example-skill' },
+      { memory_id: ids[1], split: 'val', skill_hint: 'example-skill' },
+    ],
+  };
+}
+
+function skillOptReport(overrides = {}) {
+  return {
+    night: 1,
+    accepted: true,
+    gate_action: 'accept',
+    no_edits_reason: '',
+    baseline: 0.5,
+    candidate: 0.75,
+    n_tasks: 2,
+    n_sessions: 0,
+    n_accepted_edits: 1,
+    n_rejected_edits: 0,
+    edits: [{ content: 'private optimizer proposal must not be retained' }],
+    rejected_edits: [],
+    notes: ['private optimizer rationale must not be retained'],
+    staging_dir: 'C:/private/staging',
+    adopted: false,
+    tasks_file: 'C:/private/tasks.json',
+    tasks_reviewed: true,
+    holdout_leaked: false,
+    ...overrides,
+  };
+}
+
+function receipt() {
+  return {
+    schema: 'agoragentic.harness.local-receipt.v1',
+    receipt_id: 'local_receipt_fixture',
+    proof_id: 'proof_fixture',
+    created_at: '2026-08-09T00:00:00.000Z',
+    mode: 'local_no_spend_receipt',
+    status: 'recorded',
+    spend: { amount_usdc: 0, settlement_network: 'none', settlement_status: 'not_applicable' },
+    evidence: {
+      agent_name: 'fixture-agent',
+      primary_goal: 'evaluate a reviewed SkillOpt proposal',
+      proof_status: 'passed',
+      local_artifacts: ['agent.yaml'],
+    },
+    receipt_boundary: {
+      router_invocation_created: false,
+      x402_payment_attempted: false,
+      marketplace_published: false,
+      hosted_runtime_provisioned: false,
+      memory_written: false,
+    },
+  };
+}
+
+function normalize(report) {
+  return normalizeSkillOptSleepReport(report, {
+    producer_version: SUPPORTED_SKILLOPT_VERSION,
+    source_revision: SUPPORTED_SKILLOPT_REVISION,
+    analyzed_revision: '0123456789abcdef0123456789abcdef01234567',
+    source_ref: 'skillopt-report.json',
+  });
+}
+
+test('public operator-selected memory claims produce a deterministic unreviewed SkillOpt task draft', () => {
+  const first = buildSkillOptTaskDraft(memoryExport(), selection());
+  const second = buildSkillOptTaskDraft(memoryExport(), selection());
+  assert.deepEqual(first, second);
+  assert.equal(first.format, 'skillopt_sleep.tasks.v1');
+  assert.equal(first.reviewed, false);
+  assert.equal(first.tasks.length, 2);
+  assert.deepEqual(first.tasks.map((task) => task.split), ['train', 'val']);
+  assert.equal(first.agoragentic_provenance.authority_boundary.call_provider, false);
+  assert.equal(first.agoragentic_provenance.authority_boundary.adopt_skill, false);
+  const serialized = JSON.stringify(first);
+  assert.doesNotMatch(serialized, /rhein1\/example/);
+  assert.doesNotMatch(serialized, /private_event_detail/);
+  assert.doesNotMatch(serialized, /must never leave the private ledger/);
+  const privateVariant = memoryExport();
+  privateVariant.events[0].private_event_detail = 'different private value';
+  privateVariant.claims[2].summary = 'different private claim';
+  assert.deepEqual(buildSkillOptTaskDraft(privateVariant, selection()), first);
+});
+
+test('private, unevidenced, and secret-shaped memories fail closed', () => {
+  assert.throws(() => buildSkillOptTaskDraft(memoryExport(), selection([memoryIds[0], memoryIds[2]])), /not public/);
+  const noEvidence = memoryExport();
+  noEvidence.claims[0].evidence = [];
+  noEvidence.claims[0].evidence_total = 0;
+  assert.throws(() => buildSkillOptTaskDraft(noEvidence, selection()), /no evidence reference/);
+  const secret = memoryExport();
+  secret.claims[0].summary = 'Use token=not-safe-to-export-1234567890 for the task.';
+  assert.throws(() => buildSkillOptTaskDraft(secret, selection()), /secret-shaped/);
+  const duplicate = memoryExport();
+  duplicate.claims.push({ ...duplicate.claims[0] });
+  assert.throws(() => buildSkillOptTaskDraft(duplicate, selection()), /duplicate claim identity/);
+});
+
+test('SkillOpt report normalization is bounded, hash-only, and never adopts', () => {
+  const evaluation = normalize(skillOptReport());
+  assert.equal(evaluation.result, 'pass');
+  assert.equal(evaluation.summary.total, 0);
+  assert.equal(evaluation.authority_boundary.publish, false);
+  const attached = attachEvaluationEvidenceToReceipt(receipt(), evaluation);
+  assert.equal(attached.status, 'recorded');
+  assert.equal(attached.receipt_boundary.memory_written, false);
+  const serialized = JSON.stringify(attached);
+  assert.doesNotMatch(serialized, /private optimizer proposal/);
+  assert.doesNotMatch(serialized, /private optimizer rationale/);
+  assert.doesNotMatch(serialized, /C:\/private/);
+});
+
+test('unreviewed, adopted, regressed, leaked, or incomplete reports fail or require review', () => {
+  assert.throws(() => normalizeSkillOptSleepReport(skillOptReport(), {
+    producer_version: '0.2.1',
+    source_revision: SUPPORTED_SKILLOPT_REVISION,
+    analyzed_revision: '0123456789abcdef0123456789abcdef01234567',
+    source_ref: 'skillopt-report.json',
+  }), /Unsupported SkillOpt version/);
+  assert.equal(normalize(skillOptReport({ tasks_reviewed: false })).result, 'fail');
+  assert.equal(normalize(skillOptReport({ adopted: true })).result, 'fail');
+  assert.equal(normalize(skillOptReport({ candidate: 0.25 })).result, 'fail');
+  assert.equal(normalize(skillOptReport({ holdout_leaked: true })).result, 'fail');
+  assert.equal(normalize(skillOptReport({ gate_action: 'greedy_applied' })).result, 'fail');
+  assert.equal(normalize(skillOptReport({ tasks_file: '' })).result, 'fail');
+  const missingHoldout = skillOptReport();
+  delete missingHoldout.holdout_leaked;
+  assert.equal(normalize(missingHoldout).result, 'review');
+  assert.equal(normalize(skillOptReport({ accepted: false, gate_action: 'reject', n_accepted_edits: 0 })).result, 'review');
+  assert.equal(normalize(skillOptReport({ accepted: false, gate_action: 'reject', n_accepted_edits: 1 })).result, 'fail');
+});
+
+test('selection and task draft schemas accept the canonical bridge output', async () => {
+  const ajv = new Ajv({ allErrors: true, strict: true });
+  addFormats(ajv);
+  const selectionSchema = JSON.parse(await readFile(path.join(root, 'schema', 'memory-skillopt-selection.v1.json'), 'utf8'));
+  const taskSchema = JSON.parse(await readFile(path.join(root, 'schema', 'memory-skillopt-task-draft.v1.json'), 'utf8'));
+  ajv.addSchema(selectionSchema);
+  ajv.addSchema(taskSchema);
+  assert.equal(ajv.validate(selectionSchema.$id, selection()), true, JSON.stringify(ajv.errors));
+  const draft = buildSkillOptTaskDraft(memoryExport(), selection());
+  assert.equal(ajv.validate(taskSchema.$id, draft), true, JSON.stringify(ajv.errors));
+  draft.agoragentic_provenance.authority_boundary.execute = true;
+  assert.equal(ajv.validate(taskSchema.$id, draft), false, 'unknown authority must be rejected');
+});
+
+test('CLI writes an exclusive unreviewed draft and attaches a bounded evaluation', async () => {
+  const temp = await mkdtemp(path.join(os.tmpdir(), 'memory-skillopt-'));
+  const exportPath = path.join(temp, 'memory.json');
+  const selectionPath = path.join(temp, 'selection.json');
+  const taskPath = path.join(temp, 'tasks.json');
+  const reportPath = path.join(temp, 'report.json');
+  const receiptPath = path.join(temp, 'receipt.json');
+  const attachedPath = path.join(temp, 'attached.json');
+  await Promise.all([
+    writeFile(exportPath, JSON.stringify(memoryExport())),
+    writeFile(selectionPath, JSON.stringify(selection())),
+    writeFile(reportPath, JSON.stringify(skillOptReport())),
+    writeFile(receiptPath, JSON.stringify(receipt())),
+  ]);
+  const cli = path.join(root, 'bin', 'agoragentic-memory-skillopt.mjs');
+  const exported = await execFileAsync(process.execPath, [
+    cli, 'export-tasks', '--memory-export', exportPath, '--selection', selectionPath, '--output', taskPath,
+  ]);
+  assert.equal(JSON.parse(exported.stdout).reviewed, false);
+  assert.equal(JSON.parse(await readFile(taskPath, 'utf8')).reviewed, false);
+  await assert.rejects(
+    execFileAsync(process.execPath, [cli, 'export-tasks', '--memory-export', exportPath, '--selection', selectionPath, '--output', taskPath]),
+    /output already exists/,
+  );
+  const attached = await execFileAsync(process.execPath, [
+    cli, 'attach-report', '--report', reportPath, '--receipt', receiptPath,
+    '--producer-version', SUPPORTED_SKILLOPT_VERSION, '--source-revision', SUPPORTED_SKILLOPT_REVISION,
+    '--analyzed-revision', '0123456789abcdef0123456789abcdef01234567', '--output', attachedPath,
+  ]);
+  assert.equal(JSON.parse(attached.stdout).result, 'pass');
+  assert.equal(JSON.parse(await readFile(attachedPath, 'utf8')).evaluations.length, 1);
+  await assert.rejects(
+    execFileAsync(process.execPath, [
+      cli, 'attach-report', '--report', reportPath, '--receipt', receiptPath,
+      '--analyzed-revision', '0123456789abcdef0123456789abcdef01234567',
+      '--output', path.join(temp, 'missing-provenance.json'),
+    ]),
+    /missing option: --producer-version/,
+  );
+});

--- a/integrations.json
+++ b/integrations.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.39.0",
+  "version": "2.40.0",
   "updated_at": "2026-08-09",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
@@ -1448,6 +1448,9 @@
     "micro_ecf": "micro-ecf/README.md",
     "micro_ecf_canonical_repo": "https://github.com/rhein1/agoragentic-micro-ecf",
     "harness_core": "harness-core/README.md",
+    "harness_core_memory_skillopt": "harness-core/MEMORY_SKILLOPT.md",
+    "harness_core_memory_skillopt_selection_schema": "harness-core/schema/memory-skillopt-selection.v1.json",
+    "harness_core_memory_skillopt_task_draft_schema": "harness-core/schema/memory-skillopt-task-draft.v1.json",
     "premortem_golden_loop": "premortem-golden-loop/README.md",
     "premortem_prompt": "premortem-golden-loop/PROMPT.md",
     "micro_ecf_llm_install": "micro-ecf/LLM_INSTALL.md",


### PR DESCRIPTION
## Summary
- add a deterministic Agoragentic Memory `agoragentic.memory.export.v1` to SkillOpt `skillopt_sleep.tasks.v1` task-draft bridge
- add a bounded SkillOpt `--json` CLI-summary adapter that attaches hash-only evidence to the existing Harness local receipt
- package the CLI, subpath exports, strict schemas, installed-tarball smoke coverage, and truthful source-only documentation

## Safety boundary
- accepts only explicit operator-selected public, evidence-backed task-like Memory claims
- generated task files are always `reviewed: false`; the pinned SkillOpt backend refuses real-provider replay until a human reviews them
- rejects private/unevidenced/secret-shaped claims, duplicate identities, non-gated acceptance, observed adoption, holdout leakage, score regression, and inconsistent gate evidence
- unselected private claims/events do not affect public provenance hashes
- no provider call, optimization run, automatic adoption, publication, Memory mutation, Router invocation, or spend

## Exact upstream pins
- Agoragentic Memory `0.1.0-rc.2` at `508ac3667a5ad3f6f5da323d7ddaf5f13384095d`
- Microsoft SkillOpt `0.2.0` at `47fe269d75d3def79ffd90236261d26d84868ae5`

## Validation
- `npm test` in `harness-core/`: 21/21 pass
- `npm run pack:smoke`: packed and installed outside the monorepo; docs, subpaths, schemas, and init/validate/run pass
- `npm pack --dry-run --json`: intended 72-file package, including the new CLI/docs/source/schemas
- `node scripts/verify-integrations-json.js`: pass
- `node scripts/verify-doc-links.mjs`: 228 Markdown files pass
- `git diff --cached --check`: pass before signed commit

## Program linkage
This completes the only missing implementation track in #229. Previously merged tracks: #236, #273, #275, #272, #274, and #279.

Closes #229