### PR TITLE
test(gstack): prove Harness Core 0.3 compatibility

### DIFF
--- a/.github/workflows/gstack-harness-bridge.yml
+++ b/.github/workflows/gstack-harness-bridge.yml
@@ -43,3 +43,4 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: npm install --no-audit --no-fund
       - run: npm test
+      - run: npm run test:core-compat

--- a/gstack/README.md
+++ b/gstack/README.md
@@ -46,6 +46,12 @@ The bridge retains, per supplied artifact:
 
 It does **not** retain raw workflow content, extract a success claim from the content, or infer that gstack actually ran. A `proposal_ready` listing-readiness artifact means only that the supplied local evidence bundle and Harness project passed these local gates. It still requires owner review and does not publish anything.
 
+## Harness Core compatibility evidence
+
+The published npm `latest` line remains Harness Core `0.2.0`; the source tree's review-gated `0.3.0` candidate is verified separately. `npm run test:core-compat` packs the sibling `../harness-core` source into a temporary tarball, installs that tarball in a temporary consumer while resolving its declared package dependencies, and runs the bridge fixture suite against it. The targeted regression checks the generated Harness provenance is exactly `0.3.0` and keeps the zero-spend, no-gstack-execution, no-hosted-billing, and no-marketplace-publication boundaries intact.
+
+This is local package compatibility evidence only. It does not publish Harness Core, change the bridge's published dependency line, execute gstack, call a provider, deploy a runtime, or grant any hosted authority.
+
 ## Authority boundary
 
 The bridge has no tool to:
@@ -65,9 +71,10 @@ Harness receipts remain clearly labeled local/no-spend receipts. They are not se
 ```bash
 npm run check
 npm test
+npm run test:core-compat
 ```
 
-The deterministic suite covers the complete fixture flow, absent evidence, hostile instruction-like content, malformed JSON, overwrite refusal, raw-content exclusion, and the documented CLI command.
+The deterministic suite covers the complete fixture flow, absent evidence, hostile instruction-like content, malformed JSON, overwrite refusal, raw-content exclusion, the documented CLI command, and a packed local Harness Core `0.3.0` compatibility regression. The repository CI executes that regression on Node 20, 22, and 24.
 
 ## License
 

--- a/gstack/package.json
+++ b/gstack/package.json
@@ -18,8 +18,9 @@
     "agoragentic-harness-core": "0.2.0"
   },
   "scripts": {
-    "check": "node --check gstack-harness.mjs && node --check cli.mjs && node --check test.mjs",
+    "check": "node --check gstack-harness.mjs && node --check cli.mjs && node --check test.mjs && node --check scripts/test-harness-core-compat.mjs",
     "test": "node --test test.mjs",
+    "test:core-compat": "node scripts/test-harness-core-compat.mjs",
     "pretest": "npm run check"
   },
   "repository": {

--- a/gstack/scripts/test-harness-core-compat.mjs
+++ b/gstack/scripts/test-harness-core-compat.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+// Local compatibility proof for the review-gated Harness Core candidate.
+//
+// This intentionally packs the sibling source package and installs it in a
+// throwaway consumer. npm may resolve the package's declared dependencies
+// during that setup; the bridge itself does not call the network or grant
+// runtime/financial authority.
+
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { cp, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const gstackRoot = resolve(here, '..');
+const harnessCoreRoot = resolve(gstackRoot, '..', 'harness-core');
+const npmCli = process.env.npm_execpath
+  || join(dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npm-cli.js');
+const expectedCandidateVersion = '0.3.0';
+
+if (!existsSync(npmCli)) throw new Error('Could not locate npm-cli.js for packed Harness Core compatibility verification.');
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd,
+    encoding: 'utf8',
+    env: options.env || process.env,
+    stdio: 'pipe',
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const output = [result.stdout, result.stderr].filter(Boolean).join('\n').trim();
+    throw new Error(`${command} ${args.join(' ')} exited with status ${result.status}.${output ? `\n${output}` : ''}`);
+  }
+  return result;
+}
+
+function runNpm(args, options = {}) {
+  return run(process.execPath, [npmCli, ...args], options);
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await readFile(filePath, 'utf8'));
+}
+
+async function copyBridgeConsumer(consumer) {
+  for (const file of ['gstack-harness.mjs', 'cli.mjs', 'test.mjs']) {
+    await cp(join(gstackRoot, file), join(consumer, file));
+  }
+  await cp(join(gstackRoot, 'fixtures'), join(consumer, 'fixtures'), { recursive: true });
+  await writeFile(join(consumer, 'package.json'), `${JSON.stringify({
+    name: 'gstack-harness-core-compat-consumer',
+    version: '0.0.0',
+    private: true,
+    type: 'module',
+  }, null, 2)}\n`, 'utf8');
+}
+
+let work;
+try {
+  const harnessPackage = await readJson(join(harnessCoreRoot, 'package.json'));
+  assert(harnessPackage.name === 'agoragentic-harness-core', 'Sibling Harness Core package name is unexpected.');
+  assert(
+    harnessPackage.version === expectedCandidateVersion,
+    `Expected local Harness Core ${expectedCandidateVersion}, found ${harnessPackage.version || 'unknown'}.`,
+  );
+
+  work = await mkdtemp(join(tmpdir(), 'agoragentic-gstack-harness-core-compat-'));
+  const packDir = join(work, 'pack');
+  const consumer = join(work, 'consumer');
+  await mkdir(packDir);
+  await mkdir(consumer);
+
+  const packResult = runNpm([
+    'pack',
+    '--json',
+    '--ignore-scripts',
+    '--pack-destination',
+    packDir,
+  ], { cwd: harnessCoreRoot });
+  const packed = JSON.parse(packResult.stdout);
+  assert(Array.isArray(packed) && packed.length === 1, 'npm pack must return exactly one Harness Core package record.');
+  assert(packed[0].name === harnessPackage.name, 'Packed Harness Core package name does not match package.json.');
+  assert(packed[0].version === expectedCandidateVersion, 'Packed Harness Core version is not 0.3.0.');
+  const tarball = join(packDir, packed[0].filename);
+  assert(existsSync(tarball), 'npm pack did not create the declared Harness Core tarball.');
+
+  await copyBridgeConsumer(consumer);
+  runNpm([
+    'install',
+    '--ignore-scripts',
+    '--no-audit',
+    '--no-fund',
+    '--package-lock=false',
+    tarball,
+  ], { cwd: consumer });
+
+  const installed = await readJson(join(consumer, 'node_modules', 'agoragentic-harness-core', 'package.json'));
+  assert(installed.name === harnessPackage.name, 'Temporary consumer installed an unexpected Harness Core package.');
+  assert(installed.version === expectedCandidateVersion, 'Temporary consumer did not install Harness Core 0.3.0.');
+
+  run(process.execPath, ['--test', 'test.mjs'], {
+    cwd: consumer,
+    env: {
+      ...process.env,
+      AGORAGENTIC_HARNESS_CORE_EXPECTED_VERSION: expectedCandidateVersion,
+      AGORAGENTIC_NO_SPEND: '1',
+      AGORAGENTIC_ALLOW_REAL_SPEND: '0',
+      AGORAGENTIC_ALLOW_NETWORK_CANARIES: '0',
+    },
+  });
+
+  console.log(JSON.stringify({
+    ok: true,
+    harness_core: {
+      package: installed.name,
+      version: installed.version,
+      source: 'packed_local_tarball',
+    },
+    bridge_regression: 'passed',
+    authority_boundary: {
+      gstack_execution: false,
+      hosted_runtime: false,
+      marketplace_publication: false,
+      spend: false,
+    },
+  }));
+} finally {
+  if (work) await rm(work, { recursive: true, force: true });
+}

--- a/gstack/test.mjs
+++ b/gstack/test.mjs
@@ -18,6 +18,7 @@ const fixtureArtifacts = Object.freeze({
   release: path.join(root, 'fixtures', 'artifacts', 'release.md'),
 });
 const createdAt = '2026-08-08T00:00:00.000Z';
+const expectedHarnessCoreVersion = process.env.AGORAGENTIC_HARNESS_CORE_EXPECTED_VERSION?.trim() || null;
 
 async function tempRoot() {
   return fs.mkdtemp(path.join(os.tmpdir(), 'agoragentic-gstack-'));
@@ -74,6 +75,31 @@ test('explicit fixture artifacts produce existing Harness artifact families with
   assert.equal(serialized.includes('Implement a local parser'), false);
   assert.equal(serialized.includes(path.dirname(fixtureProject)), false);
 });
+
+if (expectedHarnessCoreVersion) {
+  test(`packed Harness Core ${expectedHarnessCoreVersion} preserves local provenance and no-spend boundaries`, async t => {
+    const temp = await tempRoot();
+    t.after(() => fs.rm(temp, { recursive: true, force: true }));
+    const out = path.join(temp, 'core-compatibility');
+    const result = await compileGstackArtifacts({
+      projectDir: fixtureProject,
+      outDir: out,
+      artifacts: fixtureArtifacts,
+      createdAt,
+    });
+
+    assert.equal(result.ok, true);
+    const packet = await readOutput(out, 'agent-os-harness.json');
+    const receipt = await readOutput(out, 'local-receipt.json');
+    assert.equal(packet.generated_from?.source, 'agoragentic-harness-core');
+    assert.equal(packet.generated_from?.package_version, expectedHarnessCoreVersion);
+    assert.equal(packet.generated_from?.local_only, true);
+    assert.equal(packet.public_boundary?.hosted_billing, false);
+    assert.equal(packet.public_boundary?.marketplace_publication, false);
+    assert.equal(receipt.spend.amount_usdc, 0);
+    assert.equal(receipt.receipt_boundary.gstack_executed, false);
+  });
+}
 
 test('a missing stage writes BLOCKED evidence and omits the Agent OS export', async t => {
   const temp = await tempRoot();


### PR DESCRIPTION
## Summary
- adds a packed-local-tarball regression for the review-gated Harness Core 0.3.0 candidate
- verifies installed package identity, generated provenance, and no-spend/no-hosted boundaries
- lets the temporary consumer resolve Harness Core's declared npm dependencies with --ignore-scripts, --no-audit, and --no-fund
- runs the proof in the existing Node 20/22/24 bridge workflow without changing the published 0.2.0 dependency

## Validation
- Node 20.20.2, 22.23.1, and 24.18.0: syntax, six bridge tests, and packed-Core regression
- npm run check && npm test && npm run test:core-compat

No package publishing, hosted-surface changes, gstack execution, provider calls, or financial authority.