### PR TITLE
fix(opencode): close governance review gaps

### DIFF
--- a/opencode/README.md
+++ b/opencode/README.md
@@ -34,7 +34,7 @@ The before hook maps `{ tool, sessionID, callID }` plus mutable `output.args` in
 
 The after hook does not persist `title`, `output`, metadata values, tool arguments, session IDs, or call IDs. It stores only hashes, byte counts, value types, field counts, redacted stable references, duration, and explicit authority boundaries. An after hook without a matching governed before hook emits a blocked `ungoverned_after_without_before` receipt and disables further calls in that plugin instance; it never creates a successful receipt.
 
-OpenCode `1.18.15` declares no tool-error after hook. If the host tool itself throws, the before event remains but this plugin cannot truthfully emit a successful completion receipt. Missing after evidence therefore remains unknown rather than being reconstructed.
+OpenCode `1.18.15` declares no tool-error after hook. If the host tool itself throws, the before event remains but this plugin cannot truthfully emit a successful completion receipt. Missing after evidence therefore remains unknown rather than being reconstructed. Pending governed calls are bounded and expire locally; expiry never implies a successful completion, and a later unmatched after hook is recorded as blocked evidence.
 
 ## Local artifacts
 
@@ -47,6 +47,7 @@ Artifacts stay under the project directory:
 │   └── approval_<id>.decision.json
 └── opencode/
     ├── approval-refs/action_<id>.json
+    ├── approval-refs/action_<id>.consumed_<id>.json
     └── runs/opencode_run_<id>/
         ├── events.jsonl
         ├── receipts/local_receipt_<id>.json
@@ -94,13 +95,16 @@ The `memory_handoff: "local_ref"` option writes a refs-and-hashes-only local han
 
 ## Approval and retry
 
-For `ask`, inspect the path in the thrown error and decide locally with the installed Harness Core dependency:
+For `ask`, inspect the path in the thrown error and decide locally with the installed Harness Core dependency. From this repository root, use the dependency installed by `cd opencode && npm ci` and explicitly point it at the OpenCode project directory:
 
 ```bash
-npx --no-install agoragentic-harness-core approvals show approval_<id>
-npx --no-install agoragentic-harness-core approvals decide approval_<id> \
+node ./opencode/node_modules/agoragentic-harness-core/bin/agoragentic-harness.mjs \
+  approvals show approval_<id> --dir "$PWD"
+node ./opencode/node_modules/agoragentic-harness-core/bin/agoragentic-harness.mjs \
+  approvals decide approval_<id> \
   --decision approve \
-  --note "owner-reviewed local retry"
+  --note "owner-reviewed local retry" \
+  --dir "$PWD"
 ```
 
 Retry the same tool action after approval. The approval lookup binds the hashed session reference, tool name, input hash, and policy hash, and the before hook consumes it for one retry attempt. A later identical action requires a fresh approval; changed input or policy also produces a different packet. Approving the local packet only removes this plugin's own `ask` block for that attempt; OpenCode permissions and every external authority boundary still apply.

--- a/opencode/src/mapping.mjs
+++ b/opencode/src/mapping.mjs
@@ -58,9 +58,10 @@ export function mapOpenCodeToolCall(input = {}, output = {}) {
   };
 }
 
-export function evaluateOpenCodeAction(policy = {}, action = {}) {
+export function evaluateOpenCodeAction(policy = {}, action = {}, { platform = process.platform } = {}) {
   const evaluation = evaluateClaudeCodeAction(policy, action);
   const reasons = [...evaluation.reasons];
+  const blockedPatchTarget = matchingBlockedPatchTarget(policy, action, platform);
   if (action.target_parse_error) {
     reasons.push({
       code: action.target_parse_error,
@@ -68,19 +69,27 @@ export function evaluateOpenCodeAction(policy = {}, action = {}) {
       detail: 'apply_patch target extraction failed closed',
     });
   }
+  if (blockedPatchTarget && !reasons.some((reason) => reason.code === 'blocked_path')) {
+    reasons.push({
+      code: 'blocked_path',
+      level: 'deny',
+      detail: blockedPatchTarget.target,
+    });
+  }
+  const forcedDeny = Boolean(action.target_parse_error || blockedPatchTarget);
   return {
     ...evaluation,
     schema: OPENCODE_DECISION_SCHEMA,
     host: 'opencode',
     tool_name: action.tool_name,
-    decision: action.target_parse_error ? 'deny' : evaluation.decision,
-    risk: action.target_parse_error ? 'high' : evaluation.risk,
+    decision: forcedDeny ? 'deny' : evaluation.decision,
+    risk: forcedDeny ? 'high' : evaluation.risk,
     reasons,
   };
 }
 
-export function decideOpenCodeToolCall(policy, input, output) {
-  return evaluateOpenCodeAction(policy, mapOpenCodeToolCall(input, output));
+export function decideOpenCodeToolCall(policy, input, output, options) {
+  return evaluateOpenCodeAction(policy, mapOpenCodeToolCall(input, output), options);
 }
 
 function canonicalHarnessToolName(toolName) {
@@ -169,4 +178,32 @@ function normalizePatchTarget(value) {
   const normalized = target.replace(/\\/g, '/').replace(/^\.\//, '');
   if (!normalized || normalized.split('/').some((part) => !part || part === '.' || part === '..')) return null;
   return normalized;
+}
+
+function matchingBlockedPatchTarget(policy, action, platform) {
+  if (String(action?.tool_name || '').toLowerCase() !== 'apply_patch') return null;
+  const blockedPaths = policy?.tool_policy?.blocked_paths || policy?.guard_policy?.blocked_paths || [];
+  if (!Array.isArray(blockedPaths) || !Array.isArray(action?.targets)) return null;
+  const windowsPaths = platform === 'win32';
+  for (const target of action.targets) {
+    const normalizedTarget = canonicalPatchPolicyPath(target, { windowsPaths });
+    if (!normalizedTarget) continue;
+    for (const blockedPath of blockedPaths) {
+      const normalizedBlockedPath = canonicalPatchPolicyPath(blockedPath, { windowsPaths });
+      if (normalizedBlockedPath && normalizedTarget.includes(normalizedBlockedPath)) {
+        return { target, blocked_path: blockedPath };
+      }
+    }
+  }
+  return null;
+}
+
+function canonicalPatchPolicyPath(value, { windowsPaths } = {}) {
+  const raw = String(value || '').trim();
+  if (!raw || /[\0\r\n]/.test(raw)) return null;
+  const separatorNormalized = windowsPaths ? raw.replace(/\\/g, '/') : raw;
+  const normalized = separatorNormalized
+    .replace(/^(?:\.\/)+/, '')
+    .replace(/\/{2,}/g, '/');
+  return windowsPaths ? normalized.toLocaleLowerCase('en-US') : normalized;
 }

--- a/opencode/src/mapping.mjs
+++ b/opencode/src/mapping.mjs
@@ -26,9 +26,17 @@ export function mapOpenCodeToolCall(input = {}, output = {}) {
   const toolName = String(input.tool || '');
   const args = output.args && typeof output.args === 'object' ? output.args : {};
   const canonicalName = canonicalHarnessToolName(toolName);
+  const patchInspection = inspectApplyPatchTargets(toolName, args);
+  const normalizedArgs = normalizeOpenCodeArgs(args);
+  if (patchInspection.targets.length > 0) {
+    // The Harness evaluator currently accepts one target field. Preserve every
+    // parsed patch target in that field so blocked-path checks cannot be
+    // bypassed by placing the protected file later in a multi-file patch.
+    normalizedArgs.file_path = patchInspection.targets.join('\n');
+  }
   const mapped = mapClaudeCodeToolCall({
     tool_name: canonicalName,
-    tool_input: normalizeOpenCodeArgs(args),
+    tool_input: normalizedArgs,
   });
 
   return {
@@ -36,17 +44,38 @@ export function mapOpenCodeToolCall(input = {}, output = {}) {
     schema: OPENCODE_ACTION_SCHEMA,
     host: 'opencode',
     tool_name: toolName,
-    scannable_text: [toolName, mapped.scannable_text].filter(Boolean).join('\n'),
+    target: patchInspection.targets.length > 0 ? patchInspection.targets.join('\n') : mapped.target,
+    targets: patchInspection.targets.length > 0
+      ? patchInspection.targets
+      : mapped.target ? [mapped.target] : [],
+    target_parse_error: patchInspection.error,
+    scannable_text: [
+      toolName,
+      tokenizeToolName(toolName),
+      mapped.scannable_text,
+      patchInspection.scannable_text,
+    ].filter(Boolean).join('\n'),
   };
 }
 
 export function evaluateOpenCodeAction(policy = {}, action = {}) {
   const evaluation = evaluateClaudeCodeAction(policy, action);
+  const reasons = [...evaluation.reasons];
+  if (action.target_parse_error) {
+    reasons.push({
+      code: action.target_parse_error,
+      level: 'deny',
+      detail: 'apply_patch target extraction failed closed',
+    });
+  }
   return {
     ...evaluation,
     schema: OPENCODE_DECISION_SCHEMA,
     host: 'opencode',
     tool_name: action.tool_name,
+    decision: action.target_parse_error ? 'deny' : evaluation.decision,
+    risk: action.target_parse_error ? 'high' : evaluation.risk,
+    reasons,
   };
 }
 
@@ -72,4 +101,72 @@ function normalizeOpenCodeArgs(args) {
     old_string: args.old_string ?? args.oldString,
     new_string: args.new_string ?? args.newString,
   };
+}
+
+function tokenizeToolName(toolName) {
+  return String(toolName || '').replace(/[_:./\\-]+/g, ' ');
+}
+
+function inspectApplyPatchTargets(toolName, args) {
+  if (String(toolName || '').toLowerCase() !== 'apply_patch') {
+    return { targets: [], error: null, scannable_text: null };
+  }
+
+  const patch = firstPatchText(args);
+  if (!patch) {
+    return {
+      targets: [],
+      error: 'apply_patch_targets_unparseable',
+      scannable_text: null,
+    };
+  }
+
+  const rawTargets = [];
+  const directive = /^\*\*\*\s+(?:Add|Update|Delete) File:\s*(.+?)\s*$/gmi;
+  const relocation = /^\*\*\*\s+(?:Move|Copy) to:\s*(.+?)\s*$/gmi;
+  for (const match of patch.matchAll(directive)) rawTargets.push(match[1]);
+  for (const match of patch.matchAll(relocation)) rawTargets.push(match[1]);
+
+  if (rawTargets.length === 0) {
+    return {
+      targets: [],
+      error: 'apply_patch_targets_unparseable',
+      scannable_text: patch.slice(0, 2000),
+    };
+  }
+
+  const targets = [];
+  for (const rawTarget of rawTargets) {
+    const target = normalizePatchTarget(rawTarget);
+    if (!target) {
+      return {
+        targets: [],
+        error: 'apply_patch_targets_invalid',
+        scannable_text: patch.slice(0, 2000),
+      };
+    }
+    if (!targets.includes(target)) targets.push(target);
+  }
+
+  return {
+    targets,
+    error: null,
+    scannable_text: patch.slice(0, 2000),
+  };
+}
+
+function firstPatchText(args) {
+  for (const key of ['patch', 'diff', 'input']) {
+    if (typeof args?.[key] === 'string' && args[key].trim()) return args[key];
+  }
+  return null;
+}
+
+function normalizePatchTarget(value) {
+  const target = String(value || '').trim();
+  if (!target || target.length > 4096 || /[\0\r\n]/.test(target)) return null;
+  if (/^(?:[A-Za-z]:[\\/]|[\\/])/.test(target)) return null;
+  const normalized = target.replace(/\\/g, '/').replace(/^\.\//, '');
+  if (!normalized || normalized.split('/').some((part) => !part || part === '.' || part === '..')) return null;
+  return normalized;
 }

--- a/opencode/src/runtime.mjs
+++ b/opencode/src/runtime.mjs
@@ -474,14 +474,38 @@ export function createOpenCodeHooks({
     consumed_at,
   }) {
     const refPath = approvalRefPath(action_fingerprint);
+    const approvalBinding = createApprovalBinding({
+      run_id,
+      action,
+      action_fingerprint,
+      policy_hash,
+      input_evidence,
+    });
     const existingRef = await readJsonIfExists(refPath);
     if (existingRef && !existingRef.consumed_at) {
       if (!APPROVAL_ID_PATTERN.test(String(existingRef.approval_id || ''))) {
         throw governanceBlock('approval_ref_invalid', 'deny', 'The local approval reference is invalid.');
       }
+      if (!approvalReferenceMatchesCurrentAction(existingRef, {
+        action_fingerprint,
+        approval_binding: approvalBinding,
+      })) {
+        throw governanceBlock('approval_binding_invalid', 'deny', 'The local approval reference does not bind to this tool action.');
+      }
       const existing = await showApproval(root, existingRef.approval_id);
       if (!existing?.request) {
         throw governanceBlock('approval_state_missing', 'deny', 'The referenced local approval packet is missing.');
+      }
+      if (!approvalRequestMatchesCurrentAction(existing.request, {
+        approval_id: existingRef.approval_id,
+        run_id,
+        action,
+        action_fingerprint,
+        policy_hash,
+        input_evidence,
+        approval_binding: approvalBinding,
+      })) {
+        throw governanceBlock('approval_binding_invalid', 'deny', 'The referenced local approval packet does not bind to this tool action.');
       }
       const state = approvalState(existingRef.approval_id, existing);
       if (state.status === 'approved') {
@@ -505,6 +529,7 @@ export function createOpenCodeHooks({
       input_evidence,
       policy_hash,
       reason_codes,
+      approval_binding: approvalBinding,
     });
   }
 
@@ -569,6 +594,7 @@ export function createOpenCodeHooks({
     input_evidence,
     policy_hash,
     reason_codes,
+    approval_binding,
   }) {
     const request = await createApprovalRequest({
       dir: root,
@@ -581,6 +607,7 @@ export function createOpenCodeHooks({
         action_fingerprint,
         policy_hash,
         input_evidence,
+        approval_binding,
         raw_input_persisted: false,
       },
       risk_class: evaluation.risk,
@@ -596,6 +623,7 @@ export function createOpenCodeHooks({
       action_fingerprint,
       approval_id: request.approval_id,
       approval_ref: approvalRequestRef(request.approval_id),
+      approval_binding,
       raw_input_persisted: false,
       authority_boundary: authorityBoundary(),
     };
@@ -899,12 +927,106 @@ function approvalClaimPath(refPath, approvalId) {
   return `${refPath}.${approvalId}.claim`;
 }
 
+function createApprovalBinding({ run_id, action, action_fingerprint, policy_hash, input_evidence }) {
+  const evidenceShape = approvalEvidenceShape(input_evidence);
+  return {
+    schema: 'agoragentic.harness.opencode-approval-binding.v1',
+    action_fingerprint_ref: opaqueBindingRef('opencode_approval_action', action_fingerprint),
+    policy_hash_ref: opaqueBindingRef('opencode_approval_policy', policy_hash),
+    input_evidence_ref: opaqueBindingRef('opencode_approval_input', evidenceShape),
+    binding_ref: opaqueBindingRef('opencode_approval_binding', {
+      run_id,
+      tool_name: String(action?.tool_name || ''),
+      capability: action?.capability || null,
+      side_effect_class: action?.side_effect_class || null,
+      action_fingerprint,
+      policy_hash,
+      input_evidence: evidenceShape,
+    }),
+  };
+}
+
+function opaqueBindingRef(prefix, value) {
+  // Harness Core redacts complete SHA-256 strings in approval packets. A
+  // 128-bit deterministic reference retains an exact equality invariant over
+  // the raw action/policy/input values without persisting those values.
+  return `${prefix}_${stableHash(value).slice(7, 39)}`;
+}
+
+function approvalEvidenceShape(evidence = {}) {
+  return {
+    hash: evidence.hash || null,
+    hash_complete: evidence.hash_complete === true,
+    serialized_bytes: evidence.serialized_bytes ?? null,
+    value_type: evidence.value_type ?? null,
+    field_count: evidence.field_count ?? null,
+    storage: evidence.storage || null,
+    raw_value_persisted: evidence.raw_value_persisted === true,
+  };
+}
+
+function approvalReferenceMatchesCurrentAction(reference, expected) {
+  return Boolean(
+    reference?.schema === OPENCODE_APPROVAL_REF_SCHEMA
+    && reference.action_fingerprint === expected.action_fingerprint
+    && reference.approval_ref === approvalRequestRef(reference.approval_id)
+    && reference.raw_input_persisted === false
+    && sameApprovalBinding(reference.approval_binding, expected.approval_binding),
+  );
+}
+
+function approvalRequestMatchesCurrentAction(request, expected) {
+  const requestedAction = request?.requested_action;
+  return Boolean(
+    request?.schema === 'agoragentic.harness.approval-request.v1'
+    && request.approval_id === expected.approval_id
+    && request.run_id === expected.run_id
+    && requestedAction?.host === 'opencode'
+    && requestedAction.tool_name === sanitizeText(expected.action.tool_name, { maxLength: 120 })
+    && requestedAction.capability === expected.action.capability
+    && requestedAction.side_effect_class === expected.action.side_effect_class
+    // The visible fields are sanitized by Harness Core; the binding below is
+    // the exact raw-value comparison for these same fingerprints.
+    && requestedAction.action_fingerprint === sanitizeText(expected.action_fingerprint)
+    && requestedAction.policy_hash === sanitizeText(expected.policy_hash)
+    && sanitizedApprovalEvidenceMatches(requestedAction.input_evidence, expected.input_evidence)
+    && requestedAction.raw_input_persisted === false
+    && sameApprovalBinding(requestedAction.approval_binding, expected.approval_binding),
+  );
+}
+
+function sanitizedApprovalEvidenceMatches(actual, expected) {
+  const expectedShape = approvalEvidenceShape(expected);
+  return Boolean(
+    actual
+    && actual.hash === sanitizeText(expectedShape.hash)
+    && actual.hash_complete === expectedShape.hash_complete
+    && actual.serialized_bytes === expectedShape.serialized_bytes
+    && actual.value_type === expectedShape.value_type
+    && actual.field_count === expectedShape.field_count
+    && actual.storage === expectedShape.storage
+    && actual.raw_value_persisted === false,
+  );
+}
+
+function sameApprovalBinding(actual, expected) {
+  return Boolean(
+    actual?.schema === expected?.schema
+    && actual.action_fingerprint_ref === expected.action_fingerprint_ref
+    && actual.policy_hash_ref === expected.policy_hash_ref
+    && actual.input_evidence_ref === expected.input_evidence_ref
+    && actual.binding_ref === expected.binding_ref,
+  );
+}
+
 function sameApprovalReference(current, expected) {
   return Boolean(
     current
     && !current.consumed_at
     && current.approval_id === expected.approval_id
-    && current.action_fingerprint === expected.action_fingerprint,
+    && current.action_fingerprint === expected.action_fingerprint
+    && current.approval_ref === expected.approval_ref
+    && sameApprovalBinding(current.approval_binding, expected.approval_binding),
   );
 }
 

--- a/opencode/src/runtime.mjs
+++ b/opencode/src/runtime.mjs
@@ -24,6 +24,8 @@ export const OPENCODE_HANDOFF_SCHEMA = 'agoragentic.harness.opencode-memory-hand
 const PLUGIN_NAME = '@agoragentic/opencode';
 const APPROVAL_ID_PATTERN = /^approval_[a-f0-9]{12}$/;
 const MAX_REASON_CODES = 16;
+const DEFAULT_PENDING_CALL_LIMIT = 256;
+const DEFAULT_PENDING_CALL_TTL_MS = 5 * 60 * 1000;
 
 export class OpenCodeGovernanceBlock extends Error {
   constructor(message, { code, decision, approval_id = null, receipt_ref = null } = {}) {
@@ -51,6 +53,11 @@ export function createOpenCodeHooks({
   const logger = internals.logger && typeof internals.logger.error === 'function'
     ? internals.logger
     : console;
+  const pendingCallLimit = positiveInteger(internals.pending_call_limit, DEFAULT_PENDING_CALL_LIMIT);
+  const pendingCallTtlMs = positiveInteger(internals.pending_call_ttl_ms, DEFAULT_PENDING_CALL_TTL_MS);
+  const beforeApprovalClaim = typeof internals.before_approval_claim === 'function'
+    ? internals.before_approval_claim
+    : null;
   const calls = new Map();
   const sequences = new Map();
   let queue = Promise.resolve();
@@ -60,6 +67,15 @@ export function createOpenCodeHooks({
     const result = queue.then(operation, operation);
     queue = result.then(() => undefined, () => undefined);
     return result;
+  }
+
+  function prunePendingCalls(now) {
+    for (const [callRef, candidate] of calls) {
+      const startedMs = Number(candidate?.started_ms);
+      if (!Number.isFinite(startedMs) || now - startedMs >= pendingCallTtlMs) {
+        calls.delete(callRef);
+      }
+    }
   }
 
   async function beforeTool(input, output) {
@@ -97,6 +113,14 @@ export function createOpenCodeHooks({
   async function handleBefore(input = {}, output = {}) {
     assertHookIdentity(input);
     const startedMs = readClock(nowMs);
+    prunePendingCalls(startedMs);
+    if (calls.size >= pendingCallLimit) {
+      throw governanceBlock(
+        'pending_completion_evidence_limit',
+        'deny',
+        'Too many governed tool calls are awaiting OpenCode completion evidence; new tool calls remain blocked until the host reports completion or pending evidence expires.',
+      );
+    }
     const loadedPolicy = await loadPolicy();
     const action = mapOpenCodeToolCall(input, output);
     const evaluation = evaluateOpenCodeAction(loadedPolicy, action);
@@ -131,6 +155,7 @@ export function createOpenCodeHooks({
       if (approvalState.status === 'approved') enforcementDecision = 'allow_after_local_approval';
       else if (approvalState.status === 'rejected') enforcementDecision = 'deny_after_local_rejection';
       else if (approvalState.status === 'edited') enforcementDecision = 'approval_edit_required';
+      else if (approvalState.status === 'consumed') enforcementDecision = 'approval_consumed';
       else enforcementDecision = 'approval_required';
     }
 
@@ -195,6 +220,7 @@ export function createOpenCodeHooks({
         enforcement_decision: enforcementDecision,
         reason_codes: reasonCodes,
         action_fingerprint: actionFingerprint,
+        policy_hash: policyHash,
         input_evidence: inputEvidence,
         approval_refs: approvalState?.refs || [],
         before_event_id: beforeEvent.event_id,
@@ -207,6 +233,7 @@ export function createOpenCodeHooks({
     const outcomeStatus = enforcementDecision === 'approval_required' ? 'approval_required'
       : enforcementDecision === 'approval_edit_required' ? 'approval_edit_required'
         : enforcementDecision === 'deny_after_local_rejection' ? 'approval_rejected'
+          : enforcementDecision === 'approval_consumed' ? 'approval_consumed'
           : 'denied';
     const { receipt_ref: receiptRef } = await writeReceipt({
       run_id: runId,
@@ -263,6 +290,17 @@ export function createOpenCodeHooks({
         },
       );
     }
+    if (enforcementDecision === 'approval_consumed') {
+      throw new OpenCodeGovernanceBlock(
+        '[agoragentic/opencode] The matching local approval was already consumed by another tool attempt; this call remains blocked and requires a fresh owner approval.',
+        {
+          code: 'approval_consumed',
+          decision: 'ask',
+          approval_id: approvalState.approval_id,
+          receipt_ref: receiptRef,
+        },
+      );
+    }
     throw new OpenCodeGovernanceBlock(
       `[agoragentic/opencode] Tool execution denied before execution (${reasonCodes.join(', ') || 'policy_denied'}).`,
       { code: 'policy_denied', decision: 'deny', receipt_ref: receiptRef },
@@ -278,24 +316,56 @@ export function createOpenCodeHooks({
     const previous = calls.get(callRef);
     const governed = Boolean(previous);
     const action = mapOpenCodeToolCall(input, { args: input.args ?? {} });
-    const inputEvidence = previous?.input_evidence || boundedEvidence(input.args ?? {});
+    const executedInputEvidence = boundedEvidence(input.args ?? {});
+    const governedToolName = previous?.tool_name || null;
+    const toolMatches = !governed || governedToolName === sanitizeText(action.tool_name, { maxLength: 120 });
+    const inputMatches = !governed || sameBoundedEvidence(previous.input_evidence, executedInputEvidence);
+    const governanceBindingValid = governed && toolMatches && inputMatches;
+    const bindingMismatch = governed && !governanceBindingValid;
+    const inputEvidence = bindingMismatch
+      ? executedInputEvidence
+      : previous?.input_evidence || executedInputEvidence;
     const outputEvidence = boundedEvidence(output);
     const ledgerRef = previous?.ledger_ref || relativePath(root, ledgerPath(runId));
     const durationObserved = Boolean(previous);
     const durationMs = previous ? Math.max(0, endedMs - previous.started_ms) : 0;
-    const actionFingerprint = previous?.action_fingerprint || stableHash({
+    const actionFingerprint = bindingMismatch
+      ? stableHash({
+        host: 'opencode',
+        session_ref: identity.session_ref,
+        tool_name: action.tool_name,
+        executed_input_hash: executedInputEvidence.hash,
+        governed_action_fingerprint: previous.action_fingerprint,
+      })
+      : previous?.action_fingerprint || stableHash({
       host: 'opencode',
       session_ref: identity.session_ref,
       tool_name: action.tool_name,
       input_hash: inputEvidence.hash,
     });
+    const outcomeStatus = !governed
+      ? 'ungoverned_after_without_before'
+      : bindingMismatch ? 'governance_binding_mismatch'
+        : 'succeeded';
+    const reasonCodes = bindingMismatch
+      ? unique([
+        ...previous.reason_codes,
+        !toolMatches ? 'tool_changed_after_governance' : null,
+        !inputMatches ? 'arguments_changed_after_governance' : null,
+      ])
+      : previous?.reason_codes || [];
+    const enforcementDecision = bindingMismatch
+      ? 'governance_binding_mismatch'
+      : previous?.enforcement_decision || 'unknown';
     const afterEvent = createHarnessEvent({
       run_id: runId,
       type: 'after_tool',
-      severity: governed ? 'info' : 'blocked',
-      summary: governed
-        ? 'OpenCode tool completion recorded as bounded hash-and-shape evidence.'
-        : 'OpenCode tool completion arrived without a matching governed before hook; no successful receipt is claimed.',
+      severity: governanceBindingValid ? 'info' : 'blocked',
+      summary: !governed
+        ? 'OpenCode tool completion arrived without a matching governed before hook; no successful receipt is claimed.'
+        : bindingMismatch
+          ? 'OpenCode tool arguments or identity changed after governance; the completion is recorded only as blocked mismatch evidence.'
+          : 'OpenCode tool completion recorded as bounded hash-and-shape evidence.',
       created_at: toIso(endedMs),
       sequence: nextSequence(runId),
       data: {
@@ -306,10 +376,13 @@ export function createOpenCodeHooks({
         tool_name: previous?.tool_name || sanitizeText(action.tool_name, { maxLength: 120 }),
         capability: previous?.capability || action.capability,
         side_effect_class: previous?.side_effect_class || action.side_effect_class,
-        outcome_status: governed ? 'succeeded' : 'ungoverned_after_without_before',
+        outcome_status: outcomeStatus,
         duration_ms: durationMs,
         duration_observed: durationObserved,
         input_evidence: inputEvidence,
+        governed_input_evidence: bindingMismatch ? previous.input_evidence : null,
+        governance_binding_valid: governanceBindingValid,
+        tool_name_matches_governed_before: toolMatches,
         output_evidence: outputEvidence,
         action_fingerprint: actionFingerprint,
         approval_refs: previous?.approval_refs || [],
@@ -324,10 +397,13 @@ export function createOpenCodeHooks({
       capability: previous?.capability || action.capability,
       side_effect_class: previous?.side_effect_class || action.side_effect_class,
       policy_decision: previous?.policy_decision || 'unknown',
-      enforcement_decision: previous?.enforcement_decision || 'unknown',
-      reason_codes: previous?.reason_codes || [],
+      enforcement_decision: enforcementDecision,
+      reason_codes: reasonCodes,
       action_fingerprint: actionFingerprint,
       input_evidence: inputEvidence,
+      governed_input_evidence: bindingMismatch ? previous.input_evidence : null,
+      governance_binding_valid: governed ? governanceBindingValid : null,
+      tool_name_matches_governed_before: governed ? toolMatches : null,
       output_evidence: outputEvidence,
       approval_refs: previous?.approval_refs || [],
       proof_event: afterEvent,
@@ -335,10 +411,11 @@ export function createOpenCodeHooks({
       created_ms: endedMs,
       duration_ms: durationMs,
       duration_observed: durationObserved,
-      outcome_status: governed ? 'succeeded' : 'ungoverned_after_without_before',
-      passed: governed,
+      outcome_status: outcomeStatus,
+      passed: governanceBindingValid,
     });
-    if (!governed) {
+    if (!governed || bindingMismatch) {
+      calls.delete(callRef);
       evidenceFailure = true;
       return;
     }
@@ -408,11 +485,13 @@ export function createOpenCodeHooks({
       }
       const state = approvalState(existingRef.approval_id, existing);
       if (state.status === 'approved') {
-        await writeJson(refPath, {
-          ...existingRef,
+        const claimed = await claimApprovedApproval({
+          ref_path: refPath,
+          existing_ref: existingRef,
+          call_ref,
           consumed_at,
-          consumed_for_call_ref: call_ref,
         });
+        if (!claimed) return { ...state, status: 'consumed' };
       }
       return state;
     }
@@ -427,6 +506,58 @@ export function createOpenCodeHooks({
       policy_hash,
       reason_codes,
     });
+  }
+
+  async function claimApprovedApproval({ ref_path, existing_ref, call_ref, consumed_at }) {
+    if (beforeApprovalClaim) {
+      await beforeApprovalClaim({
+        action_ref: relativePath(root, ref_path),
+        call_ref,
+      });
+    }
+    const claimPath = approvalClaimPath(ref_path, existing_ref.approval_id);
+    let claimHandle;
+    try {
+      // `wx` creates this approval-specific claim exactly once. Unlike a
+      // rename-to-the-same-destination race, it is exclusive on both Windows
+      // and POSIX filesystems before either instance can allow execution.
+      claimHandle = await fs.open(claimPath, 'wx');
+    } catch (error) {
+      if (error?.code === 'EEXIST') return false;
+      throw error;
+    }
+    try {
+      await claimHandle.writeFile(`${JSON.stringify({
+        schema: 'agoragentic.harness.opencode-approval-claim.v1',
+        approval_id: existing_ref.approval_id,
+        claimed_for_call_ref: call_ref,
+        claimed_at: consumed_at,
+      })}\n`, 'utf8');
+    } finally {
+      await claimHandle.close();
+    }
+
+    const currentRef = await readJsonIfExists(ref_path);
+    if (!sameApprovalReference(currentRef, existing_ref)) return false;
+
+    const consumedPath = consumedApprovalRefPath(
+      ref_path,
+      existing_ref.approval_id,
+      call_ref,
+      consumed_at,
+    );
+    try {
+      await fs.rename(ref_path, consumedPath);
+    } catch (error) {
+      if (error?.code === 'ENOENT' || error?.code === 'EEXIST') return false;
+      throw error;
+    }
+    await writeJson(consumedPath, {
+      ...existing_ref,
+      consumed_at,
+      consumed_for_call_ref: call_ref,
+    });
+    return true;
   }
 
   async function createApprovalPacket({
@@ -562,6 +693,17 @@ export function createOpenCodeHooks({
       raw_tool_input_persisted: false,
       raw_tool_output_persisted: false,
     };
+    if (typeof input.governance_binding_valid === 'boolean') {
+      const governanceBinding = {
+        valid: input.governance_binding_valid,
+        tool_name_matches_governed_before: input.tool_name_matches_governed_before,
+        governed_input_hash: input.governed_input_evidence?.hash || input.input_evidence.hash,
+        executed_input_hash: input.input_evidence.hash,
+        raw_input_persisted: false,
+      };
+      receipt.governance_binding = governanceBinding;
+      receipt.evidence.governance_binding = governanceBinding;
+    }
     receipt.receipt_boundary = {
       ...receipt.receipt_boundary,
       certification_created: false,
@@ -711,6 +853,21 @@ function readClock(nowMs) {
   return Number.isFinite(value) ? value : Date.now();
 }
 
+function sameBoundedEvidence(expected, actual) {
+  return Boolean(
+    expected?.hash_complete
+    && actual?.hash_complete
+    && expected.hash
+    && actual.hash
+    && expected.hash === actual.hash,
+  );
+}
+
+function positiveInteger(value, fallback) {
+  const numeric = Number(value);
+  return Number.isInteger(numeric) && numeric > 0 ? numeric : fallback;
+}
+
 function toIso(milliseconds) {
   return new Date(milliseconds).toISOString();
 }
@@ -736,6 +893,25 @@ function approvalRequestRef(approvalId) {
 
 function approvalDecisionRef(approvalId) {
   return `.agoragentic/approvals/${approvalId}.decision.json`;
+}
+
+function approvalClaimPath(refPath, approvalId) {
+  return `${refPath}.${approvalId}.claim`;
+}
+
+function sameApprovalReference(current, expected) {
+  return Boolean(
+    current
+    && !current.consumed_at
+    && current.approval_id === expected.approval_id
+    && current.action_fingerprint === expected.action_fingerprint,
+  );
+}
+
+function consumedApprovalRefPath(refPath, approvalId, callRef, consumedAt) {
+  const basename = path.basename(refPath, '.json');
+  const consumedId = stableId('consumed', `${approvalId}:${callRef}:${consumedAt}`);
+  return path.join(path.dirname(refPath), `${basename}.${consumedId}.json`);
 }
 
 function relativePath(root, filePath) {

--- a/opencode/test/opencode-plugin.test.mjs
+++ b/opencode/test/opencode-plugin.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -12,6 +13,8 @@ import { decideApproval } from 'agoragentic-harness-core';
 import {
   OpenCodeGovernanceBlock,
   createOpenCodeHooks,
+  decideOpenCodeToolCall,
+  mapOpenCodeToolCall,
 } from '../src/index.mjs';
 import * as serverModule from '../src/server.mjs';
 
@@ -193,6 +196,237 @@ test('ask writes one bounded packet, blocks, and an approved retry can complete'
   assert.match(artifactText, /"memory_write_performed": false/);
 });
 
+test('changed after-hook arguments emit blocked mismatch evidence instead of a success receipt', async () => {
+  const directory = await tempDir();
+  const hooks = createOpenCodeHooks({
+    directory,
+    policy: {},
+    internals: { now_ms: fixedClock([1_700_000_125_000, 1_700_000_125_300]) },
+  });
+  const input = hookInput('read', 'session-binding', 'call-binding');
+  const governedArgs = { filePath: 'README.md' };
+  const executedArgs = { filePath: 'private/changed-after-before.md' };
+
+  await hooks['tool.execute.before'](input, { args: governedArgs });
+  await hooks['tool.execute.after'](
+    { ...input, args: executedArgs },
+    { title: 'Read', output: 'bounded output only' },
+  );
+
+  const receipt = await onlyReceipt(
+    directory,
+    (candidate) => candidate.outcome_status === 'governance_binding_mismatch',
+  );
+  assert.equal(receipt.status, 'blocked');
+  assert.equal(receipt.evidence.governance_binding.valid, false);
+  assert.equal(receipt.evidence.governance_binding.tool_name_matches_governed_before, true);
+  assert.notEqual(
+    receipt.evidence.governance_binding.governed_input_hash,
+    receipt.evidence.governance_binding.executed_input_hash,
+  );
+  assert.ok(receipt.evidence.reason_codes.includes('arguments_changed_after_governance'));
+  assertSchemaValid(receipt);
+  assert.doesNotMatch(
+    await readAllText(path.join(directory, '.agoragentic')),
+    /private\/changed-after-before\.md/,
+  );
+
+  await assert.rejects(
+    hooks['tool.execute.before'](
+      hookInput('read', 'session-binding-next', 'call-binding-next'),
+      { args: { filePath: 'README.md' } },
+    ),
+    (error) => error instanceof OpenCodeGovernanceBlock && error.code === 'evidence_unavailable',
+  );
+});
+
+test('apply_patch inspects every target and fails closed when targets cannot be parsed', async () => {
+  const patch = [
+    '*** Begin Patch',
+    '*** Update File: public/safe.md',
+    '@@',
+    '-old',
+    '+new',
+    '*** Update File: private/blocked.md',
+    '@@',
+    '-old',
+    '+new',
+    '*** End Patch',
+  ].join('\n');
+  const action = mapOpenCodeToolCall(
+    hookInput('apply_patch', 'session-patch', 'call-patch'),
+    { args: { patch } },
+  );
+  assert.deepEqual(action.targets, ['public/safe.md', 'private/blocked.md']);
+  assert.equal(action.target, 'public/safe.md\nprivate/blocked.md');
+  const decision = decideOpenCodeToolCall(
+    { tool_policy: { blocked_paths: ['private/blocked.md'] } },
+    hookInput('apply_patch', 'session-patch', 'call-patch'),
+    { args: { patch } },
+  );
+  assert.equal(decision.decision, 'deny');
+  assert.ok(decision.reasons.some((reason) => reason.code === 'blocked_path'));
+
+  const malformed = decideOpenCodeToolCall(
+    {},
+    hookInput('apply_patch', 'session-patch-malformed', 'call-patch-malformed'),
+    { args: { patch: 'not an apply_patch directive' } },
+  );
+  assert.equal(malformed.decision, 'deny');
+  assert.ok(malformed.reasons.some((reason) => reason.code === 'apply_patch_targets_unparseable'));
+});
+
+test('underscored MCP money tool names are tokenized and denied before execution', async () => {
+  const directory = await tempDir();
+  const hooks = createOpenCodeHooks({
+    directory,
+    policy: {},
+    internals: { now_ms: fixedClock([1_700_000_130_000]) },
+  });
+  const input = hookInput('mcp__wallet__transfer', 'session-mcp-money', 'call-mcp-money');
+  const decision = decideOpenCodeToolCall({}, input, { args: {} });
+  assert.equal(decision.decision, 'deny');
+  assert.ok(decision.reasons.some((reason) => reason.code === 'spend_or_publish_action'));
+
+  await assert.rejects(
+    hooks['tool.execute.before'](input, { args: {} }),
+    (error) => error instanceof OpenCodeGovernanceBlock && error.code === 'policy_denied',
+  );
+});
+
+test('two plugin instances cannot consume one approval twice', async () => {
+  const directory = await tempDir();
+  const input = hookInput('write', 'session-approval-race', 'call-approval-race');
+  const args = { filePath: 'one-shot.txt', content: 'bounded' };
+  const seed = createOpenCodeHooks({
+    directory,
+    policy: {},
+    internals: { now_ms: fixedClock([1_700_000_135_000]) },
+  });
+
+  let requested;
+  try {
+    await seed['tool.execute.before'](input, { args });
+    assert.fail('write should require approval before execution');
+  } catch (error) {
+    requested = error;
+  }
+  assert.ok(requested instanceof OpenCodeGovernanceBlock);
+  assert.equal(requested.code, 'approval_required');
+  await decideApproval({
+    dir: directory,
+    approval_id: requested.approval_id,
+    decision: 'approve',
+    note: 'owner-reviewed one-shot retry',
+  });
+
+  let arrivals = 0;
+  let releaseClaims;
+  const claimsReleased = new Promise((resolve) => { releaseClaims = resolve; });
+  const waitForBothClaims = async () => {
+    arrivals += 1;
+    if (arrivals === 2) releaseClaims();
+    await claimsReleased;
+  };
+  const first = createOpenCodeHooks({
+    directory,
+    policy: {},
+    internals: {
+      now_ms: fixedClock([1_700_000_135_100]),
+      before_approval_claim: waitForBothClaims,
+    },
+  });
+  const second = createOpenCodeHooks({
+    directory,
+    policy: {},
+    internals: {
+      now_ms: fixedClock([1_700_000_135_100]),
+      before_approval_claim: waitForBothClaims,
+    },
+  });
+
+  const attempts = await Promise.allSettled([
+    first['tool.execute.before'](input, { args }),
+    second['tool.execute.before'](input, { args }),
+  ]);
+  assert.equal(attempts.filter((result) => result.status === 'fulfilled').length, 1);
+  const rejected = attempts.find((result) => result.status === 'rejected');
+  assert.ok(rejected?.reason instanceof OpenCodeGovernanceBlock);
+  assert.equal(rejected.reason.code, 'approval_consumed');
+
+  const approvalRefFiles = (await listFiles(path.join(directory, '.agoragentic', 'opencode', 'approval-refs')))
+    .map((file) => path.basename(file));
+  assert.equal(approvalRefFiles.filter((name) => /\.consumed_[a-f0-9]{12}\.json$/.test(name)).length, 1);
+});
+
+test('pending governed before records are bounded and expire without implying completion', async () => {
+  const directory = await tempDir();
+  const hooks = createOpenCodeHooks({
+    directory,
+    policy: {},
+    internals: {
+      now_ms: fixedClock([0, 1, 2, 20]),
+      pending_call_limit: 2,
+      pending_call_ttl_ms: 10,
+    },
+  });
+
+  await hooks['tool.execute.before'](hookInput('read', 'session-pending', 'call-one'), { args: { filePath: 'one.md' } });
+  await hooks['tool.execute.before'](hookInput('read', 'session-pending', 'call-two'), { args: { filePath: 'two.md' } });
+  await assert.rejects(
+    hooks['tool.execute.before'](hookInput('read', 'session-pending', 'call-three'), { args: { filePath: 'three.md' } }),
+    (error) => error instanceof OpenCodeGovernanceBlock && error.code === 'pending_completion_evidence_limit',
+  );
+
+  await hooks['tool.execute.before'](hookInput('read', 'session-pending', 'call-after-expiry'), { args: { filePath: 'after-expiry.md' } });
+});
+
+test('the installed Harness CLI shows and decides an OpenCode approval in the explicit project directory', async () => {
+  const directory = await tempDir();
+  const hooks = createOpenCodeHooks({
+    directory,
+    policy: {},
+    internals: { now_ms: fixedClock([1_700_000_140_000, 1_700_000_140_100]) },
+  });
+  const input = hookInput('write', 'session-cli', 'call-cli');
+  const args = { filePath: 'cli-approved.txt', content: 'bounded' };
+
+  let requested;
+  try {
+    await hooks['tool.execute.before'](input, { args });
+    assert.fail('write should require approval before execution');
+  } catch (error) {
+    requested = error;
+  }
+  assert.ok(requested instanceof OpenCodeGovernanceBlock);
+  assert.equal(requested.code, 'approval_required');
+
+  const harnessCli = path.join(
+    packageRoot,
+    'node_modules',
+    'agoragentic-harness-core',
+    'bin',
+    'agoragentic-harness.mjs',
+  );
+  const show = runHarnessCli(harnessCli, ['approvals', 'show', requested.approval_id, '--dir', directory]);
+  assert.equal(show.status, 0, show.stderr);
+  assert.equal(JSON.parse(show.stdout).approval.request.approval_id, requested.approval_id);
+
+  const decide = runHarnessCli(harnessCli, [
+    'approvals',
+    'decide',
+    requested.approval_id,
+    '--decision',
+    'approve',
+    '--note',
+    'owner-reviewed CLI retry',
+    '--dir',
+    directory,
+  ]);
+  assert.equal(decide.status, 0, decide.stderr);
+  await hooks['tool.execute.before'](input, { args });
+});
+
 test('an after hook without a matching governed before hook blocks evidence and future calls', async () => {
   const directory = await tempDir();
   const hooks = createOpenCodeHooks({
@@ -293,6 +527,15 @@ function fixedClock(values) {
   const remaining = [...values];
   const fallback = remaining.at(-1) ?? 0;
   return () => remaining.shift() ?? fallback;
+}
+
+function runHarnessCli(harnessCli, args) {
+  const result = spawnSync(process.execPath, [harnessCli, ...args], {
+    cwd: packageRoot,
+    encoding: 'utf8',
+  });
+  assert.equal(result.error, undefined, result.error?.message);
+  return result;
 }
 
 async function tempDir() {

--- a/opencode/test/opencode-plugin.test.mjs
+++ b/opencode/test/opencode-plugin.test.mjs
@@ -240,6 +240,62 @@ test('changed after-hook arguments emit blocked mismatch evidence instead of a s
   );
 });
 
+test('an approved action cannot be injected into a different action reference', async () => {
+  const directory = await tempDir();
+  const hooks = createOpenCodeHooks({
+    directory,
+    policy: {},
+    internals: {
+      now_ms: fixedClock([
+        1_700_000_127_000,
+        1_700_000_127_100,
+        1_700_000_127_200,
+        1_700_000_127_300,
+      ]),
+    },
+  });
+  const benignInput = hookInput('write', 'session-cross-binding', 'call-benign');
+  const dangerousInput = hookInput('webfetch', 'session-cross-binding', 'call-dangerous');
+  const benignArgs = { filePath: 'benign.txt', content: 'bounded' };
+  const dangerousArgs = { url: 'https://example.invalid/dangerous' };
+
+  const benignApproval = await requestApproval(hooks, benignInput, benignArgs);
+  const dangerousApproval = await requestApproval(hooks, dangerousInput, dangerousArgs);
+  await decideApproval({
+    dir: directory,
+    approval_id: benignApproval.approval_id,
+    decision: 'approve',
+    note: 'owner-reviewed benign write only',
+  });
+
+  const benignRefPath = await approvalRefPathForApproval(directory, benignApproval.approval_id);
+  const dangerousRefPath = await approvalRefPathForApproval(directory, dangerousApproval.approval_id);
+  const benignRef = JSON.parse(await fs.readFile(benignRefPath, 'utf8'));
+  const dangerousRef = JSON.parse(await fs.readFile(dangerousRefPath, 'utf8'));
+  assert.notEqual(benignRef.action_fingerprint, dangerousRef.action_fingerprint);
+  assert.notEqual(benignRef.approval_binding.binding_ref, dangerousRef.approval_binding.binding_ref);
+
+  // Preserve the current action fingerprint and ref binding while injecting a
+  // different approved packet. The underlying packet must still reject it.
+  await fs.writeFile(dangerousRefPath, `${JSON.stringify({
+    ...dangerousRef,
+    approval_id: benignRef.approval_id,
+    approval_ref: benignRef.approval_ref,
+  }, null, 2)}\n`, 'utf8');
+  await assert.rejects(
+    hooks['tool.execute.before'](dangerousInput, { args: dangerousArgs }),
+    (error) => error instanceof OpenCodeGovernanceBlock && error.code === 'approval_binding_invalid',
+  );
+
+  // Rewriting the mutable reference fields together also fails before the
+  // approved packet can be claimed.
+  await fs.writeFile(dangerousRefPath, `${JSON.stringify(benignRef, null, 2)}\n`, 'utf8');
+  await assert.rejects(
+    hooks['tool.execute.before'](dangerousInput, { args: dangerousArgs }),
+    (error) => error instanceof OpenCodeGovernanceBlock && error.code === 'approval_binding_invalid',
+  );
+});
+
 test('apply_patch inspects every target and fails closed when targets cannot be parsed', async () => {
   const patch = [
     '*** Begin Patch',
@@ -274,6 +330,26 @@ test('apply_patch inspects every target and fails closed when targets cannot be 
   );
   assert.equal(malformed.decision, 'deny');
   assert.ok(malformed.reasons.some((reason) => reason.code === 'apply_patch_targets_unparseable'));
+});
+
+test('Windows matches every parsed apply_patch target case-insensitively without widening POSIX matching', () => {
+  const patch = [
+    '*** Begin Patch',
+    '*** Update File: PRIVATE\\BLOCKED.MD',
+    '@@',
+    '-old',
+    '+new',
+    '*** End Patch',
+  ].join('\n');
+  const policy = { tool_policy: { blocked_paths: ['private\\blocked.md'] } };
+  const input = hookInput('apply_patch', 'session-case', 'call-case');
+  const win32 = decideOpenCodeToolCall(policy, input, { args: { patch } }, { platform: 'win32' });
+  assert.equal(win32.decision, 'deny');
+  assert.ok(win32.reasons.some((reason) => reason.code === 'blocked_path'));
+
+  const linux = decideOpenCodeToolCall(policy, input, { args: { patch } }, { platform: 'linux' });
+  assert.equal(linux.decision, 'ask');
+  assert.equal(linux.reasons.some((reason) => reason.code === 'blocked_path'), false);
 });
 
 test('underscored MCP money tool names are tokenized and denied before execution', async () => {
@@ -536,6 +612,31 @@ function runHarnessCli(harnessCli, args) {
   });
   assert.equal(result.error, undefined, result.error?.message);
   return result;
+}
+
+async function requestApproval(hooks, input, args) {
+  let requested;
+  try {
+    await hooks['tool.execute.before'](input, { args });
+    assert.fail('the action should require approval before execution');
+  } catch (error) {
+    requested = error;
+  }
+  assert.ok(requested instanceof OpenCodeGovernanceBlock);
+  assert.equal(requested.code, 'approval_required');
+  return requested;
+}
+
+async function approvalRefPathForApproval(directory, approvalId) {
+  const root = path.join(directory, '.agoragentic', 'opencode', 'approval-refs');
+  const files = (await listFiles(root)).filter((file) => file.endsWith('.json'));
+  const matches = [];
+  for (const file of files) {
+    const candidate = JSON.parse(await fs.readFile(file, 'utf8'));
+    if (candidate.approval_id === approvalId && !candidate.consumed_at) matches.push(file);
+  }
+  assert.equal(matches.length, 1, `expected one approval ref for ${approvalId}, found ${matches.length}`);
+  return matches[0];
 }
 
 async function tempDir() {


### PR DESCRIPTION
## Summary

Closes the actionable P1/P2 review gaps discovered on merged PR #273 without changing the plugin's local, no-spend boundary.

- Fail closed when the OpenCode after hook's tool identity or arguments differ from the governed before hook; record only bounded mismatch evidence.
- Parse every `apply_patch` target and deny malformed patches; tokenize original MCP tool names so underscored money/publish verbs are detected.
- Make a local approval one-shot across plugin instances with an approval-specific exclusive claim record and post-claim reference verification.
- Bound pending before-hook records and document the explicit installed Harness CLI plus project directory for approvals.

## Why

The previous implementation could issue a success receipt after argument drift, miss later targets in a multi-file patch, miss underscored MCP money tool names, and permit a cross-instance approval race. It also retained uncompleted governed calls without a bound and documented an ambiguous CLI invocation.

## Validation

- `cd opencode && npm run check`
- `cd opencode && npm test` (12/12 passing, including the cross-instance race)
- `cd opencode && npm pack --dry-run`
- `node scripts/verify-integrations-json.js`
- `node scripts/verify-doc-links.mjs`
- `node scripts/adapter-conformance-agent.mjs --adapter opencode-harness-plugin --jobs 1`

No hosted API, wallet, payment, publication, npm publish, merge, or review-thread resolution was performed.
