### PR TITLE
feat(transaction-assurance): add read-only Mycelium evidence adapter

### DIFF
--- a/.github/workflows/transaction-assurance.yml
+++ b/.github/workflows/transaction-assurance.yml
@@ -49,6 +49,8 @@ jobs:
             'schema/transaction-assurance-evaluation.v1.json',
             'schema/transaction-evaluation-evidence.v1.json',
             'test/fixtures/protocol-adapter-vectors.v1.json',
+            'test/fixtures/mycelium-action-ref-v1.vectors.json',
+            'test/fixtures/mycelium-anchor-registry-v1.vectors.json',
             'vendor/acp-2026-04-17/schema.agentic_checkout.json',
             'examples/native-mandate.json',
             'examples/authority-request-input.json'

--- a/integrations.json
+++ b/integrations.json
@@ -380,7 +380,7 @@
     {
       "directory": "transaction-assurance",
       "status": "unpublished_alpha",
-      "reason": "A signed independent anchor-x402 run against pinned target and suite commits passed 42/42 with a publicly verified receipt, no network use, and no spend authority, and produced two actionable contract-clarity findings. This supplies the external evidence needed for maintainer review but excludes live compatibility; package publication, public catalog inclusion, and any ecosystem-standard claim remain separately review-gated.",
+      "reason": "A signed independent anchor-x402 run against pinned target and suite commits passed 42/42 with a publicly verified receipt, no network use, and no spend authority, and produced two actionable contract-clarity findings. The package also includes optional read-only Mycelium external-verification profiles. This supplies external evidence for maintainer review but excludes live compatibility; package publication, public catalog inclusion, and any ecosystem-standard claim remain separately review-gated.",
       "owner": "repository-maintainers",
       "tracking_ref": "https://github.com/rhein1/agoragentic-integrations/issues/246",
       "review_by": "2026-09-08",

--- a/transaction-assurance/README.md
+++ b/transaction-assurance/README.md
@@ -44,6 +44,7 @@ This is a source-visible, unpublished alpha implementation.
 - spend authority: none
 - protocol recognition: implemented
 - external cryptographic verifiers: trusted in-process callback interface implemented; verifier implementations remain external
+- optional external anchor verification: Mycelium action-reference v1 and AnchorRegistry v1 read-only profiles implemented; no writer or hosted dependency
 - hosted Agoragentic execution changes: none
 - marketplace catalog entry: intentionally deferred
 - vendor-neutral conformance suite: implemented as an offline source-only alpha
@@ -145,6 +146,11 @@ import {
   canonicalize,
   computeEnvelopeHash,
   sha256Ref,
+  normalizeExternalActionReference,
+  verifyExternalActionReferencePreimage,
+  normalizeAnchorEvidence,
+  verifyAnchorEvidence,
+  bindExternalVerification,
 } from '@agoragentic/transaction-assurance';
 ```
 
@@ -396,6 +402,14 @@ A production verifier must:
 6. avoid partnership or endorsement claims without evidence.
 
 Deterministic, license-attributed adapter vectors live in `test/fixtures/protocol-adapter-vectors.v1.json` and run on Node 20, 22, and 24. They cover unsupported versions, wrong audience/merchant/purpose, expiry, replay, changed cart/terms, payment-identifier mismatch, payment without delivery, wallet-policy scope failures, and privacy exclusions.
+
+## Optional Mycelium external verification
+
+The `./external-verification-adapters` export adds one exact Mycelium action-reference v1 profile and one read-only AnchorRegistry v1 profile. The adapter recomputes the pinned JCS/SHA-256 preimage locally and interprets raw public-chain facts returned by a trusted synchronous callback. It verifies allowlisted chain and registry identity, pinned runtime code, receipt success, target and calldata, event reference, exact block/log binding, and a 12-confirmation floor.
+
+The adapter never calls an RPC endpoint or hosted Argentum service, submits an anchor, moves money, executes a provider, or grants authority. A checked anchor proves only reference anchoring, public block timestamp, and event inclusion. It does not prove principal authority, execution correctness, delivery, settlement, or single execution. Binding adds a sibling `external_action_refs` record and separate `external_verification` state without reinterpreting any existing `authenticated_action_ref`.
+
+See [docs/MYCELIUM_EXTERNAL_VERIFICATION.md](docs/MYCELIUM_EXTERNAL_VERIFICATION.md) for immutable source pins, callback contract, fixtures, limitations, and attribution.
 
 ### AP2 field map
 

--- a/transaction-assurance/SKILL.md
+++ b/transaction-assurance/SKILL.md
@@ -100,6 +100,14 @@ Fail closed when any required field is unknown:
 - revocation;
 - action, seller, category, rail, currency, or amount limits.
 
+### Optional: bind Mycelium public anchor evidence
+
+Use the local `external-verification-adapters` export only when a transaction already carries the exact pinned Mycelium action-reference v1 profile and a separately reviewed host can supply public AnchorRegistry observations through the trusted synchronous callback boundary.
+
+The adapter is no-network and read-only. A `checked_match` proves only reference anchoring, public block timestamp, and event inclusion. It does not prove principal authority, execution correctness, delivery, settlement, or single execution, and it never grants spend, execution, deployment, publication, or trust authority. Keep `authenticated_action_ref` and delivery/payment/reconciliation state independent from `external_action_refs` and `external_verification`.
+
+See `docs/MYCELIUM_EXTERNAL_VERIFICATION.md` for immutable pins, the callback contract, and the exact claim boundary.
+
 ### 3. Prepare authority for owner review
 
 Use `buildAuthorityRequest()` or:

--- a/transaction-assurance/docs/MYCELIUM_EXTERNAL_VERIFICATION.md
+++ b/transaction-assurance/docs/MYCELIUM_EXTERNAL_VERIFICATION.md
@@ -1,0 +1,193 @@
+# Mycelium External Verification
+
+This adapter treats Mycelium as an optional external evidence source. It does not make Mycelium, Argentum, a hosted provider, or an RPC endpoint part of Agoragentic's authority, payment, delivery, or reconciliation path.
+
+```text
+Mycelium action reference
+  -> deterministic correlation value
+
+AnchorRegistry event
+  -> external timestamp and event-inclusion evidence
+
+Agoragentic Transaction Assurance
+  -> decides what that evidence means for a particular transaction
+```
+
+The implementation is local and no-network. It does not submit transactions, call a hosted Argentum API, contact an RPC endpoint, move money, execute providers, or mutate trust. A host may supply a separately reviewed synchronous verifier callback that fetches public chain facts. The adapter interprets those facts and retains only bounded references, hashes, timestamps, checks, and public event metadata.
+
+## Exact source pins
+
+### Action-reference profile
+
+| Field | Pin |
+| --- | --- |
+| Agoragentic profile | `mycelium-action-ref-v1.0` |
+| Mycelium derivation | v1, bare lowercase SHA-256 digest |
+| Immutable revision | `giskard09/argentum-core@2935c328177dca9f042fa1b910f5237ffe71da9e` |
+| Upstream tag containing the pinned v1 behavior and negative vectors | `action-ref-v2.0` |
+| Spec SHA-256 | `c893d29e8d992e88442eccdde502e22edda0c20a580d391c56af988642452554` |
+| Upstream positive-vector SHA-256 | `b6604d03c3f119224b594135d651eb74b205770cc276c46acd95dd800feb9050` |
+| Upstream negative-vector SHA-256 | `eae765de97298e2d086c41867922b7a6fe14eee4fd7efa572257658ce6876de9` |
+| Canonicalization | flat ASCII-string profile of JCS/RFC 8785 |
+| Timestamp | `YYYY-MM-DDTHH:MM:SS.mmmZ` |
+| Hash | SHA-256 over canonical UTF-8 bytes |
+| Domain separation | none |
+
+The revision is the additive v2 tag because it is the first immutable upstream revision containing the clarified v1 domain rules and executable positive and negative v1 vectors. This adapter implements only the v1 derivation. It rejects v2 values and every unqualified or unsupported profile.
+
+The upstream guarantee-model document also contains an older concatenation plus integer-timestamp construction. That construction is not byte-compatible with the pinned JCS profile and is not accepted here.
+
+The v1 derivation has no protocol domain tag. A matching v1 digest proves reproduction of the pinned four-field preimage recipe, not global uniqueness across unrelated protocols that deliberately hash the same bytes. `domain_separation: "none"` and `limitations: ["no_protocol_domain_separation"]` remain explicit in every normalized result.
+
+### AnchorRegistry profile
+
+| Field | Pin |
+| --- | --- |
+| Agoragentic profile | `mycelium-anchor-registry-v1` |
+| Immutable revision | `giskard09/giskard-payments@cd8100e63d17882ba11843882acaf5b1e069fdce` |
+| Source SHA-256 | `82437f6f5ba3952a2c7ac34700e82c03bc819662687a2d23f7cfce72aee903a0` |
+| Chains | Base `8453`, Arbitrum One `42161`, Ink `57073` |
+| Registry | `0x49fEcA52bC634a9Ab773226D16619deC547794aa` |
+| Runtime-code SHA-256 | `e2f5675b490dbb4211cfbeb89a8e8913a2215843c91c33ced8f46935b83d82ed` |
+| Call selector | `0xeecdf927` for `anchor(bytes32)` |
+| Event topic | `0xfe2289542f7a0110ac112c3a4d712afdcaaf2900a1326f4e6f340b563a0e8734` for `Anchored(bytes32,address,uint256)` |
+| Minimum finality policy | 12 confirmations |
+
+The contract has no owner, funds, role, or privileged write path. Re-anchoring is allowed. A verified event therefore proves neither uniqueness nor single execution.
+
+## Public API
+
+```javascript
+import {
+  bindExternalVerification,
+  normalizeAnchorEvidence,
+  normalizeExternalActionReference,
+  verifyAnchorEvidence,
+  verifyExternalActionReferencePreimage,
+} from '@agoragentic/transaction-assurance/external-verification-adapters';
+```
+
+### Recompute an action reference
+
+```javascript
+const normalized = normalizeExternalActionReference({
+  profile: 'mycelium-action-ref-v1.0',
+  value: 'f4ebda732e3c063bdd8547c734e4956f009bbed7f557cb949f7c8033e8c42d1d',
+});
+
+const checked = verifyExternalActionReferencePreimage(normalized, {
+  agent_id: 'giskard-self',
+  action_type: 'trail.anchor',
+  scope: 'mycelium:baseline',
+  timestamp: '2026-05-23T00:00:00.000Z',
+});
+
+// checked.recomputation === 'match'
+```
+
+The output retains a preimage hash, not the raw preimage. Wrong timestamp precision, non-ASCII fields, extra preimage keys, uppercase digest encoding, an unsupported profile, or a mismatched canonical digest fails closed or returns `recomputation: "mismatch"`. A matching result also carries a process-local recomputation marker; serialized caller JSON cannot recreate it.
+
+### Verify an external anchor
+
+First normalize the expected public evidence reference:
+
+```javascript
+const evidence = normalizeAnchorEvidence({
+  profile: 'mycelium-anchor-registry-v1',
+  action_reference_profile: 'mycelium-action-ref-v1.0',
+  action_reference: 'd0f0a32e5290e0e71efc9265d86fe517db80f1c209ddff5106b9f69ba3c181db',
+  chain_id: 'eip155:8453',
+  registry_address: '0x49fEcA52bC634a9Ab773226D16619deC547794aa',
+  transaction_hash: '0xf00a5317e47d4f4d581eb16bf08b64dde45944706c615299c334f8082562f184',
+  block_number: '48936665',
+  log_index: 71,
+});
+```
+
+Then pass a host-controlled synchronous verifier. Its callback returns raw public observation facts, not pass/fail booleans. The adapter independently checks:
+
+```text
+allowlisted chain
++ allowlisted registry
++ pinned runtime-code hash
++ successful receipt
++ exact target contract
++ exact anchor(bytes32) selector and calldata reference
++ exact Anchored event topic and reference
++ selected transaction, block, block hash, and log index
++ non-removed event
++ event timestamp equal to the observed block timestamp
++ at least 12 confirmations
+```
+
+The callback result schema is `agoragentic.external-anchor-verifier-observation.v1`. It contains the observed chain, registry, runtime bytecode, transaction status/target/input, block facts, a bounded event array, current head block, verifier/evidence references, and checked timestamp. The callback object itself never enters a portable envelope. Unknown callback fields, a Promise result, a mismatched verifier ID, or caller-supplied portable verifier JSON is rejected.
+
+Every checked result is process-bound through a non-serializable trust marker. Serializing and parsing it preserves useful evidence but cannot preserve the trusted callback boundary required to bind it into an assurance envelope. Objects labeled as already normalized are revalidated against the pinned source revision, chain, and registry allowlists rather than trusted by schema tag.
+
+## Binding to Transaction Assurance
+
+```javascript
+const bound = bindExternalVerification(envelope, anchorResult, {
+  actionReference: checked,
+});
+```
+
+Binding adds the sibling `external_action_refs` array and the separate `external_verification` state. It does not reinterpret, replace, or remove an existing `authenticated_action_ref` field.
+
+A `checked_match` binding requires both:
+
+1. an action reference whose pinned preimage recomputation is `match` and still carries its live process-local recomputation binding; and
+2. an anchor result that still carries its live process-local verifier binding.
+
+The operation recomputes the transaction-assurance envelope hash and preserves any existing trusted authority binding. It does not change:
+
+- principal or agent authority;
+- payment or settlement status;
+- execution status;
+- delivery or outcome verification;
+- reconciliation, refund, or dispute state;
+- `complete_chain_verified`;
+- spend, execution, deployment, publication, or trust authority.
+
+An anchor result reports only:
+
+```json
+{
+  "proves": [
+    "reference_anchored",
+    "public_block_timestamp",
+    "event_inclusion"
+  ],
+  "does_not_prove": [
+    "principal_authority",
+    "execution_correctness",
+    "delivery",
+    "settlement",
+    "single_execution"
+  ]
+}
+```
+
+Delivery can verify with external anchoring still `not_checked`. An anchor can verify while delivery remains unobserved. Those states are intentionally independent.
+
+## Fixture claim boundary
+
+`mycelium-action-ref-v1.vectors.json` reproduces one upstream v1 vector and adds adversarial profile, encoding, timestamp, and domain cases.
+
+`mycelium-anchor-registry-v1.vectors.json` contains:
+
+- public facts independently refetched for the cited Base transaction `0xf00a5317...f184`;
+- a clearly labeled synthetic event used only to test binding the known v1 action-reference fixture;
+- mutations for wrong chain, registry, code, receipt status, call data, event, block/log, and finality.
+
+The cited real Base transaction publishes reference `d0f0a32e...181db`, but the reviewed public source does not publish its four-field action-reference preimage. The real transaction fixture therefore proves only the AnchorRegistry verification path. It is not represented as a verified Mycelium preimage binding.
+
+## Later phases deliberately excluded
+
+No write-side anchor client is included. A future writer would require separate review, owner authorization, privacy analysis, idempotency, selective or Merkle-batched anchoring, custody policy, gas budgeting, and a real external adopter need.
+
+This adapter does not support Argentum karma, ARGT, Lightning attestations, genesis-attestor trust, hosted Mycelium accounts, or hosted verification APIs.
+
+## Attribution
+
+The action-reference concept and conformance values are derived from `giskard09/argentum-core` under Apache-2.0. The AnchorRegistry source is from `giskard09/giskard-payments` and declares MIT licensing. Agoragentic's implementation is independent and pins the exact upstream revisions and hashes above.

--- a/transaction-assurance/package.json
+++ b/transaction-assurance/package.json
@@ -16,6 +16,7 @@
   "exports": {
     ".": "./src/index.mjs",
     "./protocol-adapters": "./src/protocol-adapters.mjs",
+    "./external-verification-adapters": "./src/external-verification-adapters.mjs",
     "./conformance": "./src/conformance.mjs",
     "./evaluation-evidence": "./src/evaluation-evidence.mjs",
     "./toploc-evidence": "./src/toploc-evidence.mjs"
@@ -25,6 +26,7 @@
     "src/",
     "schema/",
     "conformance/",
+    "docs/",
     "vendor/",
     "examples/",
     "SKILL.md",
@@ -37,7 +39,7 @@
   ],
   "scripts": {
     "test": "node --test test/*.test.mjs",
-    "check": "node --check src/index.mjs && node --check src/protocol-adapters.mjs && node --check src/conformance.mjs && node --check src/evaluation-evidence.mjs && node --check src/toploc-evidence.mjs && node --check bin/agora-assure.mjs && node --check bin/run-conformance.mjs && node --check bin/verify-conformance-receipt.mjs && node --check examples/x402-generic-middleware.mjs && node --check examples/conformance-targets/x402-resource-server.mjs && node --check examples/conformance-targets/mcp-paid-tool.mjs && node --check examples/conformance-targets/agent-wallet-policy.mjs && node --check examples/conformance-targets/marketplace-listing.mjs && node --check examples/external-adopters/anchor-x402/target.mjs && node --check examples/external-adopters/anchor-x402/run.mjs",
+    "check": "node --check src/index.mjs && node --check src/protocol-adapters.mjs && node --check src/external-verification-adapters.mjs && node --check src/conformance.mjs && node --check src/evaluation-evidence.mjs && node --check src/toploc-evidence.mjs && node --check bin/agora-assure.mjs && node --check bin/run-conformance.mjs && node --check bin/verify-conformance-receipt.mjs && node --check examples/x402-generic-middleware.mjs && node --check examples/conformance-targets/x402-resource-server.mjs && node --check examples/conformance-targets/mcp-paid-tool.mjs && node --check examples/conformance-targets/agent-wallet-policy.mjs && node --check examples/conformance-targets/marketplace-listing.mjs && node --check examples/external-adopters/anchor-x402/target.mjs && node --check examples/external-adopters/anchor-x402/run.mjs",
     "self-test": "node bin/agora-assure.mjs self-test",
     "conformance": "node bin/run-conformance.mjs --target-name agoragentic-reference-evaluator --target-version 0.1.0-alpha.0 --target-commit local",
     "pack:dry": "npm pack --dry-run"

--- a/transaction-assurance/src/external-verification-adapters.mjs
+++ b/transaction-assurance/src/external-verification-adapters.mjs
@@ -1,0 +1,673 @@
+import { createHash } from 'node:crypto';
+
+import {
+  computeEnvelopeHash,
+  sha256Ref,
+} from './index.mjs';
+import {
+  bindTrustedEnvelope,
+  trustedEnvelopeBinding,
+} from './trusted-verifier-boundary.mjs';
+
+const ACTION_REF_PROFILE = 'mycelium-action-ref-v1.0';
+const ANCHOR_PROFILE = 'mycelium-anchor-registry-v1';
+const REGISTRY_ADDRESS = '0x49feca52bc634a9ab773226d16619dec547794aa';
+const RUNTIME_CODE_SHA256 = 'sha256:e2f5675b490dbb4211cfbeb89a8e8913a2215843c91c33ced8f46935b83d82ed';
+const ANCHOR_SELECTOR = '0xeecdf927';
+const ANCHORED_EVENT_TOPIC = '0xfe2289542f7a0110ac112c3a4d712afdcaaf2900a1326f4e6f340b563a0e8734';
+const MINIMUM_CONFIRMATIONS = 12;
+const ALLOWED_CHAINS = Object.freeze([
+  'eip155:8453',
+  'eip155:42161',
+  'eip155:57073',
+]);
+const ALLOWED_CHAIN_SET = new Set(ALLOWED_CHAINS);
+const trustedActionReferenceBindings = new WeakMap();
+const trustedExternalVerificationBindings = new WeakMap();
+const TIMESTAMP_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+const HEX_32_PATTERN = /^0x[a-f0-9]{64}$/;
+const BARE_HEX_32_PATTERN = /^[a-f0-9]{64}$/;
+const ADDRESS_PATTERN = /^0x[a-f0-9]{40}$/;
+const SHA256_REF_PATTERN = /^sha256:[a-f0-9]{64}$/;
+const DECIMAL_UINT_PATTERN = /^(0|[1-9]\d*)$/;
+
+export const MYCELIUM_EXTERNAL_VERIFICATION_PINS = Object.freeze({
+  action_ref_v1: Object.freeze({
+    profile: ACTION_REF_PROFILE,
+    derivation_version: 'v1',
+    specification_tag: 'action-ref-v2.0',
+    revision: '2935c328177dca9f042fa1b910f5237ffe71da9e',
+    source: 'https://github.com/giskard09/argentum-core/tree/2935c328177dca9f042fa1b910f5237ffe71da9e',
+    specification_sha256: 'sha256:c893d29e8d992e88442eccdde502e22edda0c20a580d391c56af988642452554',
+    vector_set_sha256: 'sha256:b6604d03c3f119224b594135d651eb74b205770cc276c46acd95dd800feb9050',
+    negative_vector_set_sha256: 'sha256:eae765de97298e2d086c41867922b7a6fe14eee4fd7efa572257658ce6876de9',
+    canonicalization: 'jcs-rfc8785-v1-ascii-string-domain',
+    timestamp_representation: 'rfc3339-utc-millisecond-3-digit-z',
+    domain_separation: 'none',
+    hash_algorithm: 'sha256',
+  }),
+  anchor_registry_v1: Object.freeze({
+    profile: ANCHOR_PROFILE,
+    revision: 'cd8100e63d17882ba11843882acaf5b1e069fdce',
+    source: 'https://github.com/giskard09/giskard-payments/tree/cd8100e63d17882ba11843882acaf5b1e069fdce',
+    source_sha256: 'sha256:82437f6f5ba3952a2c7ac34700e82c03bc819662687a2d23f7cfce72aee903a0',
+    registry_address: REGISTRY_ADDRESS,
+    runtime_code_sha256: RUNTIME_CODE_SHA256,
+    anchor_selector: ANCHOR_SELECTOR,
+    anchored_event_topic: ANCHORED_EVENT_TOPIC,
+    allowed_chain_ids: ALLOWED_CHAINS,
+    minimum_confirmations: MINIMUM_CONFIRMATIONS,
+  }),
+});
+
+function isObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function exactObject(value, field, required, optional = []) {
+  if (!isObject(value)) throw new TypeError(`${field} must be an object`);
+  const allowed = new Set([...required, ...optional]);
+  const unknown = Object.keys(value).filter((key) => !allowed.has(key));
+  const missing = required.filter((key) => !Object.prototype.hasOwnProperty.call(value, key));
+  if (unknown.length > 0 || missing.length > 0) {
+    throw new TypeError(
+      `${field} must use the exact field set; missing=${missing.join(',') || 'none'} unknown=${unknown.join(',') || 'none'}`,
+    );
+  }
+  return value;
+}
+
+function requiredText(value, field, maxLength = 2048) {
+  if (typeof value !== 'string' || !value.trim()) throw new TypeError(`${field} is required`);
+  return value.trim().slice(0, maxLength);
+}
+
+function optionalText(value, field, maxLength = 2048) {
+  if (value === undefined || value === null || value === '') return null;
+  return requiredText(value, field, maxLength);
+}
+
+function exactLowerHex(value, pattern, field) {
+  const normalized = requiredText(value, field).toLowerCase();
+  if (!pattern.test(normalized) || value !== normalized) {
+    throw new TypeError(`${field} must use canonical lowercase hexadecimal encoding`);
+  }
+  return normalized;
+}
+
+function address(value, field) {
+  const normalized = requiredText(value, field).toLowerCase();
+  if (!ADDRESS_PATTERN.test(normalized)) throw new TypeError(`${field} must be an EVM address`);
+  return normalized;
+}
+
+function sha256Reference(value, field) {
+  const normalized = requiredText(value, field).toLowerCase();
+  if (!SHA256_REF_PATTERN.test(normalized)) throw new TypeError(`${field} must be a sha256 reference`);
+  return normalized;
+}
+
+function uintString(value, field) {
+  const normalized = typeof value === 'bigint' ? value.toString() : String(value);
+  if (!DECIMAL_UINT_PATTERN.test(normalized)) throw new TypeError(`${field} must be an unsigned decimal integer`);
+  return normalized;
+}
+
+function safeIndex(value, field) {
+  if (!Number.isSafeInteger(value) || value < 0) throw new TypeError(`${field} must be a non-negative safe integer`);
+  return value;
+}
+
+function checkedAt(value, field) {
+  const date = new Date(requiredText(value, field));
+  if (Number.isNaN(date.getTime())) throw new TypeError(`${field} must be a date-time`);
+  return date.toISOString();
+}
+
+function noAuthority() {
+  return {
+    evidence_grants_authority: false,
+    can_spend: false,
+    can_execute: false,
+    can_fund_wallet: false,
+    can_publish: false,
+    can_deploy: false,
+    can_change_trust: false,
+  };
+}
+
+function deepFreeze(value) {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  for (const child of Object.values(value)) deepFreeze(child);
+  return value;
+}
+
+function sha256Bytes(value) {
+  return `sha256:${createHash('sha256').update(value).digest('hex')}`;
+}
+
+function normalizedActionReference(reference) {
+  if (reference?.schema === 'agoragentic.external-action-reference.v1') {
+    if (reference.source_revision !== MYCELIUM_EXTERNAL_VERIFICATION_PINS.action_ref_v1.revision) {
+      throw new TypeError('external action-reference source revision mismatch');
+    }
+    return normalizeExternalActionReference({
+      profile: reference.profile,
+      value: reference.value,
+      ...(reference.preimage_ref ? { preimage_ref: reference.preimage_ref } : {}),
+    }, {
+      artifactRef: reference.source_artifact_ref ?? undefined,
+    });
+  }
+  return normalizeExternalActionReference(reference);
+}
+
+function actionReferenceForBinding(reference) {
+  const normalized = normalizedActionReference(reference);
+  if (reference?.schema !== 'agoragentic.external-action-reference.v1') return normalized;
+  if (!['not_checked', 'match', 'mismatch'].includes(reference.recomputation)) {
+    throw new TypeError('external action-reference recomputation status is unsupported');
+  }
+  return {
+    ...normalized,
+    recomputation: reference.recomputation,
+    ...(isObject(reference.checks) ? { checks: structuredClone(reference.checks) } : {}),
+  };
+}
+
+export function normalizeExternalActionReference(artifact, options = {}) {
+  exactObject(artifact, 'artifact', ['profile', 'value'], ['preimage_ref']);
+  if (artifact.profile !== ACTION_REF_PROFILE) {
+    throw new TypeError(`unsupported external action-reference profile: ${artifact.profile}`);
+  }
+  const value = exactLowerHex(artifact.value, BARE_HEX_32_PATTERN, 'artifact.value');
+  const preimageRef = artifact.preimage_ref === undefined
+    ? null
+    : sha256Reference(artifact.preimage_ref, 'artifact.preimage_ref');
+  return {
+    schema: 'agoragentic.external-action-reference.v1',
+    profile: ACTION_REF_PROFILE,
+    source_revision: MYCELIUM_EXTERNAL_VERIFICATION_PINS.action_ref_v1.revision,
+    source_artifact_ref: optionalText(options.artifactRef, 'options.artifactRef'),
+    source_artifact_hash: sha256Ref(artifact),
+    source_artifact_embedded: false,
+    value,
+    preimage_ref: preimageRef,
+    recomputation: 'not_checked',
+    canonicalization: MYCELIUM_EXTERNAL_VERIFICATION_PINS.action_ref_v1.canonicalization,
+    timestamp_representation: MYCELIUM_EXTERNAL_VERIFICATION_PINS.action_ref_v1.timestamp_representation,
+    domain_separation: 'none',
+    hash_algorithm: 'sha256',
+    limitations: ['no_protocol_domain_separation'],
+    authority_flags: noAuthority(),
+  };
+}
+
+function canonicalActionPreimage(preimage) {
+  exactObject(preimage, 'preimage', ['agent_id', 'action_type', 'scope', 'timestamp']);
+  for (const field of ['agent_id', 'action_type', 'scope', 'timestamp']) {
+    if (typeof preimage[field] !== 'string') throw new TypeError(`preimage.${field} must be a string`);
+  }
+  for (const field of ['agent_id', 'action_type', 'scope']) {
+    if (!/^[\x00-\x7f]*$/.test(preimage[field])) {
+      throw new TypeError(`OUT_OF_PROFILE_DOMAIN: ${field}: non-ASCII character in field value`);
+    }
+  }
+  if (!TIMESTAMP_PATTERN.test(preimage.timestamp)) {
+    throw new TypeError(
+      'OUT_OF_PROFILE_DOMAIN: timestamp: expected YYYY-MM-DDTHH:MM:SS.mmmZ',
+    );
+  }
+  return JSON.stringify({
+    action_type: preimage.action_type,
+    agent_id: preimage.agent_id,
+    scope: preimage.scope,
+    timestamp: preimage.timestamp,
+  });
+}
+
+export function verifyExternalActionReferencePreimage(reference, preimage, options = {}) {
+  const normalized = normalizedActionReference(reference);
+  if (options.profile !== undefined && options.profile !== ACTION_REF_PROFILE) {
+    throw new TypeError(`unsupported external action-reference profile: ${options.profile}`);
+  }
+  const canonical = canonicalActionPreimage(preimage);
+  const digest = createHash('sha256').update(canonical, 'utf8').digest('hex');
+  const preimageRef = `sha256:${digest}`;
+  if (normalized.preimage_ref && normalized.preimage_ref !== preimageRef) {
+    return {
+      ...normalized,
+      preimage_ref: preimageRef,
+      recomputation: 'mismatch',
+      checks: {
+        exact_profile: true,
+        canonical_domain: true,
+        preimage_ref: false,
+        value: false,
+      },
+    };
+  }
+  const match = normalized.value === digest;
+  const result = {
+    ...normalized,
+    preimage_ref: preimageRef,
+    recomputation: match ? 'match' : 'mismatch',
+    checks: {
+      exact_profile: true,
+      canonical_domain: true,
+      preimage_ref: true,
+      value: match,
+    },
+  };
+  if (match) {
+    trustedActionReferenceBindings.set(result, Object.freeze({
+      result_hash: sha256Ref(result),
+    }));
+  }
+  return result;
+}
+
+function normalizedAnchorEvidence(evidence) {
+  if (evidence?.schema === 'agoragentic.external-anchor-evidence.v1') {
+    if (evidence.source_revision !== MYCELIUM_EXTERNAL_VERIFICATION_PINS.anchor_registry_v1.revision) {
+      throw new TypeError('external anchor source revision mismatch');
+    }
+    return normalizeAnchorEvidence({
+      profile: evidence.profile,
+      action_reference_profile: evidence.action_reference_profile,
+      action_reference: evidence.action_reference,
+      chain_id: evidence.chain_id,
+      registry_address: evidence.registry_address,
+      transaction_hash: evidence.transaction_hash,
+      block_number: evidence.block_number,
+      log_index: evidence.log_index,
+    }, {
+      artifactRef: evidence.source_artifact_ref ?? undefined,
+    });
+  }
+  return normalizeAnchorEvidence(evidence);
+}
+
+export function normalizeAnchorEvidence(evidence, options = {}) {
+  exactObject(evidence, 'evidence', [
+    'profile',
+    'action_reference_profile',
+    'action_reference',
+    'chain_id',
+    'registry_address',
+    'transaction_hash',
+    'block_number',
+    'log_index',
+  ]);
+  if (evidence.profile !== ANCHOR_PROFILE) {
+    throw new TypeError(`unsupported external anchor profile: ${evidence.profile}`);
+  }
+  if (evidence.action_reference_profile !== ACTION_REF_PROFILE) {
+    throw new TypeError(`unsupported anchored action-reference profile: ${evidence.action_reference_profile}`);
+  }
+  const chainId = requiredText(evidence.chain_id, 'evidence.chain_id', 100);
+  if (!ALLOWED_CHAIN_SET.has(chainId)) throw new TypeError(`unsupported anchor chain: ${chainId}`);
+  const registryAddress = address(evidence.registry_address, 'evidence.registry_address');
+  if (registryAddress !== REGISTRY_ADDRESS) throw new TypeError('anchor registry is not allowlisted');
+  return {
+    schema: 'agoragentic.external-anchor-evidence.v1',
+    profile: ANCHOR_PROFILE,
+    source_revision: MYCELIUM_EXTERNAL_VERIFICATION_PINS.anchor_registry_v1.revision,
+    source_artifact_ref: optionalText(options.artifactRef, 'options.artifactRef'),
+    source_artifact_hash: sha256Ref(evidence),
+    source_artifact_embedded: false,
+    action_reference_profile: ACTION_REF_PROFILE,
+    action_reference: exactLowerHex(
+      evidence.action_reference,
+      BARE_HEX_32_PATTERN,
+      'evidence.action_reference',
+    ),
+    chain_id: chainId,
+    registry_address: registryAddress,
+    transaction_hash: exactLowerHex(evidence.transaction_hash, HEX_32_PATTERN, 'evidence.transaction_hash'),
+    block_number: uintString(evidence.block_number, 'evidence.block_number'),
+    log_index: safeIndex(evidence.log_index, 'evidence.log_index'),
+    status: 'not_checked',
+    raw_rpc_payload_embedded: false,
+    authority_flags: noAuthority(),
+  };
+}
+
+function normalizeVerifierEvent(event, index) {
+  const field = `verifier.result.events[${index}]`;
+  exactObject(event, field, [
+    'transaction_hash',
+    'address',
+    'block_number',
+    'block_hash',
+    'log_index',
+    'removed',
+    'topics',
+    'data',
+  ]);
+  if (!Array.isArray(event.topics) || event.topics.length !== 3) {
+    throw new TypeError(`${field}.topics must contain exactly three topics`);
+  }
+  return {
+    transaction_hash: exactLowerHex(event.transaction_hash, HEX_32_PATTERN, `${field}.transaction_hash`),
+    address: address(event.address, `${field}.address`),
+    block_number: uintString(event.block_number, `${field}.block_number`),
+    block_hash: exactLowerHex(event.block_hash, HEX_32_PATTERN, `${field}.block_hash`),
+    log_index: safeIndex(event.log_index, `${field}.log_index`),
+    removed: event.removed === true,
+    topics: event.topics.map((topic, topicIndex) => exactLowerHex(
+      topic,
+      HEX_32_PATTERN,
+      `${field}.topics[${topicIndex}]`,
+    )),
+    data: exactLowerHex(event.data, HEX_32_PATTERN, `${field}.data`),
+  };
+}
+
+function verifierObservation(verifier, context) {
+  if (!isObject(verifier)) throw new TypeError('options.verifier must be a trusted in-process verifier');
+  const verifierId = requiredText(verifier.id, 'options.verifier.id');
+  if (typeof verifier.verify !== 'function') {
+    throw new TypeError('options.verifier.verify must be a trusted in-process callback');
+  }
+  const result = verifier.verify(deepFreeze(structuredClone(context)));
+  if (result && typeof result.then === 'function') {
+    throw new TypeError('options.verifier.verify must return synchronously');
+  }
+  exactObject(result, 'verifier.result', [
+    'schema',
+    'profile',
+    'chain_id',
+    'registry_address',
+    'runtime_code',
+    'transaction_hash',
+    'transaction_status',
+    'transaction_to',
+    'transaction_input',
+    'block_number',
+    'block_hash',
+    'block_timestamp',
+    'head_block_number',
+    'events',
+    'verifier_ref',
+    'evidence_ref',
+    'checked_at',
+  ]);
+  if (result.schema !== 'agoragentic.external-anchor-verifier-observation.v1') {
+    throw new TypeError('unsupported external anchor verifier observation schema');
+  }
+  if (result.profile !== ANCHOR_PROFILE) throw new TypeError('verifier profile mismatch');
+  if (requiredText(result.verifier_ref, 'verifier.result.verifier_ref') !== verifierId) {
+    throw new TypeError('verifier id does not match verifier_ref');
+  }
+  if (!Array.isArray(result.events) || result.events.length > 32) {
+    throw new TypeError('verifier.result.events must be a bounded array of at most 32 events');
+  }
+  const transactionStatus = requiredText(result.transaction_status, 'verifier.result.transaction_status');
+  if (!['success', 'reverted'].includes(transactionStatus)) {
+    throw new TypeError('verifier.result.transaction_status must be success or reverted');
+  }
+  const runtimeCode = requiredText(result.runtime_code, 'verifier.result.runtime_code', 20_000).toLowerCase();
+  if (!/^0x(?:[a-f0-9]{2})*$/.test(runtimeCode)) {
+    throw new TypeError('verifier.result.runtime_code must be canonical hexadecimal bytes');
+  }
+  const transactionInput = requiredText(
+    result.transaction_input,
+    'verifier.result.transaction_input',
+    20_000,
+  ).toLowerCase();
+  if (!/^0x(?:[a-f0-9]{2})*$/.test(transactionInput)) {
+    throw new TypeError('verifier.result.transaction_input must be canonical hexadecimal bytes');
+  }
+  return {
+    schema: result.schema,
+    profile: result.profile,
+    chain_id: requiredText(result.chain_id, 'verifier.result.chain_id', 100),
+    registry_address: address(result.registry_address, 'verifier.result.registry_address'),
+    runtime_code: runtimeCode,
+    transaction_hash: exactLowerHex(result.transaction_hash, HEX_32_PATTERN, 'verifier.result.transaction_hash'),
+    transaction_status: transactionStatus,
+    transaction_to: address(result.transaction_to, 'verifier.result.transaction_to'),
+    transaction_input: transactionInput,
+    block_number: uintString(result.block_number, 'verifier.result.block_number'),
+    block_hash: exactLowerHex(result.block_hash, HEX_32_PATTERN, 'verifier.result.block_hash'),
+    block_timestamp: uintString(result.block_timestamp, 'verifier.result.block_timestamp'),
+    head_block_number: uintString(result.head_block_number, 'verifier.result.head_block_number'),
+    events: result.events.map(normalizeVerifierEvent),
+    verifier_ref: verifierId,
+    evidence_ref: requiredText(result.evidence_ref, 'verifier.result.evidence_ref'),
+    checked_at: checkedAt(result.checked_at, 'verifier.result.checked_at'),
+  };
+}
+
+function eventTimestamp(data) {
+  return BigInt(data).toString();
+}
+
+export function verifyAnchorEvidence(evidence, options = {}) {
+  if (options.verifierEvidence !== undefined) {
+    throw new TypeError(
+      'portable verifierEvidence JSON is not trusted; supply a trusted in-process verifier callback',
+    );
+  }
+  const normalized = normalizedAnchorEvidence(evidence);
+  const minimumConfirmations = options.minimumConfirmations ?? MINIMUM_CONFIRMATIONS;
+  if (!Number.isSafeInteger(minimumConfirmations) || minimumConfirmations < MINIMUM_CONFIRMATIONS) {
+    throw new TypeError(`minimumConfirmations must be an integer of at least ${MINIMUM_CONFIRMATIONS}`);
+  }
+  const context = {
+    profile: ANCHOR_PROFILE,
+    source_revision: MYCELIUM_EXTERNAL_VERIFICATION_PINS.anchor_registry_v1.revision,
+    chain_id: normalized.chain_id,
+    registry_address: normalized.registry_address,
+    runtime_code_sha256: RUNTIME_CODE_SHA256,
+    transaction_hash: normalized.transaction_hash,
+    block_number: normalized.block_number,
+    log_index: normalized.log_index,
+    action_reference: normalized.action_reference,
+    anchor_selector: ANCHOR_SELECTOR,
+    anchored_event_topic: ANCHORED_EVENT_TOPIC,
+    minimum_confirmations: minimumConfirmations,
+  };
+  const observed = verifierObservation(options.verifier, context);
+  const expectedInput = `${ANCHOR_SELECTOR}${normalized.action_reference}`;
+  const expectedReferenceTopic = `0x${normalized.action_reference}`;
+  const selectedEvent = observed.events.find((event) => (
+    event.transaction_hash === normalized.transaction_hash
+      && event.log_index === normalized.log_index
+  ));
+  const confirmations = BigInt(observed.head_block_number) >= BigInt(observed.block_number)
+    ? BigInt(observed.head_block_number) - BigInt(observed.block_number) + 1n
+    : 0n;
+  const checks = {
+    chain_id: observed.chain_id === normalized.chain_id,
+    registry_address: observed.registry_address === normalized.registry_address,
+    runtime_code_hash: sha256Bytes(Buffer.from(observed.runtime_code.slice(2), 'hex')) === RUNTIME_CODE_SHA256,
+    transaction_hash: observed.transaction_hash === normalized.transaction_hash,
+    receipt_success: observed.transaction_status === 'success',
+    target_contract: observed.transaction_to === normalized.registry_address,
+    call_selector: observed.transaction_input.slice(0, 10) === ANCHOR_SELECTOR
+      && observed.transaction_input.length === 74,
+    calldata_reference: observed.transaction_input === expectedInput,
+    block_number: observed.block_number === normalized.block_number,
+    event_present: Boolean(selectedEvent),
+    event_address: selectedEvent?.address === normalized.registry_address,
+    event_topic: selectedEvent?.topics[0] === ANCHORED_EVENT_TOPIC,
+    event_reference: selectedEvent?.topics[1] === expectedReferenceTopic,
+    log_index: selectedEvent?.log_index === normalized.log_index,
+    event_block_number: selectedEvent?.block_number === normalized.block_number,
+    event_block_hash: selectedEvent?.block_hash === observed.block_hash,
+    event_transaction_hash: selectedEvent?.transaction_hash === normalized.transaction_hash,
+    event_not_removed: selectedEvent?.removed === false,
+    event_timestamp: selectedEvent ? eventTimestamp(selectedEvent.data) === observed.block_timestamp : false,
+    finality: confirmations >= BigInt(minimumConfirmations),
+  };
+  const failedChecks = Object.entries(checks)
+    .filter(([, passed]) => passed !== true)
+    .map(([name]) => name);
+  const observedMatchingEventCount = observed.events.filter((event) => (
+    event.address === normalized.registry_address
+      && event.topics[0] === ANCHORED_EVENT_TOPIC
+      && event.topics[1] === expectedReferenceTopic
+      && event.removed === false
+  )).length;
+  const result = {
+    schema: 'agoragentic.external-verification.v1',
+    profile: ANCHOR_PROFILE,
+    source_revision: MYCELIUM_EXTERNAL_VERIFICATION_PINS.anchor_registry_v1.revision,
+    status: failedChecks.length === 0 ? 'checked_match' : 'checked_mismatch',
+    action_reference_profile: ACTION_REF_PROFILE,
+    action_reference: normalized.action_reference,
+    checks,
+    failed_checks: failedChecks,
+    proves: failedChecks.length === 0
+      ? ['reference_anchored', 'public_block_timestamp', 'event_inclusion']
+      : [],
+    does_not_prove: [
+      'principal_authority',
+      'execution_correctness',
+      'delivery',
+      'settlement',
+      'single_execution',
+    ],
+    chain_id: normalized.chain_id,
+    registry_ref: `evm:${normalized.registry_address}`,
+    transaction_ref: `evm-tx:${normalized.transaction_hash}`,
+    block_number: normalized.block_number,
+    block_hash: observed.block_hash,
+    block_timestamp: observed.block_timestamp,
+    log_index: normalized.log_index,
+    confirmations: confirmations.toString(),
+    minimum_confirmations: minimumConfirmations,
+    observed_matching_event_count: observedMatchingEventCount,
+    verifier_ref: observed.verifier_ref,
+    evidence_ref: observed.evidence_ref,
+    checked_at: observed.checked_at,
+    raw_rpc_payload_embedded: false,
+    complete_chain_verified: false,
+    authority_flags: noAuthority(),
+  };
+  trustedExternalVerificationBindings.set(result, Object.freeze({
+    verifier_ref: observed.verifier_ref,
+    result_hash: sha256Ref(result),
+  }));
+  return result;
+}
+
+function notCheckedVerification(actionReference) {
+  return {
+    schema: 'agoragentic.external-verification.v1',
+    profile: ANCHOR_PROFILE,
+    source_revision: MYCELIUM_EXTERNAL_VERIFICATION_PINS.anchor_registry_v1.revision,
+    status: 'not_checked',
+    action_reference_profile: ACTION_REF_PROFILE,
+    action_reference: actionReference.value,
+    checks: {},
+    failed_checks: [],
+    proves: [],
+    does_not_prove: [
+      'principal_authority',
+      'execution_correctness',
+      'delivery',
+      'settlement',
+      'single_execution',
+    ],
+    chain_id: null,
+    registry_ref: null,
+    transaction_ref: null,
+    block_number: null,
+    block_hash: null,
+    block_timestamp: null,
+    log_index: null,
+    confirmations: null,
+    minimum_confirmations: MINIMUM_CONFIRMATIONS,
+    observed_matching_event_count: 0,
+    verifier_ref: null,
+    evidence_ref: null,
+    checked_at: null,
+    raw_rpc_payload_embedded: false,
+    complete_chain_verified: false,
+    authority_flags: noAuthority(),
+  };
+}
+
+export function bindExternalVerification(assuranceEnvelope, verification, options = {}) {
+  if (!isObject(assuranceEnvelope)
+    || assuranceEnvelope.schema !== 'agoragentic.transaction-assurance-envelope.v1') {
+    throw new TypeError('assuranceEnvelope must use agoragentic.transaction-assurance-envelope.v1');
+  }
+  const suppliedActionReference = options.actionReference;
+  const actionReference = actionReferenceForBinding(suppliedActionReference);
+  const externalVerification = verification ?? notCheckedVerification(actionReference);
+  if (!isObject(externalVerification)
+    || externalVerification.schema !== 'agoragentic.external-verification.v1'
+    || externalVerification.profile !== ANCHOR_PROFILE) {
+    throw new TypeError('verification must use agoragentic.external-verification.v1');
+  }
+  if (!['not_checked', 'checked_match', 'checked_mismatch'].includes(externalVerification.status)) {
+    throw new TypeError('verification status is unsupported');
+  }
+  if (externalVerification.action_reference !== actionReference.value) {
+    throw new TypeError('external verification action reference mismatch');
+  }
+  if (verification !== undefined && verification !== null) {
+    const verificationBinding = trustedExternalVerificationBindings.get(externalVerification);
+    if (!verificationBinding || verificationBinding.result_hash !== sha256Ref(externalVerification)) {
+      throw new TypeError('external verification must remain inside its trusted in-process verifier boundary');
+    }
+  }
+  if (actionReference.recomputation === 'match') {
+    const actionReferenceBinding = trustedActionReferenceBindings.get(suppliedActionReference);
+    if (!actionReferenceBinding || actionReferenceBinding.result_hash !== sha256Ref(suppliedActionReference)) {
+      throw new TypeError('matching action reference must remain inside its trusted recomputation boundary');
+    }
+  }
+  if (externalVerification.status === 'checked_match' && actionReference.recomputation !== 'match') {
+    throw new TypeError('checked external verification requires a recomputed matching action reference');
+  }
+
+  const result = structuredClone(assuranceEnvelope);
+  if (result.external_action_refs !== undefined && !Array.isArray(result.external_action_refs)) {
+    throw new TypeError('assuranceEnvelope.external_action_refs must be an array');
+  }
+  const actionRefRecord = {
+    profile: actionReference.profile,
+    value: actionReference.value,
+    preimage_ref: actionReference.preimage_ref,
+    recomputation: actionReference.recomputation,
+    source_revision: actionReference.source_revision,
+  };
+  const existing = result.external_action_refs || [];
+  const conflicting = existing.find((item) => (
+    item?.profile === actionRefRecord.profile
+      && item?.value === actionRefRecord.value
+      && sha256Ref(item) !== sha256Ref(actionRefRecord)
+  ));
+  if (conflicting) throw new TypeError('conflicting external action-reference record');
+  if (!existing.some((item) => sha256Ref(item) === sha256Ref(actionRefRecord))) {
+    existing.push(actionRefRecord);
+  }
+  const priorEnvelopeHash = assuranceEnvelope.evidence?.envelope_hash || null;
+  result.external_action_refs = existing;
+  result.external_verification = {
+    ...structuredClone(externalVerification),
+    assurance_binding: {
+      envelope_id: assuranceEnvelope.envelope_id || null,
+      prior_envelope_hash: priorEnvelopeHash,
+      binding_hash: sha256Ref({
+        envelope_id: assuranceEnvelope.envelope_id || null,
+        prior_envelope_hash: priorEnvelopeHash,
+        action_reference: actionRefRecord,
+        external_verification_hash: sha256Ref(externalVerification),
+      }),
+    },
+  };
+  result.evidence = isObject(result.evidence) ? result.evidence : {};
+  result.evidence.envelope_hash = null;
+  result.evidence.envelope_hash = computeEnvelopeHash(result);
+
+  const envelopeBinding = trustedEnvelopeBinding(assuranceEnvelope);
+  if (envelopeBinding) bindTrustedEnvelope(result, envelopeBinding);
+  return result;
+}

--- a/transaction-assurance/src/index.mjs
+++ b/transaction-assurance/src/index.mjs
@@ -1063,3 +1063,12 @@ export {
   normalizeVisaTapEvidence,
   normalizeX402Evidence,
 } from './protocol-adapters.mjs';
+
+export {
+  bindExternalVerification,
+  MYCELIUM_EXTERNAL_VERIFICATION_PINS,
+  normalizeAnchorEvidence,
+  normalizeExternalActionReference,
+  verifyAnchorEvidence,
+  verifyExternalActionReferencePreimage,
+} from './external-verification-adapters.mjs';

--- a/transaction-assurance/test/external-verification-adapters.test.mjs
+++ b/transaction-assurance/test/external-verification-adapters.test.mjs
@@ -1,0 +1,310 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+
+import {
+  bindExternalVerification,
+  computeEnvelopeHash,
+  MYCELIUM_EXTERNAL_VERIFICATION_PINS,
+  normalizeAnchorEvidence,
+  normalizeExternalActionReference,
+  verifyAnchorEvidence,
+  verifyExternalActionReferencePreimage,
+} from '../src/index.mjs';
+
+const actionVectors = JSON.parse(fs.readFileSync(
+  new URL('./fixtures/mycelium-action-ref-v1.vectors.json', import.meta.url),
+  'utf8',
+));
+const anchorVectors = JSON.parse(fs.readFileSync(
+  new URL('./fixtures/mycelium-anchor-registry-v1.vectors.json', import.meta.url),
+  'utf8',
+));
+const adapterSource = fs.readFileSync(
+  new URL('../src/external-verification-adapters.mjs', import.meta.url),
+  'utf8',
+);
+const clone = (value) => structuredClone(value);
+
+function setPath(value, dotted, replacement) {
+  const parts = dotted.split('.');
+  let cursor = value;
+  for (const part of parts.slice(0, -1)) cursor = cursor[part];
+  cursor[parts.at(-1)] = replacement;
+}
+
+function verifier(observation, inspect = () => {}) {
+  return {
+    id: observation.verifier_ref,
+    verify(context) {
+      inspect(context);
+      return clone(observation);
+    },
+  };
+}
+
+function minimalEnvelope(outcome = {}) {
+  const envelope = {
+    schema: 'agoragentic.transaction-assurance-envelope.v1',
+    envelope_id: 'tae_external_fixture',
+    state: outcome.verification_status === 'verified' ? 'outcome_verified' : 'incomplete',
+    authenticated_action_ref: 'post_pin_auth:preserve-this-existing-field',
+    payment: {
+      status: 'not_started',
+      settlement_verification: 'not_checked',
+      settlement_final: false,
+    },
+    execution: { status: 'not_started' },
+    outcome: {
+      delivery_status: 'not_observed',
+      verification_status: 'not_checked',
+      ...outcome,
+    },
+    reconciliation: { status: 'not_started' },
+    evidence: { refs: [], envelope_hash: null, complete_chain_verified: false },
+    authority_flags: {
+      envelope_grants_authority: false,
+      can_spend: false,
+      can_fund_wallet: false,
+      can_deploy: false,
+      can_publish: false,
+      can_change_trust: false,
+      can_expand_scope: false,
+    },
+  };
+  envelope.evidence.envelope_hash = computeEnvelopeHash(envelope);
+  return envelope;
+}
+
+function verifiedBaselineReference() {
+  const fixture = actionVectors.fixtures.baseline;
+  return verifyExternalActionReferencePreimage({
+    profile: actionVectors.profile,
+    value: fixture.value,
+  }, fixture.preimage);
+}
+
+test('Mycelium profiles pin exact immutable source and registry facts', () => {
+  const actionPin = MYCELIUM_EXTERNAL_VERIFICATION_PINS.action_ref_v1;
+  const anchorPin = MYCELIUM_EXTERNAL_VERIFICATION_PINS.anchor_registry_v1;
+  assert.equal(actionPin.revision, actionVectors.source.revision);
+  assert.equal(actionPin.specification_sha256, actionVectors.source.specification_sha256);
+  assert.equal(actionPin.vector_set_sha256, actionVectors.source.upstream_vector_set_sha256);
+  assert.equal(actionPin.domain_separation, 'none');
+  assert.equal(anchorPin.revision, anchorVectors.source.revision);
+  assert.equal(anchorPin.registry_address, anchorVectors.source.registry_address);
+  assert.equal(anchorPin.runtime_code_sha256, anchorVectors.source.runtime_code_sha256);
+  assert.deepEqual(anchorPin.allowed_chain_ids, [
+    'eip155:8453',
+    'eip155:42161',
+    'eip155:57073',
+  ]);
+});
+
+test('action-reference vectors enforce the exact v1 profile and canonical preimage', () => {
+  const baseline = actionVectors.fixtures.baseline;
+  for (const vector of actionVectors.vectors) {
+    const artifact = {
+      profile: actionVectors.profile,
+      value: baseline.value,
+    };
+    const preimage = clone(baseline.preimage);
+    for (const [field, replacement] of Object.entries(vector.set || {})) {
+      if (field.startsWith('preimage.')) setPath(preimage, field.slice('preimage.'.length), replacement);
+      else artifact[field] = replacement;
+    }
+    const run = () => verifyExternalActionReferencePreimage(artifact, preimage);
+    if (vector.expected === 'reject_out_of_profile_domain') {
+      assert.throws(run, /OUT_OF_PROFILE_DOMAIN/, vector.id);
+    } else if (vector.expected === 'reject_unsupported_profile') {
+      assert.throws(run, /unsupported external action-reference profile/, vector.id);
+    } else {
+      assert.equal(run().recomputation, vector.expected, vector.id);
+    }
+  }
+  const normalized = normalizeExternalActionReference({
+    profile: actionVectors.profile,
+    value: baseline.value,
+  }, { artifactRef: 'fixture://mycelium/action-ref' });
+  assert.equal(normalized.recomputation, 'not_checked');
+  assert.deepEqual(normalized.limitations, ['no_protocol_domain_separation']);
+  assert.equal(JSON.stringify(normalized).includes(baseline.preimage.agent_id), false);
+});
+
+test('the real Base anchor fixture reproduces a checked match without claiming delivery', () => {
+  const fixture = anchorVectors.fixtures.base_real_anchor;
+  const normalized = normalizeAnchorEvidence(fixture.evidence, {
+    artifactRef: 'fixture://base/anchor',
+  });
+  const result = verifyAnchorEvidence(normalized, {
+    verifier: verifier(fixture.verifier_observation, (context) => {
+      assert.equal(Object.isFrozen(context), true);
+      assert.equal(context.anchor_selector, '0xeecdf927');
+      assert.equal(context.minimum_confirmations, 12);
+    }),
+  });
+  assert.equal(result.status, 'checked_match');
+  assert.deepEqual(result.failed_checks, []);
+  assert.deepEqual(result.proves, [
+    'reference_anchored',
+    'public_block_timestamp',
+    'event_inclusion',
+  ]);
+  assert.ok(result.does_not_prove.includes('delivery'));
+  assert.ok(result.does_not_prove.includes('settlement'));
+  assert.ok(result.does_not_prove.includes('single_execution'));
+  assert.equal(result.log_index, 71);
+  assert.equal(result.block_number, '48936665');
+  assert.equal(result.raw_rpc_payload_embedded, false);
+  assert.equal(JSON.stringify(result).includes('6080604052'), false);
+});
+
+test('anchor verification fails closed across code, receipt, call, event, and finality mutations', () => {
+  const fixture = anchorVectors.fixtures.base_real_anchor;
+  const cases = [
+    ['runtime_code_hash', (value) => { value.runtime_code = '0x00'; }],
+    ['receipt_success', (value) => { value.transaction_status = 'reverted'; }],
+    ['call_selector', (value) => { value.transaction_input = `0x00000000${fixture.evidence.action_reference}`; }],
+    ['calldata_reference', (value) => { value.transaction_input = `0xeecdf927${'a'.repeat(64)}`; }],
+    ['event_present', (value) => { value.events = []; }],
+    ['event_reference', (value) => { value.events[0].topics[1] = `0x${'a'.repeat(64)}`; }],
+    ['event_block_hash', (value) => { value.events[0].block_hash = `0x${'a'.repeat(64)}`; }],
+    ['event_timestamp', (value) => { value.events[0].data = `0x${'0'.repeat(63)}1`; }],
+    ['finality', (value) => { value.head_block_number = value.block_number; }],
+  ];
+  for (const [check, mutate] of cases) {
+    const observation = clone(fixture.verifier_observation);
+    mutate(observation);
+    const result = verifyAnchorEvidence(fixture.evidence, {
+      verifier: verifier(observation),
+    });
+    assert.equal(result.status, 'checked_mismatch', check);
+    assert.ok(result.failed_checks.includes(check), check);
+    assert.deepEqual(result.proves, [], check);
+  }
+  const wrongLog = clone(fixture.evidence);
+  wrongLog.log_index = 70;
+  assert.ok(verifyAnchorEvidence(wrongLog, {
+    verifier: verifier(fixture.verifier_observation),
+  }).failed_checks.includes('event_present'));
+  const wrongChain = clone(fixture.evidence);
+  wrongChain.chain_id = 'eip155:1';
+  assert.throws(() => normalizeAnchorEvidence(wrongChain), /unsupported anchor chain/);
+  const wrongRegistry = clone(fixture.evidence);
+  wrongRegistry.registry_address = '0x1111111111111111111111111111111111111111';
+  assert.throws(() => normalizeAnchorEvidence(wrongRegistry), /not allowlisted/);
+});
+
+test('trusted verifier provenance is process-local and portable JSON cannot promote an anchor', () => {
+  const fixture = anchorVectors.fixtures.base_real_anchor;
+  assert.throws(() => verifyAnchorEvidence(fixture.evidence, {
+    verifierEvidence: fixture.verifier_observation,
+  }), /portable verifierEvidence JSON is not trusted/);
+  assert.throws(() => verifyAnchorEvidence(fixture.evidence, {
+    verifier: {
+      id: fixture.verifier_observation.verifier_ref,
+      async verify() { return clone(fixture.verifier_observation); },
+    },
+  }), /must return synchronously/);
+  const withExtra = clone(fixture.verifier_observation);
+  withExtra.claimed_delivery = true;
+  assert.throws(() => verifyAnchorEvidence(fixture.evidence, {
+    verifier: verifier(withExtra),
+  }), /exact field set/);
+
+  const normalized = normalizeAnchorEvidence(fixture.evidence);
+  const bypassChain = clone(normalized);
+  bypassChain.chain_id = 'eip155:1';
+  assert.throws(() => verifyAnchorEvidence(bypassChain, {
+    verifier: verifier(fixture.verifier_observation),
+  }), /unsupported anchor chain/);
+  const bypassRegistry = clone(normalized);
+  bypassRegistry.registry_address = '0x1111111111111111111111111111111111111111';
+  assert.throws(() => verifyAnchorEvidence(bypassRegistry, {
+    verifier: verifier(fixture.verifier_observation),
+  }), /not allowlisted/);
+});
+
+test('multiple observed anchors remain valid without becoming a uniqueness claim', () => {
+  const fixture = anchorVectors.fixtures.base_real_anchor;
+  const observation = clone(fixture.verifier_observation);
+  const second = clone(observation.events[0]);
+  second.transaction_hash = `0x${'c'.repeat(64)}`;
+  second.log_index = 72;
+  observation.events.push(second);
+  const result = verifyAnchorEvidence(fixture.evidence, {
+    verifier: verifier(observation),
+  });
+  assert.equal(result.status, 'checked_match');
+  assert.equal(result.observed_matching_event_count, 2);
+  assert.ok(result.does_not_prove.includes('single_execution'));
+});
+
+test('binding preserves authenticated identity and never upgrades outcome, payment, or reconciliation', () => {
+  const actionReference = verifiedBaselineReference();
+  const fixture = anchorVectors.fixtures.synthetic_baseline_anchor;
+  const verification = verifyAnchorEvidence(fixture.evidence, {
+    verifier: verifier(fixture.verifier_observation),
+  });
+  const envelope = minimalEnvelope();
+  const previousHash = envelope.evidence.envelope_hash;
+  const bound = bindExternalVerification(envelope, verification, { actionReference });
+  assert.equal(bound.authenticated_action_ref, envelope.authenticated_action_ref);
+  assert.equal(bound.external_action_refs.length, 1);
+  assert.equal(bound.external_action_refs[0].recomputation, 'match');
+  assert.equal(bound.external_verification.status, 'checked_match');
+  assert.equal(bound.external_verification.complete_chain_verified, false);
+  assert.equal(bound.outcome.delivery_status, 'not_observed');
+  assert.equal(bound.outcome.verification_status, 'not_checked');
+  assert.equal(bound.payment.status, 'not_started');
+  assert.equal(bound.reconciliation.status, 'not_started');
+  assert.equal(bound.state, 'incomplete');
+  assert.notEqual(bound.evidence.envelope_hash, previousHash);
+  assert.equal(bound.evidence.envelope_hash, computeEnvelopeHash(bound));
+  assert.throws(() => bindExternalVerification(
+    envelope,
+    JSON.parse(JSON.stringify(verification)),
+    { actionReference },
+  ), /trusted in-process verifier boundary/);
+  assert.throws(() => bindExternalVerification(
+    envelope,
+    verification,
+    { actionReference: JSON.parse(JSON.stringify(actionReference)) },
+  ), /trusted recomputation boundary/);
+
+  const forgedMismatch = {
+    ...JSON.parse(JSON.stringify(verification)),
+    status: 'checked_mismatch',
+    complete_chain_verified: true,
+    authority_flags: { can_spend: true },
+  };
+  assert.throws(() => bindExternalVerification(
+    envelope,
+    forgedMismatch,
+    { actionReference },
+  ), /trusted in-process verifier boundary/);
+});
+
+test('delivery can remain verified while an unchecked external anchor remains not checked', () => {
+  const actionReference = verifiedBaselineReference();
+  const envelope = minimalEnvelope({
+    delivery_status: 'delivered',
+    verification_status: 'verified',
+  });
+  const bound = bindExternalVerification(envelope, null, { actionReference });
+  assert.equal(bound.outcome.delivery_status, 'delivered');
+  assert.equal(bound.outcome.verification_status, 'verified');
+  assert.equal(bound.external_verification.status, 'not_checked');
+  assert.deepEqual(bound.external_verification.proves, []);
+  assert.equal(bound.external_verification.complete_chain_verified, false);
+});
+
+test('adapter is no-network and the package subpath exports the same API', async () => {
+  assert.doesNotMatch(
+    adapterSource,
+    /from ['"]node:(?:http|https|net|tls)['"]|\bfetch\s*\(|eth_sendRawTransaction|sendTransaction\s*\(/,
+  );
+  const exported = await import('@agoragentic/transaction-assurance/external-verification-adapters');
+  assert.equal(exported.verifyAnchorEvidence, verifyAnchorEvidence);
+  assert.equal(exported.bindExternalVerification, bindExternalVerification);
+});

--- a/transaction-assurance/test/fixtures/mycelium-action-ref-v1.vectors.json
+++ b/transaction-assurance/test/fixtures/mycelium-action-ref-v1.vectors.json
@@ -1,0 +1,81 @@
+{
+  "schema": "agoragentic.mycelium-action-ref-v1-vectors.v1",
+  "profile": "mycelium-action-ref-v1.0",
+  "source": {
+    "repository": "https://github.com/giskard09/argentum-core",
+    "revision": "2935c328177dca9f042fa1b910f5237ffe71da9e",
+    "tag": "action-ref-v2.0",
+    "derivation_version": "v1",
+    "specification_sha256": "sha256:c893d29e8d992e88442eccdde502e22edda0c20a580d391c56af988642452554",
+    "upstream_vector_set_sha256": "sha256:b6604d03c3f119224b594135d651eb74b205770cc276c46acd95dd800feb9050",
+    "upstream_negative_vector_set_sha256": "sha256:eae765de97298e2d086c41867922b7a6fe14eee4fd7efa572257658ce6876de9",
+    "license": "Apache-2.0"
+  },
+  "fixtures": {
+    "baseline": {
+      "preimage": {
+        "agent_id": "giskard-self",
+        "action_type": "trail.anchor",
+        "scope": "mycelium:baseline",
+        "timestamp": "2026-05-23T00:00:00.000Z"
+      },
+      "canonical_utf8": "{\"action_type\":\"trail.anchor\",\"agent_id\":\"giskard-self\",\"scope\":\"mycelium:baseline\",\"timestamp\":\"2026-05-23T00:00:00.000Z\"}",
+      "value": "f4ebda732e3c063bdd8547c734e4956f009bbed7f557cb949f7c8033e8c42d1d"
+    }
+  },
+  "vectors": [
+    {
+      "id": "valid-pinned-preimage",
+      "fixture": "baseline",
+      "expected": "match"
+    },
+    {
+      "id": "wrong-timestamp-precision",
+      "fixture": "baseline",
+      "set": {
+        "preimage.timestamp": "2026-05-23T00:00:00Z"
+      },
+      "expected": "reject_out_of_profile_domain"
+    },
+    {
+      "id": "noncanonical-key-order-hash",
+      "fixture": "baseline",
+      "set": {
+        "value": "ad7c0cfaa648d265ed057e6fd9fff68dbea1b546988c65afe24e92676f937b04"
+      },
+      "expected": "mismatch"
+    },
+    {
+      "id": "unsupported-profile",
+      "fixture": "baseline",
+      "set": {
+        "profile": "mycelium-action-ref-v2.0"
+      },
+      "expected": "reject_unsupported_profile"
+    },
+    {
+      "id": "v2-domain-digest-under-v1-profile",
+      "fixture": "baseline",
+      "set": {
+        "value": "c72caf19ccd3f74afeadf630e46473a828c56765abc368ba2285ab53a8b3ceae"
+      },
+      "expected": "mismatch"
+    },
+    {
+      "id": "non-ascii-scope",
+      "fixture": "baseline",
+      "set": {
+        "preimage.scope": "mycelium:r\u00e9sum\u00e9"
+      },
+      "expected": "reject_out_of_profile_domain"
+    },
+    {
+      "id": "wrong-declared-preimage-ref",
+      "fixture": "baseline",
+      "set": {
+        "preimage_ref": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      "expected": "mismatch"
+    }
+  ]
+}

--- a/transaction-assurance/test/fixtures/mycelium-anchor-registry-v1.vectors.json
+++ b/transaction-assurance/test/fixtures/mycelium-anchor-registry-v1.vectors.json
@@ -1,0 +1,118 @@
+{
+  "schema": "agoragentic.mycelium-anchor-registry-v1-vectors.v1",
+  "profile": "mycelium-anchor-registry-v1",
+  "source": {
+    "repository": "https://github.com/giskard09/giskard-payments",
+    "revision": "cd8100e63d17882ba11843882acaf5b1e069fdce",
+    "source_sha256": "sha256:82437f6f5ba3952a2c7ac34700e82c03bc819662687a2d23f7cfce72aee903a0",
+    "registry_address": "0x49feca52bc634a9ab773226d16619dec547794aa",
+    "runtime_code_sha256": "sha256:e2f5675b490dbb4211cfbeb89a8e8913a2215843c91c33ced8f46935b83d82ed",
+    "license": "MIT"
+  },
+  "fixtures": {
+    "base_real_anchor": {
+      "evidence": {
+        "profile": "mycelium-anchor-registry-v1",
+        "action_reference_profile": "mycelium-action-ref-v1.0",
+        "action_reference": "d0f0a32e5290e0e71efc9265d86fe517db80f1c209ddff5106b9f69ba3c181db",
+        "chain_id": "eip155:8453",
+        "registry_address": "0x49fEcA52bC634a9Ab773226D16619deC547794aa",
+        "transaction_hash": "0xf00a5317e47d4f4d581eb16bf08b64dde45944706c615299c334f8082562f184",
+        "block_number": "48936665",
+        "log_index": 71
+      },
+      "verifier_observation": {
+        "schema": "agoragentic.external-anchor-verifier-observation.v1",
+        "profile": "mycelium-anchor-registry-v1",
+        "chain_id": "eip155:8453",
+        "registry_address": "0x49feca52bc634a9ab773226d16619dec547794aa",
+        "runtime_code": "0x608060405234801561000f575f5ffd5b5060043610610029575f3560e01c8063eecdf9271461002d575b5f5ffd5b610047600480360381019061004291906100d2565b610049565b005b3373ffffffffffffffffffffffffffffffffffffffff16817ffe2289542f7a0110ac112c3a4d712afdcaaf2900a1326f4e6f340b563a0e8734426040516100909190610115565b60405180910390a350565b5f5ffd5b5f819050919050565b6100b18161009f565b81146100bb575f5ffd5b50565b5f813590506100cc816100a8565b92915050565b5f602082840312156100e7576100e661009b565b5b5f6100f4848285016100be565b91505092915050565b5f819050919050565b61010f816100fd565b82525050565b5f6020820190506101285f830184610106565b9291505056fea26469706673582212202267335562733f038da16f93a6cad865bbf6078cdf27bb210b3737e85b58275364736f6c63430008210033",
+        "transaction_hash": "0xf00a5317e47d4f4d581eb16bf08b64dde45944706c615299c334f8082562f184",
+        "transaction_status": "success",
+        "transaction_to": "0x49feca52bc634a9ab773226d16619dec547794aa",
+        "transaction_input": "0xeecdf927d0f0a32e5290e0e71efc9265d86fe517db80f1c209ddff5106b9f69ba3c181db",
+        "block_number": "48936665",
+        "block_hash": "0x444ef7d905a054809fb8e150e81c5ed9565f177b2e6e81bc3c66edaf3f082b2d",
+        "block_timestamp": "1784662677",
+        "head_block_number": "49756001",
+        "events": [
+          {
+            "transaction_hash": "0xf00a5317e47d4f4d581eb16bf08b64dde45944706c615299c334f8082562f184",
+            "address": "0x49feca52bc634a9ab773226d16619dec547794aa",
+            "block_number": "48936665",
+            "block_hash": "0x444ef7d905a054809fb8e150e81c5ed9565f177b2e6e81bc3c66edaf3f082b2d",
+            "log_index": 71,
+            "removed": false,
+            "topics": [
+              "0xfe2289542f7a0110ac112c3a4d712afdcaaf2900a1326f4e6f340b563a0e8734",
+              "0xd0f0a32e5290e0e71efc9265d86fe517db80f1c209ddff5106b9f69ba3c181db",
+              "0x000000000000000000000000dcc84e9798e8eb1b1b48a31b8f35e5aa7b83dbf4"
+            ],
+            "data": "0x000000000000000000000000000000000000000000000000000000006a5fca95"
+          }
+        ],
+        "verifier_ref": "verifier://fixture/base-rpc",
+        "evidence_ref": "fixture://base/tx/f00a5317",
+        "checked_at": "2026-08-09T18:00:00.000Z"
+      }
+    },
+    "synthetic_baseline_anchor": {
+      "evidence": {
+        "profile": "mycelium-anchor-registry-v1",
+        "action_reference_profile": "mycelium-action-ref-v1.0",
+        "action_reference": "f4ebda732e3c063bdd8547c734e4956f009bbed7f557cb949f7c8033e8c42d1d",
+        "chain_id": "eip155:8453",
+        "registry_address": "0x49fEcA52bC634a9Ab773226D16619deC547794aa",
+        "transaction_hash": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "block_number": "48936665",
+        "log_index": 0
+      },
+      "verifier_observation": {
+        "schema": "agoragentic.external-anchor-verifier-observation.v1",
+        "profile": "mycelium-anchor-registry-v1",
+        "chain_id": "eip155:8453",
+        "registry_address": "0x49feca52bc634a9ab773226d16619dec547794aa",
+        "runtime_code": "0x608060405234801561000f575f5ffd5b5060043610610029575f3560e01c8063eecdf9271461002d575b5f5ffd5b610047600480360381019061004291906100d2565b610049565b005b3373ffffffffffffffffffffffffffffffffffffffff16817ffe2289542f7a0110ac112c3a4d712afdcaaf2900a1326f4e6f340b563a0e8734426040516100909190610115565b60405180910390a350565b5f5ffd5b5f819050919050565b6100b18161009f565b81146100bb575f5ffd5b50565b5f813590506100cc816100a8565b92915050565b5f602082840312156100e7576100e661009b565b5b5f6100f4848285016100be565b91505092915050565b5f819050919050565b61010f816100fd565b82525050565b5f6020820190506101285f830184610106565b9291505056fea26469706673582212202267335562733f038da16f93a6cad865bbf6078cdf27bb210b3737e85b58275364736f6c63430008210033",
+        "transaction_hash": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "transaction_status": "success",
+        "transaction_to": "0x49feca52bc634a9ab773226d16619dec547794aa",
+        "transaction_input": "0xeecdf927f4ebda732e3c063bdd8547c734e4956f009bbed7f557cb949f7c8033e8c42d1d",
+        "block_number": "48936665",
+        "block_hash": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "block_timestamp": "1784662677",
+        "head_block_number": "48936676",
+        "events": [
+          {
+            "transaction_hash": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "address": "0x49feca52bc634a9ab773226d16619dec547794aa",
+            "block_number": "48936665",
+            "block_hash": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "log_index": 0,
+            "removed": false,
+            "topics": [
+              "0xfe2289542f7a0110ac112c3a4d712afdcaaf2900a1326f4e6f340b563a0e8734",
+              "0xf4ebda732e3c063bdd8547c734e4956f009bbed7f557cb949f7c8033e8c42d1d",
+              "0x000000000000000000000000dcc84e9798e8eb1b1b48a31b8f35e5aa7b83dbf4"
+            ],
+            "data": "0x000000000000000000000000000000000000000000000000000000006a5fca95"
+          }
+        ],
+        "verifier_ref": "verifier://fixture/synthetic",
+        "evidence_ref": "fixture://synthetic/baseline-anchor",
+        "checked_at": "2026-08-09T18:00:00.000Z"
+      }
+    }
+  },
+  "negative_vectors": [
+    "wrong_action_reference",
+    "wrong_chain",
+    "wrong_registry_address",
+    "wrong_runtime_code",
+    "reverted_transaction",
+    "wrong_target_or_selector",
+    "missing_event",
+    "wrong_log_index_or_block",
+    "insufficient_finality"
+  ],
+  "multi_event_rule": "A selected matching event may verify even when the bounded observation contains other valid anchors for the same reference. The result records the observed count and never claims single execution or global uniqueness."
+}


### PR DESCRIPTION
## Summary

- add an optional, version-pinned Mycelium action-reference v1 normalizer and preimage verifier
- add a read-only AnchorRegistry v1 verifier behind a trusted synchronous in-process callback
- bind external action references and verification as sibling evidence without reinterpreting `authenticated_action_ref` or advancing payment, execution, delivery, settlement, or reconciliation
- add immutable source pins, public-chain fixtures, adversarial vectors, package exports, docs, and Node 20/22/24 workflow parsing

## Trust boundary

- no network access in the adapter
- no hosted Argentum/Mycelium dependency
- no anchor writer or transaction submission
- no spend, provider execution, deployment, publication, or trust authority
- normalized schema tags are revalidated against pinned revisions and allowlists
- checked evidence and matching preimages require live process-local verifier provenance; serialized caller JSON cannot promote them
- a checked anchor proves only reference anchoring, public block timestamp, and event inclusion

## Current verification

Exact signed merged head: `5d41c1c8926aeccde4e191167544461a104353da`

- `npm run check`
- `npm test` (75/75)
- `npm run pack:dry`
- `node scripts/verify-integrations-json.js`
- `node scripts/verify-doc-links.mjs` (241 Markdown files)
- `git diff --check origin/main...HEAD`
- all 33 executed hosted checks pass
- fresh same-owner mechanical approval recorded explicitly as not independent review

## Scope

Merged on 2026-08-13 at `4729566249299054da22e8c021a001bf221f65ab`. No deploy, package publication, production write path, or ecosystem-standard claim. The independent `anchor-x402` adopter evidence is now recorded through merged #314; package publication and public-catalog inclusion remain separately review-gated.

Context: #244, #246; follows the version-pinned Transaction Assurance boundary established by #277 and the adopter findings addressed by #314.