### PR TITLE
feat(transaction-assurance): add anchor-x402 adopter pack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ examples/anydoc-document-evidence/node_modules/
 examples/anydoc-document-evidence/conformance/generated/
 examples/anydoc-document-evidence/conformance/report.json
 examples/anydoc-document-evidence/*.tgz
+transaction-assurance/node_modules/
 __pycache__/
 *.pyc
 sdk/python/build/

--- a/transaction-assurance/CONFORMANCE.md
+++ b/transaction-assurance/CONFORMANCE.md
@@ -41,6 +41,16 @@ Reference modules are included for:
 
 They demonstrate the interface only. Their passing results are not third-party evidence.
 
+## External-adopter starter packs
+
+The [`anchor-x402` starter pack](./examples/external-adopters/anchor-x402/README.md)
+provides a clean-room normalized-policy target and an offline runner that binds
+both the suite and target to exact Git commits. Agoragentic authored the starter;
+it is not external evidence until the independent operator reviews and commits
+the target in its own repository, runs it, and publishes the bounded artifacts
+plus actionable observations. The pack makes no network, payment, signature,
+live-settlement, or production-compatibility claim.
+
 ## Reports and receipts
 
 The JSON report contains every bounded result and hashes of the manifest, vector set, and materialized inputs. JUnit output has stable names and zero timing noise. The receipt binds:

--- a/transaction-assurance/examples/external-adopters/anchor-x402/README.md
+++ b/transaction-assurance/examples/external-adopters/anchor-x402/README.md
@@ -1,0 +1,82 @@
+# anchor-x402 External-Adopter Starter Pack
+
+This directory is a clean-room, Apache-2.0 starter pack for an independently
+operated `anchor-x402` run of the Agoragentic Transaction Assurance conformance
+suite. Agoragentic authored the starter. It does not become external-adopter
+evidence until the anchor-x402 operator reviews it, commits it in an
+operator-controlled repository, runs it there against an immutable suite
+commit, and publishes the bounded artifacts plus actionable observations.
+
+No source was copied from `chico10117/basepay-readiness-service`; its public
+repository exposed no license when this starter was authored on 2026-08-11.
+This pack does not call that service or any anchor-x402 endpoint.
+
+## What the target evaluates
+
+`target.mjs` is a self-contained policy evaluator for the suite's normalized,
+bounded evidence contract. It covers authority, commercial terms, limits,
+payment identity, settlement, execution, outcome validation, reconciliation,
+and privacy decisions. It intentionally does not:
+
+- parse AP2, TAP, ACP, or x402 wire payloads;
+- verify protocol or wallet signatures;
+- make network requests;
+- read environment variables or secrets;
+- call providers or execute tools;
+- authorize or move funds; or
+- claim live or production compatibility.
+
+The protocol IDs in the normalized inputs identify the suite's pinned source
+vocabulary. Accepting those normalized inputs does not claim that anchor-x402
+implements each wire protocol.
+
+## Independent run
+
+1. Copy this directory into an anchor-x402-controlled Git repository.
+2. Review `profile.v1.json` and `target.mjs` against the operator's actual
+   policy. Change them if needed; do not report an unreviewed starter as the
+   operator's implementation.
+3. Commit the reviewed files. The runner refuses dirty or untracked pack files.
+4. Check out `rhein1/agoragentic-integrations` at the exact suite commit supplied
+   by Agoragentic. Source retrieval is preparation; the conformance run itself
+   is offline.
+5. From the operator repository, run one command:
+
+```text
+node path/to/anchor-x402/run.mjs --suite-root path/to/agoragentic-integrations/transaction-assurance --suite-commit <40-character-suite-commit>
+```
+
+The runner derives the target commit from the operator repository, verifies the
+suite checkout commit, checks that the pack is tracked and clean, confines its
+output to the operator repository, and writes:
+
+- `artifacts/agoragentic-transaction-assurance/report.json`
+- `artifacts/agoragentic-transaction-assurance/junit.xml`
+- `artifacts/agoragentic-transaction-assurance/receipt.json`
+- `artifacts/agoragentic-transaction-assurance/adopter-context.json`
+
+The operator should review the files for public safety, verify the receipt with
+the public verifier, and publish the exact target commit, counts, report and
+receipt hashes, and at least one actionable observation. A passing run is not
+certification, endorsement, live-settlement proof, or production validation.
+
+## Reusable workflow
+
+After copying `target.mjs` into the operator repository, the existing reusable
+workflow can run the same target without secrets:
+
+```yaml
+jobs:
+  transaction-assurance:
+    uses: rhein1/agoragentic-integrations/.github/workflows/transaction-assurance-conformance.yml@<SUITE_COMMIT>
+    with:
+      suite-ref: <SUITE_COMMIT>
+      target-module: path/to/anchor-x402/target.mjs
+      target-name: anchor-x402-normalized-policy-adapter
+      target-version: 0.1.0
+      target-commit: ${{ github.sha }}
+```
+
+The workflow and local runner execute the target in-process. They do not claim
+to sandbox arbitrary target code; the reviewed target source is part of the
+evidence boundary.

--- a/transaction-assurance/examples/external-adopters/anchor-x402/README.md
+++ b/transaction-assurance/examples/external-adopters/anchor-x402/README.md
@@ -38,8 +38,9 @@ implements each wire protocol.
    operator's implementation.
 3. Commit the reviewed files. The runner refuses dirty or untracked pack files.
 4. Check out `rhein1/agoragentic-integrations` at the exact suite commit supplied
-   by Agoragentic. Source retrieval is preparation; the conformance run itself
-   is offline.
+   by Agoragentic and leave the suite evaluator, manifest, vectors, package
+   metadata, and transitive source inputs tracked and clean. Source retrieval is
+   preparation; the conformance run itself is offline.
 5. From the operator repository, run one command:
 
 ```text

--- a/transaction-assurance/examples/external-adopters/anchor-x402/profile.v1.json
+++ b/transaction-assurance/examples/external-adopters/anchor-x402/profile.v1.json
@@ -1,0 +1,42 @@
+{
+  "schema": "agoragentic.transaction-assurance.external-adopter-profile.v1",
+  "profile_version": "0.1.0",
+  "operator_display_name": "anchor-x402",
+  "operator_origin": "https://anchor-x402.com",
+  "target_name": "anchor-x402-normalized-policy-adapter",
+  "target_contract": "offline_normalized_evidence_policy",
+  "implementation_authorship": "agoragentic_clean_room_starter_operator_review_required",
+  "source_wire_protocol": "x402",
+  "normalized_protocol_inputs": [
+    "google_ap2",
+    "openai_stripe_acp",
+    "visa_tap",
+    "x402"
+  ],
+  "profiles_evaluated": [
+    "authority_identity",
+    "commercial_terms",
+    "execution_delivery",
+    "outcome_validation",
+    "payment_idempotency",
+    "privacy_redaction",
+    "reconciliation",
+    "settlement_finality"
+  ],
+  "network_required": false,
+  "secret_access_required": false,
+  "spend_authority": false,
+  "wire_protocol_parsing_claimed": false,
+  "signature_verification_claimed": false,
+  "live_settlement_claimed": false,
+  "production_compatibility_claimed": false,
+  "certification_claimed": false,
+  "operator_review_required": true,
+  "required_operator_assertions": [
+    "target_files_committed_in_operator_controlled_repository",
+    "profile_reviewed_against_operator_policy",
+    "run_uses_immutable_suite_and_target_commits",
+    "artifacts_reviewed_for_public_safety_before_publication",
+    "actionable_observations_reported"
+  ]
+}

--- a/transaction-assurance/examples/external-adopters/anchor-x402/run.mjs
+++ b/transaction-assurance/examples/external-adopters/anchor-x402/run.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const scriptPath = fileURLToPath(import.meta.url);
+const packDirectory = path.dirname(scriptPath);
+const commitPattern = /^[0-9a-f]{40}$/;
+
+function parseArgs(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith('--') || value === undefined) {
+      throw new TypeError('arguments must be --key value pairs');
+    }
+    options[key.slice(2)] = value;
+  }
+  return options;
+}
+
+function git(args, cwd) {
+  return execFileSync('git', ['-C', cwd, ...args], { encoding: 'utf8' }).trim();
+}
+
+function assertTrackedAndClean(repositoryRoot, files) {
+  for (const filename of files) {
+    const relative = path.relative(repositoryRoot, filename);
+    if (relative.startsWith('..') || path.isAbsolute(relative)) {
+      throw new Error('adopter pack files must remain inside the target repository');
+    }
+    git(['ls-files', '--error-unmatch', '--', relative], repositoryRoot);
+  }
+  const relativeFiles = files.map((filename) => path.relative(repositoryRoot, filename));
+  const dirty = git(['status', '--porcelain=v1', '--', ...relativeFiles], repositoryRoot);
+  if (dirty) throw new Error('adopter pack files must be committed and clean before the evidence run');
+}
+
+function sha256Bytes(value) {
+  return `sha256:${createHash('sha256').update(value).digest('hex')}`;
+}
+
+function resolveInside(root, candidate, field) {
+  const resolvedRoot = path.resolve(root);
+  const resolved = path.resolve(resolvedRoot, candidate);
+  if (resolved !== resolvedRoot && !resolved.startsWith(`${resolvedRoot}${path.sep}`)) {
+    throw new Error(`${field} must remain inside the target repository`);
+  }
+  return resolved;
+}
+
+async function writeJson(filename, value) {
+  await mkdir(path.dirname(filename), { recursive: true });
+  await writeFile(filename, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const suiteCommit = options['suite-commit'];
+  if (!commitPattern.test(suiteCommit || '')) {
+    throw new TypeError('--suite-commit must be an exact 40-character lowercase Git commit');
+  }
+  if (!options['suite-root']) throw new TypeError('--suite-root is required');
+
+  const suiteRoot = path.resolve(options['suite-root']);
+  const actualSuiteCommit = git(['rev-parse', 'HEAD'], suiteRoot);
+  if (actualSuiteCommit !== suiteCommit) {
+    throw new Error(`suite checkout mismatch: expected ${suiteCommit}, found ${actualSuiteCommit}`);
+  }
+
+  const targetRoot = git(['rev-parse', '--show-toplevel'], packDirectory);
+  const targetCommit = git(['rev-parse', 'HEAD'], targetRoot);
+  if (!commitPattern.test(targetCommit)) throw new Error('target repository HEAD is not an exact Git commit');
+
+  const profilePath = path.join(packDirectory, 'profile.v1.json');
+  const targetPath = path.join(packDirectory, 'target.mjs');
+  assertTrackedAndClean(targetRoot, [scriptPath, profilePath, targetPath]);
+  const targetModule = await import(pathToFileURL(targetPath).href);
+  if (typeof targetModule.evaluateTransactionAssuranceVector !== 'function') {
+    throw new Error('target.mjs must export evaluateTransactionAssuranceVector');
+  }
+
+  const profileRaw = await readFile(profilePath);
+  const profile = JSON.parse(profileRaw.toString('utf8'));
+  for (const field of [
+    'network_required',
+    'secret_access_required',
+    'spend_authority',
+    'wire_protocol_parsing_claimed',
+    'signature_verification_claimed',
+    'live_settlement_claimed',
+    'production_compatibility_claimed',
+    'certification_claimed',
+  ]) {
+    if (profile[field] !== false) throw new Error(`profile.${field} must remain false`);
+  }
+  if (profile.operator_review_required !== true) {
+    throw new Error('profile.operator_review_required must remain true');
+  }
+
+  const conformanceUrl = pathToFileURL(path.join(suiteRoot, 'src', 'conformance.mjs')).href;
+  const {
+    buildConformanceReceipt,
+    readJson,
+    renderConformanceJUnit,
+    runConformanceSuite,
+    verifyConformanceReceipt,
+  } = await import(conformanceUrl);
+
+  const manifest = await readJson(pathToFileURL(path.join(suiteRoot, 'conformance', 'manifest.v1.json')));
+  const vectorSet = await readJson(pathToFileURL(path.join(suiteRoot, 'conformance', 'vectors.v1.json')));
+  const report = await runConformanceSuite({
+    manifest,
+    vectorSet,
+    evaluate: targetModule.evaluateTransactionAssuranceVector,
+    target: {
+      name: profile.target_name,
+      version: profile.profile_version,
+      commit: targetCommit,
+    },
+  });
+  const receipt = buildConformanceReceipt({ manifest, vectorSet, report });
+  const verifiedReceipt = verifyConformanceReceipt({ manifest, vectorSet, report, receipt });
+  if (!verifiedReceipt.verified) throw new Error('generated conformance receipt did not verify');
+
+  const outputDirectory = resolveInside(
+    targetRoot,
+    options['output-dir'] || path.join('artifacts', 'agoragentic-transaction-assurance'),
+    '--output-dir',
+  );
+  const context = {
+    schema: 'agoragentic.transaction-assurance.external-adopter-context.v1',
+    suite_commit: suiteCommit,
+    target_commit: targetCommit,
+    target_name: profile.target_name,
+    target_version: profile.profile_version,
+    operator_display_name: profile.operator_display_name,
+    operator_origin: profile.operator_origin,
+    profile_hash: sha256Bytes(profileRaw),
+    runner_source_hash: sha256Bytes(await readFile(scriptPath)),
+    target_source_hash: sha256Bytes(await readFile(targetPath)),
+    report_hash: report.report_hash,
+    receipt_hash: receipt.receipt_hash,
+    network_used_by_suite: false,
+    spend_authority_granted: false,
+    operator_review_required: true,
+    claim_boundary: manifest.claim_boundary,
+  };
+
+  await writeJson(path.join(outputDirectory, 'report.json'), report);
+  await writeFile(path.join(outputDirectory, 'junit.xml'), renderConformanceJUnit(report), 'utf8');
+  await writeJson(path.join(outputDirectory, 'receipt.json'), receipt);
+  await writeJson(path.join(outputDirectory, 'adopter-context.json'), context);
+
+  process.stdout.write(`${JSON.stringify({
+    status: report.all_passed ? 'passed' : 'failed',
+    total: report.total,
+    passed: report.passed,
+    failed: report.failed,
+    report_hash: report.report_hash,
+    receipt_hash: receipt.receipt_hash,
+    output_directory: outputDirectory,
+    network_used_by_suite: false,
+    spend_authority_granted: false,
+  })}\n`);
+  process.exitCode = report.all_passed ? 0 : 1;
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 2;
+});

--- a/transaction-assurance/examples/external-adopters/anchor-x402/run.mjs
+++ b/transaction-assurance/examples/external-adopters/anchor-x402/run.mjs
@@ -27,17 +27,17 @@ function git(args, cwd) {
   return execFileSync('git', ['-C', cwd, ...args], { encoding: 'utf8' }).trim();
 }
 
-function assertTrackedAndClean(repositoryRoot, files) {
+function assertTrackedAndClean(repositoryRoot, files, label) {
   for (const filename of files) {
     const relative = path.relative(repositoryRoot, filename);
     if (relative.startsWith('..') || path.isAbsolute(relative)) {
-      throw new Error('adopter pack files must remain inside the target repository');
+      throw new Error(`${label} files must remain inside their repository`);
     }
     git(['ls-files', '--error-unmatch', '--', relative], repositoryRoot);
   }
   const relativeFiles = files.map((filename) => path.relative(repositoryRoot, filename));
   const dirty = git(['status', '--porcelain=v1', '--', ...relativeFiles], repositoryRoot);
-  if (dirty) throw new Error('adopter pack files must be committed and clean before the evidence run');
+  if (dirty) throw new Error(`${label} files must be committed and clean before the evidence run`);
 }
 
 function sha256Bytes(value) {
@@ -71,6 +71,18 @@ async function main() {
   if (actualSuiteCommit !== suiteCommit) {
     throw new Error(`suite checkout mismatch: expected ${suiteCommit}, found ${actualSuiteCommit}`);
   }
+  const suiteRepositoryRoot = git(['rev-parse', '--show-toplevel'], suiteRoot);
+  assertTrackedAndClean(suiteRepositoryRoot, [
+    path.join(suiteRoot, 'src', 'conformance.mjs'),
+    path.join(suiteRoot, 'src', 'index.mjs'),
+    path.join(suiteRoot, 'src', 'protocol-adapters.mjs'),
+    path.join(suiteRoot, 'src', 'trusted-verifier-boundary.mjs'),
+    path.join(suiteRoot, 'vendor', 'acp-2026-04-17', 'schema.agentic_checkout.json'),
+    path.join(suiteRoot, 'conformance', 'manifest.v1.json'),
+    path.join(suiteRoot, 'conformance', 'vectors.v1.json'),
+    path.join(suiteRoot, 'package.json'),
+    path.join(suiteRoot, 'package-lock.json'),
+  ], 'suite evidence');
 
   const targetRoot = git(['rev-parse', '--show-toplevel'], packDirectory);
   const targetCommit = git(['rev-parse', 'HEAD'], targetRoot);
@@ -78,7 +90,7 @@ async function main() {
 
   const profilePath = path.join(packDirectory, 'profile.v1.json');
   const targetPath = path.join(packDirectory, 'target.mjs');
-  assertTrackedAndClean(targetRoot, [scriptPath, profilePath, targetPath]);
+  assertTrackedAndClean(targetRoot, [scriptPath, profilePath, targetPath], 'adopter pack');
   const targetModule = await import(pathToFileURL(targetPath).href);
   if (typeof targetModule.evaluateTransactionAssuranceVector !== 'function') {
     throw new Error('target.mjs must export evaluateTransactionAssuranceVector');

--- a/transaction-assurance/examples/external-adopters/anchor-x402/target.mjs
+++ b/transaction-assurance/examples/external-adopters/anchor-x402/target.mjs
@@ -1,0 +1,96 @@
+const PROTOCOL_PINS = Object.freeze({
+  google_ap2: 'v0.2.0',
+  openai_stripe_acp: '2026-04-17',
+  visa_tap: 'commit-16d59bdf',
+  x402: '2.21.0',
+});
+
+function result(decision, code) {
+  return Object.freeze({ decision, code });
+}
+
+function hasNormalizedSections(input) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return false;
+  return [
+    'protocol',
+    'authority',
+    'terms',
+    'limits',
+    'payment',
+    'settlement',
+    'execution',
+    'outcome',
+    'reconciliation',
+    'privacy',
+  ].every((field) => input[field] && typeof input[field] === 'object' && !Array.isArray(input[field]));
+}
+
+// This target evaluates only the suite's bounded normalized evidence. It does
+// not parse wire protocols, verify signatures, call a provider, or move funds.
+export function evaluateTransactionAssuranceVector({ input } = {}) {
+  if (!hasNormalizedSections(input)) return result('deny', 'malformed_normalized_input');
+
+  const pinnedVersion = PROTOCOL_PINS[input.protocol.adapter_id];
+  if (!pinnedVersion || input.protocol.source_version !== pinnedVersion) {
+    return result('deny', 'unsupported_protocol_version');
+  }
+
+  if (input.authority.verification === 'unknown') {
+    return result('review', 'authority_verification_unknown');
+  }
+  if (input.authority.verification !== 'verified') return result('review', 'authority_unverified');
+  if (input.authority.revocation === 'revoked') return result('deny', 'authority_revoked');
+  if (input.authority.revocation !== 'active') return result('review', 'authority_revocation_unknown');
+  if (input.authority.expired) return result('deny', 'authority_expired');
+  if (!input.authority.audience_match) return result('deny', 'authority_wrong_audience');
+  if (!input.authority.agent_match) return result('deny', 'authority_wrong_agent');
+
+  for (const [field, code] of [
+    ['merchant_match', 'merchant_mismatch'],
+    ['category_match', 'category_mismatch'],
+    ['action_match', 'action_mismatch'],
+    ['rail_match', 'rail_mismatch'],
+    ['currency_match', 'currency_mismatch'],
+    ['quote_match', 'quote_changed'],
+    ['terms_match', 'terms_changed'],
+  ]) {
+    if (!input.terms[field]) return result('deny', code);
+  }
+
+  for (const [field, code] of [
+    ['per_action_within_limit', 'per_action_limit_exceeded'],
+    ['daily_within_limit', 'daily_limit_exceeded'],
+    ['total_within_limit', 'total_limit_exceeded'],
+  ]) {
+    if (!input.limits[field]) return result('deny', code);
+  }
+
+  if (!input.payment.identifier_present) return result('deny', 'payment_identifier_missing');
+  if (input.payment.identifier_reused) return result('deny', 'payment_identifier_reused');
+  if (input.payment.replay_detected) return result('deny', 'paid_retry_replay_detected');
+  if (!input.settlement.observed) return result('review', 'payment_not_observed');
+  if (!input.settlement.verified) return result('deny', 'settlement_unverified');
+  if (!input.settlement.final) return result('review', 'settlement_not_final');
+  if (!input.execution.attempted) return result('review', 'execution_not_observed');
+  if (!input.execution.succeeded) return result('deny', 'execution_failed_after_payment');
+  if (!input.execution.delivery_observed) return result('review', 'delivery_missing_after_payment');
+
+  if (input.outcome.validation === 'not_checked') return result('review', 'outcome_not_validated');
+  if (input.outcome.validation === 'failed') return result('deny', 'outcome_validation_failed');
+  if (input.outcome.validation === 'partial') return result('review', 'partial_fulfillment');
+
+  const exposedPrivacyField = Object.entries(input.privacy).find(([, exposed]) => exposed);
+  if (exposedPrivacyField) return result('deny', `privacy_${exposedPrivacyField[0]}`);
+
+  if (input.reconciliation.status === 'refund_pending') return result('review', 'refund_pending');
+  if (input.reconciliation.status === 'dispute_pending') return result('review', 'dispute_pending');
+  if (input.reconciliation.status === 'none') return result('review', 'reconciliation_incomplete');
+  if (input.reconciliation.status === 'refunded') return result('pass', 'reconciled_refunded');
+  if (input.reconciliation.status === 'dispute_resolved') {
+    return result('pass', 'reconciled_dispute_resolved');
+  }
+  if (input.reconciliation.status !== 'complete') {
+    return result('review', 'reconciliation_state_unknown');
+  }
+  return result('pass', 'complete_chain_verified');
+}

--- a/transaction-assurance/package.json
+++ b/transaction-assurance/package.json
@@ -37,7 +37,7 @@
   ],
   "scripts": {
     "test": "node --test test/*.test.mjs",
-    "check": "node --check src/index.mjs && node --check src/protocol-adapters.mjs && node --check src/conformance.mjs && node --check src/evaluation-evidence.mjs && node --check src/toploc-evidence.mjs && node --check bin/agora-assure.mjs && node --check bin/run-conformance.mjs && node --check bin/verify-conformance-receipt.mjs && node --check examples/x402-generic-middleware.mjs && node --check examples/conformance-targets/x402-resource-server.mjs && node --check examples/conformance-targets/mcp-paid-tool.mjs && node --check examples/conformance-targets/agent-wallet-policy.mjs && node --check examples/conformance-targets/marketplace-listing.mjs",
+    "check": "node --check src/index.mjs && node --check src/protocol-adapters.mjs && node --check src/conformance.mjs && node --check src/evaluation-evidence.mjs && node --check src/toploc-evidence.mjs && node --check bin/agora-assure.mjs && node --check bin/run-conformance.mjs && node --check bin/verify-conformance-receipt.mjs && node --check examples/x402-generic-middleware.mjs && node --check examples/conformance-targets/x402-resource-server.mjs && node --check examples/conformance-targets/mcp-paid-tool.mjs && node --check examples/conformance-targets/agent-wallet-policy.mjs && node --check examples/conformance-targets/marketplace-listing.mjs && node --check examples/external-adopters/anchor-x402/target.mjs && node --check examples/external-adopters/anchor-x402/run.mjs",
     "self-test": "node bin/agora-assure.mjs self-test",
     "conformance": "node bin/run-conformance.mjs --target-name agoragentic-reference-evaluator --target-version 0.1.0-alpha.0 --target-commit local",
     "pack:dry": "npm pack --dry-run"

--- a/transaction-assurance/test/external-adopter-anchor-x402.test.mjs
+++ b/transaction-assurance/test/external-adopter-anchor-x402.test.mjs
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { cp, mkdtemp, mkdir, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+import test from 'node:test';
+
+import {
+  readJson,
+  runConformanceSuite,
+  verifyConformanceReceipt,
+} from '../src/conformance.mjs';
+import { evaluateTransactionAssuranceVector } from '../examples/external-adopters/anchor-x402/target.mjs';
+
+const execFileAsync = promisify(execFile);
+const packageRoot = fileURLToPath(new URL('../', import.meta.url));
+const repositoryRoot = path.resolve(packageRoot, '..');
+const packRoot = path.join(packageRoot, 'examples', 'external-adopters', 'anchor-x402');
+const manifest = await readJson(path.join(packageRoot, 'conformance', 'manifest.v1.json'));
+const vectorSet = await readJson(path.join(packageRoot, 'conformance', 'vectors.v1.json'));
+
+test('anchor-x402 clean-room target satisfies the bounded normalized contract', async () => {
+  const report = await runConformanceSuite({
+    manifest,
+    vectorSet,
+    evaluate: evaluateTransactionAssuranceVector,
+    target: { name: 'anchor-x402-test', version: '0.1.0', commit: 'fixture' },
+  });
+  assert.equal(report.total, 42);
+  assert.equal(report.failed, 0);
+  assert.equal(report.all_passed, true);
+  assert.deepEqual(evaluateTransactionAssuranceVector(), {
+    decision: 'deny',
+    code: 'malformed_normalized_input',
+  });
+  const unknownProtocol = structuredClone(vectorSet.base_input);
+  unknownProtocol.protocol = { adapter_id: 'unknown', source_version: '1' };
+  assert.deepEqual(evaluateTransactionAssuranceVector({ input: unknownProtocol }), {
+    decision: 'deny',
+    code: 'unsupported_protocol_version',
+  });
+});
+
+test('anchor-x402 target has no circular reference, network, secret, or expected-answer dependency', async () => {
+  const source = await readFile(path.join(packRoot, 'target.mjs'), 'utf8');
+  for (const forbidden of [
+    /evaluateReferenceVector/,
+    /vector\s*\.\s*expected/,
+    /from\s+['"]node:(?:http|https|net|tls|dgram)/,
+    /\bfetch\s*\(/,
+    /process\s*\.\s*env/,
+    /child_process/,
+  ]) {
+    assert.doesNotMatch(source, forbidden);
+  }
+
+  const profile = await readJson(path.join(packRoot, 'profile.v1.json'));
+  for (const field of [
+    'network_required',
+    'secret_access_required',
+    'spend_authority',
+    'wire_protocol_parsing_claimed',
+    'signature_verification_claimed',
+    'live_settlement_claimed',
+    'production_compatibility_claimed',
+    'certification_claimed',
+  ]) assert.equal(profile[field], false, field);
+  assert.equal(profile.operator_review_required, true);
+});
+
+test('portable runner binds clean target and suite commits and emits verifiable artifacts', async () => {
+  const temp = await mkdtemp(path.join(os.tmpdir(), 'anchor-x402-adopter-'));
+  const targetRoot = path.join(temp, 'target');
+  try {
+    const copiedPack = path.join(targetRoot, 'tools', 'anchor-x402');
+    await mkdir(copiedPack, { recursive: true });
+    for (const filename of ['profile.v1.json', 'run.mjs', 'target.mjs']) {
+      await cp(path.join(packRoot, filename), path.join(copiedPack, filename));
+    }
+    await execFileAsync('git', ['init'], { cwd: targetRoot });
+    await execFileAsync('git', ['config', 'user.name', 'Conformance Test'], { cwd: targetRoot });
+    await execFileAsync('git', ['config', 'user.email', 'conformance@example.invalid'], { cwd: targetRoot });
+    await execFileAsync('git', ['config', 'commit.gpgsign', 'false'], { cwd: targetRoot });
+    await execFileAsync('git', ['add', 'tools/anchor-x402'], { cwd: targetRoot });
+    await execFileAsync('git', ['commit', '-m', 'test: add adopter pack'], { cwd: targetRoot });
+
+    const suiteCommit = (await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: repositoryRoot })).stdout.trim();
+    const runner = path.join(copiedPack, 'run.mjs');
+    const args = [runner, '--suite-root', packageRoot, '--suite-commit', suiteCommit];
+    const first = await execFileAsync(process.execPath, args, { cwd: targetRoot });
+    const firstSummary = JSON.parse(first.stdout);
+    assert.equal(firstSummary.status, 'passed');
+    assert.equal(firstSummary.total, 42);
+    assert.equal(firstSummary.failed, 0);
+
+    const output = path.join(targetRoot, 'artifacts', 'agoragentic-transaction-assurance');
+    const report = await readJson(path.join(output, 'report.json'));
+    const receipt = await readJson(path.join(output, 'receipt.json'));
+    const context = await readJson(path.join(output, 'adopter-context.json'));
+    assert.equal(context.suite_commit, suiteCommit);
+    assert.equal(context.target_commit, report.target.commit);
+    assert.equal(context.network_used_by_suite, false);
+    assert.equal(context.spend_authority_granted, false);
+    assert.match(context.runner_source_hash, /^sha256:[0-9a-f]{64}$/);
+    assert.match(context.target_source_hash, /^sha256:[0-9a-f]{64}$/);
+    assert.deepEqual(verifyConformanceReceipt({ manifest, vectorSet, report, receipt }), {
+      verified: true,
+      receipt_hash: receipt.receipt_hash,
+    });
+
+    const before = await Promise.all([
+      readFile(path.join(output, 'report.json'), 'utf8'),
+      readFile(path.join(output, 'receipt.json'), 'utf8'),
+      readFile(path.join(output, 'adopter-context.json'), 'utf8'),
+    ]);
+    await execFileAsync(process.execPath, args, { cwd: targetRoot });
+    const after = await Promise.all([
+      readFile(path.join(output, 'report.json'), 'utf8'),
+      readFile(path.join(output, 'receipt.json'), 'utf8'),
+      readFile(path.join(output, 'adopter-context.json'), 'utf8'),
+    ]);
+    assert.deepEqual(after, before);
+
+    await assert.rejects(
+      execFileAsync(process.execPath, [...args, '--output-dir', path.join('..', 'outside')], { cwd: targetRoot }),
+      /--output-dir must remain inside the target repository/,
+    );
+  } finally {
+    await rm(temp, { recursive: true, force: true });
+  }
+});

--- a/transaction-assurance/test/external-adopter-anchor-x402.test.mjs
+++ b/transaction-assurance/test/external-adopter-anchor-x402.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { execFile } from 'node:child_process';
-import { cp, mkdtemp, mkdir, readFile, rm } from 'node:fs/promises';
+import { cp, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -127,6 +127,49 @@ test('portable runner binds clean target and suite commits and emits verifiable 
     await assert.rejects(
       execFileAsync(process.execPath, [...args, '--output-dir', path.join('..', 'outside')], { cwd: targetRoot }),
       /--output-dir must remain inside the target repository/,
+    );
+
+    const dirtySuiteRepository = path.join(temp, 'dirty-suite');
+    const dirtySuiteRoot = path.join(dirtySuiteRepository, 'transaction-assurance');
+    const dirtySuiteFiles = [
+      'src/conformance.mjs',
+      'src/index.mjs',
+      'src/protocol-adapters.mjs',
+      'src/trusted-verifier-boundary.mjs',
+      'vendor/acp-2026-04-17/schema.agentic_checkout.json',
+      'conformance/manifest.v1.json',
+      'conformance/vectors.v1.json',
+      'package.json',
+      'package-lock.json',
+    ];
+    for (const relative of dirtySuiteFiles) {
+      const filename = path.join(dirtySuiteRoot, relative);
+      await mkdir(path.dirname(filename), { recursive: true });
+      await writeFile(filename, relative.endsWith('.json') ? '{}\n' : '// fixture\n', 'utf8');
+    }
+    await execFileAsync('git', ['init'], { cwd: dirtySuiteRepository });
+    await execFileAsync('git', ['config', 'user.name', 'Conformance Test'], { cwd: dirtySuiteRepository });
+    await execFileAsync('git', ['config', 'user.email', 'conformance@example.invalid'], { cwd: dirtySuiteRepository });
+    await execFileAsync('git', ['config', 'commit.gpgsign', 'false'], { cwd: dirtySuiteRepository });
+    await execFileAsync('git', ['add', '.'], { cwd: dirtySuiteRepository });
+    await execFileAsync('git', ['commit', '-m', 'test: add suite fixture'], { cwd: dirtySuiteRepository });
+    const dirtySuiteCommit = (
+      await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: dirtySuiteRepository })
+    ).stdout.trim();
+    await writeFile(
+      path.join(dirtySuiteRoot, 'src', 'conformance.mjs'),
+      '// locally modified evaluator\n',
+      'utf8',
+    );
+    await assert.rejects(
+      execFileAsync(process.execPath, [
+        runner,
+        '--suite-root',
+        dirtySuiteRoot,
+        '--suite-commit',
+        dirtySuiteCommit,
+      ], { cwd: targetRoot }),
+      /suite evidence files must be committed and clean before the evidence run/,
     );
   } finally {
     await rm(temp, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- add a portable clean-room starter pack for an independently operated `anchor-x402` conformance run
- bind the suite and target to exact Git commits and emit JSON, JUnit, receipt, and bounded adopter-context artifacts
- keep the target offline and no-spend, with explicit no-network/no-secret/no-signature/no-production-compatibility claim boundaries
- add regression coverage for all 42 vectors, fail-closed malformed/unknown inputs, source independence, commit binding, deterministic artifacts, receipt verification, and output-path confinement

## Evidence boundary
Agoragentic authored this starter. It is not external-adopter evidence and does not satisfy #246 until the anchor-x402 operator reviews and commits the pack in an operator-controlled repository, runs this exact suite head, publishes the bounded artifacts, and reports actionable observations. No payment is requested or authorized. No source was copied from `chico10117/basepay-readiness-service`.

## Validation
- `npm run check`
- `npm test` (65/65)
- `npm run self-test`
- `npm run pack:dry`
- committed-tree one-command adopter run: 42/42, receipt verified
- `node scripts/verify-doc-links.mjs`
- `node --test test/verify-doc-links.test.mjs`
- `node scripts/verify-integrations-json.js`
- `git diff --cached --check`

Closes no issue; #246 remains open pending independent operator evidence.