### PR TITLE
feat(transaction-assurance): add generated host skill

### DIFF
--- a/.agents/skills/agoragentic-assure/SKILL.md
+++ b/.agents/skills/agoragentic-assure/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: agoragentic-assure
+description: Prepare and evaluate an autonomous agent transaction without self-granting authority or moving money. Use for bounded authority requests, pre-execution checks, payment and delivery evidence, safe retry decisions, outcome verification, and reconciliation.
+---
+
+# Agoragentic Transaction Assurance
+
+Use the source-only `@agoragentic/transaction-assurance` package when an agent must bind principal authority, seller terms, payment evidence, execution, delivered outcome, and reconciliation.
+
+## Contract Pin
+
+- package: `@agoragentic/transaction-assurance`
+- version: `0.2.0-alpha.0`
+- source: `transaction-assurance`
+- authority schema: `transaction-assurance/schema/normalized-authority.v1.json`
+- evaluation schema: `transaction-assurance/schema/transaction-assurance-evaluation.v1.json`
+- network calls: none
+- authority granted by installation or evaluation: false
+
+The package is unpublished source-only alpha software. Do not substitute an npm registry package or claim registry availability.
+
+## Install And Prove Locally
+
+After approval to add local source files and dependencies:
+
+```bash
+git clone --depth 1 https://github.com/rhein1/agoragentic-integrations.git
+cd agoragentic-integrations/transaction-assurance
+npm ci
+npm run self-test
+```
+
+The self-test is local and no-spend. It requires no wallet, API key, payment method, provider call, or hosted authority.
+
+## Workflow
+
+1. Inspect the authority artifact and current rail/platform availability.
+2. Detect the protocol family without treating recognition as verification.
+3. Normalize the artifact conservatively; missing verifier evidence remains `unverified`.
+4. Prepare a proposal-only authority request for the principal.
+5. Build and evaluate a pre-execution envelope.
+6. Stop when authority, identity, terms, amount, rail, expiry, revocation, or replay evidence is missing.
+7. Execute only through a separately authorized host or rail; this skill never executes or pays.
+8. Bind returned payment, execution, outcome, and reconciliation evidence, then evaluate post-execution.
+
+## Owner Handoff
+
+The approval packet must state the purpose, exact actions, seller/category/rail/currency scope, per-action/daily/total limits, expiry, revocation behavior, data shared, expected evidence, reconciliation path, wallet requirement, risks, blocked actions, and approve/edit/reject choices. It must not contain secrets or raw private payloads.
+
+An agent may prepare this packet. It may not approve itself, broaden scope, raise a budget, invent verifier evidence, retry an ambiguous paid action blindly, or claim a complete chain while evidence is missing.
+
+## Required Result
+
+Report protocol verification, authority, terms, payment, execution, outcome, outcome verification, reconciliation, blockers, unknowns, and the next safe action. Always state:
+
+```text
+Authority granted by this report: false
+```
+
+## Advanced Context
+
+- package and API: <https://github.com/rhein1/agoragentic-integrations/tree/main/transaction-assurance>
+- transaction setup: <https://agoragentic.com/agent-setup.md>
+- agent bootstrap: <https://agoragentic.com/agent-bootstrap.json>
+- x402 evidence: <https://github.com/rhein1/agoragentic-integrations/tree/main/x402>
+- hosted Interchange: <https://github.com/rhein1/agoragentic-integrations/tree/main/interchange>

--- a/.agents/skills/agoragentic/SKILL.md
+++ b/.agents/skills/agoragentic/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agoragentic
-description: Route an Agoragentic task to the smallest applicable skill. Use when the request involves Agoragentic execution, governance, proof/receipts, deployment, selling, or integration and the correct branch is not yet known.
+description: Route an Agoragentic task to the smallest applicable skill. Use when the request involves Agoragentic execution, governance, transaction assurance, proof/receipts, deployment, selling, or integration and the correct branch is not yet known.
 ---
 
 # Agoragentic Router
@@ -10,6 +10,7 @@ Load only the smallest skill that matches the requested job:
 - **agoragentic-execute** — preview or execute a bounded capability after explicit approval.
 - **agoragentic-govern** — classify side effects, apply policy, and prepare approvals before action.
 - **agoragentic-prove** — create or inspect local proof, receipts, evidence references, and reconciliation state.
+- **agoragentic-assure** — prepare and evaluate an agent transaction without self-granting authority or moving money.
 - **agoragentic-deploy** — prepare Agent OS / Harness deployment-readiness handoffs without provisioning implicitly.
 - **agoragentic-sell** — prepare listing/payment readiness without publishing, funding, or activating settlement automatically.
 - **agoragentic-integrate** — connect an external host, framework, tool, or specialist engine to Harness governance and receipts.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
   "name": "agoragentic-integrations",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Community-maintained Claude Code plugins for Triptych OS (Agent OS) integration.",
   "owner": {
     "name": "Agoragentic",
@@ -11,8 +11,8 @@
     {
       "name": "agoragentic",
       "displayName": "Agoragentic",
-      "description": "Connect Claude Code to Triptych OS through a generated router and focused execution, governance, proof, deployment, selling, and integration skills.",
-      "version": "1.1.0",
+      "description": "Connect Claude Code to Triptych OS through a generated router and focused execution, governance, transaction assurance, proof, deployment, selling, and integration skills.",
+      "version": "1.2.0",
       "author": {
         "name": "Agoragentic",
         "email": "support@agoragentic.com"

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "agoragentic",
   "displayName": "Agoragentic",
-  "version": "1.1.0",
-  "description": "Connect Cursor to Triptych OS (Agent OS) through generated focused skills, no-spend previews, governed routing, and receipt evidence.",
+  "version": "1.2.0",
+  "description": "Connect Cursor to Triptych OS (Agent OS) through generated focused skills, no-spend transaction assurance, governed routing, and receipt evidence.",
   "author": {
     "name": "Agoragentic",
     "email": "support@agoragentic.com"

--- a/.cursor/rules/agoragentic-assure.mdc
+++ b/.cursor/rules/agoragentic-assure.mdc
@@ -1,0 +1,68 @@
+---
+description: "Prepare and evaluate an autonomous agent transaction without self-granting authority or moving money. Use for bounded authority requests, pre-execution checks, payment and delivery evidence, safe retry decisions, outcome verification, and reconciliation."
+globs:
+alwaysApply: false
+---
+
+
+# Agoragentic Transaction Assurance
+
+Use the source-only `@agoragentic/transaction-assurance` package when an agent must bind principal authority, seller terms, payment evidence, execution, delivered outcome, and reconciliation.
+
+## Contract Pin
+
+- package: `@agoragentic/transaction-assurance`
+- version: `0.2.0-alpha.0`
+- source: `transaction-assurance`
+- authority schema: `transaction-assurance/schema/normalized-authority.v1.json`
+- evaluation schema: `transaction-assurance/schema/transaction-assurance-evaluation.v1.json`
+- network calls: none
+- authority granted by installation or evaluation: false
+
+The package is unpublished source-only alpha software. Do not substitute an npm registry package or claim registry availability.
+
+## Install And Prove Locally
+
+After approval to add local source files and dependencies:
+
+```bash
+git clone --depth 1 https://github.com/rhein1/agoragentic-integrations.git
+cd agoragentic-integrations/transaction-assurance
+npm ci
+npm run self-test
+```
+
+The self-test is local and no-spend. It requires no wallet, API key, payment method, provider call, or hosted authority.
+
+## Workflow
+
+1. Inspect the authority artifact and current rail/platform availability.
+2. Detect the protocol family without treating recognition as verification.
+3. Normalize the artifact conservatively; missing verifier evidence remains `unverified`.
+4. Prepare a proposal-only authority request for the principal.
+5. Build and evaluate a pre-execution envelope.
+6. Stop when authority, identity, terms, amount, rail, expiry, revocation, or replay evidence is missing.
+7. Execute only through a separately authorized host or rail; this skill never executes or pays.
+8. Bind returned payment, execution, outcome, and reconciliation evidence, then evaluate post-execution.
+
+## Owner Handoff
+
+The approval packet must state the purpose, exact actions, seller/category/rail/currency scope, per-action/daily/total limits, expiry, revocation behavior, data shared, expected evidence, reconciliation path, wallet requirement, risks, blocked actions, and approve/edit/reject choices. It must not contain secrets or raw private payloads.
+
+An agent may prepare this packet. It may not approve itself, broaden scope, raise a budget, invent verifier evidence, retry an ambiguous paid action blindly, or claim a complete chain while evidence is missing.
+
+## Required Result
+
+Report protocol verification, authority, terms, payment, execution, outcome, outcome verification, reconciliation, blockers, unknowns, and the next safe action. Always state:
+
+```text
+Authority granted by this report: false
+```
+
+## Advanced Context
+
+- package and API: <https://github.com/rhein1/agoragentic-integrations/tree/main/transaction-assurance>
+- transaction setup: <https://agoragentic.com/agent-setup.md>
+- agent bootstrap: <https://agoragentic.com/agent-bootstrap.json>
+- x402 evidence: <https://github.com/rhein1/agoragentic-integrations/tree/main/x402>
+- hosted Interchange: <https://github.com/rhein1/agoragentic-integrations/tree/main/interchange>

--- a/.cursor/rules/agoragentic.mdc
+++ b/.cursor/rules/agoragentic.mdc
@@ -1,5 +1,5 @@
 ---
-description: "Route an Agoragentic task to the smallest applicable skill. Use when the request involves Agoragentic execution, governance, proof/receipts, deployment, selling, or integration and the correct branch is not yet known."
+description: "Route an Agoragentic task to the smallest applicable skill. Use when the request involves Agoragentic execution, governance, transaction assurance, proof/receipts, deployment, selling, or integration and the correct branch is not yet known."
 globs:
 alwaysApply: false
 ---
@@ -12,6 +12,7 @@ Load only the smallest skill that matches the requested job:
 - **agoragentic-execute** — preview or execute a bounded capability after explicit approval.
 - **agoragentic-govern** — classify side effects, apply policy, and prepare approvals before action.
 - **agoragentic-prove** — create or inspect local proof, receipts, evidence references, and reconciliation state.
+- **agoragentic-assure** — prepare and evaluate an agent transaction without self-granting authority or moving money.
 - **agoragentic-deploy** — prepare Agent OS / Harness deployment-readiness handoffs without provisioning implicitly.
 - **agoragentic-sell** — prepare listing/payment readiness without publishing, funding, or activating settlement automatically.
 - **agoragentic-integrate** — connect an external host, framework, tool, or specialist engine to Harness governance and receipts.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,10 +2,11 @@
 
 This GitHub Copilot surface uses Agoragentic Skill Pack v2. For an Agoragentic request, load or read only the smallest matching skill before acting:
 
-- `agoragentic`: Route an Agoragentic task to the smallest applicable skill. Use when the request involves Agoragentic execution, governance, proof/receipts, deployment, selling, or integration and the correct branch is not yet known.
+- `agoragentic`: Route an Agoragentic task to the smallest applicable skill. Use when the request involves Agoragentic execution, governance, transaction assurance, proof/receipts, deployment, selling, or integration and the correct branch is not yet known.
 - `agoragentic-execute`: Preview and execute a bounded Agoragentic capability after explicit owner or host approval. Use for task routing, capability matching, execution constraints, and invocation/receipt capture.
 - `agoragentic-govern`: Apply Agoragentic local governance before an agent performs side effects. Use for policy checks, approval packets, authority boundaries, and no-spend Harness or ECF preparation.
 - `agoragentic-prove`: Produce or inspect Agoragentic local proof and receipt evidence for an agent run. Use for evidence refs, hashes, run status, policy decisions, approval linkage, and reconciliation.
+- `agoragentic-assure`: Prepare and evaluate an autonomous agent transaction without self-granting authority or moving money. Use for bounded authority requests, pre-execution checks, payment and delivery evidence, safe retry decisions, outcome verification, and reconciliation. Contract pin: `@agoragentic/transaction-assurance` `0.2.0-alpha.0`; source `transaction-assurance`; schemas `transaction-assurance/schema/normalized-authority.v1.json`, `transaction-assurance/schema/transaction-assurance-evaluation.v1.json`; network `none`; authority granted `false`.
 - `agoragentic-deploy`: Prepare a bounded Agoragentic deployment handoff or preview. Use for Agent OS export, deployment-readiness evidence, runtime probes, and owner-approved transition from local proof to hosted operation.
 - `agoragentic-sell`: Prepare an Agoragentic capability for commercial listing or paid routing. Use for listing readiness, pricing/payment metadata checks, seller evidence, and marketplace handoff without publishing or spending automatically.
 - `agoragentic-integrate`: Connect an external agent host, framework, tool, or specialist engine to Agoragentic governance and receipts. Use for adapters, lifecycle mapping, MCP/tool discovery, and bounded integration design.

--- a/.opencode/skills/agoragentic-assure/SKILL.md
+++ b/.opencode/skills/agoragentic-assure/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: agoragentic-assure
+description: Prepare and evaluate an autonomous agent transaction without self-granting authority or moving money. Use for bounded authority requests, pre-execution checks, payment and delivery evidence, safe retry decisions, outcome verification, and reconciliation.
+---
+
+# Agoragentic Transaction Assurance
+
+Use the source-only `@agoragentic/transaction-assurance` package when an agent must bind principal authority, seller terms, payment evidence, execution, delivered outcome, and reconciliation.
+
+## Contract Pin
+
+- package: `@agoragentic/transaction-assurance`
+- version: `0.2.0-alpha.0`
+- source: `transaction-assurance`
+- authority schema: `transaction-assurance/schema/normalized-authority.v1.json`
+- evaluation schema: `transaction-assurance/schema/transaction-assurance-evaluation.v1.json`
+- network calls: none
+- authority granted by installation or evaluation: false
+
+The package is unpublished source-only alpha software. Do not substitute an npm registry package or claim registry availability.
+
+## Install And Prove Locally
+
+After approval to add local source files and dependencies:
+
+```bash
+git clone --depth 1 https://github.com/rhein1/agoragentic-integrations.git
+cd agoragentic-integrations/transaction-assurance
+npm ci
+npm run self-test
+```
+
+The self-test is local and no-spend. It requires no wallet, API key, payment method, provider call, or hosted authority.
+
+## Workflow
+
+1. Inspect the authority artifact and current rail/platform availability.
+2. Detect the protocol family without treating recognition as verification.
+3. Normalize the artifact conservatively; missing verifier evidence remains `unverified`.
+4. Prepare a proposal-only authority request for the principal.
+5. Build and evaluate a pre-execution envelope.
+6. Stop when authority, identity, terms, amount, rail, expiry, revocation, or replay evidence is missing.
+7. Execute only through a separately authorized host or rail; this skill never executes or pays.
+8. Bind returned payment, execution, outcome, and reconciliation evidence, then evaluate post-execution.
+
+## Owner Handoff
+
+The approval packet must state the purpose, exact actions, seller/category/rail/currency scope, per-action/daily/total limits, expiry, revocation behavior, data shared, expected evidence, reconciliation path, wallet requirement, risks, blocked actions, and approve/edit/reject choices. It must not contain secrets or raw private payloads.
+
+An agent may prepare this packet. It may not approve itself, broaden scope, raise a budget, invent verifier evidence, retry an ambiguous paid action blindly, or claim a complete chain while evidence is missing.
+
+## Required Result
+
+Report protocol verification, authority, terms, payment, execution, outcome, outcome verification, reconciliation, blockers, unknowns, and the next safe action. Always state:
+
+```text
+Authority granted by this report: false
+```
+
+## Advanced Context
+
+- package and API: <https://github.com/rhein1/agoragentic-integrations/tree/main/transaction-assurance>
+- transaction setup: <https://agoragentic.com/agent-setup.md>
+- agent bootstrap: <https://agoragentic.com/agent-bootstrap.json>
+- x402 evidence: <https://github.com/rhein1/agoragentic-integrations/tree/main/x402>
+- hosted Interchange: <https://github.com/rhein1/agoragentic-integrations/tree/main/interchange>

--- a/.opencode/skills/agoragentic/SKILL.md
+++ b/.opencode/skills/agoragentic/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agoragentic
-description: Route an Agoragentic task to the smallest applicable skill. Use when the request involves Agoragentic execution, governance, proof/receipts, deployment, selling, or integration and the correct branch is not yet known.
+description: Route an Agoragentic task to the smallest applicable skill. Use when the request involves Agoragentic execution, governance, transaction assurance, proof/receipts, deployment, selling, or integration and the correct branch is not yet known.
 ---
 
 # Agoragentic Router
@@ -10,6 +10,7 @@ Load only the smallest skill that matches the requested job:
 - **agoragentic-execute** — preview or execute a bounded capability after explicit approval.
 - **agoragentic-govern** — classify side effects, apply policy, and prepare approvals before action.
 - **agoragentic-prove** — create or inspect local proof, receipts, evidence references, and reconciliation state.
+- **agoragentic-assure** — prepare and evaluate an agent transaction without self-granting authority or moving money.
 - **agoragentic-deploy** — prepare Agent OS / Harness deployment-readiness handoffs without provisioning implicitly.
 - **agoragentic-sell** — prepare listing/payment readiness without publishing, funding, or activating settlement automatically.
 - **agoragentic-integrate** — connect an external host, framework, tool, or specialist engine to Harness governance and receipts.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -2,10 +2,11 @@
 
 This Gemini CLI surface uses Agoragentic Skill Pack v2. For an Agoragentic request, load or read only the smallest matching skill before acting:
 
-- `agoragentic`: Route an Agoragentic task to the smallest applicable skill. Use when the request involves Agoragentic execution, governance, proof/receipts, deployment, selling, or integration and the correct branch is not yet known.
+- `agoragentic`: Route an Agoragentic task to the smallest applicable skill. Use when the request involves Agoragentic execution, governance, transaction assurance, proof/receipts, deployment, selling, or integration and the correct branch is not yet known.
 - `agoragentic-execute`: Preview and execute a bounded Agoragentic capability after explicit owner or host approval. Use for task routing, capability matching, execution constraints, and invocation/receipt capture.
 - `agoragentic-govern`: Apply Agoragentic local governance before an agent performs side effects. Use for policy checks, approval packets, authority boundaries, and no-spend Harness or ECF preparation.
 - `agoragentic-prove`: Produce or inspect Agoragentic local proof and receipt evidence for an agent run. Use for evidence refs, hashes, run status, policy decisions, approval linkage, and reconciliation.
+- `agoragentic-assure`: Prepare and evaluate an autonomous agent transaction without self-granting authority or moving money. Use for bounded authority requests, pre-execution checks, payment and delivery evidence, safe retry decisions, outcome verification, and reconciliation. Contract pin: `@agoragentic/transaction-assurance` `0.2.0-alpha.0`; source `transaction-assurance`; schemas `transaction-assurance/schema/normalized-authority.v1.json`, `transaction-assurance/schema/transaction-assurance-evaluation.v1.json`; network `none`; authority granted `false`.
 - `agoragentic-deploy`: Prepare a bounded Agoragentic deployment handoff or preview. Use for Agent OS export, deployment-readiness evidence, runtime probes, and owner-approved transition from local proof to hosted operation.
 - `agoragentic-sell`: Prepare an Agoragentic capability for commercial listing or paid routing. Use for listing readiness, pricing/payment metadata checks, seller evidence, and marketplace handoff without publishing or spending automatically.
 - `agoragentic-integrate`: Connect an external agent host, framework, tool, or specialist engine to Agoragentic governance and receipts. Use for adapters, lifecycle mapping, MCP/tool discovery, and bounded integration design.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agoragentic
-description: Route an Agoragentic task to the smallest applicable skill. Use when the request involves Agoragentic execution, governance, proof/receipts, deployment, selling, or integration and the correct branch is not yet known.
+description: Route an Agoragentic task to the smallest applicable skill. Use when the request involves Agoragentic execution, governance, transaction assurance, proof/receipts, deployment, selling, or integration and the correct branch is not yet known.
 ---
 
 # Agoragentic Router
@@ -10,6 +10,7 @@ Load only the smallest skill that matches the requested job:
 - **agoragentic-execute** — preview or execute a bounded capability after explicit approval.
 - **agoragentic-govern** — classify side effects, apply policy, and prepare approvals before action.
 - **agoragentic-prove** — create or inspect local proof, receipts, evidence references, and reconciliation state.
+- **agoragentic-assure** — prepare and evaluate an agent transaction without self-granting authority or moving money.
 - **agoragentic-deploy** — prepare Agent OS / Harness deployment-readiness handoffs without provisioning implicitly.
 - **agoragentic-sell** — prepare listing/payment readiness without publishing, funding, or activating settlement automatically.
 - **agoragentic-integrate** — connect an external host, framework, tool, or specialist engine to Harness governance and receipts.

--- a/claude-code/plugin/.claude-plugin/plugin.json
+++ b/claude-code/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agoragentic",
-  "version": "1.1.0",
-  "description": "Connect Claude Code to Triptych OS through a generated router and focused execution, governance, proof, deployment, selling, and integration skills.",
+  "version": "1.2.0",
+  "description": "Connect Claude Code to Triptych OS through a generated router and focused execution, governance, transaction assurance, proof, deployment, selling, and integration skills.",
   "author": {
     "name": "Agoragentic",
     "email": "support@agoragentic.com"

--- a/claude-code/plugin/skills/agoragentic-assure/SKILL.md
+++ b/claude-code/plugin/skills/agoragentic-assure/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: agoragentic-assure
+description: Prepare and evaluate an autonomous agent transaction without self-granting authority or moving money. Use for bounded authority requests, pre-execution checks, payment and delivery evidence, safe retry decisions, outcome verification, and reconciliation.
+---
+
+# Agoragentic Transaction Assurance
+
+Use the source-only `@agoragentic/transaction-assurance` package when an agent must bind principal authority, seller terms, payment evidence, execution, delivered outcome, and reconciliation.
+
+## Contract Pin
+
+- package: `@agoragentic/transaction-assurance`
+- version: `0.2.0-alpha.0`
+- source: `transaction-assurance`
+- authority schema: `transaction-assurance/schema/normalized-authority.v1.json`
+- evaluation schema: `transaction-assurance/schema/transaction-assurance-evaluation.v1.json`
+- network calls: none
+- authority granted by installation or evaluation: false
+
+The package is unpublished source-only alpha software. Do not substitute an npm registry package or claim registry availability.
+
+## Install And Prove Locally
+
+After approval to add local source files and dependencies:
+
+```bash
+git clone --depth 1 https://github.com/rhein1/agoragentic-integrations.git
+cd agoragentic-integrations/transaction-assurance
+npm ci
+npm run self-test
+```
+
+The self-test is local and no-spend. It requires no wallet, API key, payment method, provider call, or hosted authority.
+
+## Workflow
+
+1. Inspect the authority artifact and current rail/platform availability.
+2. Detect the protocol family without treating recognition as verification.
+3. Normalize the artifact conservatively; missing verifier evidence remains `unverified`.
+4. Prepare a proposal-only authority request for the principal.
+5. Build and evaluate a pre-execution envelope.
+6. Stop when authority, identity, terms, amount, rail, expiry, revocation, or replay evidence is missing.
+7. Execute only through a separately authorized host or rail; this skill never executes or pays.
+8. Bind returned payment, execution, outcome, and reconciliation evidence, then evaluate post-execution.
+
+## Owner Handoff
+
+The approval packet must state the purpose, exact actions, seller/category/rail/currency scope, per-action/daily/total limits, expiry, revocation behavior, data shared, expected evidence, reconciliation path, wallet requirement, risks, blocked actions, and approve/edit/reject choices. It must not contain secrets or raw private payloads.
+
+An agent may prepare this packet. It may not approve itself, broaden scope, raise a budget, invent verifier evidence, retry an ambiguous paid action blindly, or claim a complete chain while evidence is missing.
+
+## Required Result
+
+Report protocol verification, authority, terms, payment, execution, outcome, outcome verification, reconciliation, blockers, unknowns, and the next safe action. Always state:
+
+```text
+Authority granted by this report: false
+```
+
+## Advanced Context
+
+- package and API: <https://github.com/rhein1/agoragentic-integrations/tree/main/transaction-assurance>
+- transaction setup: <https://agoragentic.com/agent-setup.md>
+- agent bootstrap: <https://agoragentic.com/agent-bootstrap.json>
+- x402 evidence: <https://github.com/rhein1/agoragentic-integrations/tree/main/x402>
+- hosted Interchange: <https://github.com/rhein1/agoragentic-integrations/tree/main/interchange>

--- a/claude-code/plugin/skills/agoragentic/SKILL.md
+++ b/claude-code/plugin/skills/agoragentic/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agoragentic
-description: Route an Agoragentic task to the smallest applicable skill. Use when the request involves Agoragentic execution, governance, proof/receipts, deployment, selling, or integration and the correct branch is not yet known.
+description: Route an Agoragentic task to the smallest applicable skill. Use when the request involves Agoragentic execution, governance, transaction assurance, proof/receipts, deployment, selling, or integration and the correct branch is not yet known.
 ---
 
 # Agoragentic Router
@@ -10,6 +10,7 @@ Load only the smallest skill that matches the requested job:
 - **agoragentic-execute** — preview or execute a bounded capability after explicit approval.
 - **agoragentic-govern** — classify side effects, apply policy, and prepare approvals before action.
 - **agoragentic-prove** — create or inspect local proof, receipts, evidence references, and reconciliation state.
+- **agoragentic-assure** — prepare and evaluate an agent transaction without self-granting authority or moving money.
 - **agoragentic-deploy** — prepare Agent OS / Harness deployment-readiness handoffs without provisioning implicitly.
 - **agoragentic-sell** — prepare listing/payment readiness without publishing, funding, or activating settlement automatically.
 - **agoragentic-integrate** — connect an external host, framework, tool, or specialist engine to Harness governance and receipts.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "agoragentic",
-  "version": "1.1.0",
-  "description": "Connect Gemini CLI to Triptych OS (Agent OS) through a generated router and focused execution, governance, proof, deployment, selling, and integration skills.",
+  "version": "1.2.0",
+  "description": "Connect Gemini CLI to Triptych OS (Agent OS) through a generated router and focused execution, governance, transaction assurance, proof, deployment, selling, and integration skills.",
   "mcpServers": {
     "agoragentic": {
       "command": "npx",

--- a/integrations.json
+++ b/integrations.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.41.0",
-  "updated_at": "2026-08-09",
+  "version": "2.42.0",
+  "updated_at": "2026-08-11",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
   "packages": {
@@ -1520,6 +1520,10 @@
     "buzz_signed_workspace_evidence_provenance": "examples/buzz-signed-workspace-evidence/upstream-provenance.json",
     "anydoc_document_evidence": "examples/anydoc-document-evidence/README.md",
     "anydoc_document_evidence_adapter": "examples/anydoc-document-evidence/agoragentic-anydoc.mjs",
-    "anydoc_semantic_conformance": "examples/anydoc-document-evidence/conformance/README.md"
+    "anydoc_semantic_conformance": "examples/anydoc-document-evidence/conformance/README.md",
+    "transaction_assurance_source": "transaction-assurance/README.md",
+    "transaction_assurance_skill": "skills/agoragentic-assure/SKILL.md",
+    "transaction_assurance_authority_schema": "transaction-assurance/schema/normalized-authority.v1.json",
+    "transaction_assurance_evaluation_schema": "transaction-assurance/schema/transaction-assurance-evaluation.v1.json"
   }
 }

--- a/scripts/generate-skill-pack.mjs
+++ b/scripts/generate-skill-pack.mjs
@@ -41,7 +41,12 @@ function loadManifest() {
 
 function renderRouter(title, host, skills) {
   const entries = skills
-    .map(({ id, parsed }) => `- \`${id}\`: ${parsed.fields.description}`)
+    .map(({ id, parsed, contract }) => {
+      const contractPin = contract
+        ? ` Contract pin: \`${contract.package}\` \`${contract.version}\`; source \`${contract.source}\`; schemas ${contract.schemas.map((schema) => `\`${schema}\``).join(', ')}; network \`${contract.network}\`; authority granted \`${contract.authority_granted}\`.`
+        : '';
+      return `- \`${id}\`: ${parsed.fields.description}${contractPin}`;
+    })
     .join('\n');
   return `# ${title}\n\nThis ${host} surface uses Agoragentic Skill Pack v2. For an Agoragentic request, load or read only the smallest matching skill before acting:\n\n${entries}\n\nStart with \`agoragentic\` when the route is unclear. Preview first for any action that may spend, publish, deploy, message, mutate trust, store credentials, or change hosted state. Missing policy, identity, cost, approval, or evidence means blocked. These instructions grant no authority by themselves.\n`;
 }
@@ -69,6 +74,20 @@ export function buildExpectedOutputs(manifest = loadManifest()) {
     seen.add(entry.id);
     assert.equal(entry.source, `skills/${entry.id}/SKILL.md`);
     assert.ok(Array.isArray(entry.advanced_context) && entry.advanced_context.length > 0);
+    if (entry.contract) {
+      assert.match(entry.contract.package || '', /^@[a-z0-9-]+\/[a-z0-9-]+$/);
+      assert.match(entry.contract.version || '', /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);
+      assert.match(entry.contract.source || '', /^[a-z0-9][a-z0-9/-]*$/);
+      assert.equal(entry.contract.network, 'none');
+      assert.equal(entry.contract.authority_granted, false);
+      assert.ok(Array.isArray(entry.contract.schemas) && entry.contract.schemas.length > 0);
+      const packageJson = JSON.parse(readText(`${entry.contract.source}/package.json`));
+      assert.equal(packageJson.name, entry.contract.package, `${entry.id}: package name drift`);
+      assert.equal(packageJson.version, entry.contract.version, `${entry.id}: package version drift`);
+      for (const schema of entry.contract.schemas) {
+        assert.ok(fs.existsSync(path.join(root, schema)), `${entry.id}: missing schema ${schema}`);
+      }
+    }
     const parsed = parseSkill(readText(entry.source), entry.id);
     assert.match(parsed.body, /## Advanced Context/);
     return { ...entry, parsed };

--- a/skills/README.md
+++ b/skills/README.md
@@ -21,7 +21,7 @@ npx skills add rhein1/agoragentic-integrations --skill agoragentic
 Install the complete focused pack:
 
 ```bash
-npx skills add rhein1/agoragentic-integrations --full-depth --skill agoragentic --skill agoragentic-execute --skill agoragentic-govern --skill agoragentic-prove --skill agoragentic-deploy --skill agoragentic-sell --skill agoragentic-integrate
+npx skills add rhein1/agoragentic-integrations --full-depth --skill agoragentic --skill agoragentic-execute --skill agoragentic-govern --skill agoragentic-prove --skill agoragentic-assure --skill agoragentic-deploy --skill agoragentic-sell --skill agoragentic-integrate
 ```
 
 Choose a host explicitly with `--agent codex`, `--agent claude-code`, `--agent cursor`, `--agent opencode`, `--agent github-copilot`, or another skills.sh-supported Agent Skills host. Installation does not configure credentials or grant spend, deployment, publication, or trust authority.
@@ -30,10 +30,11 @@ Choose a host explicitly with `--agent codex`, `--agent claude-code`, `--agent c
 
 | Skill | Purpose |
 |---|---|
-| `agoragentic` | Route an Agoragentic task to the smallest applicable skill. Use when the request involves Agoragentic execution, governance, proof/receipts, deployment, selling, or integration and the correct branch is not yet known. |
+| `agoragentic` | Route an Agoragentic task to the smallest applicable skill. Use when the request involves Agoragentic execution, governance, transaction assurance, proof/receipts, deployment, selling, or integration and the correct branch is not yet known. |
 | `agoragentic-execute` | Preview and execute a bounded Agoragentic capability after explicit owner or host approval. Use for task routing, capability matching, execution constraints, and invocation/receipt capture. |
 | `agoragentic-govern` | Apply Agoragentic local governance before an agent performs side effects. Use for policy checks, approval packets, authority boundaries, and no-spend Harness or ECF preparation. |
 | `agoragentic-prove` | Produce or inspect Agoragentic local proof and receipt evidence for an agent run. Use for evidence refs, hashes, run status, policy decisions, approval linkage, and reconciliation. |
+| `agoragentic-assure` | Prepare and evaluate an autonomous agent transaction without self-granting authority or moving money. Use for bounded authority requests, pre-execution checks, payment and delivery evidence, safe retry decisions, outcome verification, and reconciliation. |
 | `agoragentic-deploy` | Prepare a bounded Agoragentic deployment handoff or preview. Use for Agent OS export, deployment-readiness evidence, runtime probes, and owner-approved transition from local proof to hosted operation. |
 | `agoragentic-sell` | Prepare an Agoragentic capability for commercial listing or paid routing. Use for listing readiness, pricing/payment metadata checks, seller evidence, and marketplace handoff without publishing or spending automatically. |
 | `agoragentic-integrate` | Connect an external agent host, framework, tool, or specialist engine to Agoragentic governance and receipts. Use for adapters, lifecycle mapping, MCP/tool discovery, and bounded integration design. |

--- a/skills/agoragentic-assure/SKILL.md
+++ b/skills/agoragentic-assure/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: agoragentic-assure
+description: Prepare and evaluate an autonomous agent transaction without self-granting authority or moving money. Use for bounded authority requests, pre-execution checks, payment and delivery evidence, safe retry decisions, outcome verification, and reconciliation.
+---
+
+# Agoragentic Transaction Assurance
+
+Use the source-only `@agoragentic/transaction-assurance` package when an agent must bind principal authority, seller terms, payment evidence, execution, delivered outcome, and reconciliation.
+
+## Contract Pin
+
+- package: `@agoragentic/transaction-assurance`
+- version: `0.2.0-alpha.0`
+- source: `transaction-assurance`
+- authority schema: `transaction-assurance/schema/normalized-authority.v1.json`
+- evaluation schema: `transaction-assurance/schema/transaction-assurance-evaluation.v1.json`
+- network calls: none
+- authority granted by installation or evaluation: false
+
+The package is unpublished source-only alpha software. Do not substitute an npm registry package or claim registry availability.
+
+## Install And Prove Locally
+
+After approval to add local source files and dependencies:
+
+```bash
+git clone --depth 1 https://github.com/rhein1/agoragentic-integrations.git
+cd agoragentic-integrations/transaction-assurance
+npm ci
+npm run self-test
+```
+
+The self-test is local and no-spend. It requires no wallet, API key, payment method, provider call, or hosted authority.
+
+## Workflow
+
+1. Inspect the authority artifact and current rail/platform availability.
+2. Detect the protocol family without treating recognition as verification.
+3. Normalize the artifact conservatively; missing verifier evidence remains `unverified`.
+4. Prepare a proposal-only authority request for the principal.
+5. Build and evaluate a pre-execution envelope.
+6. Stop when authority, identity, terms, amount, rail, expiry, revocation, or replay evidence is missing.
+7. Execute only through a separately authorized host or rail; this skill never executes or pays.
+8. Bind returned payment, execution, outcome, and reconciliation evidence, then evaluate post-execution.
+
+## Owner Handoff
+
+The approval packet must state the purpose, exact actions, seller/category/rail/currency scope, per-action/daily/total limits, expiry, revocation behavior, data shared, expected evidence, reconciliation path, wallet requirement, risks, blocked actions, and approve/edit/reject choices. It must not contain secrets or raw private payloads.
+
+An agent may prepare this packet. It may not approve itself, broaden scope, raise a budget, invent verifier evidence, retry an ambiguous paid action blindly, or claim a complete chain while evidence is missing.
+
+## Required Result
+
+Report protocol verification, authority, terms, payment, execution, outcome, outcome verification, reconciliation, blockers, unknowns, and the next safe action. Always state:
+
+```text
+Authority granted by this report: false
+```
+
+## Advanced Context
+
+- package and API: <https://github.com/rhein1/agoragentic-integrations/tree/main/transaction-assurance>
+- transaction setup: <https://agoragentic.com/agent-setup.md>
+- agent bootstrap: <https://agoragentic.com/agent-bootstrap.json>
+- x402 evidence: <https://github.com/rhein1/agoragentic-integrations/tree/main/x402>
+- hosted Interchange: <https://github.com/rhein1/agoragentic-integrations/tree/main/interchange>

--- a/skills/agoragentic/SKILL.md
+++ b/skills/agoragentic/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agoragentic
-description: Route an Agoragentic task to the smallest applicable skill. Use when the request involves Agoragentic execution, governance, proof/receipts, deployment, selling, or integration and the correct branch is not yet known.
+description: Route an Agoragentic task to the smallest applicable skill. Use when the request involves Agoragentic execution, governance, transaction assurance, proof/receipts, deployment, selling, or integration and the correct branch is not yet known.
 ---
 
 # Agoragentic Router
@@ -10,6 +10,7 @@ Load only the smallest skill that matches the requested job:
 - **agoragentic-execute** — preview or execute a bounded capability after explicit approval.
 - **agoragentic-govern** — classify side effects, apply policy, and prepare approvals before action.
 - **agoragentic-prove** — create or inspect local proof, receipts, evidence references, and reconciliation state.
+- **agoragentic-assure** — prepare and evaluate an agent transaction without self-granting authority or moving money.
 - **agoragentic-deploy** — prepare Agent OS / Harness deployment-readiness handoffs without provisioning implicitly.
 - **agoragentic-sell** — prepare listing/payment readiness without publishing, funding, or activating settlement automatically.
 - **agoragentic-integrate** — connect an external host, framework, tool, or specialist engine to Harness governance and receipts.

--- a/skills/skill-pack.v2.json
+++ b/skills/skill-pack.v2.json
@@ -1,6 +1,6 @@
 {
   "schema": "agoragentic.skill-pack.v2",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "canonical_root": "skills",
   "skills": [
     {
@@ -22,6 +22,22 @@
       "id": "agoragentic-prove",
       "source": "skills/agoragentic-prove/SKILL.md",
       "advanced_context": ["harness-core", "x402"]
+    },
+    {
+      "id": "agoragentic-assure",
+      "source": "skills/agoragentic-assure/SKILL.md",
+      "advanced_context": ["transaction-assurance", "x402", "interchange"],
+      "contract": {
+        "package": "@agoragentic/transaction-assurance",
+        "version": "0.2.0-alpha.0",
+        "source": "transaction-assurance",
+        "schemas": [
+          "transaction-assurance/schema/normalized-authority.v1.json",
+          "transaction-assurance/schema/transaction-assurance-evaluation.v1.json"
+        ],
+        "network": "none",
+        "authority_granted": false
+      }
     },
     {
       "id": "agoragentic-deploy",

--- a/test/skill-pack-generation.test.mjs
+++ b/test/skill-pack-generation.test.mjs
@@ -99,3 +99,29 @@ test('skills.sh instructions expose router-only and complete-pack installs', () 
   assert.match(readme, /npx skills add rhein1\/agoragentic-integrations --skill agoragentic/);
   for (const { id } of skills) assert.match(readme, new RegExp(`--skill ${id}(?:\\s|$)`));
 });
+
+test('transaction assurance host outputs share one package and schema contract', () => {
+  const { manifest, outputs, skills } = buildExpectedOutputs();
+  const assurance = skills.find(({ id }) => id === 'agoragentic-assure');
+  assert.ok(assurance?.contract);
+  const markers = [
+    assurance.contract.package,
+    assurance.contract.version,
+    assurance.contract.source,
+    ...assurance.contract.schemas,
+  ];
+  const hostFiles = [
+    `${manifest.targets.codex.root}/agoragentic-assure/SKILL.md`,
+    `${manifest.targets.claude_code.root}/agoragentic-assure/SKILL.md`,
+    `${manifest.targets.opencode.root}/agoragentic-assure/SKILL.md`,
+    `${manifest.targets.cursor.root}/agoragentic-assure.mdc`,
+    manifest.targets.github_copilot.path,
+    manifest.targets.gemini_cli.path,
+  ];
+  for (const relativePath of hostFiles) {
+    const content = outputs.get(relativePath);
+    assert.ok(content, relativePath);
+    for (const marker of markers) assert.ok(content.includes(marker), `${relativePath}: ${marker}`);
+    assert.match(content, /authority granted (?:by installation or evaluation: false|`false`)/i, relativePath);
+  }
+});

--- a/transaction-assurance/README.md
+++ b/transaction-assurance/README.md
@@ -51,6 +51,16 @@ This is a source-visible, unpublished alpha implementation.
 
 `package.json` remains `private: true` until review, conformance fixtures, provenance, and release ownership are complete.
 
+## Agent-host install path
+
+The focused `agoragentic-assure` Agent Skill is generated from one canonical source for Codex, Claude Code, OpenCode, Cursor, GitHub Copilot, and Gemini CLI. Install it with the source-visible skill pack:
+
+```bash
+npx skills add rhein1/agoragentic-integrations --full-depth --skill agoragentic-assure
+```
+
+The skill pins this package at `0.2.0-alpha.0` and points every host to the same normalized-authority and evaluation schemas. Installing the skill does not install a registry package, configure credentials, grant authority, call a provider, or move money. The local package remains source-only; clone this repository and run the five-minute self-test below when local evaluation code is needed.
+
 ## Vendor-neutral conformance suite
 
 The package includes an offline deterministic suite covering eight profiles:


### PR DESCRIPTION
## Summary
- add a focused goragentic-assure skill and generate one contract-pinned copy for Codex, Claude Code, OpenCode, Cursor, GitHub Copilot, and Gemini CLI
- bind every host surface to @agoragentic/transaction-assurance 