### PR TITLE
fix(transaction-assurance): address external adopter findings

### DIFF
--- a/integrations.json
+++ b/integrations.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.42.0",
-  "updated_at": "2026-08-11",
+  "version": "2.42.1",
+  "updated_at": "2026-08-12",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
   "packages": {
@@ -380,7 +380,7 @@
     {
       "directory": "transaction-assurance",
       "status": "unpublished_alpha",
-      "reason": "The source-only vendor-neutral conformance suite, four version-pinned protocol profiles, deterministic runner, reports, receipt verifier, examples, and reusable workflow are implemented. A real external adopter run is still required before public catalog inclusion or any ecosystem-standard claim.",
+      "reason": "A signed independent anchor-x402 run against pinned target and suite commits passed 42/42 with a publicly verified receipt, no network use, and no spend authority, and produced two actionable contract-clarity findings. This supplies the external evidence needed for maintainer review but excludes live compatibility; package publication, public catalog inclusion, and any ecosystem-standard claim remain separately review-gated.",
       "owner": "repository-maintainers",
       "tracking_ref": "https://github.com/rhein1/agoragentic-integrations/issues/246",
       "review_by": "2026-09-08",

--- a/transaction-assurance/CONFORMANCE.md
+++ b/transaction-assurance/CONFORMANCE.md
@@ -32,6 +32,14 @@ export async function evaluateTransactionAssuranceVector({ vector, input }) {
 
 The runner rejects extra result fields. It compares the target's exact decision and code with each vector's expected result. Target code runs in the caller's Node process; the suite does not sandbox it or prove that it avoided network or secret access.
 
+`pass` is a profile-scoped clean terminal decision, not a synonym for successful
+delivery. Callers must inspect the result code. `complete_chain_verified` means
+the paid execution and delivered outcome were verified;
+`reconciled_refunded` means payment was cleanly reversed; and
+`reconciled_dispute_resolved` means the dispute reached an explicit terminal
+resolution. The latter two do not claim that the buyer received the originally
+purchased outcome.
+
 Reference modules are included for:
 
 - an x402 resource server;
@@ -50,6 +58,16 @@ it is not external evidence until the independent operator reviews and commits
 the target in its own repository, runs it, and publishes the bounded artifacts
 plus actionable observations. The pack makes no network, payment, signature,
 live-settlement, or production-compatibility claim.
+
+The first independent run is published in the
+[`hypeprinter007-stack/anchor-x402-agoragentic-adopter`](https://github.com/hypeprinter007-stack/anchor-x402-agoragentic-adopter)
+repository. Its signed target commit is
+`13d6d70bb69cac2993753a22d423870bdfebe9a5`; artifacts are committed at
+`49634dd327eed9d3e03b5a51f510d15f04794c8a`; and the artifacts bind suite commit
+`607b3dddbc441fe52554b8842b9065e60131ae3b`. The run reports 42 passed and 0
+failed, a publicly verifiable receipt, no suite network use, and no spend
+authority. Its two actionable contract-clarity observations are recorded in
+[PR #297](https://github.com/rhein1/agoragentic-integrations/pull/297#issuecomment-5270120165).
 
 ## Reports and receipts
 
@@ -90,4 +108,9 @@ The called workflow checks out the caller repository and the pinned suite separa
 
 It may not be described as certified safe, universally trusted, fraud-proof, legally comprehensive, endorsed by Agoragentic or a protocol provider, or proof of live settlement or production compatibility.
 
-The suite must not be marketed as an ecosystem standard until an external adopter runs it and reports actionable failures. That external evidence is not present yet.
+The independent run supplies the first external-adopter evidence required for
+maintainer review of this offline alpha. It produced two actionable
+contract-clarity findings but zero failed vectors; maintainers must decide
+whether that satisfies issue #246's literal "actionable failures" wording. It
+does not authorize package publication, public catalog inclusion, an
+ecosystem-standard claim, or any live compatibility claim.

--- a/transaction-assurance/README.md
+++ b/transaction-assurance/README.md
@@ -47,7 +47,7 @@ This is a source-visible, unpublished alpha implementation.
 - hosted Agoragentic execution changes: none
 - marketplace catalog entry: intentionally deferred
 - vendor-neutral conformance suite: implemented as an offline source-only alpha
-- external adopter evidence: not yet obtained
+- external adopter evidence: one independent offline run at pinned target and suite commits; 42/42 with a verified receipt, no network, and no spend authority
 
 `package.json` remains `private: true` until review, conformance fixtures, provenance, and release ownership are complete.
 
@@ -98,6 +98,14 @@ node bin/verify-conformance-receipt.mjs \
 ```
 
 The runner itself makes no network calls and grants no authority. A target module is caller-supplied code and runs with the caller's process permissions; review it before execution. The bundled examples are reference contract fixtures, not external adoption evidence.
+
+The first independent adopter evidence is published by `anchor-x402` at target
+commit `13d6d70bb69cac2993753a22d423870bdfebe9a5`, with artifacts committed at
+`49634dd327eed9d3e03b5a51f510d15f04794c8a` and bound to suite commit
+`607b3dddbc441fe52554b8842b9065e60131ae3b`. The public verifier reports the
+receipt as valid. This is bounded offline conformance evidence only; it does not
+establish live settlement, production compatibility, certification,
+endorsement, or partnership.
 
 See [CONFORMANCE.md](CONFORMANCE.md) for the target-module contract, reusable workflow, version-pinned protocol profiles, and exact claim boundary. See [CONTRIBUTING_CONFORMANCE.md](CONTRIBUTING_CONFORMANCE.md) before proposing a fixture or adapter.
 

--- a/transaction-assurance/examples/external-adopters/anchor-x402/README.md
+++ b/transaction-assurance/examples/external-adopters/anchor-x402/README.md
@@ -7,6 +7,14 @@ evidence until the anchor-x402 operator reviews it, commits it in an
 operator-controlled repository, runs it there against an immutable suite
 commit, and publishes the bounded artifacts plus actionable observations.
 
+That independent run is now published at target commit
+[`13d6d70bb69cac2993753a22d423870bdfebe9a5`](https://github.com/hypeprinter007-stack/anchor-x402-agoragentic-adopter/commit/13d6d70bb69cac2993753a22d423870bdfebe9a5)
+with artifacts committed separately at
+[`49634dd327eed9d3e03b5a51f510d15f04794c8a`](https://github.com/hypeprinter007-stack/anchor-x402-agoragentic-adopter/commit/49634dd327eed9d3e03b5a51f510d15f04794c8a).
+The receipt verifies against suite commit `607b3dddbc441fe52554b8842b9065e60131ae3b`
+with 42 passed and 0 failed. This is offline conformance evidence, not live
+compatibility, certification, endorsement, or a partnership claim.
+
 No source was copied from `chico10117/basepay-readiness-service`; its public
 repository exposed no license when this starter was authored on 2026-08-11.
 This pack does not call that service or any anchor-x402 endpoint.
@@ -29,6 +37,29 @@ and privacy decisions. It intentionally does not:
 The protocol IDs in the normalized inputs identify the suite's pinned source
 vocabulary. Accepting those normalized inputs does not claim that anchor-x402
 implements each wire protocol.
+
+## Decision semantics
+
+`pass` means the vector reached the clean terminal state required by its named
+profile. The result code remains authoritative:
+
+- `complete_chain_verified` means the paid execution and delivered outcome were
+  verified through complete reconciliation;
+- `reconciled_refunded` means payment was cleanly reversed; and
+- `reconciled_dispute_resolved` means the dispute reached an explicit terminal
+  resolution.
+
+The last two do not claim that the buyer received the originally purchased
+outcome. Pending refunds, pending disputes, and incomplete reconciliation remain
+`review`.
+
+The starter still requires exact pinned versions for a `pass`. A recognized,
+well-formed newer version returns `review` only when it remains in the target's
+bounded compatibility line (same x402 major, same pre-1 AP2 minor, or a later
+dated ACP schema). Older versions, incompatible semver lines, opaque commit-pin
+drift, malformed versions, and unknown adapters remain `deny`. A newer-version
+review never overrides an independently detected authority, terms, limit,
+payment, execution, outcome, privacy, or reconciliation denial.
 
 ## Independent run
 

--- a/transaction-assurance/examples/external-adopters/anchor-x402/target.mjs
+++ b/transaction-assurance/examples/external-adopters/anchor-x402/target.mjs
@@ -1,8 +1,8 @@
 const PROTOCOL_PINS = Object.freeze({
-  google_ap2: 'v0.2.0',
-  openai_stripe_acp: '2026-04-17',
-  visa_tap: 'commit-16d59bdf',
-  x402: '2.21.0',
+  google_ap2: Object.freeze({ version: 'v0.2.0', comparison: 'semver_patch' }),
+  openai_stripe_acp: Object.freeze({ version: '2026-04-17', comparison: 'date' }),
+  visa_tap: Object.freeze({ version: 'commit-16d59bdf', comparison: 'opaque' }),
+  x402: Object.freeze({ version: '2.21.0', comparison: 'semver_major' }),
 });
 
 function result(decision, code) {
@@ -25,15 +25,60 @@ function hasNormalizedSections(input) {
   ].every((field) => input[field] && typeof input[field] === 'object' && !Array.isArray(input[field]));
 }
 
+function parseSemver(value) {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)$/.exec(value || '');
+  if (!match) return null;
+  const parts = match.slice(1).map(Number);
+  return parts.every(Number.isSafeInteger) ? parts : null;
+}
+
+function compareSemver(left, right) {
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) return left[index] > right[index] ? 1 : -1;
+  }
+  return 0;
+}
+
+function parseDateVersion(value) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value || '')) return null;
+  const timestamp = Date.parse(`${value}T00:00:00.000Z`);
+  if (!Number.isFinite(timestamp)) return null;
+  return new Date(timestamp).toISOString().slice(0, 10) === value ? timestamp : null;
+}
+
+function isNewerCompatibleVersion(sourceVersion, pin) {
+  if (pin.comparison === 'date') {
+    const source = parseDateVersion(sourceVersion);
+    const pinned = parseDateVersion(pin.version);
+    return source !== null && pinned !== null && source > pinned;
+  }
+  if (pin.comparison !== 'semver_major' && pin.comparison !== 'semver_patch') return false;
+  const source = parseSemver(sourceVersion);
+  const pinned = parseSemver(pin.version);
+  if (!source || !pinned || compareSemver(source, pinned) <= 0 || source[0] !== pinned[0]) return false;
+  return pin.comparison !== 'semver_patch' || source[1] === pinned[1];
+}
+
+function evaluateProtocolVersion(adapterId, sourceVersion) {
+  const pin = PROTOCOL_PINS[adapterId];
+  if (!pin) return result('deny', 'unsupported_protocol_version');
+  if (sourceVersion === pin.version) return null;
+  if (isNewerCompatibleVersion(sourceVersion, pin)) {
+    return result('review', 'newer_protocol_version_review_required');
+  }
+  return result('deny', 'unsupported_protocol_version');
+}
+
 // This target evaluates only the suite's bounded normalized evidence. It does
 // not parse wire protocols, verify signatures, call a provider, or move funds.
 export function evaluateTransactionAssuranceVector({ input } = {}) {
   if (!hasNormalizedSections(input)) return result('deny', 'malformed_normalized_input');
 
-  const pinnedVersion = PROTOCOL_PINS[input.protocol.adapter_id];
-  if (!pinnedVersion || input.protocol.source_version !== pinnedVersion) {
-    return result('deny', 'unsupported_protocol_version');
-  }
+  const protocolVersionDecision = evaluateProtocolVersion(
+    input.protocol.adapter_id,
+    input.protocol.source_version,
+  );
+  if (protocolVersionDecision?.decision === 'deny') return protocolVersionDecision;
 
   if (input.authority.verification === 'unknown') {
     return result('review', 'authority_verification_unknown');
@@ -85,12 +130,14 @@ export function evaluateTransactionAssuranceVector({ input } = {}) {
   if (input.reconciliation.status === 'refund_pending') return result('review', 'refund_pending');
   if (input.reconciliation.status === 'dispute_pending') return result('review', 'dispute_pending');
   if (input.reconciliation.status === 'none') return result('review', 'reconciliation_incomplete');
-  if (input.reconciliation.status === 'refunded') return result('pass', 'reconciled_refunded');
+  if (input.reconciliation.status === 'refunded') {
+    return protocolVersionDecision || result('pass', 'reconciled_refunded');
+  }
   if (input.reconciliation.status === 'dispute_resolved') {
-    return result('pass', 'reconciled_dispute_resolved');
+    return protocolVersionDecision || result('pass', 'reconciled_dispute_resolved');
   }
   if (input.reconciliation.status !== 'complete') {
     return result('review', 'reconciliation_state_unknown');
   }
-  return result('pass', 'complete_chain_verified');
+  return protocolVersionDecision || result('pass', 'complete_chain_verified');
 }

--- a/transaction-assurance/test/external-adopter-anchor-x402.test.mjs
+++ b/transaction-assurance/test/external-adopter-anchor-x402.test.mjs
@@ -44,6 +44,51 @@ test('anchor-x402 clean-room target satisfies the bounded normalized contract', 
   });
 });
 
+test('anchor-x402 target reviews only recognizable forward-compatible version drift', () => {
+  const evaluateVersion = (adapterId, sourceVersion) => {
+    const input = structuredClone(vectorSet.base_input);
+    input.protocol = { adapter_id: adapterId, source_version: sourceVersion };
+    return evaluateTransactionAssuranceVector({ input });
+  };
+
+  assert.deepEqual(evaluateVersion('x402', '2.22.0'), {
+    decision: 'review',
+    code: 'newer_protocol_version_review_required',
+  });
+  assert.deepEqual(evaluateVersion('x402', '2.20.0'), {
+    decision: 'deny',
+    code: 'unsupported_protocol_version',
+  });
+  assert.deepEqual(evaluateVersion('x402', '3.0.0'), {
+    decision: 'deny',
+    code: 'unsupported_protocol_version',
+  });
+  assert.deepEqual(evaluateVersion('google_ap2', 'v0.2.1'), {
+    decision: 'review',
+    code: 'newer_protocol_version_review_required',
+  });
+  assert.deepEqual(evaluateVersion('google_ap2', 'v0.3.0'), {
+    decision: 'deny',
+    code: 'unsupported_protocol_version',
+  });
+  assert.deepEqual(evaluateVersion('openai_stripe_acp', '2026-05-01'), {
+    decision: 'review',
+    code: 'newer_protocol_version_review_required',
+  });
+  assert.deepEqual(evaluateVersion('visa_tap', 'commit-newer'), {
+    decision: 'deny',
+    code: 'unsupported_protocol_version',
+  });
+
+  const revokedNewerVersion = structuredClone(vectorSet.base_input);
+  revokedNewerVersion.protocol = { adapter_id: 'x402', source_version: '2.22.0' };
+  revokedNewerVersion.authority.revocation = 'revoked';
+  assert.deepEqual(evaluateTransactionAssuranceVector({ input: revokedNewerVersion }), {
+    decision: 'deny',
+    code: 'authority_revoked',
+  });
+});
+
 test('anchor-x402 target has no circular reference, network, secret, or expected-answer dependency', async () => {
   const source = await readFile(path.join(packRoot, 'target.mjs'), 'utf8');
   for (const forbidden of [


### PR DESCRIPTION
## Summary
- record and independently replay the first `anchor-x402` external-adopter evidence chain
- clarify that reconciliation `pass` codes distinguish verified delivery from a clean refund or resolved dispute
- review only recognizable newer protocol-version drift while preserving hard denial for older, incompatible, opaque, malformed, and unknown versions
- correct the stale machine inventory without claiming live compatibility, publication readiness, or ecosystem-standard status

## External evidence verification
- target commit: `13d6d70bb69cac2993753a22d423870bdfebe9a5`
- artifact commit: `49634dd327eed9d3e03b5a51f510d15f04794c8a`
- suite commit: `607b3dddbc441fe52554b8842b9065e60131ae3b`
- target and runner source hashes reproduced
- public receipt verifier returned `verified: true`
- 42 passed / 0 failed; no network use or spend authority

The run produced two actionable contract-clarity findings but zero failed vectors. This PR does not decide whether that satisfies issue #246's literal `actionable failures` wording; publication and catalog inclusion remain separately review-gated.

## Safety behavior
- a newer compatible version can only downgrade an otherwise clean result to `review`
- authority, terms, limits, payment, execution, outcome, privacy, and reconciliation denials still take precedence
- no manifest/vector change, network call, secret access, signing, payment, deployment, or production mutation

## Validation
- `node --test transaction-assurance/test/external-adopter-anchor-x402.test.mjs` (4/4)
- `npm test` in `transaction-assurance` (66/66)
- `npm run check`
- `npm run pack:dry`
- `node --test test/integration-inventory-holds.test.mjs` (5/5)
- `node scripts/verify-integrations-json.js`
- `node scripts/verify-doc-links.mjs`
- `integrations.json` schema validation with Ajv 2020
- `git diff --check`

Addresses the observations in #297 comment 5270120165. Related to #246.