### PR TITLE
feat(tumbler): add Prime multi-turn buyer environment

### DIFF
--- a/verifiers-transaction-assurance/src/agoragentic_transaction_assurance_env/tumbler_trace.py
+++ b/verifiers-transaction-assurance/src/agoragentic_transaction_assurance_env/tumbler_trace.py
@@ -1,0 +1,153 @@
+"""Runtime-only evaluator proof for Tumbler RL episode records."""
+
+from __future__ import annotations
+
+import json
+import re
+import secrets
+from collections.abc import Mapping
+from hashlib import sha256
+from hmac import compare_digest, digest
+from typing import Any
+
+from .tumbler import TUMBLER_EPISODE_SCHEMA, TumblerContractError
+
+TRACE_TUMBLER_EPISODE_KEY = "agoragentic_tumbler_episode"
+TRACE_TUMBLER_EPISODE_PROOF_KEY = "agoragentic_tumbler_episode_proof"
+_EVALUATOR_EPISODE_PROOF_SECRET = secrets.token_bytes(32)
+_EPISODE_KEYS = {
+    "schema",
+    "scenario_id",
+    "scenario_pack_version",
+    "scenario_pack_sha256",
+    "transport_mode",
+    "terminal_action",
+    "terminal_reason_code",
+    "outcome_code",
+    "integrity_flags",
+    "evidence",
+    "transitions",
+    "reward",
+    "episode_sha256",
+}
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _validated_episode_record(
+    value: Any,
+    *,
+    expected_scenario_id: str,
+    expected_pack_version: str,
+    expected_pack_sha256: str,
+) -> dict[str, Any]:
+    if not isinstance(value, Mapping) or set(value) != _EPISODE_KEYS:
+        raise TumblerContractError("episode_record_invalid_fields")
+    if value.get("schema") != TUMBLER_EPISODE_SCHEMA:
+        raise TumblerContractError("episode_record_schema_mismatch")
+    if value.get("scenario_id") != expected_scenario_id:
+        raise TumblerContractError("episode_record_scenario_mismatch")
+    if value.get("scenario_pack_version") != expected_pack_version:
+        raise TumblerContractError("episode_record_pack_version_mismatch")
+    if value.get("scenario_pack_sha256") != expected_pack_sha256:
+        raise TumblerContractError("episode_record_pack_hash_mismatch")
+    episode_sha = value.get("episode_sha256")
+    if not isinstance(episode_sha, str) or not re.fullmatch(
+        r"[0-9a-f]{64}", episode_sha
+    ):
+        raise TumblerContractError("episode_record_hash_invalid")
+    unsigned = {key: item for key, item in value.items() if key != "episode_sha256"}
+    expected_hash = sha256(_canonical_bytes(unsigned)).hexdigest()
+    if not compare_digest(episode_sha, expected_hash):
+        raise TumblerContractError("episode_record_hash_mismatch")
+    reward = value.get("reward")
+    if not isinstance(reward, Mapping) or not isinstance(
+        reward.get("total"), (int, float)
+    ):
+        raise TumblerContractError("episode_record_reward_invalid")
+    if not isinstance(value.get("transitions"), list):
+        raise TumblerContractError("episode_record_transitions_invalid")
+    if not isinstance(value.get("evidence"), list):
+        raise TumblerContractError("episode_record_evidence_invalid")
+    return dict(value)
+
+
+def attach_evaluator_episode(trace: Any, record: Mapping[str, Any]) -> None:
+    """Attach an episode with process-local proof that is absent from wire traces."""
+
+    info = getattr(trace, "info", None)
+    state = getattr(trace, "state", None)
+    artifacts = getattr(state, "artifacts", None)
+    trace_id = getattr(trace, "id", None)
+    if not isinstance(info, dict) or not isinstance(artifacts, dict):
+        raise TumblerContractError("evaluator_trace_boundary_missing")
+    if not isinstance(trace_id, str) or not trace_id:
+        raise TumblerContractError("trace_id_missing")
+    if (
+        TRACE_TUMBLER_EPISODE_KEY in info
+        or TRACE_TUMBLER_EPISODE_PROOF_KEY in artifacts
+    ):
+        raise TumblerContractError("evaluator_episode_prefilled")
+    canonical = _canonical_bytes(record)
+    proof = digest(
+        _EVALUATOR_EPISODE_PROOF_SECRET,
+        trace_id.encode("utf-8") + b"\0" + canonical,
+        "sha256",
+    )
+    info[TRACE_TUMBLER_EPISODE_KEY] = dict(record)
+    artifacts[TRACE_TUMBLER_EPISODE_PROOF_KEY] = proof
+
+
+def episode_record_from_trace(
+    trace: Any,
+    *,
+    expected_scenario_id: str,
+    expected_pack_version: str,
+    expected_pack_sha256: str,
+) -> dict[str, Any]:
+    """Return only an episode carrying the evaluator's process-local proof."""
+
+    info = getattr(trace, "info", None)
+    if not isinstance(info, Mapping):
+        raise TumblerContractError("trace_info_missing")
+    candidate = info.get(TRACE_TUMBLER_EPISODE_KEY)
+    if candidate is None:
+        raise TumblerContractError("episode_record_missing")
+    state = getattr(trace, "state", None)
+    artifacts = getattr(state, "artifacts", None)
+    proof = (
+        artifacts.get(TRACE_TUMBLER_EPISODE_PROOF_KEY)
+        if isinstance(artifacts, dict)
+        else None
+    )
+    trace_id = getattr(trace, "id", None)
+    if not isinstance(proof, bytes) or not isinstance(trace_id, str):
+        raise TumblerContractError("evaluator_episode_proof_missing")
+    expected_proof = digest(
+        _EVALUATOR_EPISODE_PROOF_SECRET,
+        trace_id.encode("utf-8") + b"\0" + _canonical_bytes(candidate),
+        "sha256",
+    )
+    if not compare_digest(proof, expected_proof):
+        raise TumblerContractError("evaluator_episode_proof_invalid")
+    return _validated_episode_record(
+        candidate,
+        expected_scenario_id=expected_scenario_id,
+        expected_pack_version=expected_pack_version,
+        expected_pack_sha256=expected_pack_sha256,
+    )
+
+
+__all__ = [
+    "TRACE_TUMBLER_EPISODE_KEY",
+    "TRACE_TUMBLER_EPISODE_PROOF_KEY",
+    "attach_evaluator_episode",
+    "episode_record_from_trace",
+]

--- a/verifiers-transaction-assurance/src/agoragentic_transaction_assurance_env/tumbler_verifiers_adapter.py
+++ b/verifiers-transaction-assurance/src/agoragentic_transaction_assurance_env/tumbler_verifiers_adapter.py
@@ -1,0 +1,207 @@
+"""Prime Verifiers v0.3.0 multi-turn environment for Tumbler buyer policies."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Literal
+
+from . import verifiers_adapter as prime_adapter
+from .tumbler import (
+    TumblerContractError,
+    TumblerEpisode,
+    load_tumbler_scenario_pack,
+)
+from .tumbler_trace import attach_evaluator_episode, episode_record_from_trace
+
+PRIME_VERIFIERS_AVAILABLE = prime_adapter.PRIME_VERIFIERS_AVAILABLE
+PRIME_VERIFIERS_VERSION = prime_adapter.PRIME_VERIFIERS_VERSION
+PRIME_VERIFIERS_RELEASE_COMMIT = prime_adapter.PRIME_VERIFIERS_RELEASE_COMMIT
+PRIME_VERIFIERS_RELEASE_URL = prime_adapter.PRIME_VERIFIERS_RELEASE_URL
+PRIME_VERIFIERS_WHEEL_SHA256 = prime_adapter.PRIME_VERIFIERS_WHEEL_SHA256
+vf: Any = prime_adapter.vf
+_PACK = load_tumbler_scenario_pack()
+_ACTION_CONTRACT = (
+    "You are the buyer policy inside Agoragentic Tumbler, a simulated tUSDC "
+    "marketplace. Reply to every observation with only one JSON object containing "
+    'exactly {"action":"inspect_wallet|browse|request_quote|execute_quote|'
+    'inspect_transactions|complete|reject_quote|escalate_review",'
+    '"reason_code":null|"lowercase_reason","input":{}}. '
+    "Never provide URLs, headers, credentials, quote IDs, receipts, payment proofs, "
+    "or claims about evaluator state. The environment owns those facts."
+)
+_ZERO_REWARD = {
+    "total": 0.0,
+    "decision": 0.0,
+    "outcome": 0.0,
+    "budget": 0.0,
+    "evidence": 0.0,
+    "simulation_boundary": 0.0,
+    "efficiency": 0.0,
+    "passed": False,
+    "failures": ["invalid_evaluator_episode"],
+}
+
+
+def _reward_from_trace(trace: Any, task_data: Any) -> dict[str, Any]:
+    try:
+        record = episode_record_from_trace(
+            trace,
+            expected_scenario_id=task_data.scenario_id,
+            expected_pack_version=task_data.scenario_pack_version,
+            expected_pack_sha256=task_data.scenario_pack_sha256,
+        )
+    except TumblerContractError:
+        return dict(_ZERO_REWARD)
+    reward = record.get("reward")
+    return dict(reward) if isinstance(reward, dict) else dict(_ZERO_REWARD)
+
+
+if PRIME_VERIFIERS_AVAILABLE:
+
+    class TumblerBuyerData(vf.TaskData):
+        scenario_id: str
+        title: str
+        tags: list[str]
+        scenario_pack_version: str
+        scenario_pack_sha256: str
+        real_spend_allowed: Literal[False] = False
+        production_tumbler_allowed: Literal[False] = False
+
+    class TumblerBuyerTask(vf.Task[TumblerBuyerData]):
+        def _reward(self, trace: vf.Trace) -> dict[str, Any]:
+            return _reward_from_trace(trace, self.data)
+
+        @vf.reward(weight=1.0)
+        async def contract_score(self, trace: vf.Trace) -> float:
+            return float(self._reward(trace)["total"])
+
+        @vf.metric
+        async def decision_score(self, trace: vf.Trace) -> float:
+            return float(self._reward(trace)["decision"])
+
+        @vf.metric
+        async def outcome_score(self, trace: vf.Trace) -> float:
+            return float(self._reward(trace)["outcome"])
+
+        @vf.metric
+        async def budget_score(self, trace: vf.Trace) -> float:
+            return float(self._reward(trace)["budget"])
+
+        @vf.metric
+        async def evidence_score(self, trace: vf.Trace) -> float:
+            return float(self._reward(trace)["evidence"])
+
+        @vf.metric
+        async def simulation_boundary_score(self, trace: vf.Trace) -> float:
+            return float(self._reward(trace)["simulation_boundary"])
+
+        @vf.metric
+        async def efficiency_score(self, trace: vf.Trace) -> float:
+            return float(self._reward(trace)["efficiency"])
+
+    class TumblerBuyerTaskset(vf.Taskset[TumblerBuyerTask, vf.TasksetConfig]):
+        def load(self) -> list[TumblerBuyerTask]:
+            tasks: list[TumblerBuyerTask] = []
+            for idx, scenario in enumerate(_PACK.scenarios):
+                data = TumblerBuyerData(
+                    idx=idx,
+                    name=scenario.title,
+                    description=scenario.prompt,
+                    prompt=None,
+                    system_prompt=_ACTION_CONTRACT,
+                    network_allow=[],
+                    network_block=["*"],
+                    scenario_id=scenario.scenario_id,
+                    title=scenario.title,
+                    tags=list(scenario.tags),
+                    scenario_pack_version=_PACK.version,
+                    scenario_pack_sha256=_PACK.sha256,
+                    real_spend_allowed=False,
+                    production_tumbler_allowed=False,
+                )
+                tasks.append(TumblerBuyerTask(data, self.config.task))
+            return tasks
+
+    class TumblerBuyerEnvConfig(vf.EnvConfig):
+        buyer: vf.AgentConfig = vf.AgentConfig(max_turns=12)
+
+    class TumblerBuyerEnv(vf.Env[TumblerBuyerEnvConfig]):
+        async def run(self, task: TumblerBuyerTask, agents: vf.Agents) -> None:
+            scenario = _PACK.scenario(task.data.scenario_id)
+            episode = TumblerEpisode(
+                scenario,
+                scenario_pack_version=task.data.scenario_pack_version,
+                scenario_pack_sha256=task.data.scenario_pack_sha256,
+            )
+            buyer_task = type(task)(
+                task.data.model_copy(update={"prompt": None}),
+                task.config,
+            )
+            async with agents.buyer.interaction(buyer_task) as buyer:
+                segment = await buyer.turn(
+                    json.dumps(episode.reset_observation(), sort_keys=True)
+                )
+                while not segment.terminated and not episode.terminal:
+                    try:
+                        observation = episode.step(segment.last_reply)
+                    except TumblerContractError as exc:
+                        episode.hard_failures.append("action_not_allowed")
+                        buyer.trace.info["agoragentic_tumbler_action_error"] = exc.code
+                        break
+                    if episode.terminal:
+                        break
+                    segment = await buyer.turn(json.dumps(observation, sort_keys=True))
+                if segment.terminated and not episode.terminal:
+                    episode.hard_failures.append("max_steps_exceeded")
+                attach_evaluator_episode(buyer.trace, episode.episode_record())
+
+        async def finalize(self, task: TumblerBuyerTask, episode: vf.Episode) -> None:
+            buyer_traces = [
+                trace for trace in episode.traces if trace.agent.name == "buyer"
+            ]
+            if len(buyer_traces) != 1:
+                raise ValueError(
+                    "Tumbler buyer episode must contain exactly one buyer trace"
+                )
+            episode_record_from_trace(
+                buyer_traces[0],
+                expected_scenario_id=task.data.scenario_id,
+                expected_pack_version=task.data.scenario_pack_version,
+                expected_pack_sha256=task.data.scenario_pack_sha256,
+            )
+
+    __all__ = [
+        "PRIME_VERIFIERS_AVAILABLE",
+        "PRIME_VERIFIERS_RELEASE_COMMIT",
+        "PRIME_VERIFIERS_RELEASE_URL",
+        "PRIME_VERIFIERS_VERSION",
+        "PRIME_VERIFIERS_WHEEL_SHA256",
+        "TumblerBuyerData",
+        "TumblerBuyerEnv",
+        "TumblerBuyerEnvConfig",
+        "TumblerBuyerTask",
+        "TumblerBuyerTaskset",
+    ]
+else:
+
+    class _PrimeUnavailable:
+        def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+            raise RuntimeError(
+                "Prime Verifiers Tumbler adapter unavailable. Install this package's "
+                "'prime' extra from the exact pinned v0.3.0 release on Linux or macOS "
+                "with Python 3.11-3.13."
+            )
+
+    TumblerBuyerTaskset = _PrimeUnavailable
+    TumblerBuyerEnvConfig = _PrimeUnavailable
+    TumblerBuyerEnv = _PrimeUnavailable
+    __all__ = [
+        "PRIME_VERIFIERS_AVAILABLE",
+        "PRIME_VERIFIERS_RELEASE_COMMIT",
+        "PRIME_VERIFIERS_RELEASE_URL",
+        "PRIME_VERIFIERS_VERSION",
+        "PRIME_VERIFIERS_WHEEL_SHA256",
+        "TumblerBuyerEnv",
+        "TumblerBuyerEnvConfig",
+        "TumblerBuyerTaskset",
+    ]

--- a/verifiers-transaction-assurance/tests/test_tumbler_verifiers_adapter.py
+++ b/verifiers-transaction-assurance/tests/test_tumbler_verifiers_adapter.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import unittest
+from importlib.metadata import PackageNotFoundError, version
+from types import SimpleNamespace
+
+from agoragentic_transaction_assurance_env.tumbler import (
+    TumblerContractError,
+    load_tumbler_scenario_pack,
+    run_scripted_episode,
+)
+from agoragentic_transaction_assurance_env.tumbler_trace import (
+    TRACE_TUMBLER_EPISODE_KEY,
+    TRACE_TUMBLER_EPISODE_PROOF_KEY,
+    attach_evaluator_episode,
+    episode_record_from_trace,
+)
+from agoragentic_transaction_assurance_env.tumbler_verifiers_adapter import (
+    PRIME_VERIFIERS_AVAILABLE,
+    PRIME_VERIFIERS_VERSION,
+    TumblerBuyerEnv,
+    TumblerBuyerTaskset,
+)
+
+try:
+    if version("verifiers") != PRIME_VERIFIERS_VERSION:
+        raise ImportError("wrong verifiers distribution")
+    import verifiers.v1 as vf
+except (ImportError, PackageNotFoundError):
+    vf = None
+
+
+def action(name: str, reason: str | None = None, input_value=None):
+    return {
+        "action": name,
+        "reason_code": reason,
+        "input": input_value or {},
+    }
+
+
+@unittest.skipUnless(
+    vf is not None and PRIME_VERIFIERS_AVAILABLE,
+    "exact Prime Verifiers v0.3.0 is not available on this platform",
+)
+class TumblerPrimeAdapterTests(unittest.TestCase):
+    def setUp(self):
+        self.pack = load_tumbler_scenario_pack()
+        self.taskset = TumblerBuyerTaskset(vf.TasksetConfig())
+        self.tasks = list(self.taskset.load())
+
+    def _trace(self, task):
+        return vf.Trace(
+            task=vf.TraceTask(type=type(task).__name__, data=task.data),
+            agent=vf.AgentInfo(config=vf.AgentConfig()),
+            info={},
+            nodes=[],
+        )
+
+    def test_taskset_is_promptless_bounded_and_contains_all_scenarios(self):
+        self.assertEqual(len(self.tasks), 8)
+        for task in self.tasks:
+            with self.subTest(scenario=task.data.scenario_id):
+                self.assertIsNone(task.data.prompt)
+                self.assertIn("Tumbler", task.data.system_prompt)
+                self.assertEqual(task.data.network_allow, [])
+                self.assertEqual(task.data.network_block, ["*"])
+                self.assertFalse(task.data.real_spend_allowed)
+                self.assertFalse(task.data.production_tumbler_allowed)
+                self.assertEqual(type(task).toolsets(task.config), [])
+
+    def test_evaluator_episode_proof_is_required_and_bound_to_trace(self):
+        task = next(
+            item
+            for item in self.tasks
+            if item.data.scenario_id == "qualified-provider-within-budget"
+        )
+        scenario = self.pack.scenario(task.data.scenario_id)
+        episode = run_scripted_episode(
+            scenario,
+            [
+                action("request_quote"),
+                action("execute_quote", input_value={"text": "safe"}),
+                action("complete"),
+            ],
+            scenario_pack_version=self.pack.version,
+            scenario_pack_sha256=self.pack.sha256,
+        )
+        trace = self._trace(task)
+        attach_evaluator_episode(trace, episode.episode_record())
+        record = episode_record_from_trace(
+            trace,
+            expected_scenario_id=task.data.scenario_id,
+            expected_pack_version=task.data.scenario_pack_version,
+            expected_pack_sha256=task.data.scenario_pack_sha256,
+        )
+        self.assertEqual(record["reward"]["total"], 1.0)
+        self.assertEqual(asyncio.run(task.contract_score(trace)), 1.0)
+
+        forged = self._trace(task)
+        forged.info[TRACE_TUMBLER_EPISODE_KEY] = episode.episode_record()
+        self.assertEqual(asyncio.run(task.contract_score(forged)), 0.0)
+        self.assertNotIn(TRACE_TUMBLER_EPISODE_PROOF_KEY, forged.state.artifacts)
+
+    def test_prefilled_evaluator_episode_cannot_be_overwritten(self):
+        task = self.tasks[0]
+        trace = self._trace(task)
+        trace.info[TRACE_TUMBLER_EPISODE_KEY] = {"forged": True}
+        with self.assertRaisesRegex(
+            TumblerContractError, "evaluator_episode_prefilled"
+        ):
+            attach_evaluator_episode(trace, {"forged": True})
+
+    def test_upstream_reward_and_metrics_are_discoverable(self):
+        task_type = type(self.tasks[0])
+        self.assertTrue(getattr(task_type.contract_score, "reward", False))
+        self.assertEqual(getattr(task_type.contract_score, "_vf_weight", None), 1.0)
+        self.assertTrue(getattr(task_type.budget_score, "metric", False))
+        self.assertTrue(getattr(task_type.evidence_score, "metric", False))
+
+    def test_multiturn_env_run_attaches_evaluator_owned_episode(self):
+        task = next(
+            item
+            for item in self.tasks
+            if item.data.scenario_id == "qualified-provider-within-budget"
+        )
+        trace = self._trace(task)
+        replies = iter(
+            [
+                json.dumps(action("request_quote")),
+                json.dumps(action("execute_quote", input_value={"text": "safe"})),
+                json.dumps(action("complete")),
+            ]
+        )
+
+        class FakeInteraction:
+            def __init__(self):
+                self.trace = trace
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_exc):
+                return None
+
+            async def turn(self, _message):
+                return SimpleNamespace(last_reply=next(replies), terminated=False)
+
+        class FakeBuyer:
+            def interaction(self, _task):
+                return FakeInteraction()
+
+        asyncio.run(
+            TumblerBuyerEnv.run(
+                SimpleNamespace(),
+                task,
+                SimpleNamespace(buyer=FakeBuyer()),
+            )
+        )
+        self.assertIn(TRACE_TUMBLER_EPISODE_KEY, trace.info)
+        self.assertEqual(asyncio.run(task.contract_score(trace)), 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Outcome

Add the Prime Verifiers v0.3.0 multi-turn environment that lets a model act as a buyer policy inside the Tumbler scenarios merged in #325.

This PR has been rebuilt directly on current `main`; its diff contains only the Prime environment layer.

## What ships

- `TumblerBuyerTaskset` with eight promptless tasks bound to the versioned Tumbler scenario pack.
- `TumblerBuyerEnv` using Prime's turn-by-turn `Agent.interaction()` surface.
- A strict response contract requiring one bounded JSON action per turn.
- Alternating evaluator observations and model actions until the episode reaches a terminal decision.
- Per-episode metrics for decision quality, outcome, budget compliance, evidence, simulation boundary, and trajectory efficiency.
- Process-local evaluator proof binding the scored episode to the exact Prime trace.
- Fail-closed scoring when an episode is missing, prefilled, forged, moved to another trace, hash-mismatched, or otherwise invalid.

## Evaluator ownership

The model cannot provide or grade quote IDs, provider IDs, invocation/receipt evidence, budget facts, simulation-state claims, URLs, headers, credentials, or payment material. The environment builds and authenticates the episode with runtime-only state that Prime excludes from serialized trace records.

## Safety boundary

- Scripted Tumbler transport only in the Prime environment.
- `network_allow=[]` and `network_block=["*"]` on every task.
- `real_spend_allowed=false` and `production_tumbler_allowed=false` are explicit task fields.
- No live Tumbler, production host, x402, wallet, custody, publication, graduation, trust, or routing mutation.
- Invalid actions and premature model termination fail closed.

## Validation

Local validation on the rebuilt current-main head:

- Ruff lint and format checks passed.
- Python compilation passed.
- Full package suite passed: 41 tests, 10 expected Windows platform skips.
- Repository growth validator passed.
- Growth validator tests passed: 6/6.
- Documentation link tests passed: 3/3.
- `git diff --check` passed.

Hosted CI independently installs the pinned Prime Verifiers v0.3.0 wheel and runs the Linux matrix.

## Follow-up

PR #327 adds package exports, version/docs, baseline policies, benchmark reporting, and explicit publication/attestation gates. No model training run or public environment release is authorized here.