### PR TITLE
feat(interchange): add a fail-closed SAM tool import contract

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -68,6 +68,17 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Validate source-only SAM Interchange adapter
+        working-directory: interchange/sam
+        env:
+          AGORAGENTIC_NO_SPEND: '1'
+          AGORAGENTIC_ALLOW_REAL_SPEND: '0'
+          AGORAGENTIC_ALLOW_NETWORK_CANARIES: '0'
+        run: |
+          npm ci --ignore-scripts
+          npm run check
+          npm test
+
       - name: Validate public SDK package sources
         run: |
           node --test test/sdk-public-source.test.mjs

--- a/interchange/sam/README.md
+++ b/interchange/sam/README.md
@@ -42,6 +42,29 @@ npm test
 The committed test suite is hermetic: it uses injected MCP fixtures and makes no
 network, provider, wallet, payment, settlement, or publication calls.
 
+## Pinned no-spend canary
+
+On 2026-08-20, the live client completed an authenticated, loopback-only canary
+against Google SAM revision
+`b42aaaf2d7f9ec450ab15e97bf704a21539de0e3`. The disposable runtime used two
+in-process SAM nodes and one synthetic read-only MCP tool. The adapter called
+only `get_mesh_info`, `discover_remote_services`, `find_remote_tools`, and
+`describe_remote_tool`; it did not call `call_remote_tool` or the synthetic
+provider tool.
+
+The sanitized receipt is committed at
+[`evidence/readonly-canary-20260820.json`](evidence/readonly-canary-20260820.json).
+It records one connected peer and one exact peer-catalog tool match. The
+ephemeral mesh did not populate a DHT provider index, so type-wide service
+discovery returned zero; the receipt preserves that limitation instead of
+turning it into a positive claim.
+
+The receipt binds the disposable canary observation to the repository owner for
+review provenance only. It does not bind a reusable SAM PeerID to a production
+Agoragentic provider account. Import eligibility, execution, payment, wallet,
+trust mutation, marketplace publication, public execute, and production
+activation all remain disabled.
+
 ## Discover SAM tools without invoking them
 
 Start an enrolled `sam-node`, then use its token path rather than placing the
@@ -82,6 +105,11 @@ the peer, service, tool, labels, and schemas. It does not emit the raw PeerID or
 tool route. `--include-private-target` exists only for a local, owner-controlled
 handoff and its output must not be committed or published. Private-target output
 intentionally does not validate against the public-safe import schema.
+
+`capture_evidence.sam_control_calls_made` lists the SAM metadata calls used by a
+live capture. `external_provider_called: false` and `provider_invoked: false`
+mean that no discovered provider tool was called; they do not claim that the
+local SAM metadata endpoint was never contacted.
 
 Tool responses, discovery rows, token material, names, descriptions, and schemas
 are bounded before normalization. Oversized or malformed metadata fails closed
@@ -130,7 +158,6 @@ commercial eligibility, or settlement proof.
   its normalized/ineligible state.
 - Add an owner-reviewed SAM PeerID-to-provider binding ceremony with rotation
   and revocation.
-- Run one free, read-only canary over the pinned SAM revision.
 - Add an explicitly approved remote invocation canary and bind request/response
   hashes plus transport status into an Interchange receipt.
 - Only then evaluate a paid canary using the existing Agoragentic money path.
@@ -138,6 +165,8 @@ commercial eligibility, or settlement proof.
 ## Compatibility statement
 
 This slice was prepared against `google/sam` revision
-`b42aaaf2d7f9ec450ab15e97bf704a21539de0e3` and the documented local Streamable
-HTTP MCP gateway. Offline tests passing do not claim live testnet validation,
-Google endorsement, provider identity, commercial eligibility, or settlement.
+`b42aaaf2d7f9ec450ab15e97bf704a21539de0e3` and completed the bounded local
+canary described above through the documented Streamable HTTP MCP gateway.
+Offline tests and this disposable canary do not claim public testnet validation,
+Google endorsement, production provider identity, commercial eligibility,
+provider execution, payment, settlement, or production activation.

--- a/interchange/sam/README.md
+++ b/interchange/sam/README.md
@@ -1,0 +1,136 @@
+# Agoragentic Interchange + Google SAM
+
+This source-only integration connects an operator-local
+[`sam-node`](https://github.com/google/sam) MCP gateway to a bounded
+Agoragentic Interchange import flow.
+
+It deliberately separates two concerns:
+
+- **SAM** supplies sovereign agent identity, private reachability, discovery,
+  policy-controlled transport, and remote MCP invocation.
+- **Agoragentic Interchange** supplies provider/account binding, buyer mandates,
+  budget and commercial policy, settlement evidence, outcome validation,
+  receipts, disputes, and reconciliation.
+
+## Current scope
+
+The integration has two parts:
+
+1. `client.mjs` connects to the local SAM MCP endpoint and performs only
+   `get_mesh_info`, `discover_remote_services`, `find_remote_tools`, and
+   `describe_remote_tool` calls.
+2. `normalize.mjs` turns an exact `find_remote_tools` row plus its matching
+   `describe_remote_tool` result into a metadata-only Interchange import packet.
+
+Neither path calls `call_remote_tool`. They do not create an Agoragentic
+listing, make a provider eligible, move funds, activate x402, mutate trust, or
+publish private mesh topology.
+
+The live client defaults to `http://127.0.0.1:8080/mcp`, accepts loopback HTTP,
+and rejects non-loopback endpoints unless the operator explicitly opts in. An
+opted-in remote endpoint must use HTTPS. Tokens may come from `SAM_API_TOKEN` or
+`SAM_API_TOKEN_PATH`; credentials embedded in endpoint URLs are rejected.
+
+## Install and validate
+
+```bash
+cd interchange/sam
+npm install
+npm test
+```
+
+The committed test suite is hermetic: it uses injected MCP fixtures and makes no
+network, provider, wallet, payment, settlement, or publication calls.
+
+## Discover SAM tools without invoking them
+
+Start an enrolled `sam-node`, then use its token path rather than placing the
+token on a command line:
+
+```bash
+export SAM_API_TOKEN_PATH="$HOME/.config/sam-mesh/api-token"
+node interchange/sam/client.mjs discover
+node interchange/sam/client.mjs discover --service code-reviewer
+```
+
+Discovery output hashes peer and tool identifiers by default. Use
+`--include-private-topology` only for an owner-controlled local diagnostic; do
+not commit or publish that output.
+
+SAM currently returns fully namespaced MCP tool names such as:
+
+```text
+mcp://code-reviewer/review_code
+```
+
+Pass the returned `tool_name` unchanged to `describe_remote_tool` and the capture
+command.
+
+## Capture one exact, description-verified observation
+
+```bash
+node interchange/sam/client.mjs capture \
+  --peer '12D3KooW...' \
+  --tool 'mcp://code-reviewer/review_code'
+```
+
+The live capture requires exactly one matching discovery row for the requested
+peer and tool, describes it, then normalizes the pair. The default packet hashes
+the peer, service, tool, labels, and schemas. It does not emit the raw PeerID or
+tool route. `--include-private-target` exists only for a local, owner-controlled
+handoff and its output must not be committed or published.
+
+A successful describe observation shows that the caller could discover and
+describe the tool at one point in time. It is not proof of provider ownership,
+ongoing reachability, safe side effects, commercial terms, successful execution,
+or settlement.
+
+## Offline normalization
+
+You can normalize previously captured JSON without connecting to SAM:
+
+```bash
+node interchange/sam/normalize.mjs \
+  --discovery ./find-remote-tool.json \
+  --description ./describe-remote-tool.json
+```
+
+Try the committed synthetic fixture:
+
+```bash
+node interchange/sam/normalize.mjs --demo
+node --test interchange/sam/normalize.test.mjs interchange/sam/client.test.mjs
+```
+
+## Eligibility boundary
+
+Every normalized SAM tool remains `eligible: false` until all of these are
+proven separately:
+
+1. The SAM PeerID/service is bound to an authenticated Agoragentic provider.
+2. Commercial terms and an owner-approved quote exist outside SAM discovery.
+3. A fresh authorization/reachability canary succeeds for the exact tool.
+4. The Interchange has a deterministic outcome validator for the purchased job.
+5. Payment and settlement remain on an existing audited Agoragentic rail.
+
+SAM routing labels are observations and routing hints. They are hashed and their
+keys are retained, but they are not treated as provider identity, authorization,
+commercial eligibility, or settlement proof.
+
+## Intended next slices
+
+- Add the `sam_mesh_tool` import kind to the hosted Interchange while preserving
+  its normalized/ineligible state.
+- Add an owner-reviewed SAM PeerID-to-provider binding ceremony with rotation
+  and revocation.
+- Run one free, read-only canary over the pinned SAM revision.
+- Add an explicitly approved remote invocation canary and bind request/response
+  hashes plus transport status into an Interchange receipt.
+- Only then evaluate a paid canary using the existing Agoragentic money path.
+
+## Compatibility statement
+
+This slice was prepared against `google/sam` revision
+`b42aaaf2d7f9ec450ab15e97bf704a21539de0e3` and the documented local Streamable
+HTTP MCP gateway. Offline tests passing do not claim live testnet validation,
+Google endorsement, provider identity, commercial eligibility, or settlement.

--- a/interchange/sam/README.md
+++ b/interchange/sam/README.md
@@ -35,7 +35,7 @@ opted-in remote endpoint must use HTTPS. Tokens may come from `SAM_API_TOKEN` or
 
 ```bash
 cd interchange/sam
-npm install
+npm ci
 npm test
 ```
 
@@ -53,7 +53,9 @@ node interchange/sam/client.mjs discover
 node interchange/sam/client.mjs discover --service code-reviewer
 ```
 
-Discovery output hashes peer and tool identifiers by default. Use
+Discovery output hashes the MCP endpoint, peer, and tool identifiers by default.
+Remote endpoint origins are emitted only with the same private diagnostic opt-in.
+Use
 `--include-private-topology` only for an owner-controlled local diagnostic; do
 not commit or publish that output.
 
@@ -78,7 +80,12 @@ The live capture requires exactly one matching discovery row for the requested
 peer and tool, describes it, then normalizes the pair. The default packet hashes
 the peer, service, tool, labels, and schemas. It does not emit the raw PeerID or
 tool route. `--include-private-target` exists only for a local, owner-controlled
-handoff and its output must not be committed or published.
+handoff and its output must not be committed or published. Private-target output
+intentionally does not validate against the public-safe import schema.
+
+Tool responses, discovery rows, token material, names, descriptions, and schemas
+are bounded before normalization. Oversized or malformed metadata fails closed
+instead of being copied into a capability-card candidate.
 
 A successful describe observation shows that the caller could discover and
 describe the tool at one point in time. It is not proof of provider ownership,

--- a/interchange/sam/canary-evidence.test.mjs
+++ b/interchange/sam/canary-evidence.test.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const evidenceUrl = new URL('./evidence/readonly-canary-20260820.json', import.meta.url);
+const provenanceUrl = new URL('./provenance.json', import.meta.url);
+
+test('sanitized canary evidence preserves every default-off boundary', async () => {
+  const evidenceText = await readFile(evidenceUrl, 'utf8');
+  const evidence = JSON.parse(evidenceText);
+  const provenance = JSON.parse(await readFile(provenanceUrl, 'utf8'));
+
+  assert.equal(evidence.provenance.sam_runtime_revision, 'b42aaaf2d7f9ec450ab15e97bf704a21539de0e3');
+  assert.equal(provenance.runtime_evidence.sam_runtime_revision, evidence.provenance.sam_runtime_revision);
+  assert.equal(
+    provenance.runtime_evidence.receipt_sha256,
+    createHash('sha256').update(evidenceText).digest('hex'),
+  );
+  assert.equal(evidence.observation.authenticated_sidecar, true);
+  assert.equal(evidence.observation.exact_peer_catalog_tool_count, 1);
+  assert.deepEqual(evidence.observation.allowed_tool_calls, [
+    'get_mesh_info',
+    'discover_remote_services',
+    'find_remote_tools',
+    'find_remote_tools',
+    'describe_remote_tool',
+  ]);
+  assert.equal(evidence.observation.call_remote_tool_used, false);
+  assert.equal(evidence.observation.provider_tool_invoked, false);
+  assert.equal(evidence.observation.funds_moved, false);
+  assert.equal(evidence.operator_provider_binding.scope, 'ephemeral_local_canary_only');
+  assert.equal(evidence.operator_provider_binding.production_provider_account_bound, false);
+  assert.equal(evidence.normalized_packet.eligibility.eligible, false);
+  assert.equal(Object.values(evidence.normalized_packet.authority_flags).some(Boolean), false);
+  assert.equal(
+    Object.entries(evidence.activation)
+      .filter(([key]) => key !== 'readonly_canary_completed')
+      .some(([, value]) => value === true),
+    false,
+  );
+  assert.equal(JSON.stringify(evidence).includes('12D3KooW'), false);
+  assert.equal(JSON.stringify(evidence).includes('mcp://agoragentic-canary/inspect_schema'), false);
+});

--- a/interchange/sam/canary-evidence.test.mjs
+++ b/interchange/sam/canary-evidence.test.mjs
@@ -13,9 +13,10 @@ test('sanitized canary evidence preserves every default-off boundary', async () 
 
   assert.equal(evidence.provenance.sam_runtime_revision, 'b42aaaf2d7f9ec450ab15e97bf704a21539de0e3');
   assert.equal(provenance.runtime_evidence.sam_runtime_revision, evidence.provenance.sam_runtime_revision);
+  const canonicalEvidenceText = evidenceText.replace(/\r\n?/g, '\n');
   assert.equal(
-    provenance.runtime_evidence.receipt_sha256,
-    createHash('sha256').update(evidenceText).digest('hex'),
+    provenance.runtime_evidence.receipt_utf8_lf_sha256,
+    createHash('sha256').update(canonicalEvidenceText).digest('hex'),
   );
   assert.equal(evidence.observation.authenticated_sidecar, true);
   assert.equal(evidence.observation.exact_peer_catalog_tool_count, 1);

--- a/interchange/sam/client.mjs
+++ b/interchange/sam/client.mjs
@@ -364,9 +364,12 @@ export async function captureSamTool({ peerId, toolName }, options = {}, depende
       authenticated: connection.authenticated,
       packet,
       capture_evidence: {
+        sam_endpoint_called: true,
+        sam_control_calls_made: ['find_remote_tools', 'describe_remote_tool'],
         find_remote_tools_succeeded: true,
         describe_remote_tool_succeeded: true,
         exact_peer_and_tool_match: true,
+        external_provider_called: false,
         provider_invoked: false,
         call_remote_tool_used: false,
         funds_moved: false,

--- a/interchange/sam/client.mjs
+++ b/interchange/sam/client.mjs
@@ -1,0 +1,353 @@
+#!/usr/bin/env node
+
+import { readFile as readFileDefault } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+
+import { hashRef, normalizeSamTool } from './normalize.mjs';
+
+export const DEFAULT_SAM_MCP_URL = 'http://127.0.0.1:8080/mcp';
+
+export class SamClientError extends Error {
+  constructor(code, message, { status = 500, retryable = false, cause } = {}) {
+    super(message, cause ? { cause } : undefined);
+    this.name = 'SamClientError';
+    this.code = code;
+    this.status = status;
+    this.retryable = retryable;
+  }
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isLoopback(hostname) {
+  const host = String(hostname || '').toLowerCase().replace(/^\[|\]$/g, '');
+  if (host === 'localhost' || host.endsWith('.localhost') || host === '::1') return true;
+  if (host.startsWith('::ffff:127.')) return true;
+  const parts = host.split('.');
+  return parts.length === 4
+    && parts[0] === '127'
+    && parts.every((part) => /^\d{1,3}$/.test(part) && Number(part) <= 255);
+}
+
+export function validateSamEndpoint(endpoint = DEFAULT_SAM_MCP_URL, { allowRemote = false } = {}) {
+  let url;
+  try {
+    url = new URL(endpoint);
+  } catch (cause) {
+    throw new SamClientError('sam_endpoint_invalid', 'SAM MCP endpoint must be an absolute URL.', {
+      status: 400,
+      cause,
+    });
+  }
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new SamClientError('sam_endpoint_protocol_invalid', 'SAM MCP endpoint must use HTTP or HTTPS.', { status: 400 });
+  }
+  if (url.username || url.password) {
+    throw new SamClientError('sam_endpoint_credentials_forbidden', 'Do not embed credentials in the SAM endpoint URL.', { status: 400 });
+  }
+  const local = isLoopback(url.hostname);
+  if (!local && !allowRemote) {
+    throw new SamClientError(
+      'sam_remote_endpoint_requires_opt_in',
+      'Only loopback SAM endpoints are accepted by default. Set allowRemote only for an operator-approved endpoint.',
+      { status: 403 },
+    );
+  }
+  if (!local && url.protocol !== 'https:') {
+    throw new SamClientError('sam_remote_endpoint_requires_https', 'An opted-in remote SAM endpoint must use HTTPS.', { status: 400 });
+  }
+  return url;
+}
+
+export async function resolveSamToken(options = {}, dependencies = {}) {
+  const env = dependencies.env || process.env;
+  const readFile = dependencies.readFile || readFileDefault;
+  const direct = String(options.token || env.SAM_API_TOKEN || '').trim();
+  const tokenPath = String(options.tokenPath || (!direct ? env.SAM_API_TOKEN_PATH || '' : '')).trim();
+  if (options.token && options.tokenPath) {
+    throw new SamClientError('sam_token_source_ambiguous', 'Provide token or tokenPath, not both.', { status: 400 });
+  }
+  let token = direct;
+  if (!token && tokenPath) {
+    let bytes;
+    try {
+      bytes = await readFile(tokenPath);
+    } catch (cause) {
+      throw new SamClientError('sam_token_file_unreadable', 'The configured SAM API token file could not be read.', {
+        status: 401,
+        cause,
+      });
+    }
+    if (bytes.length > 16_384) {
+      throw new SamClientError('sam_token_file_too_large', 'The configured SAM API token file is unexpectedly large.', { status: 400 });
+    }
+    token = bytes.toString('utf8').trim();
+  }
+  if (token && /\s/.test(token)) {
+    throw new SamClientError('sam_token_invalid', 'The SAM API token contains whitespace and was rejected.', { status: 400 });
+  }
+  return token || null;
+}
+
+export function authenticatedFetch(token, fetchImpl = globalThis.fetch) {
+  if (typeof fetchImpl !== 'function') {
+    throw new SamClientError('fetch_unavailable', 'A Fetch API implementation is required.');
+  }
+  return async (input, init = {}) => {
+    const inherited = typeof Request !== 'undefined' && input instanceof Request ? input.headers : undefined;
+    const headers = new Headers(init.headers || inherited || undefined);
+    if (token) headers.set('X-Sam-Authentication', `Bearer ${token}`);
+    return fetchImpl(input, { ...init, headers });
+  };
+}
+
+async function defaultClientFactory({ endpoint, token, fetchImpl }) {
+  let sdk;
+  try {
+    sdk = await import('@modelcontextprotocol/client');
+  } catch (cause) {
+    throw new SamClientError(
+      'mcp_client_dependency_missing',
+      'Install @modelcontextprotocol/client before connecting to a SAM node.',
+      { cause },
+    );
+  }
+  const client = new sdk.Client({ name: 'agoragentic-sam-capture', version: '0.1.0' });
+  const transport = new sdk.StreamableHTTPClientTransport(endpoint, {
+    fetch: authenticatedFetch(token, fetchImpl),
+  });
+  await client.connect(transport);
+  return client;
+}
+
+function parseTextResult(result, toolName) {
+  const texts = (result?.content || [])
+    .filter((entry) => entry?.type === 'text' && typeof entry.text === 'string')
+    .map((entry) => entry.text);
+  if (result?.isError) {
+    throw new SamClientError('sam_tool_error', `SAM tool ${toolName} returned an error.`, {
+      status: 502,
+      retryable: true,
+    });
+  }
+  if (result?.structuredContent !== undefined) return result.structuredContent;
+  if (!texts.length) return null;
+  if (texts.length === 1) {
+    try {
+      return JSON.parse(texts[0]);
+    } catch {
+      return texts[0];
+    }
+  }
+  return texts.map((text) => {
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  });
+}
+
+async function callTool(client, name, args = {}) {
+  try {
+    return parseTextResult(await client.callTool({ name, arguments: args }), name);
+  } catch (error) {
+    if (error instanceof SamClientError) throw error;
+    throw new SamClientError('sam_tool_call_failed', `SAM tool ${name} could not be called.`, {
+      status: 502,
+      retryable: true,
+      cause: error,
+    });
+  }
+}
+
+async function withClient(options, dependencies, work) {
+  const env = dependencies.env || process.env;
+  const endpoint = validateSamEndpoint(
+    options.endpoint || env.SAM_MCP_URL || DEFAULT_SAM_MCP_URL,
+    { allowRemote: options.allowRemote === true },
+  );
+  const token = await resolveSamToken(options, dependencies);
+  const injected = dependencies.client;
+  const client = injected || await (dependencies.clientFactory || defaultClientFactory)({
+    endpoint,
+    token,
+    fetchImpl: dependencies.fetch || globalThis.fetch,
+  });
+  try {
+    return await work(client, { endpoint, authenticated: Boolean(token) });
+  } finally {
+    if (!injected && typeof client?.close === 'function') await client.close();
+  }
+}
+
+function asRows(value) {
+  if (Array.isArray(value)) return value.flatMap(asRows);
+  if (isRecord(value) && Array.isArray(value.tools)) return value.tools;
+  return isRecord(value) ? [value] : [];
+}
+
+function redactMeshInfo(value, includePrivate = false) {
+  const info = isRecord(value) ? value : {};
+  const peers = Array.isArray(info.connected_peers) ? info.connected_peers : [];
+  const output = {
+    connected_peer_count: peers.length,
+    dht_size: Number.isFinite(Number(info.dht_size)) ? Number(info.dht_size) : null,
+    router_peer_ref: info.router_peer_id ? hashRef({ router_peer_id: info.router_peer_id }) : null,
+    local_api_socket_present: Boolean(info.local_api_socket),
+  };
+  if (includePrivate) output.private_mesh_info = info;
+  return output;
+}
+
+/**
+ * Inspect local mesh state and discover remote MCP tools. This path does not
+ * call any remote provider tool.
+ */
+export async function discoverSamTools(options = {}, dependencies = {}) {
+  return withClient(options, dependencies, async (client, connection) => {
+    const meshInfo = await callTool(client, 'get_mesh_info', {});
+    const services = await callTool(client, 'discover_remote_services', {
+      type: 'mcp',
+      ...(options.serviceName ? { name: String(options.serviceName) } : {}),
+    });
+    const tools = await callTool(client, 'find_remote_tools', {
+      ...(options.peerId ? { peer_id: String(options.peerId) } : {}),
+      ...(options.serviceName ? { service_name: String(options.serviceName) } : {}),
+      ...(options.toolName ? { tool_name: String(options.toolName) } : {}),
+    });
+    const rows = asRows(tools);
+    return {
+      schema: 'agoragentic.interchange.sam-discovery.v1',
+      captured_at: dependencies.now?.() || new Date().toISOString(),
+      endpoint_origin: connection.endpoint.origin,
+      authenticated: connection.authenticated,
+      mesh: redactMeshInfo(meshInfo, options.includePrivateTopology === true),
+      service_count: asRows(services).length,
+      tool_count: rows.filter((row) => !row.error).length,
+      tools: options.includePrivateTopology
+        ? rows
+        : rows.map((row) => ({
+            peer_ref: row.peer_id ? hashRef({ peer_id: row.peer_id }) : null,
+            tool_ref: row.tool_name ? hashRef({ tool_name: row.tool_name }) : null,
+            description: String(row.description || ''),
+            observed_label_keys: isRecord(row.labels) ? Object.keys(row.labels).sort() : [],
+            error: row.error || null,
+          })),
+      safety: {
+        provider_invoked: false,
+        funds_moved: false,
+        marketplace_publication: false,
+        raw_topology_public: false,
+      },
+    };
+  });
+}
+
+/**
+ * Find and describe one exact SAM tool, then normalize the observation into an
+ * ineligible Interchange import packet. No call_remote_tool request is made.
+ */
+export async function captureSamTool({ peerId, toolName }, options = {}, dependencies = {}) {
+  const peer = String(peerId || '').trim();
+  const tool = String(toolName || '').trim();
+  if (!peer) throw new SamClientError('sam_peer_id_required', 'peerId is required.', { status: 400 });
+  if (!tool) throw new SamClientError('sam_tool_name_required', 'toolName is required.', { status: 400 });
+
+  return withClient(options, dependencies, async (client, connection) => {
+    const matches = asRows(await callTool(client, 'find_remote_tools', { peer_id: peer }))
+      .filter((row) => row.peer_id === peer && row.tool_name === tool && !row.error);
+    if (matches.length !== 1) {
+      throw new SamClientError(
+        'sam_exact_tool_match_required',
+        `Expected exactly one matching tool from find_remote_tools; found ${matches.length}.`,
+        { status: 409 },
+      );
+    }
+    const description = await callTool(client, 'describe_remote_tool', {
+      peer_id: peer,
+      tool_name: tool,
+    });
+    const capturedAt = dependencies.now?.() || new Date().toISOString();
+    const packet = normalizeSamTool({
+      discovery: matches[0],
+      description,
+      observedAt: capturedAt,
+      includePrivateTarget: options.includePrivateTarget === true,
+    });
+    return {
+      schema: 'agoragentic.interchange.sam-live-capture.v1',
+      captured_at: capturedAt,
+      endpoint_origin: connection.endpoint.origin,
+      authenticated: connection.authenticated,
+      packet,
+      capture_evidence: {
+        find_remote_tools_succeeded: true,
+        describe_remote_tool_succeeded: true,
+        exact_peer_and_tool_match: true,
+        provider_invoked: false,
+        call_remote_tool_used: false,
+        funds_moved: false,
+        settlement_final: false,
+      },
+    };
+  });
+}
+
+function parseArgs(argv) {
+  const args = { command: argv[0] || '', allowRemote: false, includePrivateTopology: false };
+  for (let i = 1; i < argv.length; i += 1) {
+    const value = argv[i];
+    if (value === '--peer') args.peerId = argv[++i];
+    else if (value === '--tool') args.toolName = argv[++i];
+    else if (value === '--service') args.serviceName = argv[++i];
+    else if (value === '--endpoint') args.endpoint = argv[++i];
+    else if (value === '--token-path') args.tokenPath = argv[++i];
+    else if (value === '--allow-remote') args.allowRemote = true;
+    else if (value === '--include-private-topology') args.includePrivateTopology = true;
+    else if (value === '--include-private-target') args.includePrivateTarget = true;
+    else if (value === '--help' || value === '-h') args.help = true;
+    else throw new SamClientError('unknown_argument', `Unknown argument: ${value}`, { status: 400 });
+  }
+  return args;
+}
+
+function help() {
+  return `Usage:
+  node interchange/sam/client.mjs discover [--service NAME] [--peer PEER_ID]
+  node interchange/sam/client.mjs capture --peer PEER_ID --tool mcp://service/tool
+
+Options:
+  --endpoint URL              Defaults to http://127.0.0.1:8080/mcp.
+  --token-path PATH           Read the local SAM API token without placing it on the command line.
+  --allow-remote              Permit an operator-approved non-loopback HTTPS endpoint.
+  --include-private-topology  Include raw discovery rows in local output only.
+  --include-private-target    Include raw peer/tool target in local capture output only.
+
+This command never calls call_remote_tool and never moves funds.`;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help || !args.command) {
+    console.log(help());
+    return;
+  }
+  let result;
+  if (args.command === 'discover') result = await discoverSamTools(args);
+  else if (args.command === 'capture') result = await captureSamTool(args, args);
+  else throw new SamClientError('unknown_command', `Unknown command: ${args.command}`, { status: 400 });
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  main().catch((error) => {
+    const payload = error instanceof SamClientError
+      ? { error: { code: error.code, message: error.message, retryable: error.retryable } }
+      : { error: { code: 'unexpected_error', message: error instanceof Error ? error.message : String(error) } };
+    console.error(JSON.stringify(payload, null, 2));
+    process.exitCode = 1;
+  });
+}

--- a/interchange/sam/client.mjs
+++ b/interchange/sam/client.mjs
@@ -3,9 +3,13 @@
 import { readFile as readFileDefault } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
 
-import { hashRef, normalizeSamTool } from './normalize.mjs';
+import { hashRef, normalizeSamTool, parseSamToolName } from './normalize.mjs';
 
 export const DEFAULT_SAM_MCP_URL = 'http://127.0.0.1:8080/mcp';
+
+const MAX_SAM_TOKEN_BYTES = 16_384;
+const MAX_SAM_TOOL_RESULT_BYTES = 1_048_576;
+const MAX_SAM_DISCOVERY_ROWS = 512;
 
 export class SamClientError extends Error {
   constructor(code, message, { status = 500, retryable = false, cause } = {}) {
@@ -64,12 +68,22 @@ export function validateSamEndpoint(endpoint = DEFAULT_SAM_MCP_URL, { allowRemot
 export async function resolveSamToken(options = {}, dependencies = {}) {
   const env = dependencies.env || process.env;
   const readFile = dependencies.readFile || readFileDefault;
-  const direct = String(options.token || env.SAM_API_TOKEN || '').trim();
-  const tokenPath = String(options.tokenPath || (!direct ? env.SAM_API_TOKEN_PATH || '' : '')).trim();
-  if (options.token && options.tokenPath) {
+  const explicitToken = String(options.token || '').trim();
+  const explicitTokenPath = String(options.tokenPath || '').trim();
+  const envToken = String(env.SAM_API_TOKEN || '').trim();
+  const envTokenPath = String(env.SAM_API_TOKEN_PATH || '').trim();
+  if (explicitToken && explicitTokenPath) {
     throw new SamClientError('sam_token_source_ambiguous', 'Provide token or tokenPath, not both.', { status: 400 });
   }
-  let token = direct;
+  if (!explicitToken && !explicitTokenPath && envToken && envTokenPath) {
+    throw new SamClientError(
+      'sam_token_source_ambiguous',
+      'Set SAM_API_TOKEN or SAM_API_TOKEN_PATH, not both.',
+      { status: 400 },
+    );
+  }
+  let token = explicitToken || (explicitTokenPath ? '' : envToken);
+  const tokenPath = explicitTokenPath || (!token ? envTokenPath : '');
   if (!token && tokenPath) {
     let bytes;
     try {
@@ -80,10 +94,13 @@ export async function resolveSamToken(options = {}, dependencies = {}) {
         cause,
       });
     }
-    if (bytes.length > 16_384) {
+    if (bytes.length > MAX_SAM_TOKEN_BYTES) {
       throw new SamClientError('sam_token_file_too_large', 'The configured SAM API token file is unexpectedly large.', { status: 400 });
     }
     token = bytes.toString('utf8').trim();
+  }
+  if (Buffer.byteLength(token, 'utf8') > MAX_SAM_TOKEN_BYTES) {
+    throw new SamClientError('sam_token_too_large', 'The configured SAM API token is unexpectedly large.', { status: 400 });
   }
   if (token && /\s/.test(token)) {
     throw new SamClientError('sam_token_invalid', 'The SAM API token contains whitespace and was rejected.', { status: 400 });
@@ -132,7 +149,29 @@ function parseTextResult(result, toolName) {
       retryable: true,
     });
   }
-  if (result?.structuredContent !== undefined) return result.structuredContent;
+  const textBytes = texts.reduce((total, text) => total + Buffer.byteLength(text, 'utf8'), 0);
+  if (textBytes > MAX_SAM_TOOL_RESULT_BYTES) {
+    throw new SamClientError('sam_tool_result_too_large', `SAM tool ${toolName} returned too much text.`, {
+      status: 502,
+    });
+  }
+  if (result?.structuredContent !== undefined) {
+    let serialized;
+    try {
+      serialized = JSON.stringify(result.structuredContent);
+    } catch (cause) {
+      throw new SamClientError('sam_tool_result_invalid', `SAM tool ${toolName} returned invalid structured content.`, {
+        status: 502,
+        cause,
+      });
+    }
+    if (Buffer.byteLength(serialized || '', 'utf8') > MAX_SAM_TOOL_RESULT_BYTES) {
+      throw new SamClientError('sam_tool_result_too_large', `SAM tool ${toolName} returned too much structured content.`, {
+        status: 502,
+      });
+    }
+    return result.structuredContent;
+  }
   if (!texts.length) return null;
   if (texts.length === 1) {
     try {
@@ -184,9 +223,35 @@ async function withClient(options, dependencies, work) {
 }
 
 function asRows(value) {
-  if (Array.isArray(value)) return value.flatMap(asRows);
-  if (isRecord(value) && Array.isArray(value.tools)) return value.tools;
-  return isRecord(value) ? [value] : [];
+  const pending = [value];
+  const rows = [];
+  while (pending.length) {
+    const current = pending.pop();
+    if (Array.isArray(current)) {
+      for (let index = current.length - 1; index >= 0; index -= 1) pending.push(current[index]);
+    } else if (isRecord(current) && Array.isArray(current.tools)) {
+      pending.push(current.tools);
+    } else if (isRecord(current)) {
+      rows.push(current);
+      if (rows.length > MAX_SAM_DISCOVERY_ROWS) {
+        throw new SamClientError(
+          'sam_discovery_rows_too_many',
+          `SAM discovery exceeded the ${MAX_SAM_DISCOVERY_ROWS}-row safety limit.`,
+          { status: 502 },
+        );
+      }
+    }
+  }
+  return rows;
+}
+
+function redactEndpoint(endpoint, includePrivate = false) {
+  const output = {
+    endpoint_ref: hashRef({ origin: endpoint.origin, pathname: endpoint.pathname }),
+    endpoint_loopback: isLoopback(endpoint.hostname),
+  };
+  if (includePrivate) output.private_endpoint_origin = endpoint.origin;
+  return output;
 }
 
 function redactMeshInfo(value, includePrivate = false) {
@@ -222,7 +287,7 @@ export async function discoverSamTools(options = {}, dependencies = {}) {
     return {
       schema: 'agoragentic.interchange.sam-discovery.v1',
       captured_at: dependencies.now?.() || new Date().toISOString(),
-      endpoint_origin: connection.endpoint.origin,
+      ...redactEndpoint(connection.endpoint, options.includePrivateTopology === true),
       authenticated: connection.authenticated,
       mesh: redactMeshInfo(meshInfo, options.includePrivateTopology === true),
       service_count: asRows(services).length,
@@ -255,9 +320,24 @@ export async function captureSamTool({ peerId, toolName }, options = {}, depende
   const tool = String(toolName || '').trim();
   if (!peer) throw new SamClientError('sam_peer_id_required', 'peerId is required.', { status: 400 });
   if (!tool) throw new SamClientError('sam_tool_name_required', 'toolName is required.', { status: 400 });
+  if (peer.length > 256 || /\s/.test(peer)) {
+    throw new SamClientError('sam_peer_id_invalid', 'peerId is malformed or too long.', { status: 400 });
+  }
+  let parsedTool;
+  try {
+    parsedTool = parseSamToolName(tool);
+  } catch (cause) {
+    throw new SamClientError('sam_tool_name_invalid', 'toolName must use SAM\'s mcp://service/tool namespace.', {
+      status: 400,
+      cause,
+    });
+  }
 
   return withClient(options, dependencies, async (client, connection) => {
-    const matches = asRows(await callTool(client, 'find_remote_tools', { peer_id: peer }))
+    const matches = asRows(await callTool(client, 'find_remote_tools', {
+      peer_id: peer,
+      tool_name: parsedTool.bareToolName,
+    }))
       .filter((row) => row.peer_id === peer && row.tool_name === tool && !row.error);
     if (matches.length !== 1) {
       throw new SamClientError(
@@ -280,7 +360,7 @@ export async function captureSamTool({ peerId, toolName }, options = {}, depende
     return {
       schema: 'agoragentic.interchange.sam-live-capture.v1',
       captured_at: capturedAt,
-      endpoint_origin: connection.endpoint.origin,
+      ...redactEndpoint(connection.endpoint, options.includePrivateTarget === true),
       authenticated: connection.authenticated,
       packet,
       capture_evidence: {

--- a/interchange/sam/client.test.mjs
+++ b/interchange/sam/client.test.mjs
@@ -6,6 +6,7 @@ import {
   authenticatedFetch,
   captureSamTool,
   discoverSamTools,
+  resolveSamToken,
   validateSamEndpoint,
 } from './client.mjs';
 
@@ -54,6 +55,18 @@ test('authenticated fetch injects the SAM-specific header', async () => {
   assert.equal(headers.get('X-Test'), 'present');
 });
 
+test('explicit token paths override ambient tokens and ambiguous env sources fail closed', async () => {
+  const token = await resolveSamToken(
+    { tokenPath: '/operator/sam-token' },
+    { env: { SAM_API_TOKEN: 'wrong-ambient-token' }, readFile: async () => Buffer.from('file-token\n') },
+  );
+  assert.equal(token, 'file-token');
+  await assert.rejects(
+    resolveSamToken({}, { env: { SAM_API_TOKEN: 'one', SAM_API_TOKEN_PATH: '/two' } }),
+    (error) => error instanceof SamClientError && error.code === 'sam_token_source_ambiguous',
+  );
+});
+
 test('read-only discovery never calls a remote provider and redacts raw topology', async () => {
   const client = new FakeClient({
     get_mesh_info: text({ connected_peers: [PEER], dht_size: 1, router_peer_id: 'router-peer' }),
@@ -70,6 +83,38 @@ test('read-only discovery never calls a remote provider and redacts raw topology
   assert.equal(output.safety.provider_invoked, false);
   assert.equal(JSON.stringify(output).includes(PEER), false);
   assert.equal(JSON.stringify(output).includes(TOOL), false);
+});
+
+test('default output hashes a remote endpoint and only private diagnostics reveal its origin', async () => {
+  const responses = {
+    get_mesh_info: text({ connected_peers: [] }),
+    discover_remote_services: text([]),
+    find_remote_tools: text([]),
+  };
+  const safe = await discoverSamTools(
+    { endpoint: 'https://sam.private.example/mcp', allowRemote: true },
+    { client: new FakeClient(responses), env: {} },
+  );
+  assert.match(safe.endpoint_ref, /^sha256:[a-f0-9]{64}$/);
+  assert.equal(safe.endpoint_loopback, false);
+  assert.equal(safe.private_endpoint_origin, undefined);
+  assert.equal(JSON.stringify(safe).includes('sam.private.example'), false);
+
+  const privateOutput = await discoverSamTools(
+    { endpoint: 'https://sam.private.example/mcp', allowRemote: true, includePrivateTopology: true },
+    { client: new FakeClient(responses), env: {} },
+  );
+  assert.equal(privateOutput.private_endpoint_origin, 'https://sam.private.example');
+});
+
+test('oversized SAM tool responses fail closed before parsing', async () => {
+  const client = new FakeClient({
+    get_mesh_info: { content: [{ type: 'text', text: 'x'.repeat(1_048_577) }] },
+  });
+  await assert.rejects(
+    discoverSamTools({}, { client, env: {} }),
+    (error) => error instanceof SamClientError && error.code === 'sam_tool_result_too_large',
+  );
 });
 
 test('live capture requires one exact discovery match and describes before normalizing', async () => {
@@ -101,4 +146,13 @@ test('live capture rejects ambiguous or missing exact matches', async () => {
     captureSamTool({ peerId: PEER, toolName: TOOL }, {}, { client, env: {} }),
     (error) => error instanceof SamClientError && error.code === 'sam_exact_tool_match_required',
   );
+});
+
+test('live capture rejects malformed targets before any MCP request', async () => {
+  const client = new FakeClient({});
+  await assert.rejects(
+    captureSamTool({ peerId: PEER, toolName: 'mcp://service/tool?leak=true' }, {}, { client, env: {} }),
+    (error) => error instanceof SamClientError && error.code === 'sam_tool_name_invalid',
+  );
+  assert.deepEqual(client.calls, []);
 });

--- a/interchange/sam/client.test.mjs
+++ b/interchange/sam/client.test.mjs
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  SamClientError,
+  authenticatedFetch,
+  captureSamTool,
+  discoverSamTools,
+  validateSamEndpoint,
+} from './client.mjs';
+
+const PEER = '12D3KooWQJYx8zW9fYh5Qb6uN7mP4rT2sV1cA9eD8gF7hJ6kL5mN';
+const TOOL = 'mcp://code-reviewer/review_code';
+
+function text(value) {
+  return { content: [{ type: 'text', text: JSON.stringify(value) }] };
+}
+
+class FakeClient {
+  constructor(responses) {
+    this.responses = responses;
+    this.calls = [];
+  }
+  async callTool(request) {
+    this.calls.push(request);
+    const response = this.responses[request.name];
+    if (typeof response === 'function') return response(request);
+    if (!response) throw new Error(`Missing fake response for ${request.name}`);
+    return response;
+  }
+}
+
+test('endpoint policy is loopback-first and HTTPS-only for opted-in remotes', () => {
+  assert.equal(validateSamEndpoint('http://127.0.0.1:8080/mcp').origin, 'http://127.0.0.1:8080');
+  assert.throws(
+    () => validateSamEndpoint('https://mesh.example/mcp'),
+    (error) => error instanceof SamClientError && error.code === 'sam_remote_endpoint_requires_opt_in',
+  );
+  assert.throws(
+    () => validateSamEndpoint('http://mesh.example/mcp', { allowRemote: true }),
+    (error) => error instanceof SamClientError && error.code === 'sam_remote_endpoint_requires_https',
+  );
+  assert.equal(validateSamEndpoint('https://mesh.example/mcp', { allowRemote: true }).origin, 'https://mesh.example');
+});
+
+test('authenticated fetch injects the SAM-specific header', async () => {
+  let headers;
+  const wrapped = authenticatedFetch('secret-value', async (_input, init) => {
+    headers = init.headers;
+    return new Response('{}');
+  });
+  await wrapped('http://127.0.0.1:8080/mcp', { headers: { 'X-Test': 'present' } });
+  assert.equal(headers.get('X-Sam-Authentication'), 'Bearer secret-value');
+  assert.equal(headers.get('X-Test'), 'present');
+});
+
+test('read-only discovery never calls a remote provider and redacts raw topology', async () => {
+  const client = new FakeClient({
+    get_mesh_info: text({ connected_peers: [PEER], dht_size: 1, router_peer_id: 'router-peer' }),
+    discover_remote_services: text([{ peer_id: PEER, srv_name: 'code-reviewer' }]),
+    find_remote_tools: text([{ peer_id: PEER, tool_name: TOOL, description: 'Review code.' }]),
+  });
+  const output = await discoverSamTools({}, { client, env: {}, now: () => '2026-08-19T20:00:00.000Z' });
+  assert.deepEqual(client.calls.map((call) => call.name), [
+    'get_mesh_info',
+    'discover_remote_services',
+    'find_remote_tools',
+  ]);
+  assert.equal(output.tool_count, 1);
+  assert.equal(output.safety.provider_invoked, false);
+  assert.equal(JSON.stringify(output).includes(PEER), false);
+  assert.equal(JSON.stringify(output).includes(TOOL), false);
+});
+
+test('live capture requires one exact discovery match and describes before normalizing', async () => {
+  const client = new FakeClient({
+    find_remote_tools: text([{ peer_id: PEER, tool_name: TOOL, description: 'Review code.' }]),
+    describe_remote_tool: text({
+      peer_id: PEER,
+      tool_name: TOOL,
+      description: 'Review code.',
+      input_schema: { type: 'object', required: ['code'], properties: { code: { type: 'string' } } },
+    }),
+  });
+  const output = await captureSamTool({ peerId: PEER, toolName: TOOL }, {}, {
+    client,
+    env: {},
+    now: () => '2026-08-19T20:00:00.000Z',
+  });
+  assert.deepEqual(client.calls.map((call) => call.name), ['find_remote_tools', 'describe_remote_tool']);
+  assert.equal(output.packet.eligibility.eligible, false);
+  assert.equal(output.capture_evidence.provider_invoked, false);
+  assert.equal(output.capture_evidence.call_remote_tool_used, false);
+  assert.equal(JSON.stringify(output).includes(PEER), false);
+  assert.equal(JSON.stringify(output).includes(TOOL), false);
+});
+
+test('live capture rejects ambiguous or missing exact matches', async () => {
+  const client = new FakeClient({ find_remote_tools: text([]) });
+  await assert.rejects(
+    captureSamTool({ peerId: PEER, toolName: TOOL }, {}, { client, env: {} }),
+    (error) => error instanceof SamClientError && error.code === 'sam_exact_tool_match_required',
+  );
+});

--- a/interchange/sam/client.test.mjs
+++ b/interchange/sam/client.test.mjs
@@ -134,6 +134,12 @@ test('live capture requires one exact discovery match and describes before norma
   });
   assert.deepEqual(client.calls.map((call) => call.name), ['find_remote_tools', 'describe_remote_tool']);
   assert.equal(output.packet.eligibility.eligible, false);
+  assert.equal(output.capture_evidence.sam_endpoint_called, true);
+  assert.deepEqual(output.capture_evidence.sam_control_calls_made, [
+    'find_remote_tools',
+    'describe_remote_tool',
+  ]);
+  assert.equal(output.capture_evidence.external_provider_called, false);
   assert.equal(output.capture_evidence.provider_invoked, false);
   assert.equal(output.capture_evidence.call_remote_tool_used, false);
   assert.equal(JSON.stringify(output).includes(PEER), false);

--- a/interchange/sam/evidence/readonly-canary-20260820.json
+++ b/interchange/sam/evidence/readonly-canary-20260820.json
@@ -1,0 +1,127 @@
+{
+  "schema": "agoragentic.interchange.sam-readonly-canary.v1",
+  "recorded_at": "2026-08-20T12:11:37.652Z",
+  "provenance": {
+    "upstream_repository": "https://github.com/google/sam",
+    "sam_runtime_revision": "b42aaaf2d7f9ec450ab15e97bf704a21539de0e3",
+    "sam_runtime_revision_kind": "google_sam_base_commit",
+    "adapter_repository": "https://github.com/rhein1/agoragentic-integrations",
+    "adapter_pr": 337,
+    "adapter_revision": "6da11d4d71ee74cdafd4616f537dd0910b9daf1b",
+    "runtime_kind": "operator_controlled_ephemeral_two_node_sam_mesh"
+  },
+  "observation": {
+    "endpoint_ref": "sha256:aa57e58a95625b61956dd9c5ffc4cd6d58f7850e98e46776ba8d3fca0ea5a5bc",
+    "endpoint_loopback": true,
+    "authenticated_sidecar": true,
+    "type_discovery_service_count": 0,
+    "exact_peer_catalog_tool_count": 1,
+    "type_discovery_limit": "ephemeral_direct_peer_mesh_did_not_populate_the_dht_provider_index",
+    "exact_peer_and_tool_match": true,
+    "allowed_tool_calls": [
+      "get_mesh_info",
+      "discover_remote_services",
+      "find_remote_tools",
+      "find_remote_tools",
+      "describe_remote_tool"
+    ],
+    "call_remote_tool_used": false,
+    "provider_tool_invoked": false,
+    "funds_moved": false,
+    "settlement_attempted": false,
+    "raw_peer_id_public": false,
+    "raw_tool_target_public": false
+  },
+  "operator_provider_binding": {
+    "binding_status": "repository_owner_attested_canary_binding",
+    "operator_account": "github:rhein1",
+    "operator_account_ref": "sha256:2475fd30c9509d6f9bd5f9450b41e5240cde243b6287b453e08f29a8b2ba9610",
+    "peer_ref": "sha256:10b5b4e902639293516a7d5d9fb3136d46dc95fc9acd7d926176103c860b5292",
+    "service_ref": "sha256:2ed24e9e4faff72657d39e883ef0908a196a891702739c83f353e830dea86d28",
+    "tool_ref": "sha256:cac66fda72e07258be42c67992b2bb7b96e3c4a70068c840c6d785be8d566646",
+    "scope": "ephemeral_local_canary_only",
+    "production_provider_account_bound": false,
+    "reusable_after_canary": false,
+    "attestation_mechanism": "signed_git_commit_after_runtime_capture"
+  },
+  "activation": {
+    "readonly_canary_completed": true,
+    "import_eligible": false,
+    "execution_enabled": false,
+    "payment_enabled": false,
+    "wallet_spend_enabled": false,
+    "trust_mutation_enabled": false,
+    "marketplace_publication_enabled": false,
+    "public_execute_enabled": false,
+    "production_activation": false
+  },
+  "normalized_packet": {
+    "schema": "agoragentic.interchange.sam-tool-import.v1",
+    "generated_at": "2026-08-20T12:11:37.652Z",
+    "source_kind": "sam_mesh_tool",
+    "lifecycle_status": "normalized",
+    "manifest_hash": "sha256:bcb75c18884f34505ce18dc488887c186e93cbe19a59c9e63b42c4716581d803",
+    "capability_card_input": {
+      "name": "agoragentic-canary: inspect schema",
+      "description": "Return bounded, read-only schema metadata for the SAM canary.",
+      "category": "developer-tools",
+      "tags": [
+        "sam",
+        "mcp",
+        "sovereign-agent-mesh"
+      ],
+      "interface_kind": "sam_mesh_tool",
+      "pricing": {
+        "pricing_model": "quote_required",
+        "currency": "USDC",
+        "unit_price": "0"
+      },
+      "risk_level": "network_discovered_unbound_provider",
+      "source": {
+        "source_type": "sam_mesh_tool_observation",
+        "source_ref": "sam:10b5b4e902639293:cac66fda72e07258"
+      }
+    },
+    "transport_evidence": {
+      "transport": "sam",
+      "observation_type": "caller_supplied_find_and_describe_results",
+      "peer_ref": "sha256:10b5b4e902639293516a7d5d9fb3136d46dc95fc9acd7d926176103c860b5292",
+      "service_ref": "sha256:2ed24e9e4faff72657d39e883ef0908a196a891702739c83f353e830dea86d28",
+      "tool_ref": "sha256:cac66fda72e07258be42c67992b2bb7b96e3c4a70068c840c6d785be8d566646",
+      "schema_hash": "sha256:cfc14e0d21b3de4310145ad0eff246fb04822d433b676f9a360e10be512e5689",
+      "labels_hash": "sha256:80fe33d67f23acbe69fa0adcd48c8ea3940f1f7b57849d5a861b46de4172c8be",
+      "observed_label_keys": [],
+      "authorization_verified_by_normalizer": false,
+      "reachability_verified_by_normalizer": false,
+      "provider_account_bound": false,
+      "point_in_time_only": true
+    },
+    "eligibility": {
+      "eligible": false,
+      "blockers": [
+        "sam_provider_account_binding_required",
+        "commercial_terms_required",
+        "live_authorization_canary_required",
+        "outcome_validator_required"
+      ]
+    },
+    "authority_flags": {
+      "eligible_for_execution": false,
+      "provider_identity_bound": false,
+      "commercial_terms_bound": false,
+      "payment_enabled": false,
+      "wallet_spend_enabled": false,
+      "trust_mutation_enabled": false,
+      "marketplace_publication_enabled": false,
+      "public_execute_enabled": false
+    },
+    "safety": {
+      "metadata_only": true,
+      "external_calls_made": false,
+      "provider_invoked": false,
+      "funds_moved": false,
+      "raw_peer_id_public": false,
+      "raw_tool_target_public": false
+    }
+  }
+}

--- a/interchange/sam/fixtures/describe-remote-tool.json
+++ b/interchange/sam/fixtures/describe-remote-tool.json
@@ -1,0 +1,19 @@
+{
+  "peer_id": "12D3KooWQJYx8zW9fYh5Qb6uN7mP4rT2sV1cA9eD8gF7hJ6kL5mN",
+  "tool_name": "mcp://code-reviewer/review_code",
+  "description": "Review a code snippet and return bounded findings.",
+  "input_schema": {
+    "type": "object",
+    "required": ["code"],
+    "properties": {
+      "code": { "type": "string", "maxLength": 20000 }
+    },
+    "additionalProperties": false
+  },
+  "output_schema": {
+    "type": "object",
+    "properties": {
+      "findings": { "type": "array" }
+    }
+  }
+}

--- a/interchange/sam/fixtures/find-remote-tool.json
+++ b/interchange/sam/fixtures/find-remote-tool.json
@@ -1,0 +1,9 @@
+{
+  "peer_id": "12D3KooWQJYx8zW9fYh5Qb6uN7mP4rT2sV1cA9eD8gF7hJ6kL5mN",
+  "tool_name": "mcp://code-reviewer/review_code",
+  "description": "Review a code snippet and return bounded findings.",
+  "labels": {
+    "region": "us-east-1",
+    "team": "platform"
+  }
+}

--- a/interchange/sam/normalize.mjs
+++ b/interchange/sam/normalize.mjs
@@ -7,6 +7,13 @@ import path from 'node:path';
 
 export const SAM_TOOL_IMPORT_SCHEMA = 'agoragentic.interchange.sam-tool-import.v1';
 
+const MAX_SAM_DISCOVERY_BYTES = 131_072;
+const MAX_SAM_DESCRIPTION_BYTES = 524_288;
+const MAX_SAM_PEER_ID_LENGTH = 256;
+const MAX_SAM_TOOL_NAME_LENGTH = 512;
+const MAX_SAM_DESCRIPTION_LENGTH = 8_192;
+const MAX_SAM_SCHEMA_BYTES = 262_144;
+
 const FALSE_AUTHORITY_FLAGS = Object.freeze({
   eligible_for_execution: false,
   provider_identity_bound: false,
@@ -26,6 +33,33 @@ function cleanText(value, fallback = '') {
   if (value === undefined || value === null) return fallback;
   const normalized = String(value).trim();
   return normalized || fallback;
+}
+
+function assertJsonSize(value, maxBytes, code) {
+  let serialized;
+  try {
+    serialized = stableStringify(value);
+  } catch {
+    throw new Error(`${code}_not_serializable`);
+  }
+  if (Buffer.byteLength(serialized, 'utf8') > maxBytes) throw new Error(code);
+}
+
+function boundedText(value, { code, maxLength, fallback = '' }) {
+  const text = cleanText(value, fallback);
+  if (text.length > maxLength) throw new Error(code);
+  if (/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/.test(text)) {
+    throw new Error(`${code}_control_character`);
+  }
+  return text;
+}
+
+function validObservedAt(value) {
+  const observedAt = cleanText(value);
+  if (!observedAt || !/^\d{4}-\d{2}-\d{2}T/.test(observedAt) || !Number.isFinite(Date.parse(observedAt))) {
+    throw new Error('sam_observed_at_invalid');
+  }
+  return observedAt;
 }
 
 function canonicalize(value) {
@@ -48,16 +82,17 @@ export function hashRef(value) {
 }
 
 export function parseSamToolName(value) {
-  const toolName = cleanText(value);
+  const toolName = boundedText(value, {
+    code: 'sam_tool_name_too_long',
+    maxLength: MAX_SAM_TOOL_NAME_LENGTH,
+  });
   if (!toolName.startsWith('mcp://')) {
     throw new Error('sam_tool_name_must_use_mcp_namespace');
   }
-  const slash = toolName.lastIndexOf('/');
-  if (slash <= 'mcp://'.length || slash === toolName.length - 1) {
-    throw new Error('sam_tool_name_must_be_service_slash_tool');
-  }
-  const serviceName = toolName.slice(0, slash);
-  const bareToolName = toolName.slice(slash + 1);
+  const match = /^mcp:\/\/([A-Za-z0-9][A-Za-z0-9._-]{0,255})\/([A-Za-z0-9][A-Za-z0-9._/-]*)$/.exec(toolName);
+  if (!match) throw new Error('sam_tool_name_must_be_service_slash_tool');
+  const serviceName = `mcp://${match[1]}`;
+  const bareToolName = match[2];
   if (serviceName === 'mcp://sam.catalog' || bareToolName.startsWith('_')) {
     throw new Error('sam_system_tool_not_importable');
   }
@@ -95,10 +130,16 @@ export function normalizeSamTool({
 } = {}) {
   if (!isRecord(discovery)) throw new Error('sam_discovery_row_required');
   if (!isRecord(description)) throw new Error('sam_description_required');
+  assertJsonSize(discovery, MAX_SAM_DISCOVERY_BYTES, 'sam_discovery_row_too_large');
+  assertJsonSize(description, MAX_SAM_DESCRIPTION_BYTES, 'sam_description_too_large');
   if (cleanText(discovery.error)) throw new Error('sam_discovery_row_contains_error');
 
-  const peerId = cleanText(discovery.peer_id);
+  const peerId = boundedText(discovery.peer_id, {
+    code: 'sam_peer_id_too_long',
+    maxLength: MAX_SAM_PEER_ID_LENGTH,
+  });
   if (!peerId) throw new Error('sam_peer_id_required');
+  if (/\s/.test(peerId)) throw new Error('sam_peer_id_invalid');
 
   const parsed = parseSamToolName(discovery.tool_name);
   const describedPeerId = cleanText(description.peer_id);
@@ -108,6 +149,7 @@ export function normalizeSamTool({
 
   const inputSchema = isRecord(description.input_schema) ? description.input_schema : {};
   const outputSchema = isRecord(description.output_schema) ? description.output_schema : null;
+  assertJsonSize({ input_schema: inputSchema, output_schema: outputSchema }, MAX_SAM_SCHEMA_BYTES, 'sam_tool_schema_too_large');
   const labels = normalizeLabels(discovery.labels);
   const peerRef = hashRef({ peer_id: peerId });
   const serviceRef = hashRef({ service_name: parsed.serviceName });
@@ -115,14 +157,18 @@ export function normalizeSamTool({
   const schemaHash = hashRef({ input_schema: inputSchema, output_schema: outputSchema });
   const labelsHash = hashRef({ labels });
   const manifestHash = hashRef({ discovery, description });
-  const descriptionText = cleanText(
+  const descriptionText = boundedText(
     description.description || discovery.description,
-    'SAM-discovered MCP tool. Description was not supplied.'
+    {
+      code: 'sam_tool_description_too_long',
+      maxLength: MAX_SAM_DESCRIPTION_LENGTH,
+      fallback: 'SAM-discovered MCP tool. Description was not supplied.',
+    },
   );
 
   const packet = {
     schema: SAM_TOOL_IMPORT_SCHEMA,
-    generated_at: cleanText(observedAt),
+    generated_at: validObservedAt(observedAt),
     source_kind: 'sam_mesh_tool',
     lifecycle_status: 'normalized',
     manifest_hash: manifestHash,

--- a/interchange/sam/normalize.mjs
+++ b/interchange/sam/normalize.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+export const SAM_TOOL_IMPORT_SCHEMA = 'agoragentic.interchange.sam-tool-import.v1';
+
+const FALSE_AUTHORITY_FLAGS = Object.freeze({
+  eligible_for_execution: false,
+  provider_identity_bound: false,
+  commercial_terms_bound: false,
+  payment_enabled: false,
+  wallet_spend_enabled: false,
+  trust_mutation_enabled: false,
+  marketplace_publication_enabled: false,
+  public_execute_enabled: false,
+});
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cleanText(value, fallback = '') {
+  if (value === undefined || value === null) return fallback;
+  const normalized = String(value).trim();
+  return normalized || fallback;
+}
+
+function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (!isRecord(value)) return value;
+  const out = {};
+  for (const key of Object.keys(value).sort()) {
+    const child = value[key];
+    if (child !== undefined) out[key] = canonicalize(child);
+  }
+  return out;
+}
+
+export function stableStringify(value) {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function hashRef(value) {
+  return `sha256:${createHash('sha256').update(stableStringify(value)).digest('hex')}`;
+}
+
+export function parseSamToolName(value) {
+  const toolName = cleanText(value);
+  if (!toolName.startsWith('mcp://')) {
+    throw new Error('sam_tool_name_must_use_mcp_namespace');
+  }
+  const slash = toolName.lastIndexOf('/');
+  if (slash <= 'mcp://'.length || slash === toolName.length - 1) {
+    throw new Error('sam_tool_name_must_be_service_slash_tool');
+  }
+  const serviceName = toolName.slice(0, slash);
+  const bareToolName = toolName.slice(slash + 1);
+  if (serviceName === 'mcp://sam.catalog' || bareToolName.startsWith('_')) {
+    throw new Error('sam_system_tool_not_importable');
+  }
+  return { serviceName, bareToolName, toolName };
+}
+
+function normalizeLabels(labels) {
+  if (!isRecord(labels)) return {};
+  const out = {};
+  for (const key of Object.keys(labels).sort().slice(0, 32)) {
+    const normalizedKey = cleanText(key).slice(0, 128);
+    const normalizedValue = cleanText(labels[key]).slice(0, 256);
+    if (normalizedKey && normalizedValue) out[normalizedKey] = normalizedValue;
+  }
+  return out;
+}
+
+function publicDisplayName(serviceName, bareToolName) {
+  const service = serviceName.replace(/^mcp:\/\//, '');
+  return `${service}: ${bareToolName.replaceAll('_', ' ')}`;
+}
+
+/**
+ * Turn caller-supplied SAM find_remote_tools + describe_remote_tool results into
+ * a metadata-only Interchange import packet.
+ *
+ * This function performs no network call and therefore does not independently
+ * attest authorization, identity, reachability, pricing, or execution.
+ */
+export function normalizeSamTool({
+  discovery,
+  description,
+  observedAt = new Date().toISOString(),
+  includePrivateTarget = false,
+} = {}) {
+  if (!isRecord(discovery)) throw new Error('sam_discovery_row_required');
+  if (!isRecord(description)) throw new Error('sam_description_required');
+  if (cleanText(discovery.error)) throw new Error('sam_discovery_row_contains_error');
+
+  const peerId = cleanText(discovery.peer_id);
+  if (!peerId) throw new Error('sam_peer_id_required');
+
+  const parsed = parseSamToolName(discovery.tool_name);
+  const describedPeerId = cleanText(description.peer_id);
+  const describedToolName = cleanText(description.tool_name);
+  if (describedPeerId !== peerId) throw new Error('sam_description_peer_mismatch');
+  if (describedToolName !== parsed.toolName) throw new Error('sam_description_tool_mismatch');
+
+  const inputSchema = isRecord(description.input_schema) ? description.input_schema : {};
+  const outputSchema = isRecord(description.output_schema) ? description.output_schema : null;
+  const labels = normalizeLabels(discovery.labels);
+  const peerRef = hashRef({ peer_id: peerId });
+  const serviceRef = hashRef({ service_name: parsed.serviceName });
+  const toolRef = hashRef({ tool_name: parsed.toolName });
+  const schemaHash = hashRef({ input_schema: inputSchema, output_schema: outputSchema });
+  const labelsHash = hashRef({ labels });
+  const manifestHash = hashRef({ discovery, description });
+  const descriptionText = cleanText(
+    description.description || discovery.description,
+    'SAM-discovered MCP tool. Description was not supplied.'
+  );
+
+  const packet = {
+    schema: SAM_TOOL_IMPORT_SCHEMA,
+    generated_at: cleanText(observedAt),
+    source_kind: 'sam_mesh_tool',
+    lifecycle_status: 'normalized',
+    manifest_hash: manifestHash,
+    capability_card_input: {
+      name: publicDisplayName(parsed.serviceName, parsed.bareToolName),
+      description: descriptionText,
+      category: 'developer-tools',
+      tags: ['sam', 'mcp', 'sovereign-agent-mesh'],
+      interface_kind: 'sam_mesh_tool',
+      pricing: {
+        pricing_model: 'quote_required',
+        currency: 'USDC',
+        unit_price: '0',
+      },
+      risk_level: 'network_discovered_unbound_provider',
+      source: {
+        source_type: 'sam_mesh_tool_observation',
+        source_ref: `sam:${peerRef.slice(7, 23)}:${toolRef.slice(7, 23)}`,
+      },
+    },
+    transport_evidence: {
+      transport: 'sam',
+      observation_type: 'caller_supplied_find_and_describe_results',
+      peer_ref: peerRef,
+      service_ref: serviceRef,
+      tool_ref: toolRef,
+      schema_hash: schemaHash,
+      labels_hash: labelsHash,
+      observed_label_keys: Object.keys(labels),
+      authorization_verified_by_normalizer: false,
+      reachability_verified_by_normalizer: false,
+      provider_account_bound: false,
+      point_in_time_only: true,
+    },
+    eligibility: {
+      eligible: false,
+      blockers: [
+        'sam_provider_account_binding_required',
+        'commercial_terms_required',
+        'live_authorization_canary_required',
+        'outcome_validator_required',
+      ],
+    },
+    authority_flags: { ...FALSE_AUTHORITY_FLAGS },
+    safety: {
+      metadata_only: true,
+      external_calls_made: false,
+      provider_invoked: false,
+      funds_moved: false,
+      raw_peer_id_public: false,
+      raw_tool_target_public: false,
+    },
+  };
+
+  if (includePrivateTarget) {
+    packet.private_transport_target = {
+      peer_id: peerId,
+      service_name: parsed.serviceName,
+      tool_name: parsed.toolName,
+      observed_labels: labels,
+      note: 'Local handoff only. Never publish this object or commit credentials with it.',
+    };
+  }
+
+  return packet;
+}
+
+function parseArgs(argv) {
+  const out = { includePrivateTarget: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--include-private-target') {
+      out.includePrivateTarget = true;
+    } else if (arg === '--discovery') {
+      out.discoveryPath = argv[++index];
+    } else if (arg === '--description') {
+      out.descriptionPath = argv[++index];
+    } else if (arg === '--observed-at') {
+      out.observedAt = argv[++index];
+    } else if (arg === '--demo') {
+      out.demo = true;
+    } else if (arg === '--help' || arg === '-h') {
+      out.help = true;
+    } else {
+      throw new Error(`unknown_argument:${arg}`);
+    }
+  }
+  return out;
+}
+
+function helpText() {
+  return `Usage:
+  node interchange/sam/normalize.mjs --discovery <find-row.json> --description <describe.json>
+  node interchange/sam/normalize.mjs --demo
+
+Options:
+  --include-private-target  Include raw peer/tool routing data in local output.
+  --observed-at <ISO>       Override the observation timestamp.
+
+The default output is public-safe and metadata-only. No network calls, tool
+invocations, wallet actions, trust mutations, or marketplace publication occur.`;
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await readFile(filePath, 'utf8'));
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(helpText());
+    return;
+  }
+
+  let discoveryPath = args.discoveryPath;
+  let descriptionPath = args.descriptionPath;
+  if (args.demo) {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    discoveryPath = path.join(here, 'fixtures', 'find-remote-tool.json');
+    descriptionPath = path.join(here, 'fixtures', 'describe-remote-tool.json');
+  }
+  if (!discoveryPath || !descriptionPath) throw new Error('discovery_and_description_paths_required');
+
+  const [discovery, description] = await Promise.all([
+    readJson(discoveryPath),
+    readJson(descriptionPath),
+  ]);
+  const packet = normalizeSamTool({
+    discovery,
+    description,
+    observedAt: args.observedAt,
+    includePrivateTarget: args.includePrivateTarget,
+  });
+  process.stdout.write(`${JSON.stringify(packet, null, 2)}\n`);
+}
+
+const isEntrypoint = process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+if (isEntrypoint) {
+  main().catch((error) => {
+    console.error(JSON.stringify({ error: error.message }));
+    process.exitCode = 1;
+  });
+}

--- a/interchange/sam/normalize.test.mjs
+++ b/interchange/sam/normalize.test.mjs
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { hashRef, normalizeSamTool, parseSamToolName } from './normalize.mjs';
+
+const PEER_ID = '12D3KooWQJYx8zW9fYh5Qb6uN7mP4rT2sV1cA9eD8gF7hJ6kL5mN';
+const TOOL_NAME = 'mcp://code-reviewer/review_code';
+
+function fixture() {
+  return {
+    discovery: {
+      peer_id: PEER_ID,
+      tool_name: TOOL_NAME,
+      description: 'Review a code snippet.',
+      labels: { team: 'platform', region: 'us-east-1' },
+    },
+    description: {
+      peer_id: PEER_ID,
+      tool_name: TOOL_NAME,
+      description: 'Review a code snippet.',
+      input_schema: {
+        type: 'object',
+        required: ['code'],
+        properties: { code: { type: 'string' } },
+      },
+    },
+  };
+}
+
+test('normalizes a SAM tool without leaking the raw transport target', () => {
+  const packet = normalizeSamTool({ ...fixture(), observedAt: '2026-08-19T20:00:00.000Z' });
+  const serialized = JSON.stringify(packet);
+
+  assert.equal(packet.schema, 'agoragentic.interchange.sam-tool-import.v1');
+  assert.equal(packet.source_kind, 'sam_mesh_tool');
+  assert.equal(packet.eligibility.eligible, false);
+  assert.equal(packet.authority_flags.payment_enabled, false);
+  assert.equal(packet.authority_flags.public_execute_enabled, false);
+  assert.equal(packet.transport_evidence.authorization_verified_by_normalizer, false);
+  assert.deepEqual(packet.transport_evidence.observed_label_keys, ['region', 'team']);
+  assert.equal(packet.private_transport_target, undefined);
+  assert.equal(serialized.includes(PEER_ID), false);
+  assert.equal(serialized.includes(TOOL_NAME), false);
+  assert.match(packet.transport_evidence.peer_ref, /^sha256:[a-f0-9]{64}$/);
+});
+
+test('includes the private target only after explicit opt-in', () => {
+  const packet = normalizeSamTool({ ...fixture(), includePrivateTarget: true });
+  assert.equal(packet.private_transport_target.peer_id, PEER_ID);
+  assert.equal(packet.private_transport_target.tool_name, TOOL_NAME);
+  assert.deepEqual(packet.private_transport_target.observed_labels, {
+    region: 'us-east-1',
+    team: 'platform',
+  });
+});
+
+test('rejects a description for a different peer or tool', () => {
+  const peerMismatch = fixture();
+  peerMismatch.description.peer_id = '12D3KooWDifferent';
+  assert.throws(() => normalizeSamTool(peerMismatch), /sam_description_peer_mismatch/);
+
+  const toolMismatch = fixture();
+  toolMismatch.description.tool_name = 'mcp://code-reviewer/other_tool';
+  assert.throws(() => normalizeSamTool(toolMismatch), /sam_description_tool_mismatch/);
+});
+
+test('rejects system, malformed, and errored discovery rows', () => {
+  assert.throws(() => parseSamToolName('system://sam.catalog/list_local_services'), /mcp_namespace/);
+  assert.throws(() => parseSamToolName('mcp://missing-tool'), /service_slash_tool/);
+
+  const errored = fixture();
+  errored.discovery.error = 'failed to connect';
+  assert.throws(() => normalizeSamTool(errored), /contains_error/);
+});
+
+test('hashRef is deterministic across object key order', () => {
+  assert.equal(hashRef({ b: 2, a: 1 }), hashRef({ a: 1, b: 2 }));
+});

--- a/interchange/sam/normalize.test.mjs
+++ b/interchange/sam/normalize.test.mjs
@@ -67,6 +67,9 @@ test('rejects a description for a different peer or tool', () => {
 test('rejects system, malformed, and errored discovery rows', () => {
   assert.throws(() => parseSamToolName('system://sam.catalog/list_local_services'), /mcp_namespace/);
   assert.throws(() => parseSamToolName('mcp://missing-tool'), /service_slash_tool/);
+  assert.throws(() => parseSamToolName('mcp://service/tool?admin=true'), /service_slash_tool/);
+  assert.throws(() => parseSamToolName('mcp://service/tool#private'), /service_slash_tool/);
+  assert.throws(() => parseSamToolName('mcp://user@service/tool'), /service_slash_tool/);
 
   const errored = fixture();
   errored.discovery.error = 'failed to connect';
@@ -75,4 +78,20 @@ test('rejects system, malformed, and errored discovery rows', () => {
 
 test('hashRef is deterministic across object key order', () => {
   assert.equal(hashRef({ b: 2, a: 1 }), hashRef({ a: 1, b: 2 }));
+});
+
+test('rejects unbounded or malformed remote metadata', () => {
+  const oversizedDescription = fixture();
+  oversizedDescription.description.description = 'x'.repeat(8_193);
+  assert.throws(() => normalizeSamTool(oversizedDescription), /sam_tool_description_too_long/);
+
+  const oversizedTool = fixture();
+  oversizedTool.discovery.tool_name = `mcp://service/${'x'.repeat(512)}`;
+  oversizedTool.description.tool_name = oversizedTool.discovery.tool_name;
+  assert.throws(() => normalizeSamTool(oversizedTool), /sam_tool_name_too_long/);
+
+  assert.throws(
+    () => normalizeSamTool({ ...fixture(), observedAt: 'not-a-timestamp' }),
+    /sam_observed_at_invalid/,
+  );
 });

--- a/interchange/sam/package-lock.json
+++ b/interchange/sam/package-lock.json
@@ -1,0 +1,241 @@
+{
+  "name": "@agoragentic/interchange-sam-adapter",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@agoragentic/interchange-sam-adapter",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/client": "^2.0.0"
+      },
+      "devDependencies": {
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/client": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/client/-/client-2.0.0.tgz",
+      "integrity": "sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/core": "2.0.0",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "jose": "^6.1.3",
+        "pkce-challenge": "^5.0.0",
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@modelcontextprotocol/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
+      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/interchange/sam/package.json
+++ b/interchange/sam/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@agoragentic/interchange-sam-adapter",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Fail-closed SAM discovery and metadata normalization for Agoragentic Interchange.",
+  "scripts": {
+    "check": "node --check normalize.mjs && node --check client.mjs",
+    "test": "node --test normalize.test.mjs client.test.mjs"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/client": "^2.0.0"
+  }
+}

--- a/interchange/sam/package.json
+++ b/interchange/sam/package.json
@@ -6,12 +6,16 @@
   "description": "Fail-closed SAM discovery and metadata normalization for Agoragentic Interchange.",
   "scripts": {
     "check": "node --check normalize.mjs && node --check client.mjs",
-    "test": "node --test normalize.test.mjs client.test.mjs"
+    "test": "node --test *.test.mjs"
   },
   "engines": {
     "node": ">=20"
   },
   "dependencies": {
     "@modelcontextprotocol/client": "^2.0.0"
+  },
+  "devDependencies": {
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1"
   }
 }

--- a/interchange/sam/provenance.json
+++ b/interchange/sam/provenance.json
@@ -10,7 +10,7 @@
   "compatibility_scope": "Offline-tested client and normalizer plus an operator-controlled, no-spend, read-only canary at the pinned Google SAM revision for get_mesh_info, discover_remote_services, find_remote_tools, and describe_remote_tool. call_remote_tool is intentionally absent from this slice.",
   "runtime_evidence": {
     "receipt": "evidence/readonly-canary-20260820.json",
-    "receipt_sha256": "f4cc503ab193850e5b1762c3820974871d34ead073e9d77682afefab8428d9a6",
+    "receipt_utf8_lf_sha256": "f4cc503ab193850e5b1762c3820974871d34ead073e9d77682afefab8428d9a6",
     "observed_at": "2026-08-20T12:11:37.652Z",
     "sam_runtime_revision": "b42aaaf2d7f9ec450ab15e97bf704a21539de0e3",
     "scope": "operator_controlled_ephemeral_two_node_sam_mesh",

--- a/interchange/sam/provenance.json
+++ b/interchange/sam/provenance.json
@@ -1,0 +1,18 @@
+{
+  "schema": "agoragentic.integration-provenance.v1",
+  "integration": "google-sam",
+  "upstream": {
+    "repository": "https://github.com/google/sam",
+    "revision": "b42aaaf2d7f9ec450ab15e97bf704a21539de0e3",
+    "license": "Apache-2.0"
+  },
+  "prepared_at": "2026-08-19",
+  "compatibility_scope": "Offline-tested client and normalizer for the documented sam-node Streamable HTTP MCP tools: get_mesh_info, discover_remote_services, find_remote_tools, and describe_remote_tool. call_remote_tool is intentionally absent from this slice.",
+  "authority": {
+    "network_calls_during_tests": false,
+    "provider_calls_during_tests": false,
+    "wallet_or_payment_access": false,
+    "marketplace_publication": false,
+    "remote_provider_invocation": false
+  }
+}

--- a/interchange/sam/provenance.json
+++ b/interchange/sam/provenance.json
@@ -6,8 +6,21 @@
     "revision": "b42aaaf2d7f9ec450ab15e97bf704a21539de0e3",
     "license": "Apache-2.0"
   },
-  "prepared_at": "2026-08-19",
-  "compatibility_scope": "Offline-tested client and normalizer for the documented sam-node Streamable HTTP MCP tools: get_mesh_info, discover_remote_services, find_remote_tools, and describe_remote_tool. call_remote_tool is intentionally absent from this slice.",
+  "prepared_at": "2026-08-20",
+  "compatibility_scope": "Offline-tested client and normalizer plus an operator-controlled, no-spend, read-only canary at the pinned Google SAM revision for get_mesh_info, discover_remote_services, find_remote_tools, and describe_remote_tool. call_remote_tool is intentionally absent from this slice.",
+  "runtime_evidence": {
+    "receipt": "evidence/readonly-canary-20260820.json",
+    "receipt_sha256": "f4cc503ab193850e5b1762c3820974871d34ead073e9d77682afefab8428d9a6",
+    "observed_at": "2026-08-20T12:11:37.652Z",
+    "sam_runtime_revision": "b42aaaf2d7f9ec450ab15e97bf704a21539de0e3",
+    "scope": "operator_controlled_ephemeral_two_node_sam_mesh",
+    "authenticated_loopback": true,
+    "exact_peer_catalog_tool_count": 1,
+    "provider_tool_invoked": false,
+    "funds_moved": false,
+    "production_provider_account_bound": false,
+    "production_activation": false
+  },
   "authority": {
     "network_calls_during_tests": false,
     "provider_calls_during_tests": false,

--- a/interchange/sam/sam-tool-import.schema.json
+++ b/interchange/sam/sam-tool-import.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agoragentic.com/schemas/interchange/sam-tool-import.v1.json",
+  "title": "Agoragentic Interchange SAM Tool Import",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "generated_at",
+    "source_kind",
+    "lifecycle_status",
+    "manifest_hash",
+    "capability_card_input",
+    "transport_evidence",
+    "eligibility",
+    "authority_flags",
+    "safety"
+  ],
+  "properties": {
+    "schema": { "const": "agoragentic.interchange.sam-tool-import.v1" },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "source_kind": { "const": "sam_mesh_tool" },
+    "lifecycle_status": { "const": "normalized" },
+    "manifest_hash": { "$ref": "#/$defs/hash" },
+    "capability_card_input": {
+      "type": "object",
+      "required": ["name", "description", "category", "tags", "interface_kind", "pricing", "risk_level", "source"]
+    },
+    "transport_evidence": {
+      "type": "object",
+      "required": ["transport", "observation_type", "peer_ref", "service_ref", "tool_ref", "schema_hash", "labels_hash"]
+    },
+    "eligibility": {
+      "type": "object",
+      "required": ["eligible", "blockers"],
+      "properties": {
+        "eligible": { "const": false },
+        "blockers": { "type": "array", "minItems": 1, "items": { "type": "string" } }
+      }
+    },
+    "authority_flags": {
+      "type": "object",
+      "additionalProperties": { "const": false }
+    },
+    "safety": {
+      "type": "object",
+      "required": ["metadata_only", "external_calls_made", "provider_invoked", "funds_moved", "raw_peer_id_public", "raw_tool_target_public"],
+      "properties": {
+        "metadata_only": { "const": true },
+        "external_calls_made": { "const": false },
+        "provider_invoked": { "const": false },
+        "funds_moved": { "const": false },
+        "raw_peer_id_public": { "const": false },
+        "raw_tool_target_public": { "const": false }
+      }
+    },
+    "private_transport_target": { "type": "object" }
+  },
+  "$defs": {
+    "hash": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" }
+  }
+}

--- a/interchange/sam/sam-tool-import.schema.json
+++ b/interchange/sam/sam-tool-import.schema.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://agoragentic.com/schemas/interchange/sam-tool-import.v1.json",
-  "title": "Agoragentic Interchange SAM Tool Import",
+  "title": "Agoragentic Interchange Public-Safe SAM Tool Import",
+  "description": "Metadata-only, ineligible SAM tool observation. Private transport targets are intentionally excluded.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -24,26 +25,125 @@
     "manifest_hash": { "$ref": "#/$defs/hash" },
     "capability_card_input": {
       "type": "object",
-      "required": ["name", "description", "category", "tags", "interface_kind", "pricing", "risk_level", "source"]
+      "additionalProperties": false,
+      "required": ["name", "description", "category", "tags", "interface_kind", "pricing", "risk_level", "source"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1, "maxLength": 1024 },
+        "description": { "type": "string", "minLength": 1, "maxLength": 8192 },
+        "category": { "const": "developer-tools" },
+        "tags": {
+          "type": "array",
+          "const": ["sam", "mcp", "sovereign-agent-mesh"]
+        },
+        "interface_kind": { "const": "sam_mesh_tool" },
+        "pricing": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["pricing_model", "currency", "unit_price"],
+          "properties": {
+            "pricing_model": { "const": "quote_required" },
+            "currency": { "const": "USDC" },
+            "unit_price": { "const": "0" }
+          }
+        },
+        "risk_level": { "const": "network_discovered_unbound_provider" },
+        "source": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["source_type", "source_ref"],
+          "properties": {
+            "source_type": { "const": "sam_mesh_tool_observation" },
+            "source_ref": { "type": "string", "pattern": "^sam:[a-f0-9]{16}:[a-f0-9]{16}$" }
+          }
+        }
+      }
     },
     "transport_evidence": {
       "type": "object",
-      "required": ["transport", "observation_type", "peer_ref", "service_ref", "tool_ref", "schema_hash", "labels_hash"]
+      "additionalProperties": false,
+      "required": [
+        "transport",
+        "observation_type",
+        "peer_ref",
+        "service_ref",
+        "tool_ref",
+        "schema_hash",
+        "labels_hash",
+        "observed_label_keys",
+        "authorization_verified_by_normalizer",
+        "reachability_verified_by_normalizer",
+        "provider_account_bound",
+        "point_in_time_only"
+      ],
+      "properties": {
+        "transport": { "const": "sam" },
+        "observation_type": { "const": "caller_supplied_find_and_describe_results" },
+        "peer_ref": { "$ref": "#/$defs/hash" },
+        "service_ref": { "$ref": "#/$defs/hash" },
+        "tool_ref": { "$ref": "#/$defs/hash" },
+        "schema_hash": { "$ref": "#/$defs/hash" },
+        "labels_hash": { "$ref": "#/$defs/hash" },
+        "observed_label_keys": {
+          "type": "array",
+          "maxItems": 32,
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1, "maxLength": 128 }
+        },
+        "authorization_verified_by_normalizer": { "const": false },
+        "reachability_verified_by_normalizer": { "const": false },
+        "provider_account_bound": { "const": false },
+        "point_in_time_only": { "const": true }
+      }
     },
     "eligibility": {
       "type": "object",
+      "additionalProperties": false,
       "required": ["eligible", "blockers"],
       "properties": {
         "eligible": { "const": false },
-        "blockers": { "type": "array", "minItems": 1, "items": { "type": "string" } }
+        "blockers": {
+          "type": "array",
+          "minItems": 4,
+          "maxItems": 4,
+          "uniqueItems": true,
+          "items": {
+            "enum": [
+              "sam_provider_account_binding_required",
+              "commercial_terms_required",
+              "live_authorization_canary_required",
+              "outcome_validator_required"
+            ]
+          }
+        }
       }
     },
     "authority_flags": {
       "type": "object",
-      "additionalProperties": { "const": false }
+      "additionalProperties": false,
+      "required": [
+        "eligible_for_execution",
+        "provider_identity_bound",
+        "commercial_terms_bound",
+        "payment_enabled",
+        "wallet_spend_enabled",
+        "trust_mutation_enabled",
+        "marketplace_publication_enabled",
+        "public_execute_enabled"
+      ],
+      "properties": {
+        "eligible_for_execution": { "const": false },
+        "provider_identity_bound": { "const": false },
+        "commercial_terms_bound": { "const": false },
+        "payment_enabled": { "const": false },
+        "wallet_spend_enabled": { "const": false },
+        "trust_mutation_enabled": { "const": false },
+        "marketplace_publication_enabled": { "const": false },
+        "public_execute_enabled": { "const": false }
+      }
     },
     "safety": {
       "type": "object",
+      "additionalProperties": false,
       "required": ["metadata_only", "external_calls_made", "provider_invoked", "funds_moved", "raw_peer_id_public", "raw_tool_target_public"],
       "properties": {
         "metadata_only": { "const": true },
@@ -53,8 +153,7 @@
         "raw_peer_id_public": { "const": false },
         "raw_tool_target_public": { "const": false }
       }
-    },
-    "private_transport_target": { "type": "object" }
+    }
   },
   "$defs": {
     "hash": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" }

--- a/interchange/sam/schema.test.mjs
+++ b/interchange/sam/schema.test.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+import Ajv2020 from 'ajv/dist/2020.js';
+import addFormats from 'ajv-formats';
+
+import { normalizeSamTool } from './normalize.mjs';
+
+async function fixture(name) {
+  return JSON.parse(await readFile(new URL(`./fixtures/${name}`, import.meta.url), 'utf8'));
+}
+
+async function validator() {
+  const schema = JSON.parse(await readFile(new URL('./sam-tool-import.schema.json', import.meta.url), 'utf8'));
+  const ajv = new Ajv2020({ allErrors: true, strict: true });
+  addFormats(ajv);
+  return ajv.compile(schema);
+}
+
+test('public schema accepts the canonical packet and rejects authority omissions', async () => {
+  const validate = await validator();
+  const packet = normalizeSamTool({
+    discovery: await fixture('find-remote-tool.json'),
+    description: await fixture('describe-remote-tool.json'),
+    observedAt: '2026-08-19T20:00:00.000Z',
+  });
+  assert.equal(validate(packet), true, JSON.stringify(validate.errors));
+
+  const missingAuthority = structuredClone(packet);
+  delete missingAuthority.authority_flags.payment_enabled;
+  assert.equal(validate(missingAuthority), false);
+
+  const enabledAuthority = structuredClone(packet);
+  enabledAuthority.authority_flags.public_execute_enabled = true;
+  assert.equal(validate(enabledAuthority), false);
+});
+
+test('public schema rejects private transport targets', async () => {
+  const validate = await validator();
+  const packet = normalizeSamTool({
+    discovery: await fixture('find-remote-tool.json'),
+    description: await fixture('describe-remote-tool.json'),
+    observedAt: '2026-08-19T20:00:00.000Z',
+    includePrivateTarget: true,
+  });
+  assert.ok(packet.private_transport_target);
+  assert.equal(validate(packet), false);
+});


### PR DESCRIPTION
## Summary

Adds a source-only integration slice for Google SAM (Sovereign Agent Mesh). The adapter connects to an operator-configured `sam-node`, performs metadata discovery and exact tool description, and normalizes the observation into a bounded Interchange import packet. It never invokes a discovered provider tool.

## Included

- read-only SAM MCP client for `get_mesh_info`, `discover_remote_services`, `find_remote_tools`, and `describe_remote_tool`
- deterministic `sam_mesh_tool` normalizer
- SHA-256 references for the endpoint, peer, service, tool, labels, schemas, and source input
- endpoint origins and raw mesh topology withheld unless an operator explicitly requests private local diagnostics
- strict size, serialization, timestamp, PeerID, and SAM tool-name bounds
- explicit normalized/ineligible lifecycle with typed blockers
- forced-false execution, payment, publication, trust, and spend authority
- loopback-first endpoint policy; non-loopback endpoints require explicit opt-in and HTTPS
- unambiguous token/token-file precedence so credentials do not need to appear on the command line
- strict public-safe Draft 2020-12 schema that rejects private targets and any missing or enabled authority flag
- synthetic fixtures, provenance record, lockfile, 18 hermetic Node tests, and a hosted CI lane
- sanitized receipt from an authenticated no-spend canary against the pinned Google SAM base revision
- README explaining the SAM transport / Interchange commerce-layer boundary

## Runtime canary evidence

The adapter completed an operator-controlled, loopback-only, two-node SAM canary at `google/sam@b42aaaf2d7f9ec450ab15e97bf704a21539de0e3`.

Observed SAM control calls were exactly:

```text
get_mesh_info
discover_remote_services
find_remote_tools
find_remote_tools
describe_remote_tool
```

The canary found one exact peer-catalog tool and described it. It did not call `call_remote_tool`, invoke the synthetic provider tool, move funds, attempt settlement, publish a listing, mutate trust, or enable execution authority. The ephemeral direct-peer mesh did not populate a DHT provider index, so type-wide service discovery returned zero; the receipt records that limitation explicitly.

Sanitized evidence: `interchange/sam/evidence/readonly-canary-20260820.json`.

## Not included

- public SAM testnet validation or remote provider invocation
- use of `call_remote_tool`
- automatic hosted Agoragentic import
- reusable or production PeerID-to-provider-account binding
- listing publication or commercial eligibility
- wallet, x402, settlement, or trust mutation
- production activation or adoption evidence

## Validation

```bash
cd interchange/sam
npm ci --ignore-scripts
npm run check
npm test
npm audit --omit=dev --audit-level=high
```

Local result: 18 tests passed, 0 failed; production dependency audit found 0 vulnerabilities. Repository machine-surface and documentation-link checks also passed. GitHub Actions installs this adapter with lifecycle scripts disabled and runs its syntax and test gates directly.

## Compatibility

Prepared and canary-tested against `google/sam@b42aaaf2d7f9ec450ab15e97bf704a21539de0e3` and its documented local Streamable HTTP MCP surface. This is not a claim of public testnet validation, Google endorsement, production provider identity, commercial eligibility, provider execution, payment, settlement, or activation.

## Upstream alignment

Related upstream authorization work: google/sam#176 and google/sam#290. This PR does **not** claim either issue is fixed in Google SAM. It keeps SAM observations ineligible because discovery metadata is not authorization evidence.

## Follow-up gate

A hosted importer remains a separate PR after an owner-reviewed, revocable production PeerID-to-provider binding design and an explicitly approved remote authorization/reachability canary. Paid invocation remains on the existing audited Agoragentic money path and is not introduced here.