### PR TITLE
chore(n8n): refresh stable toolchain coherently

### DIFF
--- a/n8n/TOOLCHAIN_AUDIT.md
+++ b/n8n/TOOLCHAIN_AUDIT.md
@@ -89,6 +89,7 @@ publishing does not use that helper.
 ## Validation
 
 - `npm ci`
+- npm 10 Linux/x64 clean-install dry-run with optional dependencies included
 - `npm test`
 - `npm run lint`
 - `npm run build`

--- a/n8n/TOOLCHAIN_AUDIT.md
+++ b/n8n/TOOLCHAIN_AUDIT.md
@@ -5,22 +5,24 @@ Audit date: 2026-08-20 (supersedes 2026-08-08)
 ## Candidate
 
 - Package: `n8n-nodes-agoragentic@0.1.3`
-- Stable builder: `@n8n/node-cli@0.42.2`
+- Stable builder: `@n8n/node-cli@0.44.4`
 - Formatter: `prettier@3.9.6`
 - Linter: `eslint@9.32.0`
 - Compiler: `typescript@5.9.2`
-- Development host fixture: `n8n-workflow@2.29.3`
+- Development host fixture: `n8n-workflow@2.35.3`
+- Exact workflow peer fixture: `zod@3.25.76`
 - Release helper: `release-it@21.0.2`
 - Minimum consumer Node.js: 20.19
 - Install mode: committed lockfile plus `npm ci`
 
 ## Coordinated compatibility decision
 
-The `@n8n/node-cli` npm `stable` tag is `0.42.2`. Its generated community-node
-template still pins ESLint 9.32.0, Prettier 3.6.2, and TypeScript 5.9.2. This
-candidate advances the stable CLI and independently validates the compatible
-Prettier 3.9.6 maintenance update while preserving n8n's linter and compiler
-major lines.
+The `@n8n/node-cli` npm `stable` tag is `0.44.4`. Its peer range accepts ESLint
+9 or newer, but the CLI's current community-node lint plugin still calls the
+removed ESLint 9 rule-context API. ESLint 10 therefore fails the required lint
+gate with `TypeError: context.getFilename is not a function`. This candidate
+advances the stable CLI while preserving the tested ESLint 9.32.0, Prettier
+3.9.6, and TypeScript 5.9.2 lines.
 
 The `release-it@21.0.2` maintenance update remains development-only. It changes
 neither the published package contents nor the trusted-publishing path, and the
@@ -38,11 +40,11 @@ The rejected Dependabot majors are not a coherent toolchain:
 The release-contract test pins the complete supported set so a future isolated
 major bump cannot look valid after changing only one manifest line.
 
-`n8n-workflow@2.29.3` is an explicit development fixture, not a runtime
-constraint. The published peer remains `n8n-workflow: "*"`, so host n8n
-versions are not narrowed. The fixture keeps clean-install build tests
-deterministic and avoids treating a vulnerable auto-installed peer as shipped
-package code.
+`n8n-workflow@2.35.3` is the npm `stable` development fixture, not a runtime
+constraint. Its exact peer is satisfied by `zod@3.25.76`. The published peer
+remains `n8n-workflow: "*"`, so host n8n versions are not narrowed. These
+fixtures keep clean-install build tests deterministic and are not shipped in
+the package tarball.
 
 ## Security boundary
 
@@ -53,8 +55,8 @@ npm audit --omit=dev --audit-level=moderate
 found 0 vulnerabilities
 ```
 
-The stable n8n CLI's development-only AI SDK graph currently pins
-`@n8n/utils` to `nanoid@3.3.8`. No stable n8n CLI release contains a patched
+The development-only n8n graph currently reaches `@n8n/utils@1.43.1` and its
+`nanoid@3.3.8` pin. No compatible stable n8n release contains a patched
 upstream pin, npm proposes an invalid downgrade to node-cli 0.20.0, and the n8n
 community-node lint policy forbids an `overrides` field. The fail-closed
 `npm run audit:dev` gate therefore permits exactly these two advisories and the
@@ -68,15 +70,16 @@ escalation, or an affected-package addition/substitution fails the gate. A
 remediation-driven shrinking subset is intentionally accepted, including an
 ancestor dropping below high severity, so an upstream partial fix does not
 require weakening or rewriting the allowlist.
-Moderate LangChain/uuid findings remain visible. In particular, Dependabot
-alert #8 (`GHSA-w5hq-g745-h8pq`) remains in the CLI's nested LangChain graph:
-the stable CLI pins LangChain releases that require `uuid@^10.0.0`, so the
-patched `uuid@11.1.1` cannot satisfy that range. The explicit host fixture does
-resolve `uuid@11.1.1`; removing the nested finding requires an upstream n8n
-CLI/AI SDK release and must not be forced with the lint-forbidden `overrides`
-field. None of these development dependencies are included in the package
-`files` allowlist or npm tarball. Remove the nanoid exception as soon as stable
-n8n packages consume a patched release.
+Moderate LangChain/uuid findings remain visible. In particular, open
+Dependabot alert #8 (`GHSA-w5hq-g745-h8pq`) remains in the CLI's nested
+LangChain graph: `@langchain/classic@1.0.27` and
+`@langchain/community@1.1.27` resolve `uuid@10.0.0`, while the patched floor is
+11.1.1. The explicit workflow fixture and top-level LangChain package resolve
+`uuid@11.1.1`; removing the nested finding requires an upstream n8n CLI/AI SDK
+release and must not be forced with the lint-forbidden `overrides` field. None
+of these development dependencies are included in the package `files`
+allowlist or npm tarball. Remove the nanoid exception as soon as stable n8n
+packages consume a patched release.
 
 The prior `brace-expansion`, `ip-address`, and `undici` high findings remain
 resolved in the lockfile. `release-it@21` remains development-only and requires
@@ -89,7 +92,7 @@ publishing does not use that helper.
 - `npm test`
 - `npm run lint`
 - `npm run build`
-- formatter output comparison between Prettier 3.6.2 and 3.9.6
+- exact root dependency and peer-tree inspection
 - `npm audit --omit=dev --audit-level=moderate`
 - `npm run audit:dev`
 - `npm pack --dry-run`

--- a/n8n/package-lock.json
+++ b/n8n/package-lock.json
@@ -30,6 +30,7 @@
             "integrity": "sha512-IjLt0gd3L4jlOfilxVXTifn42FnVffMgDC04RJK1KDZpmkBWLv0XC92MVVmkxrFZNS/7l3xWgP/I3nqtX1sQHw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/node": "^18.11.18",
                 "@types/node-fetch": "^2.6.4",
@@ -92,6 +93,7 @@
             "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/Borewit"
@@ -103,6 +105,7 @@
             "integrity": "sha512-uX1kiOB3lBWvt0sdIszGZkroLj+xvo7d6CC8ORn1mqPLq76Y4fJFDGdbdLWggDF3LxtnmwJCRVgSrLo3V9RctQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@types/node": "^18.11.18",
                 "@types/node-fetch": "^2.6.4",
@@ -119,6 +122,7 @@
             "integrity": "sha512-Hi/EzgMFWz+FKyepxHTrqfTPjpsuBS4zRy3e9sbMpBgLPv+9c0R+YZEvS7Bw4mTS66QtvvURRT6zgDGFotthVQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@anthropic-ai/sdk": "^0.27.3",
                 "@browserbasehq/sdk": "^2.0.0",
@@ -139,6 +143,7 @@
             "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "peerDependencies": {
                 "zod": "^3.25.28 || ^4"
             }
@@ -246,6 +251,31 @@
                 "kuler": "^2.0.0"
             }
         },
+        "node_modules/@emnapi/core": {
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+            "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.3",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.11.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+            "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@emnapi/wasi-threads": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
@@ -253,6 +283,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -1556,7 +1587,6 @@
             "integrity": "sha512-nXmyH0FbcsASlRmC9sbqX0gjQdxgB9KcS13vkw9PMaH0zzylwZkGFU9sY0XCPa2/AokmaNTU9DOW3IUDfAtQow==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@cfworker/json-schema": "^4.0.2",
                 "@standard-schema/spec": "^1.1.0",
@@ -2105,7 +2135,6 @@
             "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -2538,7 +2567,6 @@
             "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@octokit/auth-token": "^6.0.0",
                 "@octokit/graphql": "^9.0.3",
@@ -2696,7 +2724,6 @@
             "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -2720,7 +2747,6 @@
             "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@opentelemetry/semantic-conventions": "^1.29.0"
             },
@@ -2737,7 +2763,6 @@
             "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@opentelemetry/api-logs": "0.220.0",
                 "import-in-the-middle": "^3.0.0",
@@ -2791,7 +2816,6 @@
             "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@opentelemetry/core": "2.10.0",
                 "@opentelemetry/resources": "2.10.0",
@@ -3001,6 +3025,7 @@
             "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "debug": "^4.4.3",
                 "token-types": "^6.1.1"
@@ -3018,7 +3043,8 @@
             "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
             "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@ts-morph/common": {
             "version": "0.28.1",
@@ -3049,6 +3075,7 @@
             "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/ms": "*"
             }
@@ -3072,7 +3099,8 @@
             "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
             "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/node": {
             "version": "18.19.130",
@@ -3080,6 +3108,7 @@
             "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -3090,6 +3119,7 @@
             "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "form-data": "^4.0.4"
@@ -3107,7 +3137,8 @@
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
             "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/triple-beam": {
             "version": "1.3.5",
@@ -3151,7 +3182,6 @@
             "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.65.0",
                 "@typescript-eslint/types": "8.65.0",
@@ -3703,6 +3733,7 @@
             "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "event-target-shim": "^5.0.0"
             },
@@ -3716,7 +3747,6 @@
             "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3750,6 +3780,7 @@
             "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "humanize-ms": "^1.2.1"
             },
@@ -3929,7 +3960,6 @@
             "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
@@ -4076,7 +4106,8 @@
             "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
             "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
             "dev": true,
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/buildcheck": {
             "version": "0.0.7",
@@ -4234,6 +4265,7 @@
             "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -4841,6 +4873,7 @@
             "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             }
@@ -4982,7 +5015,6 @@
             "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -5104,7 +5136,6 @@
             "integrity": "sha512-4cdstYkKCyjumM2Q9NSI03K8D2a9F4Ssz33K2lv2hQa4KmR9jPLwk3uWGtNvclfqBrPGfGuMBwsGMbe6dMRbfg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/types": "^8.56.0",
                 "comment-parser": "^1.4.1",
@@ -5352,6 +5383,7 @@
             "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -5375,7 +5407,8 @@
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -5501,6 +5534,7 @@
             "integrity": "sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@tokenizer/inflate": "^0.4.1",
                 "strtok3": "^10.3.4",
@@ -5698,7 +5732,8 @@
             "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
             "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/formdata-node": {
             "version": "4.4.1",
@@ -5706,6 +5741,7 @@
             "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "node-domexception": "1.0.0",
                 "web-streams-polyfill": "4.0.0-beta.3"
@@ -5725,6 +5761,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
@@ -6065,6 +6102,7 @@
             "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ms": "^2.0.0"
             }
@@ -6075,6 +6113,7 @@
             "integrity": "sha512-7balLY8WKk+bOhe5Vgg4zG2X6Z0zhpG/3VtYPC69evj+lVJSId8xYP7ISRzRfoeXAlJfzLNMbi2Na/0IdDiIkQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@types/debug": "4.1.12",
                 "@types/node": "18.19.80",
@@ -6103,6 +6142,7 @@
             "integrity": "sha512-kEWeMwMeIvxYkeg1gTc01awpwLbfMRZXdIhwRcakd/KlK53jmRC26LqcbIt7fnAQTu5GzlnWmzA3H6+l1u6xxQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -6113,6 +6153,7 @@
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -6131,6 +6172,7 @@
             "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -6143,7 +6185,8 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/iconv-lite": {
             "version": "0.6.3",
@@ -6177,7 +6220,8 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/ignore": {
             "version": "7.0.6",
@@ -6185,7 +6229,6 @@
             "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -6596,7 +6639,8 @@
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/issue-parser": {
             "version": "7.0.2",
@@ -6662,7 +6706,6 @@
             "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
             }
@@ -6778,6 +6821,7 @@
             "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "jws": "^4.0.1",
                 "lodash.includes": "^4.3.0",
@@ -6811,6 +6855,7 @@
             "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "buffer-equal-constant-time": "^1.0.1",
                 "ecdsa-sig-formatter": "1.0.11",
@@ -6823,6 +6868,7 @@
             "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "jwa": "^2.0.1",
                 "safe-buffer": "^5.0.1"
@@ -6966,6 +7012,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=13.2.0"
             }
@@ -6991,8 +7038,7 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
             "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/lodash.capitalize": {
             "version": "4.2.1",
@@ -7020,28 +7066,32 @@
             "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
             "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.isboolean": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
             "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.isinteger": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
             "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.isnumber": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
             "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.isplainobject": {
             "version": "4.0.6",
@@ -7069,7 +7119,8 @@
             "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
             "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.uniqby": {
             "version": "4.7.0",
@@ -7341,7 +7392,6 @@
             "integrity": "sha512-KKTx5/NPzusN1Udog4Ivt5XkXrTZKHBSChGMQQXTs+PbLhQqrVhjwIhowtA68wReb3zFaaNBe8xRE9q8nfVUhw==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
-            "peer": true,
             "dependencies": {
                 "@codemirror/autocomplete": "6.20.0",
                 "@n8n/errors": "0.13.0",
@@ -7512,6 +7562,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10.5.0"
             }
@@ -7522,6 +7573,7 @@
             "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },
@@ -8091,7 +8143,6 @@
             "integrity": "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@napi-rs/canvas": "0.1.80",
                 "pdfjs-dist": "5.4.296"
@@ -8165,6 +8216,7 @@
             "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "playwright-core": "1.62.1"
             },
@@ -8184,6 +8236,7 @@
             "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "playwright-core": "cli.js"
             },
@@ -8382,6 +8435,7 @@
             "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "punycode": "^2.3.1"
             },
@@ -8420,7 +8474,8 @@
             "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
             "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
@@ -8448,8 +8503,7 @@
             "resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-2.2.0.tgz",
             "integrity": "sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/rc9": {
             "version": "3.0.1",
@@ -8641,7 +8695,8 @@
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
             "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/resolve-from": {
             "version": "4.0.0",
@@ -8696,6 +8751,7 @@
             "integrity": "sha512-pOLi+Gdll3JekwuFjXO3fTq+L9lzMQGcSq7M5gIjExcl3Gu1hd4XXuf5o3+LuSBsaULQH7DiNbsqPd1chVpQGQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=10.7.0"
             },
@@ -9218,6 +9274,7 @@
             "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@tokenizer/token": "^0.3.0"
             },
@@ -9300,7 +9357,6 @@
             "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -9357,6 +9413,7 @@
             "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@borewit/text-codec": "^0.2.1",
                 "@tokenizer/token": "^0.3.0",
@@ -9376,6 +9433,7 @@
             "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
             "dev": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "psl": "^1.1.33",
                 "punycode": "^2.1.1",
@@ -9391,7 +9449,8 @@
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/transliteration": {
             "version": "2.3.5",
@@ -9490,7 +9549,6 @@
             "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -9543,6 +9601,7 @@
             "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -9565,7 +9624,8 @@
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
             "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/universal-user-agent": {
             "version": "7.0.3",
@@ -9580,6 +9640,7 @@
             "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 4.0.0"
             }
@@ -9658,6 +9719,7 @@
             "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
@@ -9712,6 +9774,7 @@
             "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 14"
             }
@@ -9721,7 +9784,8 @@
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
             "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
             "dev": true,
-            "license": "BSD-2-Clause"
+            "license": "BSD-2-Clause",
+            "peer": true
         },
         "node_modules/whatwg-url": {
             "version": "5.0.0",
@@ -9729,6 +9793,7 @@
             "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
@@ -10119,7 +10184,6 @@
             "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/n8n/package-lock.json
+++ b/n8n/package-lock.json
@@ -9,12 +9,13 @@
             "version": "0.1.3",
             "license": "MIT",
             "devDependencies": {
-                "@n8n/node-cli": "0.42.2",
+                "@n8n/node-cli": "0.44.4",
                 "eslint": "9.32.0",
-                "n8n-workflow": "2.29.3",
+                "n8n-workflow": "2.35.3",
                 "prettier": "3.9.6",
                 "release-it": "21.0.2",
-                "typescript": "5.9.2"
+                "typescript": "5.9.2",
+                "zod": "3.25.76"
             },
             "engines": {
                 "node": ">=20.19.0"
@@ -29,7 +30,6 @@
             "integrity": "sha512-IjLt0gd3L4jlOfilxVXTifn42FnVffMgDC04RJK1KDZpmkBWLv0XC92MVVmkxrFZNS/7l3xWgP/I3nqtX1sQHw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/node": "^18.11.18",
                 "@types/node-fetch": "^2.6.4",
@@ -92,19 +92,17 @@
             "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/Borewit"
             }
         },
         "node_modules/@browserbasehq/sdk": {
-            "version": "2.16.0",
-            "resolved": "https://registry.npmjs.org/@browserbasehq/sdk/-/sdk-2.16.0.tgz",
-            "integrity": "sha512-mPAuLRU9jWR7o0KJi9+gQnOBDUSIkoKbbFv4HjrA+80qWVcFacrNPlZmf4mguQnfZ0oP2t5c3ws6yuFyAX9vpA==",
+            "version": "2.18.0",
+            "resolved": "https://registry.npmjs.org/@browserbasehq/sdk/-/sdk-2.18.0.tgz",
+            "integrity": "sha512-uX1kiOB3lBWvt0sdIszGZkroLj+xvo7d6CC8ORn1mqPLq76Y4fJFDGdbdLWggDF3LxtnmwJCRVgSrLo3V9RctQ==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@types/node": "^18.11.18",
                 "@types/node-fetch": "^2.6.4",
@@ -121,7 +119,6 @@
             "integrity": "sha512-Hi/EzgMFWz+FKyepxHTrqfTPjpsuBS4zRy3e9sbMpBgLPv+9c0R+YZEvS7Bw4mTS66QtvvURRT6zgDGFotthVQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@anthropic-ai/sdk": "^0.27.3",
                 "@browserbasehq/sdk": "^2.0.0",
@@ -142,7 +139,6 @@
             "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "peerDependencies": {
                 "zod": "^3.25.28 || ^4"
             }
@@ -216,9 +212,9 @@
             }
         },
         "node_modules/@codemirror/view": {
-            "version": "6.43.8",
-            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.8.tgz",
-            "integrity": "sha512-qtItTDssZ/5GFfi94hrILu9j/VUeFPDPkhovEfmWFj2ipTxnzPB8DdHgfbb8HYTzLTYhrndKmyQxXUz/PDLenw==",
+            "version": "6.43.9",
+            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.9.tgz",
+            "integrity": "sha512-sTuUzTpPMFebRhg6dawChoKKgndIwfjmJgKVxBefPElcU2NwQ6AFroupk0SFqEerQyZOGRfDNnSN8Dw/lMAsXw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -250,31 +246,6 @@
                 "kuler": "^2.0.0"
             }
         },
-        "node_modules/@emnapi/core": {
-            "version": "1.11.3",
-            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
-            "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@emnapi/wasi-threads": "1.2.3",
-                "tslib": "^2.4.0"
-            }
-        },
-        "node_modules/@emnapi/runtime": {
-            "version": "1.11.3",
-            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
-            "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "tslib": "^2.4.0"
-            }
-        },
         "node_modules/@emnapi/wasi-threads": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
@@ -282,7 +253,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -1036,16 +1006,6 @@
                 }
             }
         },
-        "node_modules/@langchain/classic/node_modules/zod": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-            "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/colinhacks"
-            }
-        },
         "node_modules/@langchain/community": {
             "version": "1.1.27",
             "resolved": "https://registry.npmjs.org/@langchain/community/-/community-1.1.27.tgz",
@@ -1590,22 +1550,13 @@
                 }
             }
         },
-        "node_modules/@langchain/community/node_modules/zod": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-            "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/colinhacks"
-            }
-        },
         "node_modules/@langchain/core": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.2.0.tgz",
             "integrity": "sha512-nXmyH0FbcsASlRmC9sbqX0gjQdxgB9KcS13vkw9PMaH0zzylwZkGFU9sY0XCPa2/AokmaNTU9DOW3IUDfAtQow==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cfworker/json-schema": "^4.0.2",
                 "@standard-schema/spec": "^1.1.0",
@@ -1619,25 +1570,15 @@
                 "node": ">=20"
             }
         },
-        "node_modules/@langchain/core/node_modules/zod": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-            "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/colinhacks"
-            }
-        },
         "node_modules/@langchain/langgraph": {
-            "version": "1.4.9",
-            "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.9.tgz",
-            "integrity": "sha512-EvD9rS66Cya09y6rbMgD3Ir8miAkJQFo7FyJOPRPO736Kz3y5TeyeBDOS8ctff/jRc788bPijHx2NVFM79Qqig==",
+            "version": "1.4.12",
+            "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-1.4.12.tgz",
+            "integrity": "sha512-63iH/igH5Fh5fHqmWp09YYWaDKKB9v4RCmYNJBrnQ224rFRbjebgyYW6o5RCczN5FZxIhQj+xT51rrNmG0zi5A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@langchain/langgraph-checkpoint": "^1.1.3",
-                "@langchain/langgraph-sdk": "~1.9.28",
+                "@langchain/langgraph-checkpoint": "^1.1.5",
+                "@langchain/langgraph-sdk": "~1.9.30",
                 "@langchain/protocol": "^0.0.18",
                 "@standard-schema/spec": "1.1.0"
             },
@@ -1650,9 +1591,9 @@
             }
         },
         "node_modules/@langchain/langgraph-checkpoint": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.3.tgz",
-            "integrity": "sha512-wgzdQNeEsdw1e+4lvlj0tdq/RYR/k1vPin10g0ymGoehZDDgd9nvIllGXSXN4TFgF9sf5qQP/KTkOcLfeseIhA==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/@langchain/langgraph-checkpoint/-/langgraph-checkpoint-1.1.5.tgz",
+            "integrity": "sha512-BwDwl5VeTOh6CVuiIPgsUgfK51vTJDMSbFcSCUfjJWsl8/DPdK/mbv+ejxJstkSk/BlSPMP4JfXWcN6jD2ea2Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1663,9 +1604,9 @@
             }
         },
         "node_modules/@langchain/langgraph-sdk": {
-            "version": "1.9.28",
-            "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.28.tgz",
-            "integrity": "sha512-4j3XuM0PvtmAbL8mPfBS99ez3+ytRfgbOpAR/nOeaejTRF3Q9dNw2QnaGLGng8wLPtGLoSj+SYgUOVxy9Bv9vg==",
+            "version": "1.9.30",
+            "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-1.9.30.tgz",
+            "integrity": "sha512-hPzbhenvvFRn46PHnlkad3E+TuUIfRhNGpekR5cY12D1WKh3Viwfyz9HpzCbfVebChU9Kgk494V9RJTnh1jrPQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1782,16 +1723,6 @@
                 }
             }
         },
-        "node_modules/@langchain/openai/node_modules/zod": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-            "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/colinhacks"
-            }
-        },
         "node_modules/@langchain/protocol": {
             "version": "0.0.18",
             "resolved": "https://registry.npmjs.org/@langchain/protocol/-/protocol-0.0.18.tgz",
@@ -1850,9 +1781,9 @@
             "license": "MIT"
         },
         "node_modules/@n8n_io/ai-assistant-sdk": {
-            "version": "1.25.0",
-            "resolved": "https://registry.npmjs.org/@n8n_io/ai-assistant-sdk/-/ai-assistant-sdk-1.25.0.tgz",
-            "integrity": "sha512-7V4dwVuHIkLdwd7Cx0k1miwr3KttC4rLQ+zVLftBMmSDx6n+0/W4a8BGhwrVHNx6uQwA1UGEWz+wSfO+gtBA4Q==",
+            "version": "1.26.0",
+            "resolved": "https://registry.npmjs.org/@n8n_io/ai-assistant-sdk/-/ai-assistant-sdk-1.26.0.tgz",
+            "integrity": "sha512-iVW3dfhg48WipFhiVUjOIqo0MvFv1wrGamvbTUZusMF13NjycicLZSE1Bd4V6nLsLtSqcOfZ1m8LXFrmZyxOOw==",
             "dev": true,
             "license": "LicenseRef-n8n-enterprise",
             "engines": {
@@ -1861,19 +1792,19 @@
             }
         },
         "node_modules/@n8n/ai-node-sdk": {
-            "version": "0.23.2",
-            "resolved": "https://registry.npmjs.org/@n8n/ai-node-sdk/-/ai-node-sdk-0.23.2.tgz",
-            "integrity": "sha512-1k8XPLs2IELbtwMwu1vPX1L50pAvCuCmBZknZ8YxiJj2sd+Gr51t3KMZEQZdAP6U6rYV2wMIekQ6mW61G9taCg==",
+            "version": "0.25.4",
+            "resolved": "https://registry.npmjs.org/@n8n/ai-node-sdk/-/ai-node-sdk-0.25.4.tgz",
+            "integrity": "sha512-xcrWzCHCSlV8mVUYPQ1y7qLC37WBNaEzpW6RUUPczNikbtSni3h/DlUvWoHwuX1siSJuhfjIb656aiI2ZfREbQ==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
-                "@n8n/ai-utilities": "0.26.2"
+                "@n8n/ai-utilities": "0.28.4"
             }
         },
         "node_modules/@n8n/ai-utilities": {
-            "version": "0.26.2",
-            "resolved": "https://registry.npmjs.org/@n8n/ai-utilities/-/ai-utilities-0.26.2.tgz",
-            "integrity": "sha512-NQODtHVAs4INfJjgpQMbn7zx+8IQa/jSHl7L+DQfwm+GGF4IDm41i9QSnmuJYzjmdmdBvEE1VDFPTGeigPtK3Q==",
+            "version": "0.28.4",
+            "resolved": "https://registry.npmjs.org/@n8n/ai-utilities/-/ai-utilities-0.28.4.tgz",
+            "integrity": "sha512-B7eG4JNulAbJHgc6hBDTm66h7UXlal+v+2SIn0FPoSjdXE8k7UQZcuYYwfol5FpBb4uJiZTQNpLB2z53fp6C8A==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
@@ -1882,245 +1813,55 @@
                 "@langchain/core": "1.2.0",
                 "@langchain/openai": "1.4.4",
                 "@langchain/textsplitters": "1.0.1",
-                "@n8n/api-types": "1.33.2",
-                "@n8n/backend-network": "1.7.2",
-                "@n8n/config": "2.31.1",
+                "@n8n/api-types": "1.35.4",
+                "@n8n/backend-network": "1.9.4",
+                "@n8n/config": "2.33.3",
                 "@n8n/typescript-config": "1.9.0",
-                "@n8n/utils": "1.41.0",
+                "@n8n/utils": "1.43.1",
                 "@thednp/dommatrix": "^2.0.12",
                 "js-tiktoken": "1.0.21",
                 "langchain": "1.2.30",
                 "lodash": "4.18.1",
-                "n8n-workflow": "2.33.2",
+                "n8n-workflow": "2.35.3",
                 "pdf-parse": "2.4.5",
                 "tmp-promise": "3.0.3",
                 "undici": "^6.27.0",
-                "zod": "3.25.67",
+                "zod": "3.25.76",
                 "zod-to-json-schema": "3.23.3"
             }
         },
-        "node_modules/@n8n/ai-utilities/node_modules/@n8n/errors": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.13.0.tgz",
-            "integrity": "sha512-hUZ+ePKp2BzJL40OK1+wTVefJkKLy+mjiBT6KsejkXi1HboYoqHruFqeQZivm5PHhX3CZsHa9ZJy2LGHZrpKCQ==",
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.md",
-            "dependencies": {
-                "callsites": "3.1.0"
-            }
-        },
-        "node_modules/@n8n/ai-utilities/node_modules/@n8n/expression-runtime": {
-            "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.24.0.tgz",
-            "integrity": "sha512-ATII3IU1yAb29oFdGviJuMuL+31oSvTr31FIdVpASDyfHDGPFAbsAC0t/Gpa/RorGvjvmzu6fXow7XA0Xj5jdQ==",
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.md",
-            "dependencies": {
-                "@n8n/errors": "0.13.0",
-                "@n8n/tournament": "1.9.0",
-                "isolated-vm": "^6.1.2",
-                "jmespath": "0.16.0",
-                "js-base64": "3.7.8",
-                "jssha": "3.3.1",
-                "lodash": "4.18.1",
-                "luxon": "3.7.2",
-                "md5": "2.3.0",
-                "title-case": "3.0.3",
-                "transliteration": "2.3.5",
-                "zod": "3.25.67"
-            }
-        },
-        "node_modules/@n8n/ai-utilities/node_modules/@n8n/tournament": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.9.0.tgz",
-            "integrity": "sha512-XB88QlKuD5QO1ERrfVbb2BC2uJrHqHsbmK5FlV+hY7W6IZO4BQtGCTJmHKgwCm+mKsVwBUz3edO8rUadNX6sxg==",
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.md",
-            "dependencies": {
-                "ast-types": "^0.16.1",
-                "esprima-next": "^5.8.4",
-                "recast": "^0.22.0"
-            }
-        },
-        "node_modules/@n8n/ai-utilities/node_modules/n8n-workflow": {
-            "version": "2.33.2",
-            "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.33.2.tgz",
-            "integrity": "sha512-dGbWefR1opE5fIXKT0AQKDVxXD0LmLX4r84PGl5cGmYzqJhBS/FucRpm+nVo5EBA/fUop5qpGPGcU9BoQUb0aQ==",
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.md",
-            "dependencies": {
-                "@codemirror/autocomplete": "6.20.0",
-                "@n8n/errors": "0.13.0",
-                "@n8n/expression-runtime": "0.24.0",
-                "@n8n/tournament": "1.9.0",
-                "@n8n/utils": "1.41.0",
-                "@sentry/core": "^10.55.0",
-                "@sentry/node": "^10.55.0",
-                "ast-types": "0.16.1",
-                "axios": "1.18.0",
-                "callsites": "3.1.0",
-                "esprima-next": "5.8.4",
-                "form-data": "4.0.6",
-                "jmespath": "0.16.0",
-                "js-base64": "3.7.8",
-                "json-schema": "0.4.0",
-                "jsonrepair": "3.13.2",
-                "jssha": "3.3.1",
-                "lodash": "4.18.1",
-                "luxon": "3.7.2",
-                "md5": "2.3.0",
-                "recast": "0.22.0",
-                "ssh2": "1.15.0",
-                "title-case": "3.0.3",
-                "transliteration": "2.3.5",
-                "uuid": "11.1.1",
-                "xml2js": "0.6.2"
-            },
-            "peerDependencies": {
-                "zod": "3.25.67"
-            }
-        },
-        "node_modules/@n8n/ai-utilities/node_modules/uuid": {
-            "version": "11.1.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-            "dev": true,
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/esm/bin/uuid"
-            }
-        },
         "node_modules/@n8n/api-types": {
-            "version": "1.33.2",
-            "resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-1.33.2.tgz",
-            "integrity": "sha512-A99ssvyUXqH8tdbL2IDbK5Vj+85QLUhkS4Ukk7mH+vx+qt1/i3Lo96RI7lM6U7VJLIroZgfr7J/8JHPR112K0Q==",
+            "version": "1.35.4",
+            "resolved": "https://registry.npmjs.org/@n8n/api-types/-/api-types-1.35.4.tgz",
+            "integrity": "sha512-/SX/xJCFeQMXwr+rkfgaTvQWs1wjmuEVyJIMIcAvqyo1r1k9IqCsqnX7UQIm8iPfJBm2E5u0twFAjdIze/tprg==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
-                "@n8n_io/ai-assistant-sdk": "1.25.0",
-                "@n8n/permissions": "0.70.0",
-                "n8n-workflow": "2.33.2",
+                "@n8n_io/ai-assistant-sdk": "1.26.0",
+                "@n8n/permissions": "0.72.0",
+                "n8n-workflow": "2.35.3",
                 "xss": "1.0.15"
             },
             "peerDependencies": {
-                "zod": "3.25.67"
-            }
-        },
-        "node_modules/@n8n/api-types/node_modules/@n8n/errors": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.13.0.tgz",
-            "integrity": "sha512-hUZ+ePKp2BzJL40OK1+wTVefJkKLy+mjiBT6KsejkXi1HboYoqHruFqeQZivm5PHhX3CZsHa9ZJy2LGHZrpKCQ==",
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.md",
-            "dependencies": {
-                "callsites": "3.1.0"
-            }
-        },
-        "node_modules/@n8n/api-types/node_modules/@n8n/expression-runtime": {
-            "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.24.0.tgz",
-            "integrity": "sha512-ATII3IU1yAb29oFdGviJuMuL+31oSvTr31FIdVpASDyfHDGPFAbsAC0t/Gpa/RorGvjvmzu6fXow7XA0Xj5jdQ==",
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.md",
-            "dependencies": {
-                "@n8n/errors": "0.13.0",
-                "@n8n/tournament": "1.9.0",
-                "isolated-vm": "^6.1.2",
-                "jmespath": "0.16.0",
-                "js-base64": "3.7.8",
-                "jssha": "3.3.1",
-                "lodash": "4.18.1",
-                "luxon": "3.7.2",
-                "md5": "2.3.0",
-                "title-case": "3.0.3",
-                "transliteration": "2.3.5",
-                "zod": "3.25.67"
-            }
-        },
-        "node_modules/@n8n/api-types/node_modules/@n8n/tournament": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.9.0.tgz",
-            "integrity": "sha512-XB88QlKuD5QO1ERrfVbb2BC2uJrHqHsbmK5FlV+hY7W6IZO4BQtGCTJmHKgwCm+mKsVwBUz3edO8rUadNX6sxg==",
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.md",
-            "dependencies": {
-                "ast-types": "^0.16.1",
-                "esprima-next": "^5.8.4",
-                "recast": "^0.22.0"
-            }
-        },
-        "node_modules/@n8n/api-types/node_modules/n8n-workflow": {
-            "version": "2.33.2",
-            "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.33.2.tgz",
-            "integrity": "sha512-dGbWefR1opE5fIXKT0AQKDVxXD0LmLX4r84PGl5cGmYzqJhBS/FucRpm+nVo5EBA/fUop5qpGPGcU9BoQUb0aQ==",
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.md",
-            "dependencies": {
-                "@codemirror/autocomplete": "6.20.0",
-                "@n8n/errors": "0.13.0",
-                "@n8n/expression-runtime": "0.24.0",
-                "@n8n/tournament": "1.9.0",
-                "@n8n/utils": "1.41.0",
-                "@sentry/core": "^10.55.0",
-                "@sentry/node": "^10.55.0",
-                "ast-types": "0.16.1",
-                "axios": "1.18.0",
-                "callsites": "3.1.0",
-                "esprima-next": "5.8.4",
-                "form-data": "4.0.6",
-                "jmespath": "0.16.0",
-                "js-base64": "3.7.8",
-                "json-schema": "0.4.0",
-                "jsonrepair": "3.13.2",
-                "jssha": "3.3.1",
-                "lodash": "4.18.1",
-                "luxon": "3.7.2",
-                "md5": "2.3.0",
-                "recast": "0.22.0",
-                "ssh2": "1.15.0",
-                "title-case": "3.0.3",
-                "transliteration": "2.3.5",
-                "uuid": "11.1.1",
-                "xml2js": "0.6.2"
-            },
-            "peerDependencies": {
-                "zod": "3.25.67"
-            }
-        },
-        "node_modules/@n8n/api-types/node_modules/uuid": {
-            "version": "11.1.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-            "dev": true,
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/esm/bin/uuid"
+                "zod": "3.25.76"
             }
         },
         "node_modules/@n8n/backend-common": {
-            "version": "1.33.2",
-            "resolved": "https://registry.npmjs.org/@n8n/backend-common/-/backend-common-1.33.2.tgz",
-            "integrity": "sha512-0y8a21131PWxUiDxR7TQeSvqSCwqxwrj8/aQwiBehuznPnthhykhpyTqsizrmEQdCcalTX3e5O+o/CWtxR2m/g==",
+            "version": "1.35.4",
+            "resolved": "https://registry.npmjs.org/@n8n/backend-common/-/backend-common-1.35.4.tgz",
+            "integrity": "sha512-15vd0XAe6Lx+Qm1kjp4Fd6B1CsJ4OaLRMfbtGIkXBuIOQmDJazEklo10JN6Ovh0nHcQK8QGw+1WNfk+LQLAxSQ==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
-                "@n8n/config": "2.31.1",
-                "@n8n/constants": "0.32.0",
-                "@n8n/decorators": "1.33.2",
+                "@n8n/config": "2.33.3",
+                "@n8n/constants": "0.34.0",
+                "@n8n/decorators": "1.35.4",
                 "@n8n/di": "0.16.0",
-                "@n8n/utils": "1.41.0",
+                "@n8n/utils": "1.43.1",
                 "callsites": "3.1.0",
                 "flatted": "3.4.2",
                 "logform": "2.6.1",
-                "n8n-workflow": "2.33.2",
+                "n8n-workflow": "2.35.3",
                 "picocolors": "1.0.1",
                 "reflect-metadata": "0.2.2",
                 "stream-json": "1.9.1",
@@ -2128,206 +1869,30 @@
                 "yargs-parser": "21.1.1"
             }
         },
-        "node_modules/@n8n/backend-common/node_modules/@n8n/errors": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.13.0.tgz",
-            "integrity": "sha512-hUZ+ePKp2BzJL40OK1+wTVefJkKLy+mjiBT6KsejkXi1HboYoqHruFqeQZivm5PHhX3CZsHa9ZJy2LGHZrpKCQ==",
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.md",
-            "dependencies": {
-                "callsites": "3.1.0"
-            }
-        },
-        "node_modules/@n8n/backend-common/node_modules/@n8n/expression-runtime": {
-            "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.24.0.tgz",
-            "integrity": "sha512-ATII3IU1yAb29oFdGviJuMuL+31oSvTr31FIdVpASDyfHDGPFAbsAC0t/Gpa/RorGvjvmzu6fXow7XA0Xj5jdQ==",
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.md",
-            "dependencies": {
-                "@n8n/errors": "0.13.0",
-                "@n8n/tournament": "1.9.0",
-                "isolated-vm": "^6.1.2",
-                "jmespath": "0.16.0",
-                "js-base64": "3.7.8",
-                "jssha": "3.3.1",
-                "lodash": "4.18.1",
-                "luxon": "3.7.2",
-                "md5": "2.3.0",
-                "title-case": "3.0.3",
-                "transliteration": "2.3.5",
-                "zod": "3.25.67"
-            }
-        },
-        "node_modules/@n8n/backend-common/node_modules/@n8n/tournament": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.9.0.tgz",
-            "integrity": "sha512-XB88QlKuD5QO1ERrfVbb2BC2uJrHqHsbmK5FlV+hY7W6IZO4BQtGCTJmHKgwCm+mKsVwBUz3edO8rUadNX6sxg==",
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.md",
-            "dependencies": {
-                "ast-types": "^0.16.1",
-                "esprima-next": "^5.8.4",
-                "recast": "^0.22.0"
-            }
-        },
-        "node_modules/@n8n/backend-common/node_modules/n8n-workflow": {
-            "version": "2.33.2",
-            "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.33.2.tgz",
-            "integrity": "sha512-dGbWefR1opE5fIXKT0AQKDVxXD0LmLX4r84PGl5cGmYzqJhBS/FucRpm+nVo5EBA/fUop5qpGPGcU9BoQUb0aQ==",
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.md",
-            "dependencies": {
-                "@codemirror/autocomplete": "6.20.0",
-                "@n8n/errors": "0.13.0",
-                "@n8n/expression-runtime": "0.24.0",
-                "@n8n/tournament": "1.9.0",
-                "@n8n/utils": "1.41.0",
-                "@sentry/core": "^10.55.0",
-                "@sentry/node": "^10.55.0",
-                "ast-types": "0.16.1",
-                "axios": "1.18.0",
-                "callsites": "3.1.0",
-                "esprima-next": "5.8.4",
-                "form-data": "4.0.6",
-                "jmespath": "0.16.0",
-                "js-base64": "3.7.8",
-                "json-schema": "0.4.0",
-                "jsonrepair": "3.13.2",
-                "jssha": "3.3.1",
-                "lodash": "4.18.1",
-                "luxon": "3.7.2",
-                "md5": "2.3.0",
-                "recast": "0.22.0",
-                "ssh2": "1.15.0",
-                "title-case": "3.0.3",
-                "transliteration": "2.3.5",
-                "uuid": "11.1.1",
-                "xml2js": "0.6.2"
-            },
-            "peerDependencies": {
-                "zod": "3.25.67"
-            }
-        },
-        "node_modules/@n8n/backend-common/node_modules/uuid": {
-            "version": "11.1.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-            "dev": true,
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/esm/bin/uuid"
-            }
-        },
         "node_modules/@n8n/backend-network": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/@n8n/backend-network/-/backend-network-1.7.2.tgz",
-            "integrity": "sha512-nIa8FZwrJKz11JOVGAlEF1LyR+dfS9KXIFziry+lEljTOh5TJFWGb0m0k24WUzruNTco0bZDfHOsTx1B5fVT0g==",
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@n8n/backend-network/-/backend-network-1.9.4.tgz",
+            "integrity": "sha512-/FjUzNFeL9cTHwSiPDzX7x2Ax3nv8X/GH7MUKrLWGt1kTU41S61dxiZa/Es57rcO9RxD6na9+NGP3FNStveuKA==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
-                "@n8n/backend-common": "1.33.2",
-                "@n8n/config": "2.31.1",
-                "@n8n/constants": "0.32.0",
+                "@n8n/backend-common": "1.35.4",
+                "@n8n/config": "2.33.3",
+                "@n8n/constants": "0.34.0",
                 "@n8n/di": "0.16.0",
-                "@n8n/utils": "1.41.0",
+                "@n8n/utils": "1.43.1",
                 "axios": "1.18.0",
                 "cache-manager": "5.2.3",
                 "form-data": "4.0.6",
                 "http-proxy-agent": "7.0.2",
                 "https-proxy-agent": "7.0.6",
                 "iconv-lite": "0.6.3",
-                "n8n-workflow": "2.33.2",
+                "n8n-workflow": "2.35.3",
                 "proxy-from-env": "^1.1.0",
                 "qs": "6.15.2",
                 "reflect-metadata": "0.2.2",
-                "undici": "^7.28.0",
-                "zod": "3.25.67"
-            }
-        },
-        "node_modules/@n8n/backend-network/node_modules/@n8n/errors": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.13.0.tgz",
-            "integrity": "sha512-hUZ+ePKp2BzJL40OK1+wTVefJkKLy+mjiBT6KsejkXi1HboYoqHruFqeQZivm5PHhX3CZsHa9ZJy2LGHZrpKCQ==",
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.md",
-            "dependencies": {
-                "callsites": "3.1.0"
-            }
-        },
-        "node_modules/@n8n/backend-network/node_modules/@n8n/expression-runtime": {
-            "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.24.0.tgz",
-            "integrity": "sha512-ATII3IU1yAb29oFdGviJuMuL+31oSvTr31FIdVpASDyfHDGPFAbsAC0t/Gpa/RorGvjvmzu6fXow7XA0Xj5jdQ==",
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.md",
-            "dependencies": {
-                "@n8n/errors": "0.13.0",
-                "@n8n/tournament": "1.9.0",
-                "isolated-vm": "^6.1.2",
-                "jmespath": "0.16.0",
-                "js-base64": "3.7.8",
-                "jssha": "3.3.1",
-                "lodash": "4.18.1",
-                "luxon": "3.7.2",
-                "md5": "2.3.0",
-                "title-case": "3.0.3",
-                "transliteration": "2.3.5",
-                "zod": "3.25.67"
-            }
-        },
-        "node_modules/@n8n/backend-network/node_modules/@n8n/tournament": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.9.0.tgz",
-            "integrity": "sha512-XB88QlKuD5QO1ERrfVbb2BC2uJrHqHsbmK5FlV+hY7W6IZO4BQtGCTJmHKgwCm+mKsVwBUz3edO8rUadNX6sxg==",
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.md",
-            "dependencies": {
-                "ast-types": "^0.16.1",
-                "esprima-next": "^5.8.4",
-                "recast": "^0.22.0"
-            }
-        },
-        "node_modules/@n8n/backend-network/node_modules/n8n-workflow": {
-            "version": "2.33.2",
-            "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.33.2.tgz",
-            "integrity": "sha512-dGbWefR1opE5fIXKT0AQKDVxXD0LmLX4r84PGl5cGmYzqJhBS/FucRpm+nVo5EBA/fUop5qpGPGcU9BoQUb0aQ==",
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.md",
-            "dependencies": {
-                "@codemirror/autocomplete": "6.20.0",
-                "@n8n/errors": "0.13.0",
-                "@n8n/expression-runtime": "0.24.0",
-                "@n8n/tournament": "1.9.0",
-                "@n8n/utils": "1.41.0",
-                "@sentry/core": "^10.55.0",
-                "@sentry/node": "^10.55.0",
-                "ast-types": "0.16.1",
-                "axios": "1.18.0",
-                "callsites": "3.1.0",
-                "esprima-next": "5.8.4",
-                "form-data": "4.0.6",
-                "jmespath": "0.16.0",
-                "js-base64": "3.7.8",
-                "json-schema": "0.4.0",
-                "jsonrepair": "3.13.2",
-                "jssha": "3.3.1",
-                "lodash": "4.18.1",
-                "luxon": "3.7.2",
-                "md5": "2.3.0",
-                "recast": "0.22.0",
-                "ssh2": "1.15.0",
-                "title-case": "3.0.3",
-                "transliteration": "2.3.5",
-                "uuid": "11.1.1",
-                "xml2js": "0.6.2"
-            },
-            "peerDependencies": {
-                "zod": "3.25.67"
+                "undici": "^7.29.0",
+                "zod": "3.25.76"
             }
         },
         "node_modules/@n8n/backend-network/node_modules/undici": {
@@ -2340,148 +1905,39 @@
                 "node": ">=20.18.1"
             }
         },
-        "node_modules/@n8n/backend-network/node_modules/uuid": {
-            "version": "11.1.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-            "dev": true,
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/esm/bin/uuid"
-            }
-        },
         "node_modules/@n8n/config": {
-            "version": "2.31.1",
-            "resolved": "https://registry.npmjs.org/@n8n/config/-/config-2.31.1.tgz",
-            "integrity": "sha512-5XLfi6qeL0g7axmU8/Y9S011aj7wNEUjdWtjYb68JUkUnDWMkL/Z5MgZ1PpR/cBxUH+ytUrtGxNursEDmDjgXA==",
+            "version": "2.33.3",
+            "resolved": "https://registry.npmjs.org/@n8n/config/-/config-2.33.3.tgz",
+            "integrity": "sha512-7uIQlip7MeFtjM8XWr0xaqcCHsZ8wYK677UWBIUk10F/AdxYorVD618rBJPgR2GbL63b1zu6Zirop9jBrx7K4Q==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
-                "@n8n/constants": "0.32.0",
+                "@n8n/constants": "0.34.0",
                 "@n8n/di": "0.16.0",
                 "reflect-metadata": "0.2.2",
-                "zod": "3.25.67"
+                "zod": "3.25.76"
             }
         },
         "node_modules/@n8n/constants": {
-            "version": "0.32.0",
-            "resolved": "https://registry.npmjs.org/@n8n/constants/-/constants-0.32.0.tgz",
-            "integrity": "sha512-ewF/bQL2bjmHU9Dv5PnW8uDpYw5GlFJ0/nuAp+RDK9OJXXm19ErHb9itLyANvNTLGPQv8bb0BMvHh2kpWaa/8g==",
+            "version": "0.34.0",
+            "resolved": "https://registry.npmjs.org/@n8n/constants/-/constants-0.34.0.tgz",
+            "integrity": "sha512-d9iKTQ5ngexLwX9/eD8GmysQ9DBHb4uVmApIvjfd6vC60hckxlpYgSTV0ySeKm00+AUHA+APU6jYe5bQfoxayA==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md"
         },
         "node_modules/@n8n/decorators": {
-            "version": "1.33.2",
-            "resolved": "https://registry.npmjs.org/@n8n/decorators/-/decorators-1.33.2.tgz",
-            "integrity": "sha512-J+oUnIDlBpjzHJLEgFoTDjXSUL8LCk5GzTnJOol0j6Wb9/iTWBGQv+WOWRoCO+JfOLUxBsSVerLDXnSMZ53zVQ==",
+            "version": "1.35.4",
+            "resolved": "https://registry.npmjs.org/@n8n/decorators/-/decorators-1.35.4.tgz",
+            "integrity": "sha512-sjnfdfu0vKTtnR4CzbloHjTOr4nptXGDaRMtvOkvqi0m1gBZhmAfl4FacsJe+oS2JXtFFDMEtHIroamcWE0t/Q==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
-                "@n8n/api-types": "1.33.2",
-                "@n8n/constants": "0.32.0",
+                "@n8n/api-types": "1.35.4",
+                "@n8n/constants": "0.34.0",
                 "@n8n/di": "0.16.0",
-                "@n8n/permissions": "0.70.0",
+                "@n8n/permissions": "0.72.0",
                 "lodash": "4.18.1",
-                "n8n-workflow": "2.33.2"
-            }
-        },
-        "node_modules/@n8n/decorators/node_modules/@n8n/errors": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.13.0.tgz",
-            "integrity": "sha512-hUZ+ePKp2BzJL40OK1+wTVefJkKLy+mjiBT6KsejkXi1HboYoqHruFqeQZivm5PHhX3CZsHa9ZJy2LGHZrpKCQ==",
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.md",
-            "dependencies": {
-                "callsites": "3.1.0"
-            }
-        },
-        "node_modules/@n8n/decorators/node_modules/@n8n/expression-runtime": {
-            "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.24.0.tgz",
-            "integrity": "sha512-ATII3IU1yAb29oFdGviJuMuL+31oSvTr31FIdVpASDyfHDGPFAbsAC0t/Gpa/RorGvjvmzu6fXow7XA0Xj5jdQ==",
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.md",
-            "dependencies": {
-                "@n8n/errors": "0.13.0",
-                "@n8n/tournament": "1.9.0",
-                "isolated-vm": "^6.1.2",
-                "jmespath": "0.16.0",
-                "js-base64": "3.7.8",
-                "jssha": "3.3.1",
-                "lodash": "4.18.1",
-                "luxon": "3.7.2",
-                "md5": "2.3.0",
-                "title-case": "3.0.3",
-                "transliteration": "2.3.5",
-                "zod": "3.25.67"
-            }
-        },
-        "node_modules/@n8n/decorators/node_modules/@n8n/tournament": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.9.0.tgz",
-            "integrity": "sha512-XB88QlKuD5QO1ERrfVbb2BC2uJrHqHsbmK5FlV+hY7W6IZO4BQtGCTJmHKgwCm+mKsVwBUz3edO8rUadNX6sxg==",
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.md",
-            "dependencies": {
-                "ast-types": "^0.16.1",
-                "esprima-next": "^5.8.4",
-                "recast": "^0.22.0"
-            }
-        },
-        "node_modules/@n8n/decorators/node_modules/n8n-workflow": {
-            "version": "2.33.2",
-            "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.33.2.tgz",
-            "integrity": "sha512-dGbWefR1opE5fIXKT0AQKDVxXD0LmLX4r84PGl5cGmYzqJhBS/FucRpm+nVo5EBA/fUop5qpGPGcU9BoQUb0aQ==",
-            "dev": true,
-            "license": "SEE LICENSE IN LICENSE.md",
-            "dependencies": {
-                "@codemirror/autocomplete": "6.20.0",
-                "@n8n/errors": "0.13.0",
-                "@n8n/expression-runtime": "0.24.0",
-                "@n8n/tournament": "1.9.0",
-                "@n8n/utils": "1.41.0",
-                "@sentry/core": "^10.55.0",
-                "@sentry/node": "^10.55.0",
-                "ast-types": "0.16.1",
-                "axios": "1.18.0",
-                "callsites": "3.1.0",
-                "esprima-next": "5.8.4",
-                "form-data": "4.0.6",
-                "jmespath": "0.16.0",
-                "js-base64": "3.7.8",
-                "json-schema": "0.4.0",
-                "jsonrepair": "3.13.2",
-                "jssha": "3.3.1",
-                "lodash": "4.18.1",
-                "luxon": "3.7.2",
-                "md5": "2.3.0",
-                "recast": "0.22.0",
-                "ssh2": "1.15.0",
-                "title-case": "3.0.3",
-                "transliteration": "2.3.5",
-                "uuid": "11.1.1",
-                "xml2js": "0.6.2"
-            },
-            "peerDependencies": {
-                "zod": "3.25.67"
-            }
-        },
-        "node_modules/@n8n/decorators/node_modules/uuid": {
-            "version": "11.1.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
-            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
-            "dev": true,
-            "funding": [
-                "https://github.com/sponsors/broofa",
-                "https://github.com/sponsors/ctavan"
-            ],
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/esm/bin/uuid"
+                "n8n-workflow": "2.35.3"
             }
         },
         "node_modules/@n8n/di": {
@@ -2495,9 +1951,9 @@
             }
         },
         "node_modules/@n8n/errors": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.10.0.tgz",
-            "integrity": "sha512-Qle4gCsx7qtDRMdie3YkjuXPuo369PP32cR9Svb+INwcjLMxNzmnbJ66jFnOmLn0ntwBccUw1IecJ6axwyTgBQ==",
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/@n8n/errors/-/errors-0.13.0.tgz",
+            "integrity": "sha512-hUZ+ePKp2BzJL40OK1+wTVefJkKLy+mjiBT6KsejkXi1HboYoqHruFqeQZivm5PHhX3CZsHa9ZJy2LGHZrpKCQ==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
@@ -2505,14 +1961,14 @@
             }
         },
         "node_modules/@n8n/expression-runtime": {
-            "version": "0.20.1",
-            "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.20.1.tgz",
-            "integrity": "sha512-8UaKPCnu1hNdZvrNPRVkERPodZiQONF/BeB4uZdXKd/RsT6zOnAzdDF3I9czDpILzLbi8ViG5FeQz04PREt6dQ==",
+            "version": "0.26.1",
+            "resolved": "https://registry.npmjs.org/@n8n/expression-runtime/-/expression-runtime-0.26.1.tgz",
+            "integrity": "sha512-9DsfaQty3gl4yjn1Tj31rlHhc8vSuoanqlMVx1tsCe1m6CgcElfDbOTa0ak0WzJzedfPTllQTihyuCBmGtQsFw==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
-                "@n8n/errors": "0.10.0",
-                "@n8n/tournament": "1.5.0",
+                "@n8n/errors": "0.13.0",
+                "@n8n/tournament": "1.9.1",
                 "isolated-vm": "^6.1.2",
                 "jmespath": "0.16.0",
                 "js-base64": "3.7.8",
@@ -2522,20 +1978,20 @@
                 "md5": "2.3.0",
                 "title-case": "3.0.3",
                 "transliteration": "2.3.5",
-                "zod": "3.25.67"
+                "zod": "3.25.76"
             }
         },
         "node_modules/@n8n/node-cli": {
-            "version": "0.42.2",
-            "resolved": "https://registry.npmjs.org/@n8n/node-cli/-/node-cli-0.42.2.tgz",
-            "integrity": "sha512-lWRFQ+nwuKJIU2GJic1rCQdDYE7EyMeVoaJuryrryMXRAAeStdmgHRyws9L91Uaj+HHyj8UHFMzabMSUB5L4eg==",
+            "version": "0.44.4",
+            "resolved": "https://registry.npmjs.org/@n8n/node-cli/-/node-cli-0.44.4.tgz",
+            "integrity": "sha512-2zOrQGezneUULeRoZcSyGgfEL9Ehm7bs1rD6VvrNu24uXWwOk8n8Nfeyiho/nbzU1oWG0dRwBsQnD3/xlUXphA==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "@clack/prompts": "^0.11.0",
                 "@eslint/js": "^9.29.0",
-                "@n8n/ai-node-sdk": "0.23.2",
-                "@n8n/eslint-plugin-community-nodes": "0.27.0",
+                "@n8n/ai-node-sdk": "0.25.4",
+                "@n8n/eslint-plugin-community-nodes": "0.29.0",
                 "@oclif/core": "^4.5.2",
                 "change-case": "^5.4.4",
                 "eslint": "9.29.0",
@@ -2610,9 +2066,9 @@
             }
         },
         "node_modules/@n8n/node-cli/node_modules/@n8n/eslint-plugin-community-nodes": {
-            "version": "0.27.0",
-            "resolved": "https://registry.npmjs.org/@n8n/eslint-plugin-community-nodes/-/eslint-plugin-community-nodes-0.27.0.tgz",
-            "integrity": "sha512-qTcdOyhCODOJ2VtDBpvkWFE5+gLuwUQ+D4+AnCzCQLs0Ba/scOxRGviYZYdhwY70HfNcLpakN3xKLccwFMP6Dw==",
+            "version": "0.29.0",
+            "resolved": "https://registry.npmjs.org/@n8n/eslint-plugin-community-nodes/-/eslint-plugin-community-nodes-0.29.0.tgz",
+            "integrity": "sha512-+TvM0R8JSywAsrQpMTAQQMPwwy8rTaisBAXSDdHQyaTACtzqulXH2Al1gx0M+WwDSDpOOACBb7yTIlCxk8Ne2g==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
@@ -2649,6 +2105,7 @@
             "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -2744,29 +2201,25 @@
             }
         },
         "node_modules/@n8n/permissions": {
-            "version": "0.70.0",
-            "resolved": "https://registry.npmjs.org/@n8n/permissions/-/permissions-0.70.0.tgz",
-            "integrity": "sha512-V6egB3bM15Aiu5+124vlX6Uth/9XfveBe0KiujubKr41tMj0YVh78ozuSsQPUpA2OpHGKusdA+Im/EmYjvpPnQ==",
+            "version": "0.72.0",
+            "resolved": "https://registry.npmjs.org/@n8n/permissions/-/permissions-0.72.0.tgz",
+            "integrity": "sha512-PYQyA15cbn35l/qO5n+XF4NubfaZBAOq/shQrXQtG1/FliYRRheVHT8Y0AX6nJRMmNTtyIeKZxWk140OzUpsoA==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
-                "zod": "3.25.67"
+                "zod": "3.25.76"
             }
         },
         "node_modules/@n8n/tournament": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.5.0.tgz",
-            "integrity": "sha512-trQq+DUm3ICx7HSIf1jF3Nixuo5j5d63rqpeEiVWhaiYzLvaju6gBnenNwyR7BQIFILIa08wGWKVFjr7fRo+3Q==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@n8n/tournament/-/tournament-1.9.1.tgz",
+            "integrity": "sha512-cqlvqs1mrIsU4FyVvzLz9n8tFNfglHXwTfRNoZ/upDMahoNE2faitj/eB5HFS72gCNoS7M1/HuoA1qfv4zpt+Q==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
                 "ast-types": "^0.16.1",
                 "esprima-next": "^5.8.4",
                 "recast": "^0.22.0"
-            },
-            "engines": {
-                "node": ">=20.15",
-                "pnpm": ">=9.5"
             }
         },
         "node_modules/@n8n/typescript-config": {
@@ -2777,13 +2230,13 @@
             "license": "SEE LICENSE IN LICENSE.md"
         },
         "node_modules/@n8n/utils": {
-            "version": "1.41.0",
-            "resolved": "https://registry.npmjs.org/@n8n/utils/-/utils-1.41.0.tgz",
-            "integrity": "sha512-wjlYqMYRDI8RGNEEBQXA9Pw5FsgdqP+4tvk6HJ9POB5x9yQyF4PhHt45a2RVz0BAoGwZKuxnunR3T+pE/FbjKQ==",
+            "version": "1.43.1",
+            "resolved": "https://registry.npmjs.org/@n8n/utils/-/utils-1.43.1.tgz",
+            "integrity": "sha512-gugxDvYJUoYlDRSmgjZrYPX4nBJrYeeQFmIuMgvb3A3kVYHL1fFr2Ftu9AN5EcgkVVp7hYsj905ddcimQqQH0g==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
             "dependencies": {
-                "@n8n/constants": "0.32.0",
+                "@n8n/constants": "0.34.0",
                 "nanoid": "3.3.8"
             }
         },
@@ -3085,6 +2538,7 @@
             "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@octokit/auth-token": "^6.0.0",
                 "@octokit/graphql": "^9.0.3",
@@ -3242,6 +2696,7 @@
             "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -3265,6 +2720,7 @@
             "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/semantic-conventions": "^1.29.0"
             },
@@ -3281,6 +2737,7 @@
             "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/api-logs": "0.220.0",
                 "import-in-the-middle": "^3.0.0",
@@ -3334,6 +2791,7 @@
             "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/core": "2.10.0",
                 "@opentelemetry/resources": "2.10.0",
@@ -3399,9 +2857,9 @@
             }
         },
         "node_modules/@sentry/core": {
-            "version": "10.69.0",
-            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.69.0.tgz",
-            "integrity": "sha512-+uuqVEeiDzYuAKjZLqsROKXvRTbl/QeH0gfGRtpYib1cud4rAFWRIkFmcR7Jb7JGFYwmReyQotiTj/hcDszTZg==",
+            "version": "10.70.0",
+            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.70.0.tgz",
+            "integrity": "sha512-ozhCTDqg89oB4XmWfAwuHshABpvT7AkRpaPnogopPfMAaI61G1t8EKCJ4W7aum8JSBonlfyjPCyW5oYZFm0KvA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3412,9 +2870,9 @@
             }
         },
         "node_modules/@sentry/node": {
-            "version": "10.69.0",
-            "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.69.0.tgz",
-            "integrity": "sha512-xEXA1YGIiTZbrW6MWV34uS6JGQuQg2ijTI0zed+FsJb9JZKPYel/GZK8Km26vfTVb+yCXFmWZNBesKegNcVdzg==",
+            "version": "10.70.0",
+            "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.70.0.tgz",
+            "integrity": "sha512-SPOOVxmKTVIEtqvOKkQT163e/pOwucjS7OPsCHyRs8sFR4nfBNu0EThplyqnvqd5BWBMTPH6WTBQfo+QWHV+HA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3422,10 +2880,10 @@
                 "@opentelemetry/instrumentation": "^0.220.0",
                 "@opentelemetry/sdk-trace-base": "^2.9.0",
                 "@sentry/conventions": "^0.16.0",
-                "@sentry/core": "10.69.0",
-                "@sentry/node-core": "10.69.0",
-                "@sentry/opentelemetry": "10.69.0",
-                "@sentry/server-utils": "10.69.0",
+                "@sentry/core": "10.70.0",
+                "@sentry/node-core": "10.70.0",
+                "@sentry/opentelemetry": "10.70.0",
+                "@sentry/server-utils": "10.70.0",
                 "import-in-the-middle": "^3.0.0"
             },
             "engines": {
@@ -3433,15 +2891,15 @@
             }
         },
         "node_modules/@sentry/node-core": {
-            "version": "10.69.0",
-            "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.69.0.tgz",
-            "integrity": "sha512-IgArHczrZJxkgxoffHscj0NxQrG6kCazgmGQnlf3j58J1ec21YaUu8Tu+7G4Lo5tCiW3teQnwlKW1ttMXSqWRw==",
+            "version": "10.70.0",
+            "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.70.0.tgz",
+            "integrity": "sha512-oPOEVVNxv5WHtckx2i06Wi9FLWyvOg/1DUeX732jZ4iqT2nupINaMH4nF4f4kSvUThFnxkFSRQxwqOxgzMKhKA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@sentry/conventions": "^0.16.0",
-                "@sentry/core": "10.69.0",
-                "@sentry/opentelemetry": "10.69.0",
+                "@sentry/core": "10.70.0",
+                "@sentry/opentelemetry": "10.70.0",
                 "import-in-the-middle": "^3.0.0"
             },
             "engines": {
@@ -3473,14 +2931,14 @@
             }
         },
         "node_modules/@sentry/opentelemetry": {
-            "version": "10.69.0",
-            "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.69.0.tgz",
-            "integrity": "sha512-3FyWV6YcEJuvLrlaKGE1dHXCI+1YO0a62w7PkwlRg8yp6K6YXkmdwu9GjqaYD+Ju4tm7uC7mHIsGFQMm0M7pqQ==",
+            "version": "10.70.0",
+            "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.70.0.tgz",
+            "integrity": "sha512-UNV/2tqypcUK6FDzerAsFJn1Km/c4VZCYkUZDNbnV5S0cwAq2BYKMo4M5vovaLDBQlxA+Wk9ovbxi5wYjjl9fw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@sentry/conventions": "^0.16.0",
-                "@sentry/core": "10.69.0"
+                "@sentry/core": "10.70.0"
             },
             "engines": {
                 "node": ">=18"
@@ -3492,16 +2950,16 @@
             }
         },
         "node_modules/@sentry/server-utils": {
-            "version": "10.69.0",
-            "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.69.0.tgz",
-            "integrity": "sha512-0MwHrA8+nNvMIsqf8m3cXwCBlUjr6AS7N6CZvHJtY1DkqEvQqEbD5VIrhzEyHN/KMZIgQ8XeDCQRhjnXFQGRhg==",
+            "version": "10.70.0",
+            "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.70.0.tgz",
+            "integrity": "sha512-rzegZjMFFgCp3o+N8+XU13rfSvz4B+f8rU0ijBGrQcHdMNyfsFDTu1UTm262JofmrV2u+s+D0u0vFTnqtOGkbA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@apm-js-collab/code-transformer-bundler-plugins": "^0.7.3",
                 "@apm-js-collab/tracing-hooks": "^0.13.0",
                 "@sentry/conventions": "^0.16.0",
-                "@sentry/core": "10.69.0",
+                "@sentry/core": "10.70.0",
                 "meriyah": "^6.1.4"
             },
             "engines": {
@@ -3543,7 +3001,6 @@
             "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "debug": "^4.4.3",
                 "token-types": "^6.1.1"
@@ -3561,8 +3018,7 @@
             "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
             "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@ts-morph/common": {
             "version": "0.28.1",
@@ -3593,7 +3049,6 @@
             "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/ms": "*"
             }
@@ -3617,8 +3072,7 @@
             "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
             "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/node": {
             "version": "18.19.130",
@@ -3626,7 +3080,6 @@
             "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -3637,7 +3090,6 @@
             "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/node": "*",
                 "form-data": "^4.0.4"
@@ -3655,8 +3107,7 @@
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
             "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/triple-beam": {
             "version": "1.3.5",
@@ -3700,6 +3151,7 @@
             "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.65.0",
                 "@typescript-eslint/types": "8.65.0",
@@ -4251,7 +3703,6 @@
             "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "event-target-shim": "^5.0.0"
             },
@@ -4265,6 +3716,7 @@
             "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -4298,7 +3750,6 @@
             "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "humanize-ms": "^1.2.1"
             },
@@ -4478,6 +3929,7 @@
             "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
@@ -4624,8 +4076,7 @@
             "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
             "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
             "dev": true,
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/buildcheck": {
             "version": "0.0.7",
@@ -4783,7 +4234,6 @@
             "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -4878,9 +4328,9 @@
             }
         },
         "node_modules/cjs-module-lexer": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
-            "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.1.tgz",
+            "integrity": "sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==",
             "dev": true,
             "license": "MIT"
         },
@@ -5391,7 +4841,6 @@
             "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             }
@@ -5447,9 +4896,9 @@
             }
         },
         "node_modules/es-module-lexer": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
-            "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+            "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
             "dev": true,
             "license": "MIT"
         },
@@ -5533,6 +4982,7 @@
             "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -5654,6 +5104,7 @@
             "integrity": "sha512-4cdstYkKCyjumM2Q9NSI03K8D2a9F4Ssz33K2lv2hQa4KmR9jPLwk3uWGtNvclfqBrPGfGuMBwsGMbe6dMRbfg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/types": "^8.56.0",
                 "comment-parser": "^1.4.1",
@@ -5901,7 +5352,6 @@
             "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -5925,8 +5375,7 @@
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -6052,7 +5501,6 @@
             "integrity": "sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@tokenizer/inflate": "^0.4.1",
                 "strtok3": "^10.3.4",
@@ -6250,8 +5698,7 @@
             "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
             "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/formdata-node": {
             "version": "4.4.1",
@@ -6259,7 +5706,6 @@
             "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "node-domexception": "1.0.0",
                 "web-streams-polyfill": "4.0.0-beta.3"
@@ -6279,7 +5725,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
@@ -6620,7 +6065,6 @@
             "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ms": "^2.0.0"
             }
@@ -6631,7 +6075,6 @@
             "integrity": "sha512-7balLY8WKk+bOhe5Vgg4zG2X6Z0zhpG/3VtYPC69evj+lVJSId8xYP7ISRzRfoeXAlJfzLNMbi2Na/0IdDiIkQ==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@types/debug": "4.1.12",
                 "@types/node": "18.19.80",
@@ -6660,7 +6103,6 @@
             "integrity": "sha512-kEWeMwMeIvxYkeg1gTc01awpwLbfMRZXdIhwRcakd/KlK53jmRC26LqcbIt7fnAQTu5GzlnWmzA3H6+l1u6xxQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -6671,7 +6113,6 @@
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -6690,7 +6131,6 @@
             "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
             "dev": true,
             "license": "BSD-2-Clause",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -6703,8 +6143,7 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/iconv-lite": {
             "version": "0.6.3",
@@ -6738,8 +6177,7 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "license": "BSD-3-Clause",
-            "peer": true
+            "license": "BSD-3-Clause"
         },
         "node_modules/ignore": {
             "version": "7.0.6",
@@ -6747,6 +6185,7 @@
             "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -7157,8 +6596,7 @@
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
             "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/issue-parser": {
             "version": "7.0.2",
@@ -7224,6 +6662,7 @@
             "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
             }
@@ -7339,7 +6778,6 @@
             "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "jws": "^4.0.1",
                 "lodash.includes": "^4.3.0",
@@ -7373,7 +6811,6 @@
             "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "buffer-equal-constant-time": "^1.0.1",
                 "ecdsa-sig-formatter": "1.0.11",
@@ -7386,7 +6823,6 @@
             "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "jwa": "^2.0.1",
                 "safe-buffer": "^5.0.1"
@@ -7453,20 +6889,10 @@
                 "uuid": "dist/esm/bin/uuid"
             }
         },
-        "node_modules/langchain/node_modules/zod": {
-            "version": "4.4.3",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-            "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-            "dev": true,
-            "license": "MIT",
-            "funding": {
-                "url": "https://github.com/sponsors/colinhacks"
-            }
-        },
         "node_modules/langsmith": {
-            "version": "0.8.9",
-            "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.8.9.tgz",
-            "integrity": "sha512-6ikTB5SO+3SlBQ/+oH8K/JzhglxB8AM4RAe5bHzgWSEIHTgTe+b71bSjf1fDvlYuEXoiPn6uP10BbczrbznUnA==",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.9.0.tgz",
+            "integrity": "sha512-tlg/aG7qezAKY6G3fgADSX7PkRj+JKoF3z7QNkCMsAOvwvuzhiwP9Amn1Z+zAIxuKoWuXQdIjtFN0LVmUC1oUQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7540,7 +6966,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=13.2.0"
             }
@@ -7566,7 +6991,8 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
             "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/lodash.capitalize": {
             "version": "4.2.1",
@@ -7594,32 +7020,28 @@
             "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
             "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/lodash.isboolean": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
             "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/lodash.isinteger": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
             "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/lodash.isnumber": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
             "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/lodash.isplainobject": {
             "version": "4.0.6",
@@ -7647,8 +7069,7 @@
             "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
             "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/lodash.uniqby": {
             "version": "4.7.0",
@@ -7915,16 +7336,18 @@
             }
         },
         "node_modules/n8n-workflow": {
-            "version": "2.29.3",
-            "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.29.3.tgz",
-            "integrity": "sha512-jsJOV5o6Zd0mfCHAUthRBAZnxGgvcfjGDWdYcZf14rWxpHe4IHdBYR3eVqo/8AxsblGyDrwTQ3DfULX1d71Xog==",
+            "version": "2.35.3",
+            "resolved": "https://registry.npmjs.org/n8n-workflow/-/n8n-workflow-2.35.3.tgz",
+            "integrity": "sha512-KKTx5/NPzusN1Udog4Ivt5XkXrTZKHBSChGMQQXTs+PbLhQqrVhjwIhowtA68wReb3zFaaNBe8xRE9q8nfVUhw==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE.md",
+            "peer": true,
             "dependencies": {
                 "@codemirror/autocomplete": "6.20.0",
-                "@n8n/errors": "0.10.0",
-                "@n8n/expression-runtime": "0.20.1",
-                "@n8n/tournament": "1.5.0",
+                "@n8n/errors": "0.13.0",
+                "@n8n/expression-runtime": "0.26.1",
+                "@n8n/tournament": "1.9.1",
+                "@n8n/utils": "1.43.1",
                 "@sentry/core": "^10.55.0",
                 "@sentry/node": "^10.55.0",
                 "ast-types": "0.16.1",
@@ -7948,7 +7371,7 @@
                 "xml2js": "0.6.2"
             },
             "peerDependencies": {
-                "zod": "3.25.67"
+                "zod": "3.25.76"
             }
         },
         "node_modules/n8n-workflow/node_modules/uuid": {
@@ -8089,7 +7512,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10.5.0"
             }
@@ -8100,7 +7522,6 @@
             "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },
@@ -8670,6 +8091,7 @@
             "integrity": "sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@napi-rs/canvas": "0.1.80",
                 "pdfjs-dist": "5.4.296"
@@ -8743,7 +8165,6 @@
             "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "playwright-core": "1.62.1"
             },
@@ -8763,7 +8184,6 @@
             "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "playwright-core": "cli.js"
             },
@@ -8962,7 +8382,6 @@
             "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "punycode": "^2.3.1"
             },
@@ -9001,8 +8420,7 @@
             "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
             "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
@@ -9030,7 +8448,8 @@
             "resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-2.2.0.tgz",
             "integrity": "sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/rc9": {
             "version": "3.0.1",
@@ -9222,8 +8641,7 @@
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
             "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/resolve-from": {
             "version": "4.0.0",
@@ -9278,7 +8696,6 @@
             "integrity": "sha512-pOLi+Gdll3JekwuFjXO3fTq+L9lzMQGcSq7M5gIjExcl3Gu1hd4XXuf5o3+LuSBsaULQH7DiNbsqPd1chVpQGQ==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=10.7.0"
             },
@@ -9801,7 +9218,6 @@
             "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@tokenizer/token": "^0.3.0"
             },
@@ -9884,6 +9300,7 @@
             "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -9940,7 +9357,6 @@
             "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@borewit/text-codec": "^0.2.1",
                 "@tokenizer/token": "^0.3.0",
@@ -9960,7 +9376,6 @@
             "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
             "dev": true,
             "license": "BSD-3-Clause",
-            "peer": true,
             "dependencies": {
                 "psl": "^1.1.33",
                 "punycode": "^2.1.1",
@@ -9976,8 +9391,7 @@
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/transliteration": {
             "version": "2.3.5",
@@ -10076,6 +9490,7 @@
             "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -10128,7 +9543,6 @@
             "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -10151,8 +9565,7 @@
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
             "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/universal-user-agent": {
             "version": "7.0.3",
@@ -10167,7 +9580,6 @@
             "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 4.0.0"
             }
@@ -10246,7 +9658,6 @@
             "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
@@ -10301,7 +9712,6 @@
             "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 14"
             }
@@ -10311,8 +9721,7 @@
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
             "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
             "dev": true,
-            "license": "BSD-2-Clause",
-            "peer": true
+            "license": "BSD-2-Clause"
         },
         "node_modules/whatwg-url": {
             "version": "5.0.0",
@@ -10320,7 +9729,6 @@
             "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "tr46": "~0.0.3",
                 "webidl-conversions": "^3.0.0"
@@ -10706,11 +10114,12 @@
             }
         },
         "node_modules/zod": {
-            "version": "3.25.67",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-            "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/n8n/package.json
+++ b/n8n/package.json
@@ -49,12 +49,13 @@
         ]
     },
     "devDependencies": {
-        "@n8n/node-cli": "0.42.2",
+        "@n8n/node-cli": "0.44.4",
         "eslint": "9.32.0",
-        "n8n-workflow": "2.29.3",
+        "n8n-workflow": "2.35.3",
         "prettier": "3.9.6",
         "release-it": "21.0.2",
-        "typescript": "5.9.2"
+        "typescript": "5.9.2",
+        "zod": "3.25.76"
     },
     "peerDependencies": {
         "n8n-workflow": "*"

--- a/n8n/test/release.test.cjs
+++ b/n8n/test/release.test.cjs
@@ -14,21 +14,24 @@ test('0.1.3 release metadata is locked to the stable n8n toolchain', () => {
 	const lock = readJson('package-lock.json');
 
 	assert.equal(pkg.version, '0.1.3');
-	assert.equal(pkg.devDependencies['@n8n/node-cli'], '0.42.2');
+	assert.equal(pkg.devDependencies['@n8n/node-cli'], '0.44.4');
 	assert.equal(pkg.devDependencies.eslint, '9.32.0');
 	assert.equal(pkg.devDependencies.prettier, '3.9.6');
 	assert.equal(pkg.devDependencies.typescript, '5.9.2');
-	assert.equal(pkg.devDependencies['n8n-workflow'], '2.29.3');
+	assert.equal(pkg.devDependencies['n8n-workflow'], '2.35.3');
+	assert.equal(pkg.devDependencies.zod, '3.25.76');
 	assert.equal(pkg.peerDependencies['n8n-workflow'], '*');
 	assert.equal(pkg.devDependencies['release-it'], '21.0.2');
 	assert.equal(pkg.engines.node, '>=20.19.0');
 	assert.equal(pkg.repository.directory, 'n8n');
 	assert.equal(lock.packages[''].version, pkg.version);
-	assert.equal(lock.packages[''].devDependencies['@n8n/node-cli'], '0.42.2');
+	assert.equal(lock.packages[''].devDependencies['@n8n/node-cli'], '0.44.4');
 	assert.equal(lock.packages[''].devDependencies.eslint, '9.32.0');
 	assert.equal(lock.packages[''].devDependencies.prettier, '3.9.6');
 	assert.equal(lock.packages[''].devDependencies.typescript, '5.9.2');
-	assert.equal(lock.packages[''].devDependencies['n8n-workflow'], '2.29.3');
+	assert.equal(lock.packages[''].devDependencies['n8n-workflow'], '2.35.3');
+	assert.equal(lock.packages[''].devDependencies['release-it'], '21.0.2');
+	assert.equal(lock.packages[''].devDependencies.zod, '3.25.76');
 	assert.equal(lock.packages[''].peerDependencies['n8n-workflow'], '*');
 });
 

--- a/n8n/test/release.test.cjs
+++ b/n8n/test/release.test.cjs
@@ -53,3 +53,10 @@ test('current n8n metadata includes required subtitle and themed icons', () => {
 	assert.equal(fs.existsSync(path.join(root, 'credentials', 'agoragentic.dark.svg')), true);
 	assert.equal(readJson('tsconfig.json').compilerOptions.incremental, false);
 });
+
+test('lockfile retains cross-platform optional dependencies required on Linux', () => {
+	const lock = readJson('package-lock.json');
+
+	assert.ok(lock.packages['node_modules/@emnapi/core']);
+	assert.ok(lock.packages['node_modules/@emnapi/runtime']);
+});


### PR DESCRIPTION
## Summary

- update the n8n community-node builder to the current stable `@n8n/node-cli@0.44.4`
- update the development workflow fixture to stable `n8n-workflow@2.35.3`
- satisfy its exact peer with `zod@3.25.76`
- retain ESLint 9.32.0 because ESLint 10 crashes the required n8n lint plugin
- retain cross-platform optional lock entries required by Linux CI
- refresh the lockfile, release contract, and evidence-bounded toolchain audit

This supersedes #335 and #336. It does not use `--force`, `legacy-peer-deps`, or dependency overrides.

Dependabot alert #8 remains accurately documented as development-only: nested LangChain packages still resolve vulnerable `uuid@10.0.0`, while production-package audit and tarball contents remain clean.

## Validation

- Windows/npm 11 `npm ci`
- npm 10 Linux/x64 clean-install dry-run with optional dependencies included
- `npm run check` (11 tests, lint, build)
- `npm audit --omit=dev --audit-level=moderate` (0 vulnerabilities)
- `npm run audit:dev` (expected 2 advisories / 8 affected dev nodes)
- `npm pack --dry-run`
- integrations and ecosystem machine-surface verification
- 244 documentation links
- 86 repository tests
- `git diff --check`