### PR TITLE
chore(ci): refresh Actions v7 pins coherently

### DIFF
--- a/.github/workflows/agent-payments-assurance-challenge.yml
+++ b/.github/workflows/agent-payments-assurance-challenge.yml
@@ -35,8 +35,8 @@ jobs:
       run:
         working-directory: agent-payments-assurance-challenge
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
       - name: Syntax checks

--- a/.github/workflows/anydoc-document-evidence.yml
+++ b/.github/workflows/anydoc-document-evidence.yml
@@ -37,8 +37,8 @@ jobs:
       run:
         working-directory: examples/anydoc-document-evidence
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install pinned AnyDoc package

--- a/.github/workflows/anydoc-semantic-conformance.yml
+++ b/.github/workflows/anydoc-semantic-conformance.yml
@@ -48,13 +48,13 @@ jobs:
       run:
         working-directory: examples/anydoc-document-evidence
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: examples/anydoc-document-evidence/package-lock.json
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.13'
       - name: Install lockfile-pinned parser and fixture dependencies
@@ -108,7 +108,7 @@ jobs:
         run: npm run verify:packed
       - name: Upload bounded report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: anydoc-semantic-conformance-node-${{ matrix.node-version }}
           path: examples/anydoc-document-evidence/conformance/report.json

--- a/.github/workflows/buzz-signed-workspace-evidence.yml
+++ b/.github/workflows/buzz-signed-workspace-evidence.yml
@@ -37,8 +37,8 @@ jobs:
       run:
         working-directory: examples/buzz-signed-workspace-evidence
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
       - name: Syntax and tests

--- a/.github/workflows/gstack-harness-bridge.yml
+++ b/.github/workflows/gstack-harness-bridge.yml
@@ -37,8 +37,8 @@ jobs:
       run:
         working-directory: gstack
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install --no-audit --no-fund

--- a/.github/workflows/harness-core-extraction.yml
+++ b/.github/workflows/harness-core-extraction.yml
@@ -33,10 +33,10 @@ jobs:
   prepare-and-verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
       - name: Test preparation guards

--- a/.github/workflows/harness-evaluation-adapters.yml
+++ b/.github/workflows/harness-evaluation-adapters.yml
@@ -31,8 +31,8 @@ jobs:
       AGORAGENTIC_ALLOW_REAL_SPEND: '0'
       AGORAGENTIC_ALLOW_NETWORK_CANARIES: '0'
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/hyperframes-receipt-video.yml
+++ b/.github/workflows/hyperframes-receipt-video.yml
@@ -38,8 +38,8 @@ jobs:
       run:
         working-directory: hyperframes
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
       - name: Install FFmpeg

--- a/.github/workflows/prime-agent-governance.yml
+++ b/.github/workflows/prime-agent-governance.yml
@@ -41,8 +41,8 @@ jobs:
       AGORAGENTIC_ALLOW_REAL_SPEND: '0'
       AGORAGENTIC_ALLOW_NETWORK_CANARIES: '0'
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
       - name: Syntax checks

--- a/.github/workflows/publish-harness-core.yml
+++ b/.github/workflows/publish-harness-core.yml
@@ -16,10 +16,10 @@ jobs:
       run:
         working-directory: harness-core
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
 
       - name: Setup Node for npm trusted publishing
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@v7.0.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -16,10 +16,10 @@ jobs:
       run:
         working-directory: mcp
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
 
       - name: Setup Node for npm trusted publishing
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@v7.0.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish-micro-ecf.yml
+++ b/.github/workflows/publish-micro-ecf.yml
@@ -19,10 +19,10 @@ jobs:
       run:
         working-directory: micro-ecf
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
 
       - name: Setup Node for npm trusted publishing
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@v7.0.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish-n8n.yml
+++ b/.github/workflows/publish-n8n.yml
@@ -16,10 +16,10 @@ jobs:
       run:
         working-directory: n8n
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
 
       - name: Setup Node for npm trusted publishing
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@v7.0.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -25,10 +25,10 @@ jobs:
       run:
         working-directory: sdk/python
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
 
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@v7.0.0
         with:
           python-version: '3.x'
 

--- a/.github/workflows/transaction-assurance-conformance.yml
+++ b/.github/workflows/transaction-assurance-conformance.yml
@@ -50,8 +50,8 @@ jobs:
       run:
         working-directory: transaction-assurance
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -68,16 +68,16 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out caller target
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: target
       - name: Check out pinned suite
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: rhein1/agoragentic-integrations
           ref: ${{ inputs.suite-ref }}
           path: suite
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
           cache: npm
@@ -109,7 +109,7 @@ jobs:
           node suite/transaction-assurance/bin/verify-conformance-receipt.mjs \
             artifacts/report.json artifacts/receipt.json
       - name: Upload bounded conformance artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: transaction-assurance-conformance
           path: artifacts/

--- a/.github/workflows/transaction-assurance-evaluator-evidence.yml
+++ b/.github/workflows/transaction-assurance-evaluator-evidence.yml
@@ -30,8 +30,8 @@ jobs:
       AGORAGENTIC_ALLOW_REAL_SPEND: '0'
       AGORAGENTIC_ALLOW_NETWORK_CANARIES: '0'
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/transaction-assurance-toploc-evidence.yml
+++ b/.github/workflows/transaction-assurance-toploc-evidence.yml
@@ -31,8 +31,8 @@ jobs:
       AGORAGENTIC_ALLOW_REAL_SPEND: '0'
       AGORAGENTIC_ALLOW_NETWORK_CANARIES: '0'
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/transaction-assurance.yml
+++ b/.github/workflows/transaction-assurance.yml
@@ -31,8 +31,8 @@ jobs:
       AGORAGENTIC_ALLOW_REAL_SPEND: '0'
       AGORAGENTIC_ALLOW_NETWORK_CANARIES: '0'
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -54,17 +54,17 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@v7.0.0
         with:
           node-version: '20'
 
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@v7.0.0
         with:
           python-version: '3.x'
 
@@ -148,7 +148,7 @@ jobs:
           npm pack --dry-run
 
       - name: Setup Node 22 for n8n toolchain
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@v7.0.0
         with:
           node-version: '22'
 
@@ -207,7 +207,7 @@ jobs:
         run: node scripts/verify-doc-links.mjs
 
       - name: Setup Python 3.13 for Crawl4AI
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@v7.0.0
         with:
           python-version: '3.13'
 
@@ -327,9 +327,9 @@ jobs:
   payment-contracts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
       - name: Setup Node 24 for native TypeScript contract tests
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@v7.0.0
         with:
           node-version: '24'
       - name: Test payment safety contracts
@@ -346,13 +346,13 @@ jobs:
   adapter-conformance:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@v7.0.1
       - name: Setup Node 24 for TypeScript syntax checks
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@v7.0.0
         with:
           node-version: '24'
       - name: Setup Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@v7.0.0
         with:
           python-version: '3.x'
       - name: Test forked conformance agent
@@ -365,7 +365,7 @@ jobs:
         run: node scripts/adapter-conformance-agent.mjs --jobs 4 --report "${RUNNER_TEMP}/adapter-conformance-report.json"
       - name: Upload conformance evidence
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: adapter-conformance-${{ github.sha }}
           path: ${{ runner.temp }}/adapter-conformance-report.json


### PR DESCRIPTION
## Summary
- refresh `actions/checkout` to v7.0.1
- refresh `actions/setup-node` and `actions/setup-python` to v7.0.0
- refresh `actions/upload-artifact` to v7.0.1
- preserve existing workflow triggers, permissions, caches, environments, and publishing controls

This intentionally consolidates and supersedes Dependabot PRs #304, #305, #306, and #309 so strict-base validation is paid once instead of repeatedly rebasing adjacent workflow edits.

## Validation
- parsed all 20 workflow YAML files
- verified the diff changes action references only
- `node scripts/verify-integrations-json.js`
- `node scripts/verify-ecosystem-profile.js`
- `node scripts/verify-doc-links.mjs` (244 files)
- `node --test test/*.test.mjs test/*.test.cjs` (86 passed)
- `git diff --check`

No workflow permissions, event triggers, OIDC settings, release environments, or package-publishing behavior changed.