### PR TITLE
feat(cli): add local governance front door

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -82,6 +82,7 @@ jobs:
       - name: Validate public SDK package sources
         run: |
           node --test test/sdk-public-source.test.mjs
+          node --test test/local-governance-cli.test.mjs
           node --check sdk/node/index.js
           node --check sdk/node/index.mjs
           node --check sdk/agent-os-cli/cli.js
@@ -179,6 +180,9 @@ jobs:
 
       - name: Validate integrations.json against schema
         run: ajv validate -s integrations.schema.json -d integrations.json --all-errors --spec=draft2020 -c ajv-formats
+
+      - name: Validate local governance policy schema
+        run: ajv validate -s sdk/node/schema/local-governance-policy.v1.json -d sdk/node/schema/local-governance-policy.example.json --all-errors --spec=draft2020
 
       - name: Validate Interchange external pilot evidence
         run: |

--- a/sdk/agent-os-cli/README.md
+++ b/sdk/agent-os-cli/README.md
@@ -24,6 +24,8 @@ The CLI is a thin wrapper around the public `agoragentic` package. The canonical
 
 `run -- <command>` evaluates that action before it spawns anything. `--yes` satisfies an `ask` decision but never overrides `deny`. The subprocess uses `shell: false`, and its local receipt excludes raw arguments, environment values, stdout, and stderr. The receipt is local process evidence only; it is not host execution, provider execution, deployment, payment, settlement, or on-chain proof.
 
+On Windows, call native executables such as `node` or `python` directly. Batch shims (`npm.cmd`, `*.bat`) are not shell-launched; failed starts return nonzero and receive a local failed-start receipt.
+
 For the complete public workflow, see the integrations repo guides:
 
 - [How an agent gets Agent OS](https://github.com/rhein1/agoragentic-integrations/blob/main/agent-os/GET_THE_OS.md)

--- a/sdk/agent-os-cli/README.md
+++ b/sdk/agent-os-cli/README.md
@@ -5,6 +5,10 @@ Terminal CLI for the hosted Agoragentic Triptych OS (Agent OS) control plane.
 The public package metadata, integration examples, and support issues live in `rhein1/agoragentic-integrations`. Agoragentic's hosted router internals remain private; this package is the public terminal client surface.
 
 ```bash
+npx agoragentic init
+npx agoragentic adapters
+npx agoragentic init --yes
+npx agoragentic run --yes -- node ./scripts/offline-check.mjs
 npx agora toolkit
 npx agora mcp
 npx agoragentic-os doctor
@@ -12,7 +16,13 @@ npx agora doctor
 AGORAGENTIC_API_KEY=amk_your_api_key npx agoragentic-os doctor
 ```
 
-The CLI is a thin wrapper around the public `agoragentic` package. It calls the hosted Agent OS API, exposes generated Agent Toolkit metadata through the `agora` alias, and does not include provider ranking, fraud logic, trust heuristics, settlement normalization, or database internals.
+The CLI is a thin wrapper around the public `agoragentic` package. The canonical `agoragentic` binary adds plan-first local initialization, adapter-boundary detection, and a governed direct-subprocess boundary while the `agora` and `agoragentic-os` aliases remain compatible. Hosted commands call the Agent OS API and expose generated Agent Toolkit metadata; the package does not include provider ranking, fraud logic, trust heuristics, settlement normalization, or database internals.
+
+## Local Governance
+
+`init` is no-write by default. `init --yes` creates a minimal JSON-compatible `agoragentic.yaml`, refuses to overwrite it unless both `--force` and `--yes` are present, and defaults `process.run` to `ask`.
+
+`run -- <command>` evaluates that action before it spawns anything. `--yes` satisfies an `ask` decision but never overrides `deny`. The subprocess uses `shell: false`, and its local receipt excludes raw arguments, environment values, stdout, and stderr. The receipt is local process evidence only; it is not host execution, provider execution, deployment, payment, settlement, or on-chain proof.
 
 For the complete public workflow, see the integrations repo guides:
 
@@ -33,6 +43,9 @@ Quickstart guide: [https://agoragentic.com/guides/agent-os-quickstart/](https://
 
 ## Safety
 
+- `init` proposes writes unless `--yes` is supplied and will not silently replace an existing policy.
+- `adapters` reports marker-based detection and the exact supported boundary; detection is not activation proof.
+- `run` governs only the directly spawned local process and does not claim descendant, provider, payment, or settlement interception.
 - `doctor` without an API key validates public discovery only.
 - `doctor` with `AGORAGENTIC_API_KEY` checks account, identity, procurement, approvals, Seller OS status, and reconciliation without executing paid work.
 - Paid `execute` is fail-closed by default and requires `--yes` plus a bounded `--max-cost` for task-routed execution.

--- a/sdk/agent-os-cli/package.json
+++ b/sdk/agent-os-cli/package.json
@@ -3,6 +3,7 @@
   "version": "1.7.1",
   "description": "No-spend Triptych OS (Agent OS) CLI for Agoragentic hosted control-plane readiness, procurement, approvals, receipts, and reconciliation.",
   "bin": {
+    "agoragentic": "cli.js",
     "agoragentic-os": "cli.js",
     "agora": "cli.js"
   },

--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -57,6 +57,41 @@ npx agoragentic-os doctor
 AGORAGENTIC_API_KEY=amk_your_api_key npx agoragentic-os doctor
 ```
 
+## Local Governance Front Door
+
+The reviewed source adds `agoragentic` as an umbrella binary while preserving the existing `agora` and `agoragentic-os` aliases. Registry publication remains a separate owner-reviewed release.
+
+Start with a no-write plan, inspect detected host boundaries, then explicitly create the policy:
+
+```sh
+npx agoragentic init
+npx agoragentic adapters
+npx agoragentic init --yes
+```
+
+The generated `agoragentic.yaml` is JSON-compatible YAML and defaults `process.run` to `ask`. It preserves spend and retry authority as owner-only. Run an existing command only after reviewing the boundary and explicitly approving the ask decision:
+
+```sh
+npx agoragentic run --yes -- node ./scripts/offline-check.mjs
+```
+
+`run` uses a direct subprocess boundary with `shell: false`. A policy `deny` can never be overridden by `--yes`. Local receipts contain the executable basename, argument count, command-shape digest, timing, exit status, and policy decision; they do not store raw arguments, environment values, stdout, or stderr. These receipts prove only the local boundary. They are not host, provider, deployment, payment, settlement, or on-chain proof.
+
+For an in-process JavaScript tool, use the same evaluator:
+
+```javascript
+const { govern } = require('agoragentic/governance');
+
+const safeTool = govern(sendEmail, {
+  action: 'email.send',
+  policy: './agoragentic.yaml',
+  receipts: true,
+  approve: async ({ action }) => requestOwnerApproval(action),
+});
+```
+
+The approval callback receives only the normalized action and argument count. Result evidence is shape-only by default, and raw tool inputs or outputs are not persisted.
+
 ## Hosted Router Model
 
 `agoragentic` is a thin client to the Agoragentic-hosted Agent OS router.
@@ -320,7 +355,7 @@ Use them to:
 
 ## Agent Toolkit / Agent OS CLI
 
-The `agora` / `agoragentic-os` CLI is a thin public client for the hosted Agent OS API plus generated Agent Toolkit metadata. It does not include provider ranking, fraud logic, trust heuristics, settlement normalization, or database internals.
+The `agoragentic` / `agora` / `agoragentic-os` CLI combines the bounded local governance front door above with a thin public client for the hosted Agent OS API and generated Agent Toolkit metadata. It does not include provider ranking, fraud logic, trust heuristics, settlement normalization, or database internals.
 
 ```bash
 # Generated toolkit manifest for agents and package builders.

--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -77,6 +77,8 @@ npx agoragentic run --yes -- node ./scripts/offline-check.mjs
 
 `run` uses a direct subprocess boundary with `shell: false`. A policy `deny` can never be overridden by `--yes`. Local receipts contain the executable basename, argument count, command-shape digest, timing, exit status, and policy decision; they do not store raw arguments, environment values, stdout, or stderr. These receipts prove only the local boundary. They are not host, provider, deployment, payment, settlement, or on-chain proof.
 
+On Windows, invoke a native executable such as `node` or `python` directly. Batch shims such as `npm.cmd` and `*.bat` are intentionally not launched because doing so would require a command shell; a failed start is recorded as local evidence and returns nonzero.
+
 For an in-process JavaScript tool, use the same evaluator:
 
 ```javascript

--- a/sdk/node/agent-os.js
+++ b/sdk/node/agent-os.js
@@ -285,6 +285,9 @@ async function runCli(argv = process.argv.slice(2), env = process.env, io = defa
                 result = commandAdapters(runtime);
                 break;
             case 'run':
+                if (!parsed.separatorUsed) {
+                    throw userError('The run command requires "--" before the existing command.');
+                }
                 result = await commandRun(parsed.positionals.slice(1), parsed.flags, env, {
                     ...runtime,
                     spawn: spawnProcess,
@@ -1255,10 +1258,12 @@ async function commandReceipts(client, positionals) {
 function parseArgs(argv) {
     const flags = {};
     const positionals = [];
+    let separatorUsed = false;
 
     for (let i = 0; i < argv.length; i += 1) {
         const token = argv[i];
         if (token === '--') {
+            separatorUsed = true;
             positionals.push(...argv.slice(i + 1));
             break;
         }
@@ -1283,7 +1288,7 @@ function parseArgs(argv) {
         }
     }
 
-    return { flags, positionals };
+    return { flags, positionals, separatorUsed };
 }
 
 function readInput(flags) {

--- a/sdk/node/agent-os.js
+++ b/sdk/node/agent-os.js
@@ -15,6 +15,7 @@ const { spawn } = require('child_process');
 const agoragentic = require('./index');
 const toolkit = require('./agent-toolkit');
 const x402Guard = require('./x402-guard');
+const localGovernance = require('./local-governance');
 
 const DEFAULT_BASE_URL = 'https://agoragentic.com';
 const PAID_EXECUTION_HELP = 'Paid execution is disabled by default. Add --yes (or --execute) and an explicit --max-cost for task-routed execution.';
@@ -193,6 +194,9 @@ function usage() {
     return `Agoragentic Agent OS CLI
 
 Usage:
+  agoragentic init [--yes] [--force] [--policy agoragentic.yaml]
+  agoragentic adapters
+  agoragentic run [--policy agoragentic.yaml] [--yes] -- <existing command>
   agoragentic-os doctor [--api-key amk_...] [--base-url URL]
   agora toolkit [commands|mcp|skills|exports|json]
   agora env live --key-file ./key.json
@@ -248,6 +252,8 @@ Key recovery:
   Guide: ${DEFAULT_BASE_URL}/guides/agent-os-quickstart/
 
 Safety:
+  init is plan-only unless --yes is supplied. Local run evaluates process.run
+  before spawning, never overrides deny, and records only redacted local evidence.
   All control-plane commands are free reads/preflights. The execute command refuses
   to run paid work unless --yes or --execute is supplied. Task-routed execution
   also requires --max-cost. Direct invoke and listing publish also require --yes.
@@ -272,6 +278,18 @@ async function runCli(argv = process.argv.slice(2), env = process.env, io = defa
     try {
         let result;
         switch (command) {
+            case 'init':
+                result = commandInit(parsed.flags, runtime);
+                break;
+            case 'adapters':
+                result = commandAdapters(runtime);
+                break;
+            case 'run':
+                result = await commandRun(parsed.positionals.slice(1), parsed.flags, env, {
+                    ...runtime,
+                    spawn: spawnProcess,
+                });
+                break;
             case 'toolkit':
                 result = await commandToolkit(parsed.positionals.slice(1), parsed.flags);
                 break;
@@ -415,6 +433,65 @@ async function runCli(argv = process.argv.slice(2), env = process.env, io = defa
         });
         return status === 0 ? 1 : status;
     }
+}
+
+function commandInit(flags, runtime = {}) {
+    return localGovernance.initializeProject({
+        cwd: runtimeCwd(runtime),
+        policyPath: stringFlag(flags, 'policy') || localGovernance.DEFAULT_POLICY_FILE,
+        write: flags.yes === true,
+        force: flags.force === true,
+    });
+}
+
+function commandAdapters(runtime = {}) {
+    return {
+        schema: 'agoragentic.adapter-detection.v1',
+        adapters: localGovernance.detectAdapters(runtimeCwd(runtime)),
+        note: 'Detection proves only local project markers. It does not prove host activation, provider execution, deployment, payment, or settlement.',
+    };
+}
+
+async function commandRun(positionals, flags, env, runtime = {}) {
+    const result = await localGovernance.runGovernedCommand(
+        requiredArg(positionals[0], 'command after "run --"'),
+        positionals.slice(1),
+        {
+            cwd: runtimeCwd(runtime),
+            policy: stringFlag(flags, 'policy') || localGovernance.DEFAULT_POLICY_FILE,
+            approved: flags.yes === true,
+            env,
+            spawn: runtime.spawn,
+            stdio: runtime.stdio,
+            now: runtime.now,
+            randomUUID: runtime.randomUUID,
+        }
+    );
+    const publicResult = {
+        exit_code: result.exit_code,
+        signal: result.signal,
+        receipt: result.receipt,
+    };
+    if (result.error) {
+        const err = new Error(`Governed command failed to start: ${result.error.message}`);
+        err.code = 'local_process_start_failed';
+        err.exitCode = 1;
+        err.response = publicResult;
+        throw err;
+    }
+    if (result.exit_code !== 0) {
+        const err = new Error(`Governed command exited with status ${result.exit_code}.`);
+        err.code = 'local_process_failed';
+        err.exitCode = Number.isInteger(result.exit_code) && result.exit_code > 0 ? result.exit_code : 1;
+        err.response = publicResult;
+        throw err;
+    }
+    return publicResult;
+}
+
+function runtimeCwd(runtime) {
+    if (typeof runtime.cwd === 'function') return runtime.cwd();
+    return runtime.cwd || process.cwd();
 }
 
 async function commandDoctor(client, { baseUrl, apiKey }) {

--- a/sdk/node/local-governance.d.ts
+++ b/sdk/node/local-governance.d.ts
@@ -1,0 +1,45 @@
+export type GovernanceDecision = 'allow' | 'ask' | 'deny';
+
+export const POLICY_SCHEMA: 'agoragentic.local-governance-policy.v1';
+export const RECEIPT_SCHEMA: 'agoragentic.local-action-receipt.v1';
+export const DEFAULT_POLICY_FILE: 'agoragentic.yaml';
+
+export interface LocalGovernancePolicy {
+  schema: 'agoragentic.local-governance-policy.v1';
+  default_decision: GovernanceDecision;
+  receipts?: { enabled?: boolean; directory?: string };
+  actions: Record<string, { decision: GovernanceDecision; approval?: string }>;
+  authority?: { spend?: 'owner_only'; retry?: 'owner_only' };
+}
+
+export interface GovernOptions<TResult = unknown> {
+  action: string;
+  policy?: string | LocalGovernancePolicy;
+  cwd?: string;
+  approved?: boolean;
+  receipts?: boolean;
+  approve?: (request: { action: string; argument_count: number }) => boolean | Promise<boolean>;
+  evidence?: (result: TResult) => unknown | Promise<unknown>;
+  onReceipt?: (receipt: unknown) => void | Promise<void>;
+}
+
+export function createDefaultPolicy(): LocalGovernancePolicy;
+export function detectAdapters(cwd?: string): unknown[];
+export function initializeProject(options?: { cwd?: string; policyPath?: string; write?: boolean; force?: boolean }): unknown;
+export function loadPolicy(policy?: string | LocalGovernancePolicy, options?: { cwd?: string }): LocalGovernancePolicy;
+export function evaluatePolicy(policy: LocalGovernancePolicy, action: string, options?: { approved?: boolean }): unknown;
+export function govern<TArgs extends unknown[], TResult>(
+  tool: (...args: TArgs) => TResult | Promise<TResult>,
+  options: GovernOptions<TResult>
+): (...args: TArgs) => Promise<TResult>;
+export function runGovernedCommand(
+  executable: string,
+  args?: string[],
+  options?: {
+    cwd?: string;
+    policy?: string | LocalGovernancePolicy;
+    approved?: boolean;
+    env?: Record<string, string | undefined>;
+    stdio?: unknown;
+  }
+): Promise<unknown>;

--- a/sdk/node/local-governance.js
+++ b/sdk/node/local-governance.js
@@ -1,0 +1,463 @@
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const POLICY_SCHEMA = 'agoragentic.local-governance-policy.v1';
+const RECEIPT_SCHEMA = 'agoragentic.local-action-receipt.v1';
+const DEFAULT_POLICY_FILE = 'agoragentic.yaml';
+const DECISIONS = new Set(['allow', 'ask', 'deny']);
+
+const ADAPTERS = Object.freeze([
+    {
+        id: 'process',
+        label: 'Local subprocess',
+        markers: [],
+        integration_level: 'pre_action_enforcement',
+        proof_class: 'local_process_evidence',
+        boundary: 'Only the directly spawned process is governed; descendants and provider-side effects are not intercepted.',
+    },
+    {
+        id: 'mcp',
+        label: 'MCP host',
+        markers: ['.mcp.json', 'mcp.json', '.cursor/mcp.json'],
+        integration_level: 'manifest_mapping',
+        proof_class: 'configuration_presence',
+        boundary: 'Configuration detection only; generic MCP tool calls are not intercepted by this CLI.',
+    },
+    {
+        id: 'claude-code',
+        label: 'Claude Code',
+        markers: ['.claude/settings.json', '.claude/settings.local.json'],
+        integration_level: 'manifest_mapping',
+        proof_class: 'configuration_presence',
+        boundary: 'Host configuration detection only; use a reviewed host hook or Harness adapter for in-path enforcement.',
+    },
+    {
+        id: 'opencode',
+        label: 'OpenCode',
+        markers: ['opencode.json', 'opencode.jsonc', '.opencode'],
+        integration_level: 'manifest_mapping',
+        proof_class: 'configuration_presence',
+        boundary: 'Host configuration detection only; plugin activation and live interception remain separate evidence.',
+    },
+    {
+        id: 'node',
+        label: 'Node.js project',
+        markers: ['package.json'],
+        integration_level: 'framework_mapping',
+        proof_class: 'project_marker',
+        boundary: 'Project detection only; wrap a specific tool or use the governed subprocess command for enforcement.',
+    },
+    {
+        id: 'python',
+        label: 'Python project',
+        markers: ['pyproject.toml', 'requirements.txt', 'setup.py'],
+        integration_level: 'framework_mapping',
+        proof_class: 'project_marker',
+        boundary: 'Project detection only; Python in-process governance is a separate adapter surface.',
+    },
+]);
+
+function createDefaultPolicy() {
+    return {
+        schema: POLICY_SCHEMA,
+        default_decision: 'ask',
+        receipts: {
+            enabled: true,
+            directory: '.agoragentic/receipts',
+        },
+        actions: {
+            'process.run': {
+                decision: 'ask',
+                approval: 'explicit_cli_yes',
+            },
+        },
+        authority: {
+            spend: 'owner_only',
+            retry: 'owner_only',
+        },
+    };
+}
+
+function detectAdapters(cwd = process.cwd(), fsImpl = fs) {
+    const root = path.resolve(cwd);
+    return ADAPTERS.map((adapter) => {
+        const evidence = adapter.markers.filter((marker) => fsImpl.existsSync(path.join(root, marker)));
+        return {
+            id: adapter.id,
+            label: adapter.label,
+            detected: adapter.id === 'process' || evidence.length > 0,
+            evidence,
+            integration_level: adapter.integration_level,
+            proof_class: adapter.proof_class,
+            boundary: adapter.boundary,
+        };
+    });
+}
+
+function initializeProject(options = {}) {
+    const cwd = path.resolve(options.cwd || process.cwd());
+    const policyPath = resolveProjectPath(cwd, options.policyPath || DEFAULT_POLICY_FILE, 'policy');
+    const exists = fs.existsSync(policyPath);
+    const proposal = {
+        schema: 'agoragentic.init-plan.v1',
+        cwd_digest: digest(path.basename(cwd)),
+        policy_path: relativeDisplayPath(cwd, policyPath),
+        detected_adapters: detectAdapters(cwd).filter((adapter) => adapter.detected),
+        proposed_policy: createDefaultPolicy(),
+        writes_require_confirmation: true,
+    };
+
+    if (!options.write) {
+        return { ...proposal, status: exists ? 'existing_policy_detected' : 'planned', written: false };
+    }
+    if (exists && !options.force) {
+        throw governanceError('policy_exists', `Refusing to overwrite ${proposal.policy_path}; add --force with --yes to replace it.`, 2);
+    }
+
+    fs.mkdirSync(path.dirname(policyPath), { recursive: true });
+    fs.writeFileSync(policyPath, `${JSON.stringify(createDefaultPolicy(), null, 2)}\n`, {
+        encoding: 'utf8',
+        mode: 0o600,
+        flag: options.force ? 'w' : 'wx',
+    });
+    return { ...proposal, status: exists ? 'replaced' : 'created', written: true };
+}
+
+function loadPolicy(policy = DEFAULT_POLICY_FILE, options = {}) {
+    if (policy && typeof policy === 'object' && !Array.isArray(policy)) {
+        return validatePolicy(policy);
+    }
+    const cwd = path.resolve(options.cwd || process.cwd());
+    const policyPath = resolveProjectPath(cwd, policy || DEFAULT_POLICY_FILE, 'policy');
+    if (!fs.existsSync(policyPath)) {
+        throw governanceError('policy_missing', `No local governance policy found at ${relativeDisplayPath(cwd, policyPath)}. Run "agoragentic init --yes" first.`, 2);
+    }
+    let parsed;
+    try {
+        parsed = JSON.parse(fs.readFileSync(policyPath, 'utf8'));
+    } catch (err) {
+        throw governanceError('policy_invalid', `Policy must use JSON-compatible YAML: ${err.message}`, 2);
+    }
+    return validatePolicy(parsed);
+}
+
+function validatePolicy(policy) {
+    if (!policy || policy.schema !== POLICY_SCHEMA) {
+        throw governanceError('policy_invalid', `Policy schema must be ${POLICY_SCHEMA}.`, 2);
+    }
+    validateDecision(policy.default_decision, 'default_decision');
+    if (!policy.actions || typeof policy.actions !== 'object' || Array.isArray(policy.actions)) {
+        throw governanceError('policy_invalid', 'Policy actions must be an object.', 2);
+    }
+    for (const [action, rule] of Object.entries(policy.actions)) {
+        normalizeAction(action);
+        if (!rule || typeof rule !== 'object' || Array.isArray(rule)) {
+            throw governanceError('policy_invalid', `Policy rule for ${action} must be an object.`, 2);
+        }
+        validateDecision(rule.decision, `actions.${action}.decision`);
+    }
+    if (policy.receipts !== undefined) {
+        if (!policy.receipts || typeof policy.receipts !== 'object' || Array.isArray(policy.receipts)) {
+            throw governanceError('policy_invalid', 'Policy receipts must be an object.', 2);
+        }
+        if (policy.receipts.enabled !== undefined && typeof policy.receipts.enabled !== 'boolean') {
+            throw governanceError('policy_invalid', 'receipts.enabled must be a boolean.', 2);
+        }
+        if (policy.receipts.directory !== undefined && (typeof policy.receipts.directory !== 'string' || !policy.receipts.directory.trim())) {
+            throw governanceError('policy_invalid', 'receipts.directory must be a non-empty string.', 2);
+        }
+    }
+    if (policy.authority?.spend !== undefined && policy.authority.spend !== 'owner_only') {
+        throw governanceError('policy_invalid', 'authority.spend must remain owner_only.', 2);
+    }
+    if (policy.authority?.retry !== undefined && policy.authority.retry !== 'owner_only') {
+        throw governanceError('policy_invalid', 'authority.retry must remain owner_only.', 2);
+    }
+    return policy;
+}
+
+function evaluatePolicy(policy, action, options = {}) {
+    const normalizedAction = normalizeAction(action);
+    const validated = validatePolicy(policy);
+    const rule = validated.actions[normalizedAction] || validated.actions['*'] || {};
+    const decision = rule.decision || validated.default_decision;
+    const approved = options.approved === true;
+    return {
+        action: normalizedAction,
+        decision,
+        approval_required: decision === 'ask',
+        approval_granted: decision === 'ask' ? approved : null,
+        execute: decision === 'allow' || (decision === 'ask' && approved),
+        reason: decision === 'deny'
+            ? 'policy_denied'
+            : (decision === 'ask' && !approved ? 'explicit_approval_required' : 'policy_boundary_passed'),
+        authority: {
+            spend: validated.authority?.spend || 'owner_only',
+            retry: validated.authority?.retry || 'owner_only',
+        },
+    };
+}
+
+function govern(tool, options = {}) {
+    if (typeof tool !== 'function') {
+        throw new TypeError('govern(tool, options) requires a function.');
+    }
+    const action = normalizeAction(options.action);
+    return async function governedTool(...args) {
+        const cwd = path.resolve(options.cwd || process.cwd());
+        const loadedPolicy = loadPolicy(options.policy || DEFAULT_POLICY_FILE, { cwd });
+        const policy = options.receipts === undefined
+            ? loadedPolicy
+            : { ...loadedPolicy, receipts: { ...(loadedPolicy.receipts || {}), enabled: options.receipts === true } };
+        prepareReceiptDirectory(policy, cwd);
+        let approved = options.approved === true;
+        const initial = evaluatePolicy(policy, action, { approved });
+        if (initial.decision === 'ask' && !approved && typeof options.approve === 'function') {
+            approved = await options.approve({ action, argument_count: args.length }) === true;
+        }
+        const decision = evaluatePolicy(policy, action, { approved });
+        const startedAt = nowIso(options);
+        if (!decision.execute) {
+            const receipt = writeReceipt(policy, cwd, buildReceipt({
+                options,
+                action,
+                classification: 'local_tool_evidence',
+                decision,
+                startedAt,
+                finishedAt: startedAt,
+                outcome: 'not_executed',
+                evidence: { argument_count: args.length },
+            }));
+            throw governanceError(decision.reason, `Action ${action} was not executed: ${decision.reason}.`, 3, { receipt });
+        }
+
+        try {
+            const result = await tool(...args);
+            const finishedAt = nowIso(options);
+            const evidence = typeof options.evidence === 'function'
+                ? summarizeEvidence(await options.evidence(result))
+                : summarizeEvidence(result);
+            const receipt = writeReceipt(policy, cwd, buildReceipt({
+                options,
+                action,
+                classification: 'local_tool_evidence',
+                decision,
+                startedAt,
+                finishedAt,
+                outcome: 'completed',
+                evidence: { argument_count: args.length, result: evidence },
+            }));
+            if (typeof options.onReceipt === 'function') await options.onReceipt(receipt);
+            return result;
+        } catch (err) {
+            const finishedAt = nowIso(options);
+            const receipt = writeReceipt(policy, cwd, buildReceipt({
+                options,
+                action,
+                classification: 'local_tool_evidence',
+                decision,
+                startedAt,
+                finishedAt,
+                outcome: 'failed',
+                evidence: { argument_count: args.length, error_code: safeErrorCode(err) },
+            }));
+            err.agoragenticReceipt = receipt;
+            throw err;
+        }
+    };
+}
+
+async function runGovernedCommand(executable, args = [], options = {}) {
+    if (!executable || typeof executable !== 'string') {
+        throw governanceError('command_missing', 'A command is required after "agoragentic run --".', 2);
+    }
+    const cwd = path.resolve(options.cwd || process.cwd());
+    const policy = loadPolicy(options.policy || DEFAULT_POLICY_FILE, { cwd });
+    prepareReceiptDirectory(policy, cwd);
+    const decision = evaluatePolicy(policy, 'process.run', { approved: options.approved === true });
+    const startedAt = nowIso(options);
+    const shape = {
+        executable: path.basename(executable),
+        argument_count: args.length,
+        command_shape_digest: digest(JSON.stringify([path.basename(executable), args.length])),
+        cwd_digest: digest(path.basename(cwd)),
+    };
+
+    if (!decision.execute) {
+        const receipt = writeReceipt(policy, cwd, buildReceipt({
+            options,
+            action: 'process.run',
+            classification: 'local_process_evidence',
+            decision,
+            startedAt,
+            finishedAt: startedAt,
+            outcome: 'not_executed',
+            evidence: shape,
+        }));
+        throw governanceError(decision.reason, `Command was not executed: ${decision.reason}.`, 3, { receipt });
+    }
+
+    const processResult = await waitForProcess(options.spawn || spawn, executable, args, {
+        cwd,
+        env: options.env || process.env,
+        stdio: options.stdio || 'inherit',
+        shell: false,
+        windowsHide: true,
+    });
+    const finishedAt = nowIso(options);
+    const receipt = writeReceipt(policy, cwd, buildReceipt({
+        options,
+        action: 'process.run',
+        classification: 'local_process_evidence',
+        decision,
+        startedAt,
+        finishedAt,
+        outcome: processResult.error ? 'failed_to_start' : (processResult.exit_code === 0 ? 'completed' : 'failed'),
+        evidence: {
+            ...shape,
+            exit_code: processResult.exit_code,
+            signal: processResult.signal,
+            error_code: processResult.error ? safeErrorCode(processResult.error) : null,
+        },
+    }));
+    return { ...processResult, receipt };
+}
+
+function buildReceipt({ options, action, classification, decision, startedAt, finishedAt, outcome, evidence }) {
+    const randomUUID = options.randomUUID || crypto.randomUUID;
+    const id = `alr_${randomUUID().replace(/-/g, '')}`;
+    return {
+        schema: RECEIPT_SCHEMA,
+        receipt_id: id,
+        classification,
+        action,
+        decision,
+        outcome,
+        started_at: startedAt,
+        finished_at: finishedAt,
+        evidence,
+        proof_scope: {
+            local_boundary: true,
+            host_execution: false,
+            provider_execution: false,
+            deployment: false,
+            payment: false,
+            settlement: false,
+            on_chain_verification: false,
+        },
+    };
+}
+
+function writeReceipt(policy, cwd, receipt) {
+    if (policy.receipts?.enabled === false) return null;
+    const directory = prepareReceiptDirectory(policy, cwd);
+    const receiptPath = path.join(directory, `${receipt.receipt_id}.json`);
+    fs.writeFileSync(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, { encoding: 'utf8', mode: 0o600, flag: 'wx' });
+    return { ...receipt, path: relativeDisplayPath(cwd, receiptPath) };
+}
+
+function prepareReceiptDirectory(policy, cwd) {
+    if (policy.receipts?.enabled === false) return null;
+    const directory = resolveProjectPath(cwd, policy.receipts?.directory || '.agoragentic/receipts', 'receipt directory');
+    fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+    return directory;
+}
+
+function waitForProcess(spawnProcess, executable, args, options) {
+    return new Promise((resolve) => {
+        let child;
+        try {
+            child = spawnProcess(executable, args, options);
+        } catch (error) {
+            resolve({ exit_code: null, signal: null, error });
+            return;
+        }
+        child.once('error', (error) => resolve({ exit_code: null, signal: null, error }));
+        child.once('exit', (code, signal) => resolve({ exit_code: code, signal: signal || null, error: null }));
+    });
+}
+
+function summarizeEvidence(value) {
+    if (value === null || value === undefined) return { type: String(value) };
+    if (Array.isArray(value)) return { type: 'array', length: value.length };
+    if (typeof value === 'object') return { type: 'object', keys: Object.keys(value).sort().slice(0, 32) };
+    return { type: typeof value };
+}
+
+function normalizeAction(action) {
+    const normalized = String(action || '').trim().toLowerCase();
+    if (!/^(?:\*|[a-z0-9][a-z0-9._:-]{0,127})$/.test(normalized)) {
+        throw governanceError('action_invalid', 'Action must use lowercase letters, numbers, dots, underscores, colons, or dashes.', 2);
+    }
+    return normalized;
+}
+
+function validateDecision(value, label) {
+    if (!DECISIONS.has(value)) {
+        throw governanceError('policy_invalid', `${label} must be allow, ask, or deny.`, 2);
+    }
+}
+
+function resolveProjectPath(cwd, target, label) {
+    const resolved = path.resolve(cwd, target);
+    const relative = path.relative(cwd, resolved);
+    if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+        throw governanceError('path_outside_project', `${label} must stay inside the current project.`, 2);
+    }
+    const realRoot = fs.realpathSync(cwd);
+    let existingAncestor = resolved;
+    while (!fs.existsSync(existingAncestor)) {
+        const parent = path.dirname(existingAncestor);
+        if (parent === existingAncestor) break;
+        existingAncestor = parent;
+    }
+    const realAncestor = fs.realpathSync(existingAncestor);
+    const realRelative = path.relative(realRoot, realAncestor);
+    if (realRelative === '..' || realRelative.startsWith(`..${path.sep}`) || path.isAbsolute(realRelative)) {
+        throw governanceError('path_outside_project', `${label} resolves outside the current project.`, 2);
+    }
+    return resolved;
+}
+
+function relativeDisplayPath(cwd, target) {
+    const relative = path.relative(cwd, target) || '.';
+    return relative.split(path.sep).join('/');
+}
+
+function digest(value) {
+    return `sha256:${crypto.createHash('sha256').update(String(value)).digest('hex')}`;
+}
+
+function nowIso(options) {
+    const now = options.now ? options.now() : new Date();
+    return (now instanceof Date ? now : new Date(now)).toISOString();
+}
+
+function safeErrorCode(err) {
+    return typeof err?.code === 'string' && /^[A-Za-z0-9_.-]{1,64}$/.test(err.code) ? err.code : 'error';
+}
+
+function governanceError(code, message, exitCode = 1, response) {
+    const err = new Error(message);
+    err.code = code;
+    err.exitCode = exitCode;
+    if (response) err.response = response;
+    return err;
+}
+
+module.exports = {
+    POLICY_SCHEMA,
+    RECEIPT_SCHEMA,
+    DEFAULT_POLICY_FILE,
+    createDefaultPolicy,
+    detectAdapters,
+    initializeProject,
+    loadPolicy,
+    evaluatePolicy,
+    govern,
+    runGovernedCommand,
+};

--- a/sdk/node/local-governance.mjs
+++ b/sdk/node/local-governance.mjs
@@ -1,0 +1,16 @@
+import governance from './local-governance.js';
+
+export const {
+  POLICY_SCHEMA,
+  RECEIPT_SCHEMA,
+  DEFAULT_POLICY_FILE,
+  createDefaultPolicy,
+  detectAdapters,
+  initializeProject,
+  loadPolicy,
+  evaluatePolicy,
+  govern,
+  runGovernedCommand,
+} = governance;
+
+export default governance;

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "bin": {
+    "agoragentic": "agent-os.js",
     "agoragentic-os": "agent-os.js",
     "agora": "agent-os.js"
   },
@@ -36,6 +37,11 @@
     },
     "./agent-os": {
       "require": "./agent-os.js"
+    },
+    "./governance": {
+      "require": "./local-governance.js",
+      "import": "./local-governance.mjs",
+      "types": "./local-governance.d.ts"
     },
     "./agent-toolkit": {
       "require": "./agent-toolkit.js",
@@ -116,6 +122,11 @@
     "index.mjs",
     "index.d.ts",
     "agent-os.js",
+    "local-governance.js",
+    "local-governance.mjs",
+    "local-governance.d.ts",
+    "schema/local-governance-policy.v1.json",
+    "schema/local-governance-policy.example.json",
     "agent-toolkit.js",
     "agent-toolkit.d.ts",
     "agent-toolkit.generated.json",

--- a/sdk/node/schema/local-governance-policy.example.json
+++ b/sdk/node/schema/local-governance-policy.example.json
@@ -1,0 +1,18 @@
+{
+  "schema": "agoragentic.local-governance-policy.v1",
+  "default_decision": "ask",
+  "receipts": {
+    "enabled": true,
+    "directory": ".agoragentic/receipts"
+  },
+  "actions": {
+    "process.run": {
+      "decision": "ask",
+      "approval": "explicit_cli_yes"
+    }
+  },
+  "authority": {
+    "spend": "owner_only",
+    "retry": "owner_only"
+  }
+}

--- a/sdk/node/schema/local-governance-policy.v1.json
+++ b/sdk/node/schema/local-governance-policy.v1.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agoragentic.com/schemas/local-governance-policy.v1.json",
+  "title": "Agoragentic local governance policy",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema", "default_decision", "actions"],
+  "properties": {
+    "schema": { "const": "agoragentic.local-governance-policy.v1" },
+    "default_decision": { "enum": ["allow", "ask", "deny"] },
+    "receipts": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "directory": { "type": "string", "minLength": 1 }
+      }
+    },
+    "actions": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["decision"],
+        "properties": {
+          "decision": { "enum": ["allow", "ask", "deny"] },
+          "approval": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "spend": { "const": "owner_only" },
+        "retry": { "const": "owner_only" }
+      }
+    }
+  }
+}

--- a/test/local-governance-cli.test.mjs
+++ b/test/local-governance-cli.test.mjs
@@ -41,6 +41,18 @@ function fakeSpawn(exitCode = 0, calls = []) {
   };
 }
 
+function failingSpawn(code = 'ENOENT') {
+  return () => {
+    const child = new EventEmitter();
+    queueMicrotask(() => {
+      const error = new Error('not found');
+      error.code = code;
+      child.emit('error', error);
+    });
+    return child;
+  };
+}
+
 function readOnlyReceipt(cwd) {
   const directory = path.join(cwd, '.agoragentic', 'receipts');
   const files = fs.readdirSync(directory);
@@ -135,6 +147,24 @@ test('run executes after ask approval and writes a redacted local-only receipt',
   assert.equal(receipt.value.proof_scope.provider_execution, false);
   assert.equal(receipt.value.proof_scope.payment, false);
   assert.equal(receipt.raw.includes(secret), false);
+});
+
+test('run records a bounded receipt when a direct executable cannot start', async (t) => {
+  const cwd = workspace();
+  t.after(() => fs.rmSync(cwd, { recursive: true, force: true }));
+  fs.writeFileSync(path.join(cwd, 'agoragentic.yaml'), `${JSON.stringify(createDefaultPolicy(), null, 2)}\n`);
+  const captured = captureIo();
+
+  assert.equal(await runCli(['run', '--yes', '--', 'missing-command', 'private-argument'], {}, captured.io, {
+    cwd,
+    spawn: failingSpawn(),
+    stdio: 'ignore',
+  }), 1);
+  assert.match(captured.stderr(), /local_process_start_failed/);
+  const receipt = readOnlyReceipt(cwd);
+  assert.equal(receipt.value.outcome, 'failed_to_start');
+  assert.equal(receipt.value.evidence.error_code, 'ENOENT');
+  assert.equal(receipt.raw.includes('private-argument'), false);
 });
 
 test('govern blocks before invocation and emits shape-only evidence after approval', async (t) => {

--- a/test/local-governance-cli.test.mjs
+++ b/test/local-governance-cli.test.mjs
@@ -93,6 +93,11 @@ test('run fails closed on ask or deny without spawning', async (t) => {
   fs.writeFileSync(path.join(cwd, 'agoragentic.yaml'), `${JSON.stringify(createDefaultPolicy(), null, 2)}\n`);
   const calls = [];
 
+  const missingSeparator = captureIo();
+  assert.equal(await runCli(['run', 'node', 'secret-value'], {}, missingSeparator.io, { cwd, spawn: fakeSpawn(0, calls) }), 2);
+  assert.equal(calls.length, 0);
+  assert.match(missingSeparator.stderr(), /requires.*--/);
+
   const ask = captureIo();
   assert.equal(await runCli(['run', '--', 'node', 'secret-value'], {}, ask.io, { cwd, spawn: fakeSpawn(0, calls) }), 3);
   assert.equal(calls.length, 0);

--- a/test/local-governance-cli.test.mjs
+++ b/test/local-governance-cli.test.mjs
@@ -1,0 +1,199 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+
+const require = createRequire(import.meta.url);
+const { runCli } = require('../sdk/node/agent-os.js');
+const {
+  createDefaultPolicy,
+  evaluatePolicy,
+  govern,
+  initializeProject,
+} = require('../sdk/node/local-governance.js');
+
+function workspace() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'agoragentic-governance-'));
+}
+
+function captureIo() {
+  let stdout = '';
+  let stderr = '';
+  return {
+    io: {
+      stdout: { write: (value) => { stdout += value; } },
+      stderr: { write: (value) => { stderr += value; } },
+    },
+    stdout: () => stdout,
+    stderr: () => stderr,
+  };
+}
+
+function fakeSpawn(exitCode = 0, calls = []) {
+  return (executable, args, options) => {
+    calls.push({ executable, args, options });
+    const child = new EventEmitter();
+    queueMicrotask(() => child.emit('exit', exitCode, null));
+    return child;
+  };
+}
+
+function readOnlyReceipt(cwd) {
+  const directory = path.join(cwd, '.agoragentic', 'receipts');
+  const files = fs.readdirSync(directory);
+  assert.equal(files.length, 1);
+  return {
+    raw: fs.readFileSync(path.join(directory, files[0]), 'utf8'),
+    value: JSON.parse(fs.readFileSync(path.join(directory, files[0]), 'utf8')),
+  };
+}
+
+test('init is plan-first, detects markers, and writes only with explicit confirmation', async (t) => {
+  const cwd = workspace();
+  t.after(() => fs.rmSync(cwd, { recursive: true, force: true }));
+  fs.writeFileSync(path.join(cwd, 'package.json'), '{}\n');
+
+  const planned = captureIo();
+  assert.equal(await runCli(['init'], {}, planned.io, { cwd }), 0);
+  assert.equal(fs.existsSync(path.join(cwd, 'agoragentic.yaml')), false);
+  const plan = JSON.parse(planned.stdout());
+  assert.equal(plan.result.status, 'planned');
+  assert.equal(plan.result.detected_adapters.some((adapter) => adapter.id === 'node'), true);
+
+  const written = captureIo();
+  assert.equal(await runCli(['init', '--yes'], {}, written.io, { cwd }), 0);
+  assert.equal(fs.existsSync(path.join(cwd, 'agoragentic.yaml')), true);
+  assert.equal(JSON.parse(written.stdout()).result.written, true);
+
+  const refused = captureIo();
+  assert.equal(await runCli(['init', '--yes'], {}, refused.io, { cwd }), 2);
+  assert.match(refused.stderr(), /policy_exists/);
+});
+
+test('adapters distinguishes marker detection from enforcement', async (t) => {
+  const cwd = workspace();
+  t.after(() => fs.rmSync(cwd, { recursive: true, force: true }));
+  fs.mkdirSync(path.join(cwd, '.claude'));
+  fs.writeFileSync(path.join(cwd, '.claude', 'settings.json'), '{}\n');
+
+  const captured = captureIo();
+  assert.equal(await runCli(['adapters'], {}, captured.io, { cwd }), 0);
+  const result = JSON.parse(captured.stdout()).result;
+  assert.equal(result.adapters.find((adapter) => adapter.id === 'process').integration_level, 'pre_action_enforcement');
+  assert.equal(result.adapters.find((adapter) => adapter.id === 'claude-code').detected, true);
+  assert.match(result.note, /does not prove host activation/);
+});
+
+test('run fails closed on ask or deny without spawning', async (t) => {
+  const cwd = workspace();
+  t.after(() => fs.rmSync(cwd, { recursive: true, force: true }));
+  fs.writeFileSync(path.join(cwd, 'agoragentic.yaml'), `${JSON.stringify(createDefaultPolicy(), null, 2)}\n`);
+  const calls = [];
+
+  const ask = captureIo();
+  assert.equal(await runCli(['run', '--', 'node', 'secret-value'], {}, ask.io, { cwd, spawn: fakeSpawn(0, calls) }), 3);
+  assert.equal(calls.length, 0);
+  assert.match(ask.stderr(), /explicit_approval_required/);
+
+  fs.rmSync(path.join(cwd, '.agoragentic'), { recursive: true, force: true });
+  const deniedPolicy = createDefaultPolicy();
+  deniedPolicy.actions['process.run'].decision = 'deny';
+  fs.writeFileSync(path.join(cwd, 'agoragentic.yaml'), `${JSON.stringify(deniedPolicy, null, 2)}\n`);
+  const denied = captureIo();
+  assert.equal(await runCli(['run', '--yes', '--', 'node', 'secret-value'], {}, denied.io, { cwd, spawn: fakeSpawn(0, calls) }), 3);
+  assert.equal(calls.length, 0);
+  assert.match(denied.stderr(), /policy_denied/);
+});
+
+test('run executes after ask approval and writes a redacted local-only receipt', async (t) => {
+  const cwd = workspace();
+  t.after(() => fs.rmSync(cwd, { recursive: true, force: true }));
+  fs.writeFileSync(path.join(cwd, 'agoragentic.yaml'), `${JSON.stringify(createDefaultPolicy(), null, 2)}\n`);
+  const calls = [];
+  const captured = captureIo();
+  const secret = 'super-secret-token';
+
+  assert.equal(await runCli(['run', '--yes', '--', 'node', '--token', secret], {}, captured.io, {
+    cwd,
+    spawn: fakeSpawn(0, calls),
+    stdio: 'ignore',
+  }), 0);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].options.shell, false);
+
+  const receipt = readOnlyReceipt(cwd);
+  assert.equal(receipt.value.classification, 'local_process_evidence');
+  assert.equal(receipt.value.evidence.argument_count, 2);
+  assert.equal(receipt.value.proof_scope.provider_execution, false);
+  assert.equal(receipt.value.proof_scope.payment, false);
+  assert.equal(receipt.raw.includes(secret), false);
+});
+
+test('govern blocks before invocation and emits shape-only evidence after approval', async (t) => {
+  const cwd = workspace();
+  t.after(() => fs.rmSync(cwd, { recursive: true, force: true }));
+  const policy = createDefaultPolicy();
+  policy.actions['email.send'] = { decision: 'ask', approval: 'owner_callback' };
+  let calls = 0;
+  const wrapped = govern(async (payload) => {
+    calls += 1;
+    return { delivered: true, secret: payload.secret };
+  }, {
+    action: 'email.send',
+    policy,
+    cwd,
+    approve: async () => true,
+  });
+
+  const secret = 'private-message';
+  assert.deepEqual(await wrapped({ secret }), { delivered: true, secret });
+  assert.equal(calls, 1);
+  const receipt = readOnlyReceipt(cwd);
+  assert.equal(receipt.value.classification, 'local_tool_evidence');
+  assert.deepEqual(receipt.value.evidence.result, { type: 'object', keys: ['delivered', 'secret'] });
+  assert.equal(receipt.raw.includes(secret), false);
+});
+
+test('runtime validation refuses delegated spend or retry authority', () => {
+  const delegatedSpend = createDefaultPolicy();
+  delegatedSpend.authority.spend = 'agent';
+  assert.throws(() => evaluatePolicy(delegatedSpend, 'process.run'), /authority\.spend must remain owner_only/);
+
+  const delegatedRetry = createDefaultPolicy();
+  delegatedRetry.authority.retry = 'agent';
+  assert.throws(() => evaluatePolicy(delegatedRetry, 'process.run'), /authority\.retry must remain owner_only/);
+});
+
+test('policy and receipt paths cannot escape the project boundary', (t) => {
+  const cwd = workspace();
+  t.after(() => fs.rmSync(cwd, { recursive: true, force: true }));
+  assert.throws(
+    () => initializeProject({ cwd, policyPath: '../outside.yaml' }),
+    /policy must stay inside the current project/
+  );
+
+  const policy = createDefaultPolicy();
+  policy.receipts.directory = '../outside-receipts';
+  let calls = 0;
+  const wrapped = govern(async () => {
+    calls += 1;
+    return true;
+  }, {
+    action: 'process.run',
+    policy,
+    cwd,
+    approved: true,
+  });
+  return assert.rejects(wrapped(), /receipt directory must stay inside the current project/).then(() => {
+    assert.equal(calls, 0);
+  });
+});
+
+test('ESM governance entry exposes the same public primitive', async () => {
+  const module = await import('../sdk/node/local-governance.mjs');
+  assert.equal(typeof module.govern, 'function');
+  assert.equal(module.POLICY_SCHEMA, 'agoragentic.local-governance-policy.v1');
+});


### PR DESCRIPTION
## Summary\n\nImplements the first bounded Front Door Phase 2 tranche from #334:\n\n- adds the compatibility-preserving goragentic bin while retaining gora and goragentic-os\n- adds plan-first init, marker-aware dapters, and policy-gated un -- <command>\n- adds the reusable CommonJS/ESM goragentic/governance primitive\n- adds a strict local policy schema, example policy, redacted local receipts, and hermetic tests\n\n## Safety boundaries\n\n- init performs no write without --yes and refuses overwrite without --force --yes\n- sk requires explicit approval; deny cannot be overridden\n- subprocess execution uses shell: false\n- raw arguments, environment values, stdout, stderr, tool inputs, and tool outputs are not persisted\n- spend and retry authority remain owner_only\n- receipts explicitly deny host, provider, deployment, payment, settlement, and on-chain proof\n- local policy and receipt paths cannot escape the project, including through existing symlink ancestors\n- npm publication is not part of this PR\n\n## Validation\n\n- 
ode --test test/local-governance-cli.test.mjs: 8/8\n- all repository Node tests: 98/98\n- SDK source parity: 5/5\n- policy JSON Schema validation: pass\n- integration, client-distribution, growth-example, and documentation validators: pass\n- Node and CLI package dry-runs: pass\n- direct temporary-project init / un smoke: pass with redacted local-only receipt\n- git diff --check: pass\n- signed commit: dca821\n\n## Remaining #334 work\n\nPython in-process governance, multidimensional capability records/generated tables, cross-repository inventory parity, rename preflight, and remaining discovery surfaces stay separately reviewable.