### PR TITLE
feat(catalog): add integration capability records

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -182,6 +182,9 @@ jobs:
       - name: Validate integrations.json against schema
         run: ajv validate -s integrations.schema.json -d integrations.json --all-errors --spec=draft2020 -c ajv-formats
 
+      - name: Verify generated integration capability status
+        run: node scripts/generate-integration-capability-status.mjs --check
+
       - name: Validate local governance policy schema
         run: ajv validate -s sdk/node/schema/local-governance-policy.v1.json -d sdk/node/schema/local-governance-policy.example.json --all-errors --spec=draft2020
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The generic Harness `run` path validates configuration and policy and records a 
 | OpenCode | Experimental before / after hook adapter pinned to an exact host contract fixture | Source candidate with bounded local evidence; not a general end-to-end compatibility claim |
 | LangGraph, CrewAI, Codex, MCP, Hermes, Rust reference runtime, and others | Mapping examples and adapter contracts | Mapping or example support is not the same as in-path enforcement |
 
-Read [Integration capability levels](./docs/INTEGRATION_CAPABILITY_LEVELS.md) before interpreting an integration status.
+Read [Integration capability levels](./docs/INTEGRATION_CAPABILITY_LEVELS.md) before interpreting an integration status. The [generated capability status](./docs/INTEGRATION_CAPABILITY_STATUS.md) shows the selected records and their evidence boundaries directly from `integrations.json`.
 
 ## Choose one path
 
@@ -109,7 +109,7 @@ custom Node.js  ─┘
 
 Browse the machine-readable catalog in [`integrations.json`](./integrations.json). A catalog entry does not automatically mean live enforcement, deployed compatibility, or payment readiness.
 
-At this revision, the canonical `integrations.json` manifest contains **105** surfaces. `ecosystem.json` is the count holder; generated public copy should read from the machine inventory rather than maintain an independent number.
+At this revision, the canonical `integrations.json` manifest contains **106** surfaces. `ecosystem.json` is the count holder; generated public copy should read from the machine inventory rather than maintain an independent number.
 
 ### Govern what the agent may know
 
@@ -216,6 +216,7 @@ Experimental and source-only integrations retain the limits stated in their own 
 | Surface | Purpose |
 |---|---|
 | [`integrations.json`](./integrations.json) | Canonical integration and package inventory |
+| [Generated integration capability status](./docs/INTEGRATION_CAPABILITY_STATUS.md) | Human-readable capability and evidence table derived from the canonical inventory |
 | [`ecosystem.json`](./ecosystem.json) | Durable product map and public entry points |
 | [Interchange research record](./interchange/research/README.md) | Evidence-bounded production research index and publication status |
 | [Interchange production evidence ledger](./interchange/evidence/interchange-production-research-ledger.v1.json) | Machine-readable experiment, finding, authority, and claim-boundary record |

--- a/assets/agoragentic-agent-commerce-banner.svg
+++ b/assets/agoragentic-agent-commerce-banner.svg
@@ -13,7 +13,7 @@
   <text x="104" y="312" fill="#f7f9fc" font-family="Inter, Arial, sans-serif" font-size="38" font-weight="600">Route work. Keep proof.</text>
   <text x="104" y="394" fill="#bbc7da" font-family="Inter, Arial, sans-serif" font-size="24">Frameworks, SDKs, MCP, A2A,</text>
   <text x="104" y="428" fill="#bbc7da" font-family="Inter, Arial, sans-serif" font-size="24">local governance, and receipts.</text>
-  <text x="104" y="536" fill="#ff8a70" font-family="JetBrains Mono, Consolas, monospace" font-size="20">105 public surfaces  |  one governed router</text>
+  <text x="104" y="536" fill="#ff8a70" font-family="JetBrains Mono, Consolas, monospace" font-size="20">106 public surfaces  |  one governed router</text>
   <g transform="translate(792 112)">
     <rect x="0" y="18" width="142" height="78" rx="6" fill="#111b30" stroke="#55d7de" stroke-width="4"/>
     <text x="19" y="52" fill="#f7f9fc" font-family="Inter, Arial, sans-serif" font-size="19" font-weight="700">FRAMEWORK</text>

--- a/docs/INTEGRATION_CAPABILITY_LEVELS.md
+++ b/docs/INTEGRATION_CAPABILITY_LEVELS.md
@@ -141,6 +141,7 @@ The catalog can migrate without breaking existing entries:
 
 - [`integrations.json`](../integrations.json)
 - [`integrations.schema.json`](../integrations.schema.json)
+- [Generated integration capability status](./INTEGRATION_CAPABILITY_STATUS.md)
 - [`ecosystem.json`](../ecosystem.json)
 - [Harness Core](../harness-core/)
 - [Distribution status](./DISTRIBUTION.md)

--- a/docs/INTEGRATION_CAPABILITY_STATUS.md
+++ b/docs/INTEGRATION_CAPABILITY_STATUS.md
@@ -1,0 +1,45 @@
+# Generated integration capability status
+
+> Generated from [`integrations.json`](../integrations.json) by `scripts/generate-integration-capability-status.mjs`. Do not edit this table independently.
+>
+> These records describe bounded implementation and evidence surfaces. They do not grant authority, activate a host adapter, prove deployment, authorize spend, or establish settlement.
+
+Capability records: **10** of **106** catalog entries.
+
+## Capabilities
+
+| Integration | Router client | Manifest mapping | Pre-action enforcement | Post-action evidence | Approval support | Receipt support | Agent OS export |
+|---|---|---|---|---|---|---|---|
+| [Agent OS Control Plane](../agent-os/README.md) | example | none | none | host_observed | record_only | hosted_execution | none |
+| [Claude Code Plugin](../claude-code/README.md) | none | documented | none | none | none | none | none |
+| [Codex Harness Mapping Stub](../harness-core/README.md) | none | documented | none | none | none | none | none |
+| [CrewAI](../crewai/README.md) | example | none | none | host_observed | none | hosted_execution | none |
+| [Agoragentic Harness Core](../harness-core/README.md) | none | tested | tested | local | host_enforced | local | tested |
+| [LangGraph](../langgraph/README.md) | example | none | none | host_observed | none | hosted_execution | none |
+| [MCP (Claude, VS Code, Cursor)](../mcp/README.md) | tested | none | none | host_observed | none | hosted_execution | preview |
+| [n8n Community Node](../n8n/README.md) | example | none | none | host_observed | none | hosted_execution | none |
+| [OpenAI Agents SDK](../openai-agents/README.md) | example | none | none | host_observed | none | hosted_execution | none |
+| [OpenCode Harness Plugin](../opencode/README.md) | none | tested | experimental | local | host_enforced | local | none |
+
+## Evidence and requirements
+
+| Integration | Host version tested | Proof class | Last verified | Evidence | Network required | Spend capable |
+|---|---|---|---|---|---|---|
+| Agent OS Control Plane | unknown | static | 2026-08-20T18:45:00Z | [agent-os/agent_os_node.mjs](../agent-os/agent_os_node.mjs) | yes | yes |
+| Claude Code Plugin | unknown | static | 2026-08-20T18:45:00Z | [claude-code/README.md](../claude-code/README.md) | no | no |
+| Codex Harness Mapping Stub | unknown | static | 2026-08-20T18:45:00Z | [harness-core/src/adapters/index.mjs](../harness-core/src/adapters/index.mjs) | no | no |
+| CrewAI | unknown | static | 2026-08-20T18:45:00Z | [crewai/agoragentic_crewai.py](../crewai/agoragentic_crewai.py) | yes | yes |
+| Agoragentic Harness Core | unknown | local | 2026-08-20T18:45:00Z | [harness-core/test/cli.test.cjs](../harness-core/test/cli.test.cjs) | no | no |
+| LangGraph | unknown | static | 2026-08-20T18:45:00Z | [langgraph/agoragentic_langgraph.py](../langgraph/agoragentic_langgraph.py) | yes | yes |
+| MCP (Claude, VS Code, Cursor) | unknown | local | 2026-08-20T18:45:00Z | [mcp/test/v2-remote-relay.test.js](../mcp/test/v2-remote-relay.test.js) | yes | yes |
+| n8n Community Node | unknown | static | 2026-08-20T18:45:00Z | [n8n/nodes/Agoragentic/Agoragentic.node.ts](../n8n/nodes/Agoragentic/Agoragentic.node.ts) | yes | yes |
+| OpenAI Agents SDK | unknown | static | 2026-08-20T18:45:00Z | [openai-agents/agoragentic_openai.py](../openai-agents/agoragentic_openai.py) | yes | yes |
+| OpenCode Harness Plugin | 1.18.15 contract fixture | local | 2026-08-20T18:45:00Z | [opencode/test/opencode-plugin.test.mjs](../opencode/test/opencode-plugin.test.mjs) | no | no |
+
+## Interpretation
+
+- `example` and `documented` are weaker than tested runtime support.
+- `static` proof means source or documentation was inspected; it is not host-runtime evidence.
+- A local or hosted execution receipt is not settlement evidence.
+- `spend_capable: yes` describes a reachable code path, not authority to spend.
+- Unknown host versions remain `unknown` until exact runtime evidence is recorded.

--- a/ecosystem.json
+++ b/ecosystem.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./ecosystem.schema.json",
   "schema": "agoragentic.ecosystem-profile.v1",
-  "updated_at": "2026-08-18",
+  "updated_at": "2026-08-20",
   "brand": {
     "name": "Agoragentic",
     "promise": "Keep your framework. Add Agoragentic's open integration, governance, and evidence surfaces, then connect to Triptych OS operation or commerce when needed.",
@@ -137,7 +137,7 @@
   ],
   "inventory": {
     "integration_manifest": "./integrations.json",
-    "integration_count": 105,
+    "integration_count": 106,
     "count_rule": "integration_count must equal integrations.json.integrations.length",
     "public_copy_rule": "Public surfaces should read the count from this profile or link to the manifest instead of independently hard-coding it."
   },

--- a/integrations.json
+++ b/integrations.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.45.0",
+  "version": "2.46.0",
   "updated_at": "2026-08-20",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
@@ -422,7 +422,28 @@
       "status": "ready",
       "path": "agent-os/agent_os_node.mjs",
       "install": "node 18+ or pip install requests",
-      "docs": "agent-os/README.md"
+      "docs": "agent-os/README.md",
+      "capability_record": {
+        "capabilities": {
+          "router_client": "example",
+          "manifest_mapping": "none",
+          "pre_action_enforcement": "none",
+          "post_action_evidence": "host_observed",
+          "approval_support": "record_only",
+          "receipt_support": "hosted_execution",
+          "agent_os_export": "none"
+        },
+        "evidence": {
+          "host_version_tested": "unknown",
+          "proof_class": "static",
+          "last_verified_at": "2026-08-20T18:45:00Z",
+          "evidence_ref": "agent-os/agent_os_node.mjs"
+        },
+        "requirements": {
+          "network_required": true,
+          "spend_capable": true
+        }
+      }
     },
     {
       "id": "agoragentic-rust-framework",
@@ -503,7 +524,28 @@
       "status": "beta",
       "path": "n8n/nodes/Agoragentic/Agoragentic.node.ts",
       "install": "npm install n8n-nodes-agoragentic",
-      "docs": "n8n/README.md"
+      "docs": "n8n/README.md",
+      "capability_record": {
+        "capabilities": {
+          "router_client": "example",
+          "manifest_mapping": "none",
+          "pre_action_enforcement": "none",
+          "post_action_evidence": "host_observed",
+          "approval_support": "none",
+          "receipt_support": "hosted_execution",
+          "agent_os_export": "none"
+        },
+        "evidence": {
+          "host_version_tested": "unknown",
+          "proof_class": "static",
+          "last_verified_at": "2026-08-20T18:45:00Z",
+          "evidence_ref": "n8n/nodes/Agoragentic/Agoragentic.node.ts"
+        },
+        "requirements": {
+          "network_required": true,
+          "spend_capable": true
+        }
+      }
     },
     {
       "id": "open-wallet-standard",
@@ -558,7 +600,59 @@
       "status": "beta",
       "path": "harness-core/bin/agoragentic-harness.mjs",
       "install": "npx agoragentic-harness-core@latest init",
-      "docs": "harness-core/README.md"
+      "docs": "harness-core/README.md",
+      "capability_record": {
+        "capabilities": {
+          "router_client": "none",
+          "manifest_mapping": "tested",
+          "pre_action_enforcement": "tested",
+          "post_action_evidence": "local",
+          "approval_support": "host_enforced",
+          "receipt_support": "local",
+          "agent_os_export": "tested"
+        },
+        "evidence": {
+          "host_version_tested": "unknown",
+          "proof_class": "local",
+          "last_verified_at": "2026-08-20T18:45:00Z",
+          "evidence_ref": "harness-core/test/cli.test.cjs"
+        },
+        "requirements": {
+          "network_required": false,
+          "spend_capable": false
+        }
+      }
+    },
+    {
+      "id": "codex-harness-mapping",
+      "name": "Codex Harness Mapping Stub",
+      "language": "javascript",
+      "status": "experimental",
+      "path": "harness-core/src/adapters/index.mjs",
+      "install": "npx agoragentic-harness-core@latest adapters",
+      "docs": "harness-core/README.md",
+      "compatibility_scope": "Cataloged local no-spend mapping contract only; no Codex host hook, tool interception, execution, or runtime receipt claim",
+      "capability_record": {
+        "capabilities": {
+          "router_client": "none",
+          "manifest_mapping": "documented",
+          "pre_action_enforcement": "none",
+          "post_action_evidence": "none",
+          "approval_support": "none",
+          "receipt_support": "none",
+          "agent_os_export": "none"
+        },
+        "evidence": {
+          "host_version_tested": "unknown",
+          "proof_class": "static",
+          "last_verified_at": "2026-08-20T18:45:00Z",
+          "evidence_ref": "harness-core/src/adapters/index.mjs"
+        },
+        "requirements": {
+          "network_required": false,
+          "spend_capable": false
+        }
+      }
     },
     {
       "id": "premortem-golden-loop",
@@ -585,7 +679,28 @@
       "status": "ready",
       "path": "crewai/agoragentic_crewai.py",
       "install": "pip install agoragentic",
-      "docs": "crewai/README.md"
+      "docs": "crewai/README.md",
+      "capability_record": {
+        "capabilities": {
+          "router_client": "example",
+          "manifest_mapping": "none",
+          "pre_action_enforcement": "none",
+          "post_action_evidence": "host_observed",
+          "approval_support": "none",
+          "receipt_support": "hosted_execution",
+          "agent_os_export": "none"
+        },
+        "evidence": {
+          "host_version_tested": "unknown",
+          "proof_class": "static",
+          "last_verified_at": "2026-08-20T18:45:00Z",
+          "evidence_ref": "crewai/agoragentic_crewai.py"
+        },
+        "requirements": {
+          "network_required": true,
+          "spend_capable": true
+        }
+      }
     },
     {
       "id": "mcp",
@@ -594,7 +709,28 @@
       "status": "ready",
       "path": "mcp/mcp-server.js",
       "install": "npx agoragentic-mcp",
-      "docs": "mcp/README.md"
+      "docs": "mcp/README.md",
+      "capability_record": {
+        "capabilities": {
+          "router_client": "tested",
+          "manifest_mapping": "none",
+          "pre_action_enforcement": "none",
+          "post_action_evidence": "host_observed",
+          "approval_support": "none",
+          "receipt_support": "hosted_execution",
+          "agent_os_export": "preview"
+        },
+        "evidence": {
+          "host_version_tested": "unknown",
+          "proof_class": "local",
+          "last_verified_at": "2026-08-20T18:45:00Z",
+          "evidence_ref": "mcp/test/v2-remote-relay.test.js"
+        },
+        "requirements": {
+          "network_required": true,
+          "spend_capable": true
+        }
+      }
     },
     {
       "id": "agent-client-protocol",
@@ -621,7 +757,28 @@
       "status": "ready",
       "path": "openai-agents/agoragentic_openai.py",
       "install": "pip install agoragentic",
-      "docs": "openai-agents/README.md"
+      "docs": "openai-agents/README.md",
+      "capability_record": {
+        "capabilities": {
+          "router_client": "example",
+          "manifest_mapping": "none",
+          "pre_action_enforcement": "none",
+          "post_action_evidence": "host_observed",
+          "approval_support": "none",
+          "receipt_support": "hosted_execution",
+          "agent_os_export": "none"
+        },
+        "evidence": {
+          "host_version_tested": "unknown",
+          "proof_class": "static",
+          "last_verified_at": "2026-08-20T18:45:00Z",
+          "evidence_ref": "openai-agents/agoragentic_openai.py"
+        },
+        "requirements": {
+          "network_required": true,
+          "spend_capable": true
+        }
+      }
     },
     {
       "id": "elizaos",
@@ -918,7 +1075,28 @@
       "status": "ready",
       "path": "langgraph/agoragentic_langgraph.py",
       "install": "pip install requests langgraph langchain-core",
-      "docs": "langgraph/README.md"
+      "docs": "langgraph/README.md",
+      "capability_record": {
+        "capabilities": {
+          "router_client": "example",
+          "manifest_mapping": "none",
+          "pre_action_enforcement": "none",
+          "post_action_evidence": "host_observed",
+          "approval_support": "none",
+          "receipt_support": "hosted_execution",
+          "agent_os_export": "none"
+        },
+        "evidence": {
+          "host_version_tested": "unknown",
+          "proof_class": "static",
+          "last_verified_at": "2026-08-20T18:45:00Z",
+          "evidence_ref": "langgraph/agoragentic_langgraph.py"
+        },
+        "requirements": {
+          "network_required": true,
+          "spend_capable": true
+        }
+      }
     },
     {
       "id": "cloudflare-agents",
@@ -1305,7 +1483,28 @@
       "status": "ready",
       "path": "claude-code/README.md",
       "install": "/plugin marketplace add rhein1/agoragentic-integrations; /plugin install agoragentic@agoragentic-integrations",
-      "docs": "claude-code/README.md"
+      "docs": "claude-code/README.md",
+      "capability_record": {
+        "capabilities": {
+          "router_client": "none",
+          "manifest_mapping": "documented",
+          "pre_action_enforcement": "none",
+          "post_action_evidence": "none",
+          "approval_support": "none",
+          "receipt_support": "none",
+          "agent_os_export": "none"
+        },
+        "evidence": {
+          "host_version_tested": "unknown",
+          "proof_class": "static",
+          "last_verified_at": "2026-08-20T18:45:00Z",
+          "evidence_ref": "claude-code/README.md"
+        },
+        "requirements": {
+          "network_required": false,
+          "spend_capable": false
+        }
+      }
     },
     {
       "id": "cline-mcp",
@@ -1341,7 +1540,28 @@
       "status": "experimental",
       "path": "opencode/src/server.mjs",
       "install": "cd opencode && npm ci",
-      "docs": "opencode/README.md"
+      "docs": "opencode/README.md",
+      "capability_record": {
+        "capabilities": {
+          "router_client": "none",
+          "manifest_mapping": "tested",
+          "pre_action_enforcement": "experimental",
+          "post_action_evidence": "local",
+          "approval_support": "host_enforced",
+          "receipt_support": "local",
+          "agent_os_export": "none"
+        },
+        "evidence": {
+          "host_version_tested": "1.18.15 contract fixture",
+          "proof_class": "local",
+          "last_verified_at": "2026-08-20T18:45:00Z",
+          "evidence_ref": "opencode/test/opencode-plugin.test.mjs"
+        },
+        "requirements": {
+          "network_required": false,
+          "spend_capable": false
+        }
+      }
     },
     {
       "id": "gstack-harness-bridge",

--- a/integrations.schema.json
+++ b/integrations.schema.json
@@ -347,6 +347,143 @@
         "compatibility_scope": {
           "type": "string",
           "description": "Exact source or runtime boundary for an experimental integration."
+        },
+        "capability_record": {
+          "$ref": "#/$defs/integrationCapabilityRecord"
+        }
+      }
+    },
+    "integrationCapabilityRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "capabilities",
+        "evidence",
+        "requirements"
+      ],
+      "properties": {
+        "capabilities": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "router_client",
+            "manifest_mapping",
+            "pre_action_enforcement",
+            "post_action_evidence",
+            "approval_support",
+            "receipt_support",
+            "agent_os_export"
+          ],
+          "properties": {
+            "router_client": {
+              "enum": [
+                "none",
+                "example",
+                "tested"
+              ]
+            },
+            "manifest_mapping": {
+              "enum": [
+                "none",
+                "documented",
+                "tested"
+              ]
+            },
+            "pre_action_enforcement": {
+              "enum": [
+                "none",
+                "experimental",
+                "tested"
+              ]
+            },
+            "post_action_evidence": {
+              "enum": [
+                "none",
+                "local",
+                "host_observed",
+                "provider_observed"
+              ]
+            },
+            "approval_support": {
+              "enum": [
+                "none",
+                "record_only",
+                "host_enforced",
+                "hosted_enforced"
+              ]
+            },
+            "receipt_support": {
+              "enum": [
+                "none",
+                "local",
+                "hosted_execution",
+                "settlement"
+              ]
+            },
+            "agent_os_export": {
+              "enum": [
+                "none",
+                "preview",
+                "tested"
+              ]
+            }
+          }
+        },
+        "evidence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "host_version_tested",
+            "proof_class",
+            "last_verified_at",
+            "evidence_ref"
+          ],
+          "properties": {
+            "host_version_tested": {
+              "type": "string",
+              "minLength": 1
+            },
+            "proof_class": {
+              "enum": [
+                "static",
+                "local",
+                "host_runtime",
+                "provider",
+                "deployed",
+                "settlement"
+              ]
+            },
+            "last_verified_at": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time"
+            },
+            "evidence_ref": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "minLength": 1
+            }
+          }
+        },
+        "requirements": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "network_required",
+            "spend_capable"
+          ],
+          "properties": {
+            "network_required": {
+              "type": "boolean"
+            },
+            "spend_capable": {
+              "type": "boolean"
+            }
+          }
         }
       }
     }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -62,7 +62,7 @@ The canonical tool list is `integrations.json#tools`. The table below highlights
 
 ## Selected Integration Matrix
 
-The canonical inventory is `integrations.json` and contains 105 integration surfaces as of 2026-08-09. These tables are representative entry points, not a complete count.
+The canonical inventory is `integrations.json` and contains 106 integration surfaces as of 2026-08-20. These tables are representative entry points, not a complete count.
 
 ### Python Integrations
 
@@ -250,6 +250,7 @@ Compatibility document: specs/ACP-SPEC.md. It is not the production wire contrac
 |-------|----------|
 | Machine index | integrations.json |
 | JSON Schema | integrations.schema.json |
+| Generated capability status | docs/INTEGRATION_CAPABILITY_STATUS.md |
 | Ecosystem profile | ecosystem.json |
 | Ecosystem profile schema | ecosystem.schema.json |
 | Client distribution status | docs/DISTRIBUTION.md |

--- a/llms.txt
+++ b/llms.txt
@@ -24,7 +24,7 @@
 - Or call agoragentic_register at runtime
 
 ## Integrations
-- Canonical inventory: `integrations.json` (105 indexed surfaces as of 2026-08-09).
+- Canonical inventory: `integrations.json` (106 indexed surfaces as of 2026-08-20).
 - Client-native packages: Cursor (`.cursor-plugin/plugin.json`), Gemini CLI (`gemini-extension.json`), Claude Code (`.claude-plugin/marketplace.json`), Cline (`llms-install.md`), and the experimental OpenCode Harness source plugin (`opencode/`). Package readiness does not imply external marketplace approval or live host compatibility.
 - Python frameworks include LangChain, LangGraph, Deep Agents, ClawTeam, CrewAI, AutoGen, OpenAI Agents, Google ADK, Haystack, pydantic-ai, smolagents, Agno, Griptape, LiveKit Agents, Pipecat, LlamaIndex, AgentScope, DSPy, Browser Use, and Langflow.
 - JavaScript/TypeScript frameworks and workflows include MCP, Vercel AI, Cloudflare Agents, Mastra, Bee Agent, ElizaOS, n8n, VoltAgent, Genkit, OpenAI Agents TypeScript, AG-UI, and experimental World AgentKit pre-payment composition.
@@ -46,6 +46,7 @@
 ## Machine Index
 - integrations.json — structured index of all integrations, tools, packages
 - integrations.schema.json — JSON Schema for validation
+- docs/INTEGRATION_CAPABILITY_STATUS.md — generated human-readable capability and evidence table
 - ecosystem.json — durable public portfolio profile and live-truth links
 - ecosystem.schema.json — included JSON Schema for the ecosystem profile
 - docs/catalog-profile.json — canonical descriptions, assets, package coordinate, authority boundary, and channel status

--- a/scripts/generate-integration-capability-status.mjs
+++ b/scripts/generate-integration-capability-status.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const manifestPath = path.join(root, 'integrations.json');
+const outputPath = path.join(root, 'docs', 'INTEGRATION_CAPABILITY_STATUS.md');
+
+function cell(value) {
+  return String(value ?? 'none').replaceAll('|', '\\|').replaceAll(/\r?\n/g, ' ');
+}
+
+function relativeLink(label, target) {
+  return target ? `[${cell(label)}](../${target})` : cell(label);
+}
+
+export function renderCapabilityStatus(manifest) {
+  const integrations = (manifest.integrations || [])
+    .filter((integration) => integration.capability_record)
+    .sort((left, right) => left.id.localeCompare(right.id));
+
+  const lines = [
+    '# Generated integration capability status',
+    '',
+    '> Generated from [`integrations.json`](../integrations.json) by `scripts/generate-integration-capability-status.mjs`. Do not edit this table independently.',
+    '>',
+    '> These records describe bounded implementation and evidence surfaces. They do not grant authority, activate a host adapter, prove deployment, authorize spend, or establish settlement.',
+    '',
+    `Capability records: **${integrations.length}** of **${manifest.integrations?.length || 0}** catalog entries.`,
+    '',
+    '## Capabilities',
+    '',
+    '| Integration | Router client | Manifest mapping | Pre-action enforcement | Post-action evidence | Approval support | Receipt support | Agent OS export |',
+    '|---|---|---|---|---|---|---|---|',
+  ];
+
+  for (const integration of integrations) {
+    const capabilities = integration.capability_record.capabilities;
+    lines.push([
+      relativeLink(integration.name, integration.docs || integration.path),
+      cell(capabilities.router_client),
+      cell(capabilities.manifest_mapping),
+      cell(capabilities.pre_action_enforcement),
+      cell(capabilities.post_action_evidence),
+      cell(capabilities.approval_support),
+      cell(capabilities.receipt_support),
+      cell(capabilities.agent_os_export),
+    ].join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
+  }
+
+  lines.push(
+    '',
+    '## Evidence and requirements',
+    '',
+    '| Integration | Host version tested | Proof class | Last verified | Evidence | Network required | Spend capable |',
+    '|---|---|---|---|---|---|---|',
+  );
+
+  for (const integration of integrations) {
+    const { evidence, requirements } = integration.capability_record;
+    lines.push([
+      cell(integration.name),
+      cell(evidence.host_version_tested),
+      cell(evidence.proof_class),
+      cell(evidence.last_verified_at || 'not verified'),
+      evidence.evidence_ref ? relativeLink(evidence.evidence_ref, evidence.evidence_ref) : 'none',
+      requirements.network_required ? 'yes' : 'no',
+      requirements.spend_capable ? 'yes' : 'no',
+    ].join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
+  }
+
+  lines.push(
+    '',
+    '## Interpretation',
+    '',
+    '- `example` and `documented` are weaker than tested runtime support.',
+    '- `static` proof means source or documentation was inspected; it is not host-runtime evidence.',
+    '- A local or hosted execution receipt is not settlement evidence.',
+    '- `spend_capable: yes` describes a reachable code path, not authority to spend.',
+    '- Unknown host versions remain `unknown` until exact runtime evidence is recorded.',
+    '',
+  );
+
+  return lines.join('\n');
+}
+
+export function verifyCapabilityStatus({ manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')), expected = fs.readFileSync(outputPath, 'utf8') } = {}) {
+  const generated = renderCapabilityStatus(manifest);
+  return { ok: generated === expected, generated, expected };
+}
+
+function main() {
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const generated = renderCapabilityStatus(manifest);
+  if (process.argv.includes('--write')) {
+    fs.writeFileSync(outputPath, generated, 'utf8');
+    console.log(`Wrote ${path.relative(root, outputPath)}`);
+    return;
+  }
+  if (process.argv.includes('--check')) {
+    const expected = fs.readFileSync(outputPath, 'utf8');
+    if (generated !== expected) {
+      console.error('Integration capability status is stale. Run: node scripts/generate-integration-capability-status.mjs --write');
+      process.exitCode = 1;
+      return;
+    }
+    console.log('Integration capability status is current.');
+    return;
+  }
+  process.stdout.write(generated);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/scripts/verify-integrations-json.js
+++ b/scripts/verify-integrations-json.js
@@ -200,6 +200,63 @@ function assertInventoryCoverage(manifest) {
   }
 }
 
+function assertCapabilityRecords(manifest) {
+  const requiredIds = [
+    'agent-os',
+    'claude-code-plugin',
+    'codex-harness-mapping',
+    'crewai',
+    'harness-core',
+    'langgraph',
+    'mcp',
+    'n8n',
+    'openai-agents',
+    'opencode-harness-plugin',
+  ];
+  const integrations = new Map((manifest.integrations || []).map((entry) => [entry.id, entry]));
+
+  for (const id of requiredIds) {
+    if (!integrations.get(id)?.capability_record) {
+      fail(`integrations.json ${id} must include a capability_record`);
+    }
+  }
+
+  for (const integration of manifest.integrations || []) {
+    const record = integration.capability_record;
+    if (!record) continue;
+    const { capabilities, evidence, requirements } = record;
+    if (evidence.evidence_ref) {
+      const evidencePath = path.resolve(root, evidence.evidence_ref);
+      const relative = path.relative(root, evidencePath);
+      if (relative === '..' || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+        fail(`${integration.id}.capability_record.evidence_ref escapes the repository`);
+      } else if (!fs.existsSync(evidencePath)) {
+        fail(`${integration.id}.capability_record.evidence_ref does not exist: ${evidence.evidence_ref}`);
+      }
+    }
+    if (evidence.last_verified_at && new Date(evidence.last_verified_at).getTime() > Date.now()) {
+      fail(`${integration.id}.capability_record.evidence.last_verified_at is in the future`);
+    }
+    const tested = [
+      capabilities.router_client,
+      capabilities.manifest_mapping,
+      capabilities.pre_action_enforcement,
+      capabilities.agent_os_export,
+    ].includes('tested');
+    if (tested && (evidence.proof_class === 'static' || !evidence.evidence_ref || !evidence.last_verified_at)) {
+      fail(`${integration.id} tested capabilities require non-static dated evidence`);
+    }
+    if (capabilities.pre_action_enforcement === 'none'
+      && ['host_enforced', 'hosted_enforced'].includes(capabilities.approval_support)) {
+      fail(`${integration.id} cannot claim enforced approvals without pre-action enforcement`);
+    }
+    if (capabilities.receipt_support === 'settlement'
+      && (evidence.proof_class !== 'settlement' || requirements.spend_capable !== true)) {
+      fail(`${integration.id} settlement receipt support requires settlement proof and a spend-capable path`);
+    }
+  }
+}
+
 function assertDiscoveryParity(manifest) {
   const readme = fs.readFileSync(path.join(root, 'README.md'), 'utf8');
   const llms = fs.readFileSync(path.join(root, 'llms.txt'), 'utf8');
@@ -354,6 +411,7 @@ if (duplicates.length) fail(`integrations.json has duplicate top-level keys: ${d
 const manifest = JSON.parse(rawManifest);
 assertManifestShape(manifest);
 assertInventoryCoverage(manifest);
+assertCapabilityRecords(manifest);
 assertDiscoveryParity(manifest);
 assertMachineCopy();
 assertProtocolNamespaces(manifest);

--- a/test/integration-capability-status.test.mjs
+++ b/test/integration-capability-status.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  renderCapabilityStatus,
+  verifyCapabilityStatus,
+} from '../scripts/generate-integration-capability-status.mjs';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const manifest = JSON.parse(fs.readFileSync(path.join(root, 'integrations.json'), 'utf8'));
+const expected = fs.readFileSync(
+  path.join(root, 'docs', 'INTEGRATION_CAPABILITY_STATUS.md'),
+  'utf8',
+);
+
+test('generated capability status matches the machine inventory', () => {
+  const result = verifyCapabilityStatus({ manifest, expected });
+  assert.equal(result.ok, true);
+  assert.equal(result.generated, expected);
+});
+
+test('generated capability status retains proof and authority boundaries', () => {
+  const rendered = renderCapabilityStatus(manifest);
+  assert.match(rendered, /do not grant authority/i);
+  assert.match(rendered, /Codex Harness Mapping Stub.*none.*documented.*none/);
+  assert.match(rendered, /OpenCode Harness Plugin.*experimental.*local/);
+  assert.doesNotMatch(rendered, /Codex Harness Mapping Stub.*host_enforced/);
+  assert.doesNotMatch(rendered, /settlement \|/);
+});
+
+test('a machine-record change makes the committed status stale', () => {
+  const changed = structuredClone(manifest);
+  changed.integrations.find((entry) => entry.id === 'crewai')
+    .capability_record.capabilities.router_client = 'tested';
+  assert.notEqual(renderCapabilityStatus(changed), expected);
+});


### PR DESCRIPTION
## Summary

- add multidimensional capability records for the initial high-traffic integration set
- generate a human-readable capability/evidence table from `integrations.json`
- fail validation when required records, evidence references, proof boundaries, or generated status drift
- add a bounded Codex mapping stub that grants no host hook, execution, receipt, spend, or deployment claim
- keep the canonical inventory count synchronized at 106 across public surfaces

This advances the capability-record tranche of #334. It does not activate an adapter, grant authority, prove deployment, authorize spend, or establish settlement.

## Validation

- `npx --yes --package ajv-cli@5 --package ajv-formats@3 ajv validate -s integrations.schema.json -d integrations.json -c ajv-formats --spec=draft2020 --strict=false`
- `node scripts/generate-integration-capability-status.mjs --check`
- `node scripts/verify-integrations-json.js`
- `node scripts/verify-client-distribution.mjs`
- `node scripts/verify-doc-links.mjs`
- `node scripts/validate-growth-examples.mjs --base origin/main`
- `node --test test/integration-capability-status.test.mjs`
- all root Node tests: 99 passed
- Harness Core tests: 21 passed
- OpenCode tests: 14 passed
- MCP tests: 8 passed
- `git diff --check`