### PR TITLE
chore(catalog): unify counts and add rename preflight

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -185,6 +185,12 @@ jobs:
       - name: Verify generated integration capability status
         run: node scripts/generate-integration-capability-status.mjs --check
 
+      - name: Verify canonical integration count projections
+        run: node scripts/sync-integration-counts.mjs --check
+
+      - name: Verify repository rename preflight
+        run: node scripts/generate-repository-rename-preflight.mjs --check
+
       - name: Validate local governance policy schema
         run: ajv validate -s sdk/node/schema/local-governance-policy.v1.json -d sdk/node/schema/local-governance-policy.example.json --all-errors --spec=draft2020
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,9 @@ Agoragentic is Agent OS for deployed agents and swarms. Micro ECF is the local c
 ```
 integrations.json          ← machine-readable index (start here)
 integrations.schema.json   ← JSON Schema for the index
+docs/INTEGRATION_CAPABILITY_STATUS.md ← generated evidence-level status
+docs/repository-rename-preflight.json ← generated rename dependency inventory
+docs/REPOSITORY_RENAME_PREFLIGHT.md   ← no-authority rename and rollback packet
 SKILL.md                   ← capability description for LLMs
 llms.txt                   ← thin bootstrap for language models
 llms-full.txt              ← expanded context for deep ingestion
@@ -57,6 +60,7 @@ Always expand ACP on first use. `acp/`, `--acp`, and `ACP_REGISTRY.md` mean **Ag
 3. Match the existing tool naming pattern (`agoragentic_*`)
 4. Validate `integrations.json` against `integrations.schema.json` after changes
 5. Add/update the per-framework `README.md` if you add or change an integration
+6. Run `node scripts/sync-integration-counts.mjs --check` and `node scripts/generate-repository-rename-preflight.mjs --check`
 
 ### If you are an agent or builder that wants to use Agent OS:
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use Agoragentic integrations in your research, please cite this repository."
 title: "Agoragentic Integrations"
 abstract: >-
-  Ninety-three public integration surfaces connecting agent frameworks, protocols,
+  Public integration surfaces connecting agent frameworks, protocols,
   wallets, workflows, local providers, SDKs, and MCP to Triptych OS (Agent OS)
   and the Agoragentic Router / Marketplace. Integrations use task-oriented
   execute(), provider preview, and receipt references. Paid USDC execution on

--- a/INTEGRATION_CATALOG_GUIDE.md
+++ b/INTEGRATION_CATALOG_GUIDE.md
@@ -2,7 +2,7 @@
 
 ![Agoragentic integrations: connect agents, route work, keep receipts](./assets/agoragentic-integrations-social.png)
 
-**105 public integration surfaces for Triptych OS (Agent OS), Router execution, local governance, MCP, A2A, client-native plugins, frameworks, workflows, wallets, and receipt-aware agent commerce.**
+**106 public integration surfaces for Triptych OS (Agent OS), Router execution, local governance, MCP, A2A, client-native plugins, frameworks, workflows, wallets, and receipt-aware agent commerce.**
 
 [![npm](https://img.shields.io/npm/v/agoragentic-mcp?label=MCP%20Server&color=cb3837)](https://www.npmjs.com/package/agoragentic-mcp)
 [![PyPI](https://img.shields.io/pypi/v/agoragentic?label=Python%20SDK&color=3775A9)](https://pypi.org/project/agoragentic/)
@@ -53,7 +53,7 @@ curl "https://agoragentic.com/api/commerce/receipts/rcpt_YOUR_RECEIPT" \
 
 | Repo / package | What it is |
 |---|---|
-| **[agoragentic-integrations](https://github.com/rhein1/agoragentic-integrations)** | 105 indexed surfaces across client plugins, frameworks, protocols, wallets, workflows, local providers, SDKs, and MCP |
+| **[agoragentic-integrations](https://github.com/rhein1/agoragentic-integrations)** | 106 indexed surfaces across client plugins, frameworks, protocols, wallets, workflows, local providers, SDKs, and MCP |
 | [agoragentic-ecf-core](https://github.com/rhein1/agoragentic-ecf-core) | Self-hosted context-governance runtime (npm `agoragentic-ecf-core`) |
 | [Micro ECF](https://github.com/rhein1/agoragentic-micro-ecf) | Open local context wedge (npm `agoragentic-micro-ecf`) |
 | [agoragentic-premortem-golden-loop](https://github.com/rhein1/agoragentic-premortem-golden-loop) | Pre-launch release-readiness CLI (npm `agoragentic-premortem-golden-loop`) |
@@ -78,6 +78,8 @@ Agent workflow contracts: [governed agent runs](./docs/agent-workflow-contracts.
 | LLM instructions | [/llms.txt](https://agoragentic.com/llms.txt) |
 | Client distribution status | [`docs/DISTRIBUTION.md`](./docs/DISTRIBUTION.md) |
 | Offline machine-surface check | `node scripts/verify-integrations-json.js` |
+| Canonical inventory-count check | `node scripts/sync-integration-counts.mjs --check` |
+| Repository rename preflight | [`docs/REPOSITORY_RENAME_PREFLIGHT.md`](./docs/REPOSITORY_RENAME_PREFLIGHT.md) |
 | Offline adapter conformance | `node scripts/adapter-conformance-agent.mjs` |
 
 ## Protocol Names
@@ -192,7 +194,7 @@ The canonical descriptions, assets, package coordinate, authority boundary, and 
 
 ## Featured Integration Paths
 
-The table below highlights useful entry points. The complete canonical inventory contains **105** surfaces in [`integrations.json`](./integrations.json), including client plugins, framework adapters, protocols, wallets, workflow tools, local providers, and reference integrations.
+The table below highlights useful entry points. The complete canonical inventory contains **106** surfaces in [`integrations.json`](./integrations.json), including client plugins, framework adapters, protocols, wallets, workflow tools, local providers, and reference integrations.
 
 | Framework | Language | Status | Path | Docs |
 |-----------|----------|--------|------|------|
@@ -461,6 +463,8 @@ Your Agent  →  Integration (tools/MCP)  →  Agent OS + Agoragentic API
 | JSON Schema | [`integrations.schema.json`](./integrations.schema.json) |
 | Ecosystem profile | [`ecosystem.json`](./ecosystem.json) |
 | Ecosystem profile schema | [`ecosystem.schema.json`](./ecosystem.schema.json) |
+| Repository rename preflight | [`docs/REPOSITORY_RENAME_PREFLIGHT.md`](./docs/REPOSITORY_RENAME_PREFLIGHT.md) |
+| Machine rename dependency inventory | [`docs/repository-rename-preflight.json`](./docs/repository-rename-preflight.json) |
 | Client distribution status | [`docs/DISTRIBUTION.md`](./docs/DISTRIBUTION.md) |
 | Canonical directory packet | [`docs/catalog-profile.json`](./docs/catalog-profile.json) |
 | Cursor plugin | [`.cursor-plugin/plugin.json`](./.cursor-plugin/plugin.json) |

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ Experimental and source-only integrations retain the limits stated in their own 
 |---|---|
 | [`integrations.json`](./integrations.json) | Canonical integration and package inventory |
 | [Generated integration capability status](./docs/INTEGRATION_CAPABILITY_STATUS.md) | Human-readable capability and evidence table derived from the canonical inventory |
+| [Repository rename preflight](./docs/REPOSITORY_RENAME_PREFLIGHT.md) | Human-readable dependency, rollout, and rollback packet; no rename is authorized |
+| [`repository-rename-preflight.json`](./docs/repository-rename-preflight.json) | Deterministic per-file rename dependency inventory |
 | [`ecosystem.json`](./ecosystem.json) | Durable product map and public entry points |
 | [Interchange research record](./interchange/research/README.md) | Evidence-bounded production research index and publication status |
 | [Interchange production evidence ledger](./interchange/evidence/interchange-production-research-ledger.v1.json) | Machine-readable experiment, finding, authority, and claim-boundary record |
@@ -243,6 +245,8 @@ Live machine surfaces are authoritative for current availability. Repository doc
 ```bash
 node scripts/adapter-conformance-agent.mjs --adapter your-integration-id
 node scripts/verify-integrations-json.js
+node scripts/sync-integration-counts.mjs --check
+node scripts/generate-repository-rename-preflight.mjs --check
 ```
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md), [distribution status](./docs/DISTRIBUTION.md), and [community testing](./docs/COMMUNITY_TESTING.md).

--- a/docs/REPOSITORY_RENAME_PREFLIGHT.md
+++ b/docs/REPOSITORY_RENAME_PREFLIGHT.md
@@ -1,0 +1,63 @@
+# Repository Rename Preflight
+
+> **No repository rename has been executed or authorized.** This is a deterministic dependency inventory and rollback plan.
+
+- Source repository: `rhein1/agoragentic-integrations`
+- Canonical manifest: `2.46.0` as of `2026-08-20`
+- Safe to rename now: **false**
+- Authorized target: **none**
+- Affected tracked files: **131**
+- Exact repository references: **300**
+
+## Reference Classes
+
+| Class | Files |
+|---|---:|
+| `installer_or_clone` | 27 |
+| `machine_discovery` | 41 |
+| `package_registry_metadata` | 21 |
+| `public_documentation` | 65 |
+| `raw_content_url` | 2 |
+| `release_or_provenance` | 8 |
+| `reusable_action` | 2 |
+| `source_or_test` | 21 |
+
+## Reusable Action Blockers
+
+These consumers can fail immediately after a rename and must be migrated first.
+
+| Location | Reference |
+|---|---|
+| `transaction-assurance/CONFORMANCE.md:101` | `uses: rhein1/agoragentic-integrations/.github/workflows/transaction-assurance-conformance.yml@<SUITE_COMMIT>` |
+| `transaction-assurance/examples/external-adopters/anchor-x402/README.md:118` | `uses: rhein1/agoragentic-integrations/.github/workflows/transaction-assurance-conformance.yml@<SUITE_COMMIT>` |
+
+## Raw Content URLs
+
+| Location | Reference |
+|---|---|
+| `autogen/README.md:9` | `curl -O https://raw.githubusercontent.com/rhein1/agoragentic-integrations/main/autogen/agoragentic_autogen.py` |
+| `langchain/README.md:9` | `curl -O https://raw.githubusercontent.com/rhein1/agoragentic-integrations/main/langchain/agoragentic_tools.py` |
+
+## Owner Decisions
+
+- Choose the final owner and repository name; no target is authorized by this packet.
+- Choose a compatibility window for package metadata, clone URLs, raw-content URLs, and reusable action consumers.
+- Choose whether external consumers receive a deprecation notice before the rename.
+
+## Rollout
+
+1. Freeze unrelated changes and capture the current default-branch SHA.
+2. Update reusable action consumers to immutable SHAs or the final repository path before renaming.
+3. Rename through GitHub, then update package metadata, installers, raw-content URLs, discovery files, and public documentation.
+4. Run repository validation and external no-spend smoke checks against both redirected and canonical URLs.
+5. Publish a bounded migration notice that distinguishes redirects from permanent compatibility guarantees.
+
+## Rollback
+
+Trigger: Any broken reusable action, installer, raw-content URL, package metadata, discovery surface, or external no-spend smoke check.
+
+1. Restore the previous GitHub repository name while the redirect remains uncontested.
+2. Revert the rename reference commit and republish only metadata that was already changed.
+3. Re-run the full validation suite and external no-spend smoke checks before lifting the freeze.
+
+The complete per-file inventory is in [`repository-rename-preflight.json`](./repository-rename-preflight.json).

--- a/docs/repository-rename-preflight.json
+++ b/docs/repository-rename-preflight.json
@@ -1,0 +1,1600 @@
+{
+  "schema_version": "1.0.0",
+  "source_manifest_version": "2.46.0",
+  "as_of": "2026-08-20",
+  "source_repository": "rhein1/agoragentic-integrations",
+  "safe_to_rename": false,
+  "target_repository": null,
+  "summary": {
+    "file_count": 131,
+    "occurrence_count": 300,
+    "category_file_counts": {
+      "installer_or_clone": 27,
+      "machine_discovery": 41,
+      "package_registry_metadata": 21,
+      "public_documentation": 65,
+      "raw_content_url": 2,
+      "release_or_provenance": 8,
+      "reusable_action": 2,
+      "source_or_test": 21
+    }
+  },
+  "reusable_action_references": [
+    {
+      "path": "transaction-assurance/CONFORMANCE.md",
+      "line": 101,
+      "reference": "uses: rhein1/agoragentic-integrations/.github/workflows/transaction-assurance-conformance.yml@<SUITE_COMMIT>"
+    },
+    {
+      "path": "transaction-assurance/examples/external-adopters/anchor-x402/README.md",
+      "line": 118,
+      "reference": "uses: rhein1/agoragentic-integrations/.github/workflows/transaction-assurance-conformance.yml@<SUITE_COMMIT>"
+    }
+  ],
+  "raw_content_urls": [
+    {
+      "path": "autogen/README.md",
+      "line": 9,
+      "reference": "curl -O https://raw.githubusercontent.com/rhein1/agoragentic-integrations/main/autogen/agoragentic_autogen.py"
+    },
+    {
+      "path": "langchain/README.md",
+      "line": 9,
+      "reference": "curl -O https://raw.githubusercontent.com/rhein1/agoragentic-integrations/main/langchain/agoragentic_tools.py"
+    }
+  ],
+  "owner_decisions": [
+    "Choose the final owner and repository name; no target is authorized by this packet.",
+    "Choose a compatibility window for package metadata, clone URLs, raw-content URLs, and reusable action consumers.",
+    "Choose whether external consumers receive a deprecation notice before the rename."
+  ],
+  "rollout": [
+    "Freeze unrelated changes and capture the current default-branch SHA.",
+    "Update reusable action consumers to immutable SHAs or the final repository path before renaming.",
+    "Rename through GitHub, then update package metadata, installers, raw-content URLs, discovery files, and public documentation.",
+    "Run repository validation and external no-spend smoke checks against both redirected and canonical URLs.",
+    "Publish a bounded migration notice that distinguishes redirects from permanent compatibility guarantees."
+  ],
+  "rollback": {
+    "trigger": "Any broken reusable action, installer, raw-content URL, package metadata, discovery surface, or external no-spend smoke check.",
+    "steps": [
+      "Restore the previous GitHub repository name while the redirect remains uncontested.",
+      "Revert the rename reference commit and republish only metadata that was already changed.",
+      "Re-run the full validation suite and external no-spend smoke checks before lifting the freeze."
+    ]
+  },
+  "files": [
+    {
+      "path": ".agents/skills/agoragentic-assure/SKILL.md",
+      "occurrences": 4,
+      "line_numbers": [
+        27,
+        62,
+        65,
+        66
+      ],
+      "categories": [
+        "installer_or_clone",
+        "public_documentation"
+      ]
+    },
+    {
+      "path": ".agents/skills/agoragentic-deploy/SKILL.md",
+      "occurrences": 2,
+      "line_numbers": [
+        20,
+        21
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": ".agents/skills/agoragentic-execute/SKILL.md",
+      "occurrences": 2,
+      "line_numbers": [
+        23,
+        24
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": ".agents/skills/agoragentic-govern/SKILL.md",
+      "occurrences": 2,
+      "line_numbers": [
+        21,
+        22
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": ".agents/skills/agoragentic-integrate/SKILL.md",
+      "occurrences": 3,
+      "line_numbers": [
+        22,
+        23,
+        24
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": ".agents/skills/agoragentic-prove/SKILL.md",
+      "occurrences": 2,
+      "line_numbers": [
+        27,
+        28
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": ".agents/skills/agoragentic-sell/SKILL.md",
+      "occurrences": 1,
+      "line_numbers": [
+        22
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": ".agents/skills/agoragentic/SKILL.md",
+      "occurrences": 6,
+      "line_numbers": [
+        34,
+        38,
+        39,
+        41,
+        42,
+        43
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": ".cursor-plugin/plugin.json",
+      "occurrences": 1,
+      "line_numbers": [
+        12
+      ],
+      "categories": [
+        "machine_discovery",
+        "package_registry_metadata"
+      ]
+    },
+    {
+      "path": ".cursor/rules/agoragentic-assure.mdc",
+      "occurrences": 4,
+      "line_numbers": [
+        29,
+        64,
+        67,
+        68
+      ],
+      "categories": [
+        "installer_or_clone",
+        "source_or_test"
+      ]
+    },
+    {
+      "path": ".cursor/rules/agoragentic-deploy.mdc",
+      "occurrences": 2,
+      "line_numbers": [
+        22,
+        23
+      ],
+      "categories": [
+        "source_or_test"
+      ]
+    },
+    {
+      "path": ".cursor/rules/agoragentic-execute.mdc",
+      "occurrences": 2,
+      "line_numbers": [
+        25,
+        26
+      ],
+      "categories": [
+        "source_or_test"
+      ]
+    },
+    {
+      "path": ".cursor/rules/agoragentic-govern.mdc",
+      "occurrences": 2,
+      "line_numbers": [
+        23,
+        24
+      ],
+      "categories": [
+        "source_or_test"
+      ]
+    },
+    {
+      "path": ".cursor/rules/agoragentic-integrate.mdc",
+      "occurrences": 3,
+      "line_numbers": [
+        24,
+        25,
+        26
+      ],
+      "categories": [
+        "source_or_test"
+      ]
+    },
+    {
+      "path": ".cursor/rules/agoragentic-prove.mdc",
+      "occurrences": 2,
+      "line_numbers": [
+        29,
+        30
+      ],
+      "categories": [
+        "source_or_test"
+      ]
+    },
+    {
+      "path": ".cursor/rules/agoragentic-sell.mdc",
+      "occurrences": 1,
+      "line_numbers": [
+        24
+      ],
+      "categories": [
+        "source_or_test"
+      ]
+    },
+    {
+      "path": ".cursor/rules/agoragentic.mdc",
+      "occurrences": 6,
+      "line_numbers": [
+        36,
+        40,
+        41,
+        43,
+        44,
+        45
+      ],
+      "categories": [
+        "source_or_test"
+      ]
+    },
+    {
+      "path": ".github/ISSUE_TEMPLATE/config.yml",
+      "occurrences": 3,
+      "line_numbers": [
+        4,
+        7,
+        10
+      ],
+      "categories": [
+        "machine_discovery"
+      ]
+    },
+    {
+      "path": ".github/workflows/transaction-assurance-conformance.yml",
+      "occurrences": 1,
+      "line_numbers": [
+        77
+      ],
+      "categories": [
+        "machine_discovery"
+      ]
+    },
+    {
+      "path": ".opencode/skills/agoragentic-assure/SKILL.md",
+      "occurrences": 4,
+      "line_numbers": [
+        27,
+        62,
+        65,
+        66
+      ],
+      "categories": [
+        "installer_or_clone",
+        "public_documentation"
+      ]
+    },
+    {
+      "path": ".opencode/skills/agoragentic-deploy/SKILL.md",
+      "occurrences": 2,
+      "line_numbers": [
+        20,
+        21
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": ".opencode/skills/agoragentic-execute/SKILL.md",
+      "occurrences": 2,
+      "line_numbers": [
+        23,
+        24
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": ".opencode/skills/agoragentic-govern/SKILL.md",
+      "occurrences": 2,
+      "line_numbers": [
+        21,
+        22
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": ".opencode/skills/agoragentic-integrate/SKILL.md",
+      "occurrences": 3,
+      "line_numbers": [
+        22,
+        23,
+        24
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": ".opencode/skills/agoragentic-prove/SKILL.md",
+      "occurrences": 2,
+      "line_numbers": [
+        27,
+        28
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": ".opencode/skills/agoragentic-sell/SKILL.md",
+      "occurrences": 1,
+      "line_numbers": [
+        22
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": ".opencode/skills/agoragentic/SKILL.md",
+      "occurrences": 6,
+      "line_numbers": [
+        34,
+        38,
+        39,
+        41,
+        42,
+        43
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "a2a/agent-card.json",
+      "occurrences": 1,
+      "line_numbers": [
+        76
+      ],
+      "categories": [
+        "machine_discovery"
+      ]
+    },
+    {
+      "path": "ACP_REGISTRY.md",
+      "occurrences": 1,
+      "line_numbers": [
+        68
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "acp/agent.json",
+      "occurrences": 1,
+      "line_numbers": [
+        8
+      ],
+      "categories": [
+        "machine_discovery",
+        "package_registry_metadata"
+      ]
+    },
+    {
+      "path": "agent-payments-assurance-challenge/package.json",
+      "occurrences": 2,
+      "line_numbers": [
+        30,
+        34
+      ],
+      "categories": [
+        "installer_or_clone",
+        "machine_discovery",
+        "package_registry_metadata"
+      ]
+    },
+    {
+      "path": "AGENTS.md",
+      "occurrences": 2,
+      "line_numbers": [
+        126,
+        127
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "autogen/README.md",
+      "occurrences": 1,
+      "line_numbers": [
+        9
+      ],
+      "categories": [
+        "public_documentation",
+        "raw_content_url"
+      ]
+    },
+    {
+      "path": "CHANGELOG.md",
+      "occurrences": 14,
+      "line_numbers": [
+        220,
+        221,
+        222,
+        223,
+        224,
+        225,
+        226,
+        227,
+        228,
+        229,
+        230,
+        231,
+        232,
+        233
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "CITATION.cff",
+      "occurrences": 1,
+      "line_numbers": [
+        14
+      ],
+      "categories": [
+        "source_or_test"
+      ]
+    },
+    {
+      "path": "claude-code/plugin/.claude-plugin/plugin.json",
+      "occurrences": 1,
+      "line_numbers": [
+        10
+      ],
+      "categories": [
+        "machine_discovery",
+        "package_registry_metadata"
+      ]
+    },
+    {
+      "path": "claude-code/plugin/skills/agoragentic-assure/SKILL.md",
+      "occurrences": 4,
+      "line_numbers": [
+        27,
+        62,
+        65,
+        66
+      ],
+      "categories": [
+        "installer_or_clone",
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "claude-code/plugin/skills/agoragentic-deploy/SKILL.md",
+      "occurrences": 2,
+      "line_numbers": [
+        20,
+        21
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "claude-code/plugin/skills/agoragentic-execute/SKILL.md",
+      "occurrences": 2,
+      "line_numbers": [
+        23,
+        24
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "claude-code/plugin/skills/agoragentic-govern/SKILL.md",
+      "occurrences": 2,
+      "line_numbers": [
+        21,
+        22
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "claude-code/plugin/skills/agoragentic-integrate/SKILL.md",
+      "occurrences": 3,
+      "line_numbers": [
+        22,
+        23,
+        24
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "claude-code/plugin/skills/agoragentic-prove/SKILL.md",
+      "occurrences": 2,
+      "line_numbers": [
+        27,
+        28
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "claude-code/plugin/skills/agoragentic-sell/SKILL.md",
+      "occurrences": 1,
+      "line_numbers": [
+        22
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "claude-code/plugin/skills/agoragentic/SKILL.md",
+      "occurrences": 6,
+      "line_numbers": [
+        34,
+        38,
+        39,
+        41,
+        42,
+        43
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "claude-code/README.md",
+      "occurrences": 1,
+      "line_numbers": [
+        10
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "CONTRIBUTING.md",
+      "occurrences": 1,
+      "line_numbers": [
+        38
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "crawl4ai/agoragentic_crawl4ai.py",
+      "occurrences": 1,
+      "line_numbers": [
+        49
+      ],
+      "categories": [
+        "source_or_test"
+      ]
+    },
+    {
+      "path": "cursor/README.md",
+      "occurrences": 1,
+      "line_numbers": [
+        16
+      ],
+      "categories": [
+        "installer_or_clone",
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "dify/agoragentic_provider.json",
+      "occurrences": 1,
+      "line_numbers": [
+        185
+      ],
+      "categories": [
+        "machine_discovery"
+      ]
+    },
+    {
+      "path": "distribution/agent-payments-stack/correction.json",
+      "occurrences": 2,
+      "line_numbers": [
+        36,
+        43
+      ],
+      "categories": [
+        "machine_discovery"
+      ]
+    },
+    {
+      "path": "distribution/context-hub/content/agoragentic/docs/agent-os-api/javascript/DOC.md",
+      "occurrences": 1,
+      "line_numbers": [
+        171
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "docs/BRAND_SYSTEM.md",
+      "occurrences": 1,
+      "line_numbers": [
+        194
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "docs/catalog-profile.json",
+      "occurrences": 2,
+      "line_numbers": [
+        9,
+        60
+      ],
+      "categories": [
+        "machine_discovery",
+        "package_registry_metadata"
+      ]
+    },
+    {
+      "path": "docs/COMMUNITY_TESTING.md",
+      "occurrences": 2,
+      "line_numbers": [
+        27,
+        49
+      ],
+      "categories": [
+        "installer_or_clone",
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "docs/work-packs/MATRAIX_COHORT_ASSURANCE_ADAPTER.md",
+      "occurrences": 1,
+      "line_numbers": [
+        4
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "docs/work-packs/MATRAIX_COHORT_ASSURANCE_REPRESENTATION_INTEGRITY.md",
+      "occurrences": 2,
+      "line_numbers": [
+        4,
+        6
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "ecosystem.json",
+      "occurrences": 4,
+      "line_numbers": [
+        16,
+        17,
+        50,
+        104
+      ],
+      "categories": [
+        "machine_discovery",
+        "package_registry_metadata"
+      ]
+    },
+    {
+      "path": "elizaos/package.json",
+      "occurrences": 1,
+      "line_numbers": [
+        23
+      ],
+      "categories": [
+        "machine_discovery",
+        "package_registry_metadata"
+      ]
+    },
+    {
+      "path": "examples/agoragentic-growth/2026-06-29-langgraph-agent-builder-execute-buyer-ad-26c9e34803/langgraph_agent_builder_execute_buyer_adapter.mjs",
+      "occurrences": 1,
+      "line_numbers": [
+        232
+      ],
+      "categories": [
+        "source_or_test"
+      ]
+    },
+    {
+      "path": "examples/agoragentic-growth/2026-06-30-agents-shipgate-mcp-seller-listing-mjs-4cf5445a35/agents_shipgate_mcp_seller_listing.mjs",
+      "occurrences": 1,
+      "line_numbers": [
+        63
+      ],
+      "categories": [
+        "release_or_provenance"
+      ]
+    },
+    {
+      "path": "examples/agoragentic-growth/2026-07-02-ibanforge-x402-execute-receipt-adapter-m-9a04cdff61/ibanforge_x402_execute_receipt_adapter.mjs",
+      "occurrences": 1,
+      "line_numbers": [
+        357
+      ],
+      "categories": [
+        "source_or_test"
+      ]
+    },
+    {
+      "path": "examples/agoragentic-growth/2026-07-05-render-x402-execute-tool-integration-doc-80657415c3/render_x402_execute_tool_integration_doc_pr.mjs",
+      "occurrences": 1,
+      "line_numbers": [
+        165
+      ],
+      "categories": [
+        "source_or_test"
+      ]
+    },
+    {
+      "path": "examples/agoragentic-growth/2026-07-08-apiad-aegis-local-execute-usage-wrapper--a2c7a71b20/apiad_aegis_local_execute_usage_wrapper.mjs",
+      "occurrences": 1,
+      "line_numbers": [
+        511
+      ],
+      "categories": [
+        "release_or_provenance"
+      ]
+    },
+    {
+      "path": "examples/anydoc-document-evidence/package.json",
+      "occurrences": 1,
+      "line_numbers": [
+        54
+      ],
+      "categories": [
+        "installer_or_clone",
+        "machine_discovery",
+        "package_registry_metadata",
+        "release_or_provenance"
+      ]
+    },
+    {
+      "path": "examples/buzz-signed-workspace-evidence/package.json",
+      "occurrences": 1,
+      "line_numbers": [
+        35
+      ],
+      "categories": [
+        "installer_or_clone",
+        "machine_discovery",
+        "package_registry_metadata",
+        "release_or_provenance"
+      ]
+    },
+    {
+      "path": "extraction/harness-core/standalone-overlay/MIGRATION.md",
+      "occurrences": 1,
+      "line_numbers": [
+        10
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "gemini-cli/README.md",
+      "occurrences": 1,
+      "line_numbers": [
+        8
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "glama.json",
+      "occurrences": 1,
+      "line_numbers": [
+        7
+      ],
+      "categories": [
+        "machine_discovery"
+      ]
+    },
+    {
+      "path": "gstack/package.json",
+      "occurrences": 1,
+      "line_numbers": [
+        28
+      ],
+      "categories": [
+        "installer_or_clone",
+        "machine_discovery",
+        "package_registry_metadata"
+      ]
+    },
+    {
+      "path": "harness-core/package.json",
+      "occurrences": 3,
+      "line_numbers": [
+        79,
+        82,
+        84
+      ],
+      "categories": [
+        "installer_or_clone",
+        "machine_discovery",
+        "package_registry_metadata"
+      ]
+    },
+    {
+      "path": "harness-core/README.md",
+      "occurrences": 7,
+      "line_numbers": [
+        146,
+        148,
+        190,
+        463,
+        511,
+        512,
+        513
+      ],
+      "categories": [
+        "installer_or_clone",
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "harness-core/test/cli.test.cjs",
+      "occurrences": 1,
+      "line_numbers": [
+        66
+      ],
+      "categories": [
+        "installer_or_clone"
+      ]
+    },
+    {
+      "path": "harness-core/TRUSTED_PUBLISHING.md",
+      "occurrences": 1,
+      "line_numbers": [
+        19
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "hyperframes/package.json",
+      "occurrences": 1,
+      "line_numbers": [
+        27
+      ],
+      "categories": [
+        "installer_or_clone",
+        "machine_discovery",
+        "package_registry_metadata"
+      ]
+    },
+    {
+      "path": "hyperframes/schemas/local-render-receipt.schema.json",
+      "occurrences": 1,
+      "line_numbers": [
+        3
+      ],
+      "categories": [
+        "machine_discovery"
+      ]
+    },
+    {
+      "path": "hyperframes/schemas/sanitized-timeline.schema.json",
+      "occurrences": 1,
+      "line_numbers": [
+        3
+      ],
+      "categories": [
+        "machine_discovery"
+      ]
+    },
+    {
+      "path": "INTEGRATION_CATALOG_GUIDE.md",
+      "occurrences": 5,
+      "line_numbers": [
+        56,
+        132,
+        189,
+        190,
+        411
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "integrations.json",
+      "occurrences": 14,
+      "line_numbers": [
+        59,
+        68,
+        77,
+        86,
+        92,
+        100,
+        361,
+        373,
+        385,
+        397,
+        409,
+        1467,
+        1476,
+        1485
+      ],
+      "categories": [
+        "installer_or_clone",
+        "machine_discovery"
+      ]
+    },
+    {
+      "path": "integrations.schema.json",
+      "occurrences": 1,
+      "line_numbers": [
+        272
+      ],
+      "categories": [
+        "machine_discovery"
+      ]
+    },
+    {
+      "path": "interchange/evidence/interchange-production-research-ledger.v1.json",
+      "occurrences": 3,
+      "line_numbers": [
+        186,
+        190,
+        220
+      ],
+      "categories": [
+        "machine_discovery",
+        "release_or_provenance"
+      ]
+    },
+    {
+      "path": "interchange/sam/evidence/readonly-canary-20260820.json",
+      "occurrences": 1,
+      "line_numbers": [
+        8
+      ],
+      "categories": [
+        "machine_discovery",
+        "release_or_provenance"
+      ]
+    },
+    {
+      "path": "interchange/SANDBOX_WALKTHROUGH.md",
+      "occurrences": 1,
+      "line_numbers": [
+        19
+      ],
+      "categories": [
+        "installer_or_clone",
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "interchange/schemas/agent-card-federation-extension.schema.json",
+      "occurrences": 1,
+      "line_numbers": [
+        3
+      ],
+      "categories": [
+        "machine_discovery"
+      ]
+    },
+    {
+      "path": "interchange/schemas/external-pilot-evidence.schema.json",
+      "occurrences": 1,
+      "line_numbers": [
+        3
+      ],
+      "categories": [
+        "machine_discovery",
+        "release_or_provenance"
+      ]
+    },
+    {
+      "path": "interchange/schemas/federation-challenge-response.params.schema.json",
+      "occurrences": 1,
+      "line_numbers": [
+        3
+      ],
+      "categories": [
+        "machine_discovery"
+      ]
+    },
+    {
+      "path": "interchange/schemas/federation-follow-referral.params.schema.json",
+      "occurrences": 1,
+      "line_numbers": [
+        3
+      ],
+      "categories": [
+        "machine_discovery"
+      ]
+    },
+    {
+      "path": "interchange/schemas/post-pin-auth.schema.json",
+      "occurrences": 1,
+      "line_numbers": [
+        3
+      ],
+      "categories": [
+        "machine_discovery"
+      ]
+    },
+    {
+      "path": "langchain/README.md",
+      "occurrences": 1,
+      "line_numbers": [
+        9
+      ],
+      "categories": [
+        "public_documentation",
+        "raw_content_url"
+      ]
+    },
+    {
+      "path": "llms-full.txt",
+      "occurrences": 2,
+      "line_numbers": [
+        110,
+        111
+      ],
+      "categories": [
+        "machine_discovery",
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "mcp/package.json",
+      "occurrences": 2,
+      "line_numbers": [
+        45,
+        50
+      ],
+      "categories": [
+        "installer_or_clone",
+        "machine_discovery",
+        "package_registry_metadata"
+      ]
+    },
+    {
+      "path": "mcp/server.json",
+      "occurrences": 1,
+      "line_numbers": [
+        8
+      ],
+      "categories": [
+        "machine_discovery"
+      ]
+    },
+    {
+      "path": "micro-ecf/LLM_INSTALL.md",
+      "occurrences": 1,
+      "line_numbers": [
+        6
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "micro-ecf/package.json",
+      "occurrences": 3,
+      "line_numbers": [
+        11,
+        14,
+        16
+      ],
+      "categories": [
+        "installer_or_clone",
+        "machine_discovery",
+        "package_registry_metadata"
+      ]
+    },
+    {
+      "path": "micro-ecf/README.md",
+      "occurrences": 1,
+      "line_numbers": [
+        212
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "n8n/credentials/AgoragenticApi.credentials.ts",
+      "occurrences": 1,
+      "line_numbers": [
+        16
+      ],
+      "categories": [
+        "source_or_test"
+      ]
+    },
+    {
+      "path": "n8n/nodes/Agoragentic/Agoragentic.node.json",
+      "occurrences": 2,
+      "line_numbers": [
+        9,
+        14
+      ],
+      "categories": [
+        "machine_discovery"
+      ]
+    },
+    {
+      "path": "n8n/package.json",
+      "occurrences": 2,
+      "line_numbers": [
+        21,
+        70
+      ],
+      "categories": [
+        "installer_or_clone",
+        "machine_discovery",
+        "package_registry_metadata"
+      ]
+    },
+    {
+      "path": "opencode/package.json",
+      "occurrences": 3,
+      "line_numbers": [
+        35,
+        38,
+        40
+      ],
+      "categories": [
+        "installer_or_clone",
+        "machine_discovery",
+        "package_registry_metadata"
+      ]
+    },
+    {
+      "path": "ows/README.md",
+      "occurrences": 1,
+      "line_numbers": [
+        91
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "premortem-golden-loop/package.json",
+      "occurrences": 2,
+      "line_numbers": [
+        42,
+        47
+      ],
+      "categories": [
+        "installer_or_clone",
+        "machine_discovery",
+        "package_registry_metadata"
+      ]
+    },
+    {
+      "path": "scripts/generate-skill-pack.mjs",
+      "occurrences": 3,
+      "line_numbers": [
+        61
+      ],
+      "categories": [
+        "source_or_test"
+      ]
+    },
+    {
+      "path": "scripts/prepare-harness-core-extraction.mjs",
+      "occurrences": 8,
+      "line_numbers": [
+        114,
+        115,
+        116,
+        117,
+        121,
+        123,
+        129,
+        135
+      ],
+      "categories": [
+        "installer_or_clone",
+        "source_or_test"
+      ]
+    },
+    {
+      "path": "scripts/sync-integration-counts.mjs",
+      "occurrences": 1,
+      "line_numbers": [
+        52
+      ],
+      "categories": [
+        "source_or_test"
+      ]
+    },
+    {
+      "path": "scripts/verify-harness-core-extraction.mjs",
+      "occurrences": 1,
+      "line_numbers": [
+        127
+      ],
+      "categories": [
+        "release_or_provenance"
+      ]
+    },
+    {
+      "path": "scripts/verify-integrations-json.js",
+      "occurrences": 1,
+      "line_numbers": [
+        296
+      ],
+      "categories": [
+        "source_or_test"
+      ]
+    },
+    {
+      "path": "sdk/agent-os-cli/package.json",
+      "occurrences": 2,
+      "line_numbers": [
+        26,
+        33
+      ],
+      "categories": [
+        "installer_or_clone",
+        "machine_discovery",
+        "package_registry_metadata"
+      ]
+    },
+    {
+      "path": "sdk/agent-os-cli/README.md",
+      "occurrences": 3,
+      "line_numbers": [
+        5,
+        31,
+        32
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "sdk/node/agent-os-harness.generated.json",
+      "occurrences": 3,
+      "line_numbers": [
+        8,
+        51,
+        124
+      ],
+      "categories": [
+        "machine_discovery"
+      ]
+    },
+    {
+      "path": "sdk/node/package.json",
+      "occurrences": 2,
+      "line_numbers": [
+        108,
+        115
+      ],
+      "categories": [
+        "installer_or_clone",
+        "machine_discovery",
+        "package_registry_metadata"
+      ]
+    },
+    {
+      "path": "sdk/node/README.md",
+      "occurrences": 1,
+      "line_numbers": [
+        47
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "sdk/python/pyproject.toml",
+      "occurrences": 2,
+      "line_numbers": [
+        45,
+        49
+      ],
+      "categories": [
+        "package_registry_metadata"
+      ]
+    },
+    {
+      "path": "SKILL.md",
+      "occurrences": 6,
+      "line_numbers": [
+        34,
+        38,
+        39,
+        41,
+        42,
+        43
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "skills/agoragentic-assure/SKILL.md",
+      "occurrences": 4,
+      "line_numbers": [
+        27,
+        62,
+        65,
+        66
+      ],
+      "categories": [
+        "installer_or_clone",
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "skills/agoragentic-deploy/SKILL.md",
+      "occurrences": 2,
+      "line_numbers": [
+        20,
+        21
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "skills/agoragentic-execute/SKILL.md",
+      "occurrences": 2,
+      "line_numbers": [
+        23,
+        24
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "skills/agoragentic-govern/SKILL.md",
+      "occurrences": 2,
+      "line_numbers": [
+        21,
+        22
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "skills/agoragentic-integrate/SKILL.md",
+      "occurrences": 3,
+      "line_numbers": [
+        22,
+        23,
+        24
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "skills/agoragentic-prove/SKILL.md",
+      "occurrences": 2,
+      "line_numbers": [
+        27,
+        28
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "skills/agoragentic-sell/SKILL.md",
+      "occurrences": 1,
+      "line_numbers": [
+        22
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "skills/agoragentic/SKILL.md",
+      "occurrences": 6,
+      "line_numbers": [
+        34,
+        38,
+        39,
+        41,
+        42,
+        43
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "skills/README.md",
+      "occurrences": 3,
+      "line_numbers": [
+        12,
+        18,
+        24
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "smolagents/README.md",
+      "occurrences": 1,
+      "line_numbers": [
+        139
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "specs/ACP-SPEC.md",
+      "occurrences": 2,
+      "line_numbers": [
+        354
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "submit-prs.mjs",
+      "occurrences": 4,
+      "line_numbers": [
+        107,
+        161,
+        242,
+        255
+      ],
+      "categories": [
+        "source_or_test"
+      ]
+    },
+    {
+      "path": "syrin/README.md",
+      "occurrences": 1,
+      "line_numbers": [
+        200
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "test/harness-core-extraction.test.mjs",
+      "occurrences": 8,
+      "line_numbers": [
+        26,
+        27,
+        30,
+        31,
+        34,
+        64,
+        82,
+        83
+      ],
+      "categories": [
+        "installer_or_clone",
+        "source_or_test"
+      ]
+    },
+    {
+      "path": "transaction-assurance/CONFORMANCE.md",
+      "occurrences": 2,
+      "line_numbers": [
+        70,
+        101
+      ],
+      "categories": [
+        "public_documentation",
+        "reusable_action"
+      ]
+    },
+    {
+      "path": "transaction-assurance/examples/external-adopters/anchor-x402/README.md",
+      "occurrences": 2,
+      "line_numbers": [
+        81,
+        118
+      ],
+      "categories": [
+        "public_documentation",
+        "reusable_action"
+      ]
+    },
+    {
+      "path": "transaction-assurance/package.json",
+      "occurrences": 2,
+      "line_numbers": [
+        65,
+        70
+      ],
+      "categories": [
+        "installer_or_clone",
+        "machine_discovery",
+        "package_registry_metadata"
+      ]
+    },
+    {
+      "path": "transaction-assurance/README.md",
+      "occurrences": 2,
+      "line_numbers": [
+        60,
+        446
+      ],
+      "categories": [
+        "public_documentation"
+      ]
+    },
+    {
+      "path": "x402/buyer-demo.js",
+      "occurrences": 2,
+      "line_numbers": [
+        29,
+        427
+      ],
+      "categories": [
+        "source_or_test"
+      ]
+    }
+  ]
+}

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -251,6 +251,8 @@ Compatibility document: specs/ACP-SPEC.md. It is not the production wire contrac
 | Machine index | integrations.json |
 | JSON Schema | integrations.schema.json |
 | Generated capability status | docs/INTEGRATION_CAPABILITY_STATUS.md |
+| Repository rename preflight | docs/REPOSITORY_RENAME_PREFLIGHT.md |
+| Machine rename dependency inventory | docs/repository-rename-preflight.json |
 | Ecosystem profile | ecosystem.json |
 | Ecosystem profile schema | ecosystem.schema.json |
 | Client distribution status | docs/DISTRIBUTION.md |

--- a/llms.txt
+++ b/llms.txt
@@ -47,6 +47,8 @@
 - integrations.json — structured index of all integrations, tools, packages
 - integrations.schema.json — JSON Schema for validation
 - docs/INTEGRATION_CAPABILITY_STATUS.md — generated human-readable capability and evidence table
+- docs/REPOSITORY_RENAME_PREFLIGHT.md — no-authority repository rename dependency and rollback packet
+- docs/repository-rename-preflight.json — deterministic per-file rename dependency inventory
 - ecosystem.json — durable public portfolio profile and live-truth links
 - ecosystem.schema.json — included JSON Schema for the ecosystem profile
 - docs/catalog-profile.json — canonical descriptions, assets, package coordinate, authority boundary, and channel status

--- a/scripts/generate-integration-capability-status.mjs
+++ b/scripts/generate-integration-capability-status.mjs
@@ -8,6 +8,10 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const manifestPath = path.join(root, 'integrations.json');
 const outputPath = path.join(root, 'docs', 'INTEGRATION_CAPABILITY_STATUS.md');
 
+function normalizeLineEndings(text) {
+  return text.replaceAll('\r\n', '\n');
+}
+
 function cell(value) {
   return String(value ?? 'none').replaceAll('|', '\\|').replaceAll(/\r?\n/g, ' ');
 }
@@ -88,7 +92,8 @@ export function renderCapabilityStatus(manifest) {
 
 export function verifyCapabilityStatus({ manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')), expected = fs.readFileSync(outputPath, 'utf8') } = {}) {
   const generated = renderCapabilityStatus(manifest);
-  return { ok: generated === expected, generated, expected };
+  const normalizedExpected = normalizeLineEndings(expected);
+  return { ok: generated === normalizedExpected, generated, expected: normalizedExpected };
 }
 
 function main() {
@@ -100,8 +105,7 @@ function main() {
     return;
   }
   if (process.argv.includes('--check')) {
-    const expected = fs.readFileSync(outputPath, 'utf8');
-    if (generated !== expected) {
+    if (!verifyCapabilityStatus({ manifest }).ok) {
       console.error('Integration capability status is stale. Run: node scripts/generate-integration-capability-status.mjs --write');
       process.exitCode = 1;
       return;

--- a/scripts/generate-repository-rename-preflight.mjs
+++ b/scripts/generate-repository-rename-preflight.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const sourceRepository = ['rhein1', 'agoragentic-integrations'].join('/');
+const markdownPath = 'docs/REPOSITORY_RENAME_PREFLIGHT.md';
+const jsonPath = 'docs/repository-rename-preflight.json';
+const generatedPaths = new Set([markdownPath, jsonPath]);
+
+function countOccurrences(text, needle) {
+  return text.split(needle).length - 1;
+}
+
+function categoryForLine(filePath, line) {
+  const categories = new Set();
+  const lowerPath = filePath.toLowerCase();
+  const lowerLine = line.toLowerCase();
+
+  if (/\buses:\s*[^\s]+/.test(line)) categories.add('reusable_action');
+  if (lowerLine.includes('raw.githubusercontent.com/')) categories.add('raw_content_url');
+  if (/git clone|git\+https|npm (?:install|i)|pnpm (?:add|install)|yarn add|uv tool install|pipx install/.test(lowerLine)) {
+    categories.add('installer_or_clone');
+  }
+  if (/package\.json$|pyproject\.toml$|cargo\.toml$|\.nuspec$/.test(lowerPath)
+    || /"(?:repository|homepage|bugs|funding)"\s*:/.test(line)) {
+    categories.add('package_registry_metadata');
+  }
+  if (/provenance|release|evidence|attestation/.test(lowerPath)
+    || /source_(?:repository|url)|release_url|provenance/.test(lowerLine)) {
+    categories.add('release_or_provenance');
+  }
+  if (/^(?:integrations|ecosystem)\.json$|^(?:llms|llms-full)\.txt$|\.ya?ml$|\.json$/.test(lowerPath)) {
+    categories.add('machine_discovery');
+  }
+  if (/\.md$|\.txt$|\.html?$/.test(lowerPath)) categories.add('public_documentation');
+  if (!categories.size) categories.add('source_or_test');
+  return [...categories];
+}
+
+function lineRecords(filePath, text, repositorySlug) {
+  const records = [];
+  for (const [index, line] of text.split(/\r?\n/).entries()) {
+    const occurrences = countOccurrences(line, repositorySlug);
+    if (!occurrences) continue;
+    records.push({
+      line: index + 1,
+      occurrences,
+      categories: categoryForLine(filePath, line),
+      text: line.trim(),
+    });
+  }
+  return records;
+}
+
+export function buildRepositoryRenamePreflight({ manifest, files, repositorySlug = sourceRepository }) {
+  const records = [];
+  const reusableActionReferences = [];
+  const rawContentUrls = [];
+
+  for (const file of files) {
+    if (generatedPaths.has(file.path) || !file.text.includes(repositorySlug)) continue;
+    const lines = lineRecords(file.path, file.text, repositorySlug);
+    const categories = [...new Set(lines.flatMap((line) => line.categories))].sort();
+    const occurrences = lines.reduce((sum, line) => sum + line.occurrences, 0);
+    records.push({
+      path: file.path,
+      occurrences,
+      line_numbers: lines.map((line) => line.line),
+      categories,
+    });
+
+    for (const line of lines) {
+      if (line.categories.includes('reusable_action')) {
+        reusableActionReferences.push({ path: file.path, line: line.line, reference: line.text });
+      }
+      if (line.categories.includes('raw_content_url')) {
+        rawContentUrls.push({ path: file.path, line: line.line, reference: line.text });
+      }
+    }
+  }
+
+  records.sort((left, right) => left.path.localeCompare(right.path));
+  reusableActionReferences.sort((left, right) => left.path.localeCompare(right.path) || left.line - right.line);
+  rawContentUrls.sort((left, right) => left.path.localeCompare(right.path) || left.line - right.line);
+
+  const categoryCounts = {};
+  for (const record of records) {
+    for (const category of record.categories) categoryCounts[category] = (categoryCounts[category] ?? 0) + 1;
+  }
+
+  return {
+    schema_version: '1.0.0',
+    source_manifest_version: manifest.version,
+    as_of: manifest.updated_at,
+    source_repository: repositorySlug,
+    safe_to_rename: false,
+    target_repository: null,
+    summary: {
+      file_count: records.length,
+      occurrence_count: records.reduce((sum, record) => sum + record.occurrences, 0),
+      category_file_counts: Object.fromEntries(Object.entries(categoryCounts).sort(([left], [right]) => left.localeCompare(right))),
+    },
+    reusable_action_references: reusableActionReferences,
+    raw_content_urls: rawContentUrls,
+    owner_decisions: [
+      'Choose the final owner and repository name; no target is authorized by this packet.',
+      'Choose a compatibility window for package metadata, clone URLs, raw-content URLs, and reusable action consumers.',
+      'Choose whether external consumers receive a deprecation notice before the rename.',
+    ],
+    rollout: [
+      'Freeze unrelated changes and capture the current default-branch SHA.',
+      'Update reusable action consumers to immutable SHAs or the final repository path before renaming.',
+      'Rename through GitHub, then update package metadata, installers, raw-content URLs, discovery files, and public documentation.',
+      'Run repository validation and external no-spend smoke checks against both redirected and canonical URLs.',
+      'Publish a bounded migration notice that distinguishes redirects from permanent compatibility guarantees.',
+    ],
+    rollback: {
+      trigger: 'Any broken reusable action, installer, raw-content URL, package metadata, discovery surface, or external no-spend smoke check.',
+      steps: [
+        'Restore the previous GitHub repository name while the redirect remains uncontested.',
+        'Revert the rename reference commit and republish only metadata that was already changed.',
+        'Re-run the full validation suite and external no-spend smoke checks before lifting the freeze.',
+      ],
+    },
+    files: records,
+  };
+}
+
+export function renderRepositoryRenamePreflight(report) {
+  const categoryRows = Object.entries(report.summary.category_file_counts)
+    .map(([category, count]) => `| \`${category}\` | ${count} |`)
+    .join('\n');
+  const actionRows = report.reusable_action_references.length
+    ? report.reusable_action_references.map((item) => `| \`${item.path}:${item.line}\` | \`${item.reference.replaceAll('|', '\\|')}\` |`).join('\n')
+    : '| None found | None |';
+  const rawRows = report.raw_content_urls.length
+    ? report.raw_content_urls.map((item) => `| \`${item.path}:${item.line}\` | \`${item.reference.replaceAll('|', '\\|')}\` |`).join('\n')
+    : '| None found | None |';
+  const decisions = report.owner_decisions.map((item) => `- ${item}`).join('\n');
+  const rollout = report.rollout.map((item, index) => `${index + 1}. ${item}`).join('\n');
+  const rollback = report.rollback.steps.map((item, index) => `${index + 1}. ${item}`).join('\n');
+
+  return `# Repository Rename Preflight\n\n` +
+    `> **No repository rename has been executed or authorized.** This is a deterministic dependency inventory and rollback plan.\n\n` +
+    `- Source repository: \`${report.source_repository}\`\n` +
+    `- Canonical manifest: \`${report.source_manifest_version}\` as of \`${report.as_of}\`\n` +
+    `- Safe to rename now: **${report.safe_to_rename}**\n` +
+    `- Authorized target: **none**\n` +
+    `- Affected tracked files: **${report.summary.file_count}**\n` +
+    `- Exact repository references: **${report.summary.occurrence_count}**\n\n` +
+    `## Reference Classes\n\n| Class | Files |\n|---|---:|\n${categoryRows}\n\n` +
+    `## Reusable Action Blockers\n\nThese consumers can fail immediately after a rename and must be migrated first.\n\n| Location | Reference |\n|---|---|\n${actionRows}\n\n` +
+    `## Raw Content URLs\n\n| Location | Reference |\n|---|---|\n${rawRows}\n\n` +
+    `## Owner Decisions\n\n${decisions}\n\n` +
+    `## Rollout\n\n${rollout}\n\n` +
+    `## Rollback\n\nTrigger: ${report.rollback.trigger}\n\n${rollback}\n\n` +
+    `The complete per-file inventory is in [\`repository-rename-preflight.json\`](./repository-rename-preflight.json).\n`;
+}
+
+function trackedTextFiles() {
+  const tracked = execFileSync('git', ['ls-files', '-z'], { cwd: root, encoding: 'utf8' })
+    .split('\0')
+    .filter(Boolean)
+    .filter((filePath) => !generatedPaths.has(filePath));
+  const files = [];
+  for (const filePath of tracked) {
+    const buffer = fs.readFileSync(path.join(root, filePath));
+    if (buffer.includes(0)) continue;
+    files.push({ path: filePath.replaceAll('\\', '/'), text: buffer.toString('utf8') });
+  }
+  return files;
+}
+
+export function generateRepositoryRenamePreflight() {
+  const manifest = JSON.parse(fs.readFileSync(path.join(root, 'integrations.json'), 'utf8'));
+  const report = buildRepositoryRenamePreflight({ manifest, files: trackedTextFiles() });
+  return {
+    report,
+    json: `${JSON.stringify(report, null, 2)}\n`,
+    markdown: renderRepositoryRenamePreflight(report),
+  };
+}
+
+export function verifyRepositoryRenamePreflight() {
+  const generated = generateRepositoryRenamePreflight();
+  const expectedJson = fs.readFileSync(path.join(root, jsonPath), 'utf8');
+  const expectedMarkdown = fs.readFileSync(path.join(root, markdownPath), 'utf8');
+  return {
+    ok: generated.json === expectedJson && generated.markdown === expectedMarkdown,
+    json_current: generated.json === expectedJson,
+    markdown_current: generated.markdown === expectedMarkdown,
+    report: generated.report,
+  };
+}
+
+function main() {
+  const generated = generateRepositoryRenamePreflight();
+  if (process.argv.includes('--write')) {
+    fs.writeFileSync(path.join(root, jsonPath), generated.json, 'utf8');
+    fs.writeFileSync(path.join(root, markdownPath), generated.markdown, 'utf8');
+    console.log(`Wrote ${jsonPath} and ${markdownPath}`);
+    return;
+  }
+
+  const result = verifyRepositoryRenamePreflight();
+  if (!result.ok) {
+    console.error(`Repository rename preflight is stale (json=${result.json_current}, markdown=${result.markdown_current}).`);
+    console.error('Run: node scripts/generate-repository-rename-preflight.mjs --write');
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`Repository rename preflight is current (${result.report.summary.file_count} files, ${result.report.summary.occurrence_count} references).`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/scripts/sync-integration-counts.mjs
+++ b/scripts/sync-integration-counts.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const manifestPath = path.join(root, 'integrations.json');
+
+const surfaceRules = [
+  {
+    path: 'README.md',
+    replacements: [
+      {
+        label: 'root README inventory count',
+        pattern: /At this revision, the canonical `integrations\.json` manifest contains \*\*\d+\*\* surfaces\./g,
+        render: ({ count }) => `At this revision, the canonical \`integrations.json\` manifest contains **${count}** surfaces.`,
+      },
+    ],
+  },
+  {
+    path: 'llms.txt',
+    replacements: [
+      {
+        label: 'LLM bootstrap inventory count',
+        pattern: /- Canonical inventory: `integrations\.json` \(\d+ indexed surfaces as of \d{4}-\d{2}-\d{2}\)\./g,
+        render: ({ count, date }) => `- Canonical inventory: \`integrations.json\` (${count} indexed surfaces as of ${date}).`,
+      },
+    ],
+  },
+  {
+    path: 'llms-full.txt',
+    replacements: [
+      {
+        label: 'LLM full-context inventory count',
+        pattern: /The canonical inventory is `integrations\.json` and contains \d+ integration surfaces as of \d{4}-\d{2}-\d{2}\./g,
+        render: ({ count, date }) => `The canonical inventory is \`integrations.json\` and contains ${count} integration surfaces as of ${date}.`,
+      },
+    ],
+  },
+  {
+    path: 'INTEGRATION_CATALOG_GUIDE.md',
+    replacements: [
+      {
+        label: 'catalog hero inventory count',
+        pattern: /\*\*\d+ public integration surfaces for Triptych OS/g,
+        render: ({ count }) => `**${count} public integration surfaces for Triptych OS`,
+      },
+      {
+        label: 'catalog family inventory count',
+        pattern: /\| \*\*\[agoragentic-integrations\]\(https:\/\/github\.com\/rhein1\/agoragentic-integrations\)\*\* \| \d+ indexed surfaces/g,
+        render: ({ count }) => `| **[agoragentic-integrations](https://github.com/rhein1/agoragentic-integrations)** | ${count} indexed surfaces`,
+      },
+      {
+        label: 'catalog featured-path inventory count',
+        pattern: /The complete canonical inventory contains \*\*\d+\*\* surfaces in/g,
+        render: ({ count }) => `The complete canonical inventory contains **${count}** surfaces in`,
+      },
+    ],
+  },
+  {
+    path: 'assets/agoragentic-agent-commerce-banner.svg',
+    replacements: [
+      {
+        label: 'social banner inventory count',
+        pattern: />\d+ public surfaces  \|  one governed router</g,
+        render: ({ count }) => `>${count} public surfaces  |  one governed router<`,
+      },
+    ],
+  },
+  {
+    path: 'ecosystem.json',
+    replacements: [
+      {
+        label: 'ecosystem profile date',
+        pattern: /"updated_at": "\d{4}-\d{2}-\d{2}"/g,
+        render: ({ date }) => `"updated_at": "${date}"`,
+      },
+      {
+        label: 'ecosystem profile inventory count',
+        pattern: /"integration_count": \d+/g,
+        render: ({ count }) => `"integration_count": ${count}`,
+      },
+    ],
+  },
+];
+
+function replaceExactlyOnce(text, rule, context, relativePath) {
+  const matches = [...text.matchAll(rule.pattern)];
+  if (matches.length !== 1) {
+    throw new Error(`${relativePath}: expected one ${rule.label} marker, found ${matches.length}`);
+  }
+  return text.replace(rule.pattern, rule.render(context));
+}
+
+export function planIntegrationCountSync({ manifest, readFile = (relativePath) => fs.readFileSync(path.join(root, relativePath), 'utf8') }) {
+  const count = Array.isArray(manifest.integrations) ? manifest.integrations.length : -1;
+  const date = manifest.updated_at;
+  if (count < 1) throw new Error('integrations.json must contain at least one integration');
+  if (typeof date !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    throw new Error('integrations.json updated_at must be an ISO date');
+  }
+
+  const context = { count, date };
+  return surfaceRules.map((surface) => {
+    const before = readFile(surface.path);
+    const after = surface.replacements.reduce(
+      (text, rule) => replaceExactlyOnce(text, rule, context, surface.path),
+      before,
+    );
+    return { path: surface.path, before, after, changed: before !== after };
+  });
+}
+
+export function verifyIntegrationCountSync() {
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const updates = planIntegrationCountSync({ manifest });
+  return { ok: updates.every((update) => !update.changed), updates };
+}
+
+function main() {
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  const updates = planIntegrationCountSync({ manifest });
+  const stale = updates.filter((update) => update.changed);
+
+  if (process.argv.includes('--write')) {
+    for (const update of stale) {
+      fs.writeFileSync(path.join(root, update.path), update.after, 'utf8');
+      console.log(`Updated ${update.path}`);
+    }
+    if (!stale.length) console.log('Integration count surfaces are already current.');
+    return;
+  }
+
+  if (stale.length) {
+    console.error(`Integration count surfaces are stale: ${stale.map((update) => update.path).join(', ')}`);
+    console.error('Run: node scripts/sync-integration-counts.mjs --write');
+    process.exitCode = 1;
+    return;
+  }
+  console.log('Integration count surfaces are current.');
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/test/integration-capability-status.test.mjs
+++ b/test/integration-capability-status.test.mjs
@@ -19,7 +19,7 @@ const expected = fs.readFileSync(
 test('generated capability status matches the machine inventory', () => {
   const result = verifyCapabilityStatus({ manifest, expected });
   assert.equal(result.ok, true);
-  assert.equal(result.generated, expected);
+  assert.equal(result.generated, result.expected);
 });
 
 test('generated capability status retains proof and authority boundaries', () => {
@@ -35,5 +35,5 @@ test('a machine-record change makes the committed status stale', () => {
   const changed = structuredClone(manifest);
   changed.integrations.find((entry) => entry.id === 'crewai')
     .capability_record.capabilities.router_client = 'tested';
-  assert.notEqual(renderCapabilityStatus(changed), expected);
+  assert.equal(verifyCapabilityStatus({ manifest: changed, expected }).ok, false);
 });

--- a/test/integration-count-sync.test.mjs
+++ b/test/integration-count-sync.test.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  planIntegrationCountSync,
+  verifyIntegrationCountSync,
+} from '../scripts/sync-integration-counts.mjs';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const manifest = JSON.parse(fs.readFileSync(path.join(root, 'integrations.json'), 'utf8'));
+
+test('all public count surfaces match the canonical inventory', () => {
+  const result = verifyIntegrationCountSync();
+  assert.equal(result.ok, true);
+  assert.deepEqual(result.updates.filter((update) => update.changed), []);
+});
+
+test('an inventory change makes every projected count surface stale', () => {
+  const changed = structuredClone(manifest);
+  changed.integrations.push({ id: 'fixture-only' });
+  const updates = planIntegrationCountSync({ manifest: changed });
+  assert.deepEqual(
+    updates.filter((update) => update.changed).map((update) => update.path).sort(),
+    [
+      'INTEGRATION_CATALOG_GUIDE.md',
+      'README.md',
+      'assets/agoragentic-agent-commerce-banner.svg',
+      'ecosystem.json',
+      'llms-full.txt',
+      'llms.txt',
+    ],
+  );
+});
+
+test('missing projection markers fail closed instead of silently skipping copy', () => {
+  assert.throws(
+    () => planIntegrationCountSync({
+      manifest,
+      readFile(relativePath) {
+        if (relativePath === 'README.md') return 'marker removed';
+        return fs.readFileSync(path.join(root, relativePath), 'utf8');
+      },
+    }),
+    /expected one root README inventory count marker/,
+  );
+});

--- a/test/repository-rename-preflight.test.mjs
+++ b/test/repository-rename-preflight.test.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildRepositoryRenamePreflight,
+  renderRepositoryRenamePreflight,
+  verifyRepositoryRenamePreflight,
+} from '../scripts/generate-repository-rename-preflight.mjs';
+
+const repositorySlug = ['rhein1', 'agoragentic-integrations'].join('/');
+const manifest = { version: '9.9.9', updated_at: '2026-08-20' };
+
+test('committed repository rename preflight matches tracked references', () => {
+  const result = verifyRepositoryRenamePreflight();
+  assert.equal(result.ok, true);
+  assert.equal(result.report.safe_to_rename, false);
+  assert.equal(result.report.target_repository, null);
+});
+
+test('preflight classifies action, raw URL, installer, and package references', () => {
+  const report = buildRepositoryRenamePreflight({
+    manifest,
+    repositorySlug,
+    files: [
+      { path: '.github/workflows/reuse.yml', text: `uses: ${repositorySlug}/.github/actions/check@main\n` },
+      { path: 'docs/raw.md', text: `https://raw.githubusercontent.com/${repositorySlug}/main/file.json\n` },
+      { path: 'README.md', text: `git clone https://github.com/${repositorySlug}.git\n` },
+      { path: 'package.json', text: `{"repository":"https://github.com/${repositorySlug}"}\n` },
+    ],
+  });
+
+  assert.equal(report.summary.file_count, 4);
+  assert.equal(report.reusable_action_references.length, 1);
+  assert.equal(report.raw_content_urls.length, 1);
+  assert.equal(report.summary.category_file_counts.reusable_action, 1);
+  assert.equal(report.summary.category_file_counts.raw_content_url, 1);
+  assert.equal(report.summary.category_file_counts.installer_or_clone, 1);
+  assert.equal(report.summary.category_file_counts.package_registry_metadata, 1);
+});
+
+test('preflight remains a non-authorizing migration packet', () => {
+  const report = buildRepositoryRenamePreflight({ manifest, repositorySlug, files: [] });
+  const markdown = renderRepositoryRenamePreflight(report);
+  assert.equal(report.safe_to_rename, false);
+  assert.equal(report.target_repository, null);
+  assert.match(markdown, /No repository rename has been executed or authorized/);
+  assert.match(markdown, /## Rollback/);
+});


### PR DESCRIPTION
## Summary
- derive public integration counts from the canonical manifest and enforce parity in CI
- generate a deterministic repository-rename dependency inventory with rollout and rollback guidance
- make capability-status verification line-ending stable across Windows and CI

## Validation
- `node scripts/generate-integration-capability-status.mjs --check`
- `node scripts/sync-integration-counts.mjs --check`
- `node scripts/generate-repository-rename-preflight.mjs --check`
- repository machine-surface, distribution, and documentation verifiers
- root Node test suite: 108 passed, 0 failed

No repository rename is authorized or performed by this PR.