### PR TITLE
Sync Harness Core 0.4.2 release evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a status-safe 1280x640 integrations banner and first-viewport discovery copy.
 
 ### Changed
+- Bumped the canonical manifest to `2.50.0`, synchronized current Harness Core discovery and source-only consumers to published `0.4.2`, and added exact protected-publish, npm provenance, clean-room export, and observer-only AHP evidence while preserving the immutable `0.3.1` cutover record.
+- Updated the gstack clean-room compatibility regression and the OpenCode source package lock to exact Harness Core `0.4.2`; no provider, host-runtime, payment, x402, deployment, publication, or authority claim was added.
 - Bumped the canonical manifest to `2.47.0` and completed the Harness Core standalone cutover. The canonical source is now `rhein1/agoragentic-harness-core`; release `v0.3.1` is published through the standalone trusted-publishing workflow with npm provenance, and the legacy monorepo path is a durable migration pointer with exact release evidence.
 - Updated the source-only OpenCode and gstack consumers to exact published Harness Core `0.3.1`; gstack compatibility now installs the registry package in a clean temporary consumer instead of packing sibling source.
 - Bumped the canonical manifest to `2.41.0` and reconciled the Interchange

--- a/INTEGRATION_CATALOG_GUIDE.md
+++ b/INTEGRATION_CATALOG_GUIDE.md
@@ -150,7 +150,7 @@ Use this chooser before picking a framework wrapper:
 | Call a self-hosted Rust framework runtime from TypeScript or Python | `AGORAGENTIC_RUST_AGENT_URL=http://127.0.0.1:8080` plus `rust-framework/` examples | HTTP/JSON runtime contract |
 | Inspect the MCP/ACP protocol and host-enforcement contract | `npm --prefix mcp ci && npm --prefix mcp run build` from a source checkout | Unpublished source candidate; direct relay launch remains disabled |
 | Prepare local context, policy, source maps, and Harness exports before hosted deployment | `npx agoragentic-micro-ecf@latest` | Micro ECF local wedge |
-| Build no-spend local configuration proof, receipt, Agent OS export, and listing-readiness artifacts | `npx agoragentic-harness-core@latest` | Harness Core v0.3.1 from the canonical standalone repository |
+| Build no-spend local configuration proof, receipt, Agent OS export, and listing-readiness artifacts | `npx agoragentic-harness-core@latest` | Harness Core v0.4.2 from the canonical standalone repository |
 | Convert local office documents into process-isolated, coverage-accounted evidence handoffs | `cd examples/anydoc-document-evidence && npm ci` | Experimental source-only AnyDoc adapter; no intentional upload, OCR, context attachment, or publication |
 | Apply Harness allow/ask/deny policy inside the exact pinned OpenCode tool hooks | `cd opencode && npm ci` from a source checkout | Experimental `@agoragentic/opencode` source candidate; OpenCode 1.18.15 contract fixture only, not published |
 | Convert explicit gstack planning/review/QA/release files into bounded Harness evidence | `cd gstack && npm install` | Experimental source-only artifact bridge; does not run gstack or retain raw workflow content |

--- a/README.md
+++ b/README.md
@@ -231,7 +231,8 @@ Do not install `agoragentic-mcp` from npm or inject `AGORAGENTIC_API_KEY` into i
 | [Repository rename preflight](./docs/REPOSITORY_RENAME_PREFLIGHT.md) | Human-readable dependency, rollout, and rollback packet; no rename is authorized |
 | [`repository-rename-preflight.json`](./docs/repository-rename-preflight.json) | Deterministic per-file rename dependency inventory |
 | [`ecosystem.json`](./ecosystem.json) | Durable product map and public entry points |
-| [Harness Core standalone release evidence](./harness-core/STANDALONE_RELEASE_EVIDENCE.json) | Exact repository, release, npm integrity, provenance, clean-room, and authority-boundary cutover record |
+| [Harness Core current release evidence](./harness-core/CURRENT_RELEASE_EVIDENCE.json) | Current `0.4.2` release, npm integrity, protected publication, provenance, clean-room exports, and observer-only AHP proof |
+| [Harness Core standalone cutover evidence](./harness-core/STANDALONE_RELEASE_EVIDENCE.json) | Immutable historical `0.3.1` repository-cutover record |
 | [Interchange research record](./interchange/research/README.md) | Evidence-bounded production research index and publication status |
 | [Interchange production evidence ledger](./interchange/evidence/interchange-production-research-ledger.v1.json) | Machine-readable experiment, finding, authority, and claim-boundary record |
 | [Interchange publication evidence gaps](./interchange/research/EVIDENCE_GAPS.md) | Explicit blockers and unsupported claims that remain open |

--- a/docs/INTEGRATION_CAPABILITY_STATUS.md
+++ b/docs/INTEGRATION_CAPABILITY_STATUS.md
@@ -27,9 +27,9 @@ Capability records: **10** of **107** catalog entries.
 |---|---|---|---|---|---|---|
 | Agent OS Control Plane | unknown | static | 2026-08-20T18:45:00Z | [agent-os/agent_os_node.mjs](../agent-os/agent_os_node.mjs) | yes | yes |
 | Claude Code Plugin | unknown | static | 2026-08-20T18:45:00Z | [claude-code/README.md](../claude-code/README.md) | no | no |
-| Codex Harness Mapping Stub | unknown | static | 2026-08-21T03:58:21Z | [harness-core/STANDALONE_RELEASE_EVIDENCE.json](../harness-core/STANDALONE_RELEASE_EVIDENCE.json) | no | no |
+| Codex Harness Mapping Stub | unknown | static | 2026-08-28T03:31:00Z | [harness-core/CURRENT_RELEASE_EVIDENCE.json](../harness-core/CURRENT_RELEASE_EVIDENCE.json) | no | no |
 | CrewAI | unknown | static | 2026-08-20T18:45:00Z | [crewai/agoragentic_crewai.py](../crewai/agoragentic_crewai.py) | yes | yes |
-| Agoragentic Harness Core | standalone package 0.3.1 | local | 2026-08-21T03:58:21Z | [harness-core/STANDALONE_RELEASE_EVIDENCE.json](../harness-core/STANDALONE_RELEASE_EVIDENCE.json) | no | no |
+| Agoragentic Harness Core | standalone package 0.4.2 | local | 2026-08-28T03:31:00Z | [harness-core/CURRENT_RELEASE_EVIDENCE.json](../harness-core/CURRENT_RELEASE_EVIDENCE.json) | no | no |
 | LangGraph | unknown | static | 2026-08-20T18:45:00Z | [langgraph/agoragentic_langgraph.py](../langgraph/agoragentic_langgraph.py) | yes | yes |
 | MCP (Claude, VS Code, Cursor) | unknown | local | 2026-08-24T00:00:00Z | [mcp/test/security-enforcement.test.js](../mcp/test/security-enforcement.test.js) | no | no |
 | n8n Community Node | unknown | static | 2026-08-20T18:45:00Z | [n8n/nodes/Agoragentic/Agoragentic.node.ts](../n8n/nodes/Agoragentic/Agoragentic.node.ts) | yes | yes |

--- a/docs/REPOSITORY_RENAME_PREFLIGHT.md
+++ b/docs/REPOSITORY_RENAME_PREFLIGHT.md
@@ -3,7 +3,7 @@
 > **No repository rename has been executed or authorized.** This is a deterministic dependency inventory and rollback plan.
 
 - Source repository: `rhein1/agoragentic-integrations`
-- Canonical manifest: `2.49.0` as of `2026-08-25`
+- Canonical manifest: `2.50.0` as of `2026-08-28`
 - Safe to rename now: **false**
 - Authorized target: **none**
 - Affected tracked files: **139**

--- a/docs/repository-rename-preflight.json
+++ b/docs/repository-rename-preflight.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0.0",
-  "source_manifest_version": "2.49.0",
-  "as_of": "2026-08-25",
+  "source_manifest_version": "2.50.0",
+  "as_of": "2026-08-28",
   "source_repository": "rhein1/agoragentic-integrations",
   "safe_to_rename": false,
   "target_repository": null,
@@ -453,8 +453,6 @@
       "path": "CHANGELOG.md",
       "occurrences": 14,
       "line_numbers": [
-        225,
-        226,
         227,
         228,
         229,
@@ -466,7 +464,9 @@
         235,
         236,
         237,
-        238
+        238,
+        239,
+        240
       ],
       "categories": [
         "public_documentation"
@@ -955,19 +955,19 @@
         16,
         37,
         46,
-        69,
-        78,
-        87,
-        96,
-        102,
-        110,
-        119,
-        381,
-        393,
-        405,
-        417,
-        429,
-        441
+        70,
+        79,
+        88,
+        97,
+        103,
+        111,
+        120,
+        382,
+        394,
+        406,
+        418,
+        430,
+        442
       ],
       "categories": [
         "machine_discovery"

--- a/ecosystem.json
+++ b/ecosystem.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./ecosystem.schema.json",
   "schema": "agoragentic.ecosystem-profile.v1",
-  "updated_at": "2026-08-25",
+  "updated_at": "2026-08-28",
   "brand": {
     "name": "Agoragentic",
     "promise": "Keep your framework. Add Agoragentic's open integration, governance, and evidence surfaces, then connect to Triptych OS operation or commerce when needed.",

--- a/extraction/harness-core/README.md
+++ b/extraction/harness-core/README.md
@@ -8,9 +8,10 @@ release surfaces.
 Current canonical state:
 
 - Source: <https://github.com/rhein1/agoragentic-harness-core>
-- Release: <https://github.com/rhein1/agoragentic-harness-core/releases/tag/v0.3.1>
+- Current release: <https://github.com/rhein1/agoragentic-harness-core/releases/tag/v0.4.2>
 - npm: <https://www.npmjs.com/package/agoragentic-harness-core>
-- Cutover evidence: [`../../harness-core/STANDALONE_RELEASE_EVIDENCE.json`](../../harness-core/STANDALONE_RELEASE_EVIDENCE.json)
+- Historical `0.3.1` cutover evidence: [`../../harness-core/STANDALONE_RELEASE_EVIDENCE.json`](../../harness-core/STANDALONE_RELEASE_EVIDENCE.json)
+- Current `0.4.2` release evidence: [`../../harness-core/CURRENT_RELEASE_EVIDENCE.json`](../../harness-core/CURRENT_RELEASE_EVIDENCE.json)
 - Legacy source pointer: [`../../harness-core/README.md`](../../harness-core/README.md)
 
 The standalone package keeps the existing package name, CLI aliases, exports, schemas, and

--- a/gstack/README.md
+++ b/gstack/README.md
@@ -50,7 +50,7 @@ It does **not** retain raw workflow content, extract a success claim from the co
 
 The canonical Harness Core source is the standalone
 [`rhein1/agoragentic-harness-core`](https://github.com/rhein1/agoragentic-harness-core)
-repository. This bridge pins published package `0.3.1`. `npm run test:core-compat` installs that exact npm
+repository. This bridge pins published package `0.4.2`. `npm run test:core-compat` installs that exact npm
 version into a temporary clean consumer, verifies standalone repository metadata and all four CLI aliases,
 then runs the bridge fixture suite against it. The targeted regression keeps the zero-spend,
 no-gstack-execution, no-hosted-billing, and no-marketplace-publication boundaries intact.
@@ -80,7 +80,7 @@ npm test
 npm run test:core-compat
 ```
 
-The deterministic suite covers the complete fixture flow, absent evidence, hostile instruction-like content, malformed JSON, overwrite refusal, raw-content exclusion, the documented CLI command, and a clean-room published Harness Core `0.3.1` compatibility regression. The repository CI executes that regression on Node 20, 22, and 24.
+The deterministic suite covers the complete fixture flow, absent evidence, hostile instruction-like content, malformed JSON, overwrite refusal, raw-content exclusion, the documented CLI command, and a clean-room published Harness Core `0.4.2` compatibility regression. The repository CI executes that regression on Node 20, 22, and 24.
 
 ## License
 

--- a/gstack/package-lock.json
+++ b/gstack/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0-alpha.0",
       "license": "MIT",
       "dependencies": {
-        "agoragentic-harness-core": "0.3.1"
+        "agoragentic-harness-core": "0.4.2"
       },
       "bin": {
         "agoragentic-gstack-harness": "cli.mjs"
@@ -18,12 +18,20 @@
         "node": ">=20"
       }
     },
+    "node_modules/@microsoft/agent-host-protocol": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/agent-host-protocol/-/agent-host-protocol-0.8.0.tgz",
+      "integrity": "sha512-Tg1EsWXENx55RB3igfaSTclxvck2RcBS+LPRSGxi86yLhoeJgldtjSH5aDZZTll0tSw7fzbkSOte3/B9ExRFVg==",
+      "license": "MIT"
+    },
     "node_modules/agoragentic-harness-core": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/agoragentic-harness-core/-/agoragentic-harness-core-0.3.1.tgz",
-      "integrity": "sha512-72w05AUaegIm1uVktCrDYRqtiD61jb1F6dVvY8H7Ks9/UYEuTN/3ViMq32NweCGy/9PZVLXeulBjIlD63ieoMg==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/agoragentic-harness-core/-/agoragentic-harness-core-0.4.2.tgz",
+      "integrity": "sha512-lrY8wUIzLev8lJzA7XKPBOAvT2tcs/G5dHkHCzFY8ummcpbi2MI+Fi9knqd+rXszSowWPn5HnRi0qNGcgtHHqg==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@microsoft/agent-host-protocol": "0.8.0",
+        "ws": "8.21.3",
         "yaml": "^2.5.0"
       },
       "bin": {
@@ -34,6 +42,27 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yaml": {

--- a/gstack/package.json
+++ b/gstack/package.json
@@ -15,7 +15,7 @@
     ".": "./gstack-harness.mjs"
   },
   "dependencies": {
-    "agoragentic-harness-core": "0.3.1"
+    "agoragentic-harness-core": "0.4.2"
   },
   "scripts": {
     "check": "node --check gstack-harness.mjs && node --check cli.mjs && node --check test.mjs && node --check scripts/test-harness-core-compat.mjs",

--- a/gstack/scripts/test-harness-core-compat.mjs
+++ b/gstack/scripts/test-harness-core-compat.mjs
@@ -14,7 +14,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 const gstackRoot = resolve(here, '..');
 const npmCli = process.env.npm_execpath
   || join(dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npm-cli.js');
-const expectedPublishedVersion = '0.3.1';
+const expectedPublishedVersion = '0.4.2';
 const expectedPackage = `agoragentic-harness-core@${expectedPublishedVersion}`;
 
 function run(command, args, options = {}) {

--- a/harness-core/CURRENT_RELEASE_EVIDENCE.json
+++ b/harness-core/CURRENT_RELEASE_EVIDENCE.json
@@ -1,0 +1,163 @@
+{
+  "schema": "agoragentic.harness-core.current-release-evidence.v1",
+  "recorded_at": "2026-08-28T03:31:00Z",
+  "canonical_repository": "https://github.com/rhein1/agoragentic-harness-core",
+  "release": {
+    "tag": "v0.4.2",
+    "url": "https://github.com/rhein1/agoragentic-harness-core/releases/tag/v0.4.2",
+    "target_commit": "d858f955023df8094855e36ca23d8399d9460000",
+    "published_at": "2026-08-28T03:30:10Z",
+    "draft": false,
+    "prerelease": false
+  },
+  "npm": {
+    "package": "agoragentic-harness-core",
+    "version": "0.4.2",
+    "latest": "0.4.2",
+    "published_at": "2026-08-28T03:25:21.623Z",
+    "tarball": "https://registry.npmjs.org/agoragentic-harness-core/-/agoragentic-harness-core-0.4.2.tgz",
+    "tarball_bytes": 122546,
+    "shasum": "085288174ab553e81e1dd8e41159c97b81dccb98",
+    "integrity": "sha512-lrY8wUIzLev8lJzA7XKPBOAvT2tcs/G5dHkHCzFY8ummcpbi2MI+Fi9knqd+rXszSowWPn5HnRi0qNGcgtHHqg==",
+    "sha512_hex": "96b63cc142332debfc949cc0ed728f04e02f4f6b5cb3f1b97479070b3158f2e9a67296e2d8c23e162f649ea77ead7b334a8c163e7e479d18b4a8d19c82d1c7aa",
+    "file_count": 83,
+    "unpacked_bytes": 541822,
+    "attestations": "https://registry.npmjs.org/-/npm/v1/attestations/agoragentic-harness-core@0.4.2",
+    "attestation_count": 2,
+    "provenance_predicate": "https://slsa.dev/provenance/v1",
+    "repository": "git+https://github.com/rhein1/agoragentic-harness-core.git"
+  },
+  "publishing": {
+    "trusted_publisher_repository": "rhein1/agoragentic-harness-core",
+    "trusted_publisher_workflow": "publish.yml",
+    "github_environment": "npm-publish",
+    "github_environment_id": 20608341669,
+    "workflow_run": "https://github.com/rhein1/agoragentic-harness-core/actions/runs/33138725802",
+    "workflow_run_id": 33138725802,
+    "verify_job_id": 98744526958,
+    "publish_job_id": 98744549242,
+    "deployment_id": 6135032091,
+    "event": "push",
+    "ref": "refs/tags/v0.4.2",
+    "conclusion": "success",
+    "environment_approval": {
+      "approved_at": "2026-08-28T03:23:40Z",
+      "approver": "jmborden1112-beep",
+      "classification": "owner_authorized_mechanical_solo_maintainer_separation",
+      "independent_human_review": false
+    }
+  },
+  "protected_main_ci": {
+    "commit": "d858f955023df8094855e36ca23d8399d9460000",
+    "run": "https://github.com/rhein1/agoragentic-harness-core/actions/runs/32921588959",
+    "conclusion": "success",
+    "required_checks": [
+      { "context": "test (18)", "job_id": 98036063571, "github_app_id": 15368 },
+      { "context": "test (20)", "job_id": 98036063558, "github_app_id": 15368 },
+      { "context": "test (22)", "job_id": 98036063518, "github_app_id": 15368 },
+      { "context": "test (24)", "job_id": 98036063412, "github_app_id": 15368 }
+    ]
+  },
+  "clean_room": {
+    "published_package_installed": true,
+    "version": "0.4.2",
+    "dependencies": {
+      "@microsoft/agent-host-protocol": "0.8.0",
+      "ws": "8.21.3",
+      "yaml": "2.9.0"
+    },
+    "declared_exports": 38,
+    "javascript_exports_loaded": 15,
+    "json_schema_exports_loaded": 23,
+    "declared_bin_aliases_present": 4,
+    "unique_bin_targets_syntax_checked": 2,
+    "help_aliases_exit_zero": 3,
+    "memory_skillopt_help": {
+      "exit_code": 1,
+      "classification": "expected_usage_for_cli_without_help_command",
+      "mutating_subcommand_executed": false
+    },
+    "registry_signature_audit": "passed",
+    "content_manifest_sha256": "a875a97c3cb93d824aacea23f4d966840cee3c7fac3b5e6a4b665cea38c532ed",
+    "result": "passed"
+  },
+  "ahp_observer": {
+    "adapter_version": "1.0.0",
+    "protocol_version": "0.8.0",
+    "mode": "local_no_spend_observation_only",
+    "allowed_outbound_methods": [
+      "initialize",
+      "subscribe",
+      "unsubscribe"
+    ],
+    "prohibited_method_count": 26,
+    "authority_flags_false": 20,
+    "authority_flags": {
+      "dispatch_action": false,
+      "create_session": false,
+      "dispose_session": false,
+      "create_chat": false,
+      "terminal_input": false,
+      "terminal_claim": false,
+      "resource_write": false,
+      "resource_delete": false,
+      "resource_move": false,
+      "authenticate": false,
+      "provide_client_tools": false,
+      "approve_tool_calls": false,
+      "run_automation": false,
+      "mutate_automation": false,
+      "provider_dispatch": false,
+      "wallet_mutation": false,
+      "x402_settlement": false,
+      "marketplace_publication": false,
+      "trust_mutation": false,
+      "owner_approval_bypass": false
+    },
+    "base_authority_booleans_false": 30,
+    "base_authority": {
+      "mode": "local_no_spend",
+      "wallet_spend": false,
+      "wallet_mutation": false,
+      "deploy_runtime": false,
+      "hosted_runtime_provisioning": false,
+      "marketplace_publication": false,
+      "x402_settlement": false,
+      "x402_route_activation": false,
+      "trust_mutation": false,
+      "ranking_mutation": false,
+      "provider_dispatch": false,
+      "public_execute_mutation": false,
+      "public_invoke_mutation": false,
+      "private_ecf_export": false,
+      "owner_approval_bypass": false,
+      "process_control": false,
+      "arbitrary_shell": false,
+      "dispatch_action": false,
+      "create_session": false,
+      "dispose_session": false,
+      "create_chat": false,
+      "terminal_input": false,
+      "terminal_claim": false,
+      "resource_write": false,
+      "resource_delete": false,
+      "resource_move": false,
+      "authenticate": false,
+      "provide_client_tools": false,
+      "approve_tool_calls": false,
+      "run_automation": false,
+      "mutate_automation": false
+    }
+  },
+  "authority": {
+    "provider_dispatch": false,
+    "wallet_mutation": false,
+    "spend": false,
+    "x402_settlement": false,
+    "deployment": false,
+    "marketplace_publication": false,
+    "trust_mutation": false,
+    "hosted_memory": false,
+    "owner_approval_bypass": false
+  }
+}

--- a/harness-core/README.md
+++ b/harness-core/README.md
@@ -4,7 +4,7 @@ Harness Core is now maintained in its standalone canonical repository:
 
 - Source: <https://github.com/rhein1/agoragentic-harness-core>
 - npm: <https://www.npmjs.com/package/agoragentic-harness-core>
-- Current release: <https://github.com/rhein1/agoragentic-harness-core/releases/tag/v0.3.1>
+- Current release: <https://github.com/rhein1/agoragentic-harness-core/releases/tag/v0.4.2>
 - Migration guide: <https://github.com/rhein1/agoragentic-harness-core/blob/main/MIGRATION.md>
 - Schemas and API exports: <https://github.com/rhein1/agoragentic-harness-core/tree/main/schema>
 
@@ -24,8 +24,10 @@ surface, and schema subpaths remain compatible. Source consumers should update r
 `rhein1/agoragentic-harness-core`.
 
 This directory is intentionally a thin pointer. It contains no second package manifest, runtime,
-binary, schema, profile, template, or test copy. Exact release and migration evidence is recorded in
-[`STANDALONE_RELEASE_EVIDENCE.json`](./STANDALONE_RELEASE_EVIDENCE.json).
+binary, schema, profile, template, or test copy. The immutable cutover facts remain in
+[`STANDALONE_RELEASE_EVIDENCE.json`](./STANDALONE_RELEASE_EVIDENCE.json); current `0.4.2` release,
+provenance, clean-room, protected-publish, and observer-only AHP evidence is in
+[`CURRENT_RELEASE_EVIDENCE.json`](./CURRENT_RELEASE_EVIDENCE.json).
 
 Harness Core remains a local, no-spend governance and evidence layer. Its local receipts are not settlement receipts,
 certifications, endorsements, marketplace verification, or proof that a host executed a task. It grants no provider

--- a/integrations.json
+++ b/integrations.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.49.0",
-  "updated_at": "2026-08-25",
+  "version": "2.50.0",
+  "updated_at": "2026-08-28",
   "canonical_url": "https://agoragentic.com",
   "canonical_manifest": "https://agoragentic.com/.well-known/agent-marketplace.json",
   "packages": {
@@ -58,6 +58,7 @@
     },
     "harness_core": {
       "name": "agoragentic-harness-core",
+      "version": "0.4.2",
       "install": "npx agoragentic-harness-core@latest init",
       "registry": "https://www.npmjs.com/package/agoragentic-harness-core",
       "distribution_status": "published",
@@ -645,10 +646,10 @@
           "agent_os_export": "tested"
         },
         "evidence": {
-          "host_version_tested": "standalone package 0.3.1",
+          "host_version_tested": "standalone package 0.4.2",
           "proof_class": "local",
-          "last_verified_at": "2026-08-21T03:58:21Z",
-          "evidence_ref": "harness-core/STANDALONE_RELEASE_EVIDENCE.json"
+          "last_verified_at": "2026-08-28T03:31:00Z",
+          "evidence_ref": "harness-core/CURRENT_RELEASE_EVIDENCE.json"
         },
         "requirements": {
           "network_required": false,
@@ -678,8 +679,8 @@
         "evidence": {
           "host_version_tested": "unknown",
           "proof_class": "static",
-          "last_verified_at": "2026-08-21T03:58:21Z",
-          "evidence_ref": "harness-core/STANDALONE_RELEASE_EVIDENCE.json"
+          "last_verified_at": "2026-08-28T03:31:00Z",
+          "evidence_ref": "harness-core/CURRENT_RELEASE_EVIDENCE.json"
         },
         "requirements": {
           "network_required": false,
@@ -1749,8 +1750,10 @@
     "harness_core": "harness-core/README.md",
     "harness_core_canonical_repository": "https://github.com/rhein1/agoragentic-harness-core",
     "harness_core_npm": "https://www.npmjs.com/package/agoragentic-harness-core",
-    "harness_core_release": "https://github.com/rhein1/agoragentic-harness-core/releases/tag/v0.3.1",
-    "harness_core_release_evidence": "harness-core/STANDALONE_RELEASE_EVIDENCE.json",
+    "harness_core_release": "https://github.com/rhein1/agoragentic-harness-core/releases/tag/v0.4.2",
+    "harness_core_release_evidence": "harness-core/CURRENT_RELEASE_EVIDENCE.json",
+    "harness_core_cutover_release": "https://github.com/rhein1/agoragentic-harness-core/releases/tag/v0.3.1",
+    "harness_core_cutover_evidence": "harness-core/STANDALONE_RELEASE_EVIDENCE.json",
     "harness_core_memory_skillopt": "https://github.com/rhein1/agoragentic-harness-core/blob/main/MEMORY_SKILLOPT.md",
     "harness_core_memory_skillopt_selection_schema": "https://raw.githubusercontent.com/rhein1/agoragentic-harness-core/main/schema/memory-skillopt-selection.v1.json",
     "harness_core_memory_skillopt_task_draft_schema": "https://raw.githubusercontent.com/rhein1/agoragentic-harness-core/main/schema/memory-skillopt-task-draft.v1.json",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -11,7 +11,7 @@ The published packages and repo-local source/CLI surfaces are:
 - **Node.js SDK**: `npm install agoragentic` (npm, Node ≥16)
 - **MCP / Agent Client Protocol reference**: `npm --prefix mcp ci && npm --prefix mcp run build` from this checkout, then optionally `node mcp/dist/mcp-server.cjs --acp` (unpublished, non-installable 2.0.0 source; the npm name resolves a legacy direct relay and must not be used; remote work fails closed without qualified host enforcement)
 - **Micro ECF**: run `npx agoragentic-micro-ecf@latest plan --dir .` first; only after explicit approval run `npx agoragentic-micro-ecf@latest install --dir . --yes` (npm, Node ≥18)
-- **Harness Core**: `npx agoragentic-harness-core@latest init` (standalone package v0.3.1 from `https://github.com/rhein1/agoragentic-harness-core`, Node ≥18)
+- **Harness Core**: `npx agoragentic-harness-core@latest init` (standalone package v0.4.2 from `https://github.com/rhein1/agoragentic-harness-core`, Node ≥18)
 - **OpenCode Harness plugin**: `cd opencode && npm ci` from a source checkout (experimental `@agoragentic/opencode` candidate; exact OpenCode 1.18.15 contract fixture only; not published)
 - **gstack Harness bridge**: `cd gstack && npm install` from a source checkout (experimental explicit-artifact adapter; no gstack execution, raw-content retention, hosted authority, or spend)
 - **HyperFrames receipt video workflow**: `cd hyperframes && npm install` from a source checkout (experimental local-only receipt/evidence renderer; deterministic sanitized scenes and hash-bound MP4 receipt, with external rendering, hosted deployment, provider calls, publication, listing, x402, and spend disabled)
@@ -65,7 +65,7 @@ The canonical tool list is `integrations.json#tools`. The table below highlights
 
 ## Selected Integration Matrix
 
-The canonical inventory is `integrations.json` and contains 107 integration surfaces as of 2026-08-25. These tables are representative entry points, not a complete count.
+The canonical inventory is `integrations.json` and contains 107 integration surfaces as of 2026-08-28. These tables are representative entry points, not a complete count.
 
 ### Python Integrations
 

--- a/llms.txt
+++ b/llms.txt
@@ -10,7 +10,7 @@
 - MCP: `npm --prefix mcp ci && npm --prefix mcp run build` from this source checkout (unpublished, non-installable 2.0.0 protocol/reference candidate; remote calls fail closed without a separately qualified host boundary; the npm name resolves a legacy direct relay and must not be used)
 - Agent Client Protocol (ACP): `node mcp/dist/mcp-server.cjs --acp` after that source build (owned metadata only; remote calls blocked)
 - Micro ECF: run `npx agoragentic-micro-ecf@latest plan --dir .` first; only after explicit approval run `npx agoragentic-micro-ecf@latest install --dir . --yes` (local context CLI, Node ≥18)
-- Harness Core: `npx agoragentic-harness-core@latest init` (published standalone local no-spend CLI; canonical source `https://github.com/rhein1/agoragentic-harness-core`, current release v0.3.1, Node ≥18)
+- Harness Core: `npx agoragentic-harness-core@latest init` (published standalone local no-spend CLI; canonical source `https://github.com/rhein1/agoragentic-harness-core`, current release v0.4.2, Node ≥18)
 - OpenCode Harness plugin: `cd opencode && npm ci` from a source checkout (experimental `@agoragentic/opencode` candidate; exact OpenCode 1.18.15 contract fixture only; not published)
 - gstack Harness bridge: `cd gstack && npm install` from a source checkout (experimental explicit-artifact adapter; does not run gstack, retain raw workflow content, call providers, publish, or spend)
 - HyperFrames receipt video workflow: `cd hyperframes && npm install` from a source checkout (experimental local-only receipt/evidence renderer; deterministic sanitized scenes and hash-bound MP4 receipt, with no external rendering, hosted deployment, provider, publication, listing, x402, or spend authority)
@@ -26,7 +26,7 @@
 - The unpublished MCP/ACP source candidate does not consume or forward this key. The npm package is a legacy direct relay and must not be used. Use SDK/REST auth only; never inject the key into either MCP surface.
 
 ## Integrations
-- Canonical inventory: `integrations.json` (107 indexed surfaces as of 2026-08-25).
+- Canonical inventory: `integrations.json` (107 indexed surfaces as of 2026-08-28).
 - Client-native packages: Cursor (`.cursor-plugin/plugin.json`), Gemini CLI (`gemini-extension.json`), Claude Code (`.claude-plugin/marketplace.json`), Cline (`llms-install.md`), and the experimental OpenCode Harness source plugin (`opencode/`). Package readiness does not imply external marketplace approval or live host compatibility.
 - Python frameworks include LangChain, LangGraph, Deep Agents, ClawTeam, CrewAI, AutoGen, OpenAI Agents, Google ADK, Haystack, pydantic-ai, smolagents, Agno, Griptape, LiveKit Agents, Pipecat, LlamaIndex, AgentScope, DSPy, Browser Use, and Langflow.
 - JavaScript/TypeScript frameworks and workflows include the fail-closed MCP/ACP protocol reference, Risk Fork, Vercel AI, Cloudflare Agents, Mastra, Bee Agent, ElizaOS, n8n, VoltAgent, Genkit, OpenAI Agents TypeScript, AG-UI, and experimental World AgentKit pre-payment composition.

--- a/opencode/package-lock.json
+++ b/opencode/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "agoragentic-harness-core": "0.3.1"
+        "agoragentic-harness-core": "0.4.2"
       },
       "devDependencies": {
         "ajv": "^8.20.0"
@@ -19,12 +19,20 @@
         "opencode": "=1.18.15"
       }
     },
+    "node_modules/@microsoft/agent-host-protocol": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/agent-host-protocol/-/agent-host-protocol-0.8.0.tgz",
+      "integrity": "sha512-Tg1EsWXENx55RB3igfaSTclxvck2RcBS+LPRSGxi86yLhoeJgldtjSH5aDZZTll0tSw7fzbkSOte3/B9ExRFVg==",
+      "license": "MIT"
+    },
     "node_modules/agoragentic-harness-core": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/agoragentic-harness-core/-/agoragentic-harness-core-0.3.1.tgz",
-      "integrity": "sha512-72w05AUaegIm1uVktCrDYRqtiD61jb1F6dVvY8H7Ks9/UYEuTN/3ViMq32NweCGy/9PZVLXeulBjIlD63ieoMg==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/agoragentic-harness-core/-/agoragentic-harness-core-0.4.2.tgz",
+      "integrity": "sha512-lrY8wUIzLev8lJzA7XKPBOAvT2tcs/G5dHkHCzFY8ummcpbi2MI+Fi9knqd+rXszSowWPn5HnRi0qNGcgtHHqg==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@microsoft/agent-host-protocol": "0.8.0",
+        "ws": "8.21.3",
         "yaml": "^2.5.0"
       },
       "bin": {
@@ -93,6 +101,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yaml": {

--- a/opencode/package.json
+++ b/opencode/package.json
@@ -16,7 +16,7 @@
     "README.md"
   ],
   "dependencies": {
-    "agoragentic-harness-core": "0.3.1"
+    "agoragentic-harness-core": "0.4.2"
   },
   "devDependencies": {
     "ajv": "^8.20.0"

--- a/scripts/verify-ecosystem-profile.js
+++ b/scripts/verify-ecosystem-profile.js
@@ -198,14 +198,18 @@ function verifyEcosystemProfile({ root = defaultRoot, quiet = false } = {}) {
       .map((claim) => `docs/BRAND_SYSTEM.md unsupported Harness Core claim: ${claim}`));
 
     const harnessReadmePath = path.join(root, 'harness-core', 'README.md');
-    const harnessEvidencePath = path.join(root, 'harness-core', 'STANDALONE_RELEASE_EVIDENCE.json');
+    const harnessCutoverEvidencePath = path.join(root, 'harness-core', 'STANDALONE_RELEASE_EVIDENCE.json');
+    const harnessCurrentEvidencePath = path.join(root, 'harness-core', 'CURRENT_RELEASE_EVIDENCE.json');
     const harnessReadme = fs.readFileSync(harnessReadmePath, 'utf8');
-    const harnessEvidence = readJson(harnessEvidencePath, errors, root);
+    const harnessCutoverEvidence = readJson(harnessCutoverEvidencePath, errors, root);
+    const harnessCurrentEvidence = readJson(harnessCurrentEvidencePath, errors, root);
 
     for (const required of [
       'https://github.com/rhein1/agoragentic-harness-core',
       'https://www.npmjs.com/package/agoragentic-harness-core',
-      'releases/tag/v0.3.1',
+      'releases/tag/v0.4.2',
+      'CURRENT_RELEASE_EVIDENCE.json',
+      'STANDALONE_RELEASE_EVIDENCE.json',
       'thin pointer',
       'not settlement receipts',
     ]) {
@@ -218,15 +222,43 @@ function verifyEcosystemProfile({ root = defaultRoot, quiet = false } = {}) {
     if (harnessProduct?.repository !== 'https://github.com/rhein1/agoragentic-harness-core') {
       errors.push('ecosystem.json Harness Core product must point to the standalone repository');
     }
-    if (harnessEvidence?.source_cutover?.duplicate_canonical_implementation_removed !== true) {
-      errors.push('Harness Core release evidence must record duplicate source removal');
+    if (harnessCutoverEvidence?.source_cutover?.duplicate_canonical_implementation_removed !== true) {
+      errors.push('Harness Core cutover evidence must record duplicate source removal');
     }
-    if (harnessEvidence?.npm?.version !== '0.3.1') {
-      errors.push('Harness Core release evidence must record npm 0.3.1');
+    if (harnessCutoverEvidence?.npm?.version !== '0.3.1') {
+      errors.push('Harness Core cutover evidence must remain pinned to npm 0.3.1');
     }
-    if (harnessEvidence?.authority
-      && !Object.values(harnessEvidence.authority).every((value) => value === false)) {
-      errors.push('Harness Core release evidence must not grant authority');
+    const cutoverAuthorityKeys = [
+      'deployment', 'hosted_memory', 'marketplace_publication', 'owner_approval_bypass',
+      'provider_dispatch', 'spend', 'trust_mutation', 'wallet', 'x402',
+    ];
+    const currentAuthorityKeys = [
+      'deployment', 'hosted_memory', 'marketplace_publication', 'owner_approval_bypass',
+      'provider_dispatch', 'spend', 'trust_mutation', 'wallet_mutation', 'x402_settlement',
+    ];
+    if (JSON.stringify(Object.keys(harnessCutoverEvidence?.authority || {}).sort())
+      !== JSON.stringify(cutoverAuthorityKeys)) {
+      errors.push('Harness Core cutover authority evidence must be complete');
+    } else if (!Object.values(harnessCutoverEvidence.authority).every((value) => value === false)) {
+      errors.push('Harness Core cutover evidence must not grant authority');
+    }
+    if (harnessCurrentEvidence?.npm?.version !== '0.4.2'
+      || harnessCurrentEvidence?.npm?.latest !== '0.4.2') {
+      errors.push('Harness Core current release evidence must record npm latest 0.4.2');
+    }
+    if (harnessCurrentEvidence?.publishing?.workflow_run_id !== 33138725802
+      || harnessCurrentEvidence?.publishing?.github_environment !== 'npm-publish') {
+      errors.push('Harness Core current release evidence must record the protected publish run');
+    }
+    if (harnessCurrentEvidence?.ahp_observer?.authority_flags_false !== 20
+      || harnessCurrentEvidence?.ahp_observer?.base_authority_booleans_false !== 30) {
+      errors.push('Harness Core current release evidence must preserve observer-only AHP authority counts');
+    }
+    if (JSON.stringify(Object.keys(harnessCurrentEvidence?.authority || {}).sort())
+      !== JSON.stringify(currentAuthorityKeys)) {
+      errors.push('Harness Core current release authority evidence must be complete');
+    } else if (!Object.values(harnessCurrentEvidence.authority).every((value) => value === false)) {
+      errors.push('Harness Core current release evidence must not grant authority');
     }
   }
 

--- a/scripts/verify-harness-core-cutover.mjs
+++ b/scripts/verify-harness-core-cutover.mjs
@@ -4,8 +4,32 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
-export const EXPECTED_VERSION = '0.3.1';
+export const CUTOVER_VERSION = '0.3.1';
+export const CURRENT_VERSION = '0.4.2';
+export const CUTOVER_AUTHORITY_KEYS = [
+  'deployment',
+  'hosted_memory',
+  'marketplace_publication',
+  'owner_approval_bypass',
+  'provider_dispatch',
+  'spend',
+  'trust_mutation',
+  'wallet',
+  'x402',
+];
+export const CURRENT_AUTHORITY_KEYS = [
+  'deployment',
+  'hosted_memory',
+  'marketplace_publication',
+  'owner_approval_bypass',
+  'provider_dispatch',
+  'spend',
+  'trust_mutation',
+  'wallet_mutation',
+  'x402_settlement',
+];
 export const EXPECTED_POINTER_FILES = [
+  'CURRENT_RELEASE_EVIDENCE.json',
   'README.md',
   'STANDALONE_RELEASE_EVIDENCE.json',
 ];
@@ -42,6 +66,20 @@ function check(condition, message, errors) {
   if (!condition) errors.push(message);
 }
 
+export function validateAllFalseAuthority(record, expectedKeys, label) {
+  const actualKeys = record && typeof record === 'object' && !Array.isArray(record)
+    ? Object.keys(record).sort()
+    : [];
+  const requiredKeys = [...expectedKeys].sort();
+  if (JSON.stringify(actualKeys) !== JSON.stringify(requiredKeys)) {
+    return [`${label} authority evidence keys must equal: ${requiredKeys.join(', ')}`];
+  }
+  const enabled = Object.entries(record)
+    .filter(([, value]) => value !== false)
+    .map(([key]) => key);
+  return enabled.length ? [`${label} authority evidence enables or misstates: ${enabled.join(', ')}`] : [];
+}
+
 export function verifyHarnessCoreCutover({ root = defaultRoot } = {}) {
   const errors = [];
   const pointerRoot = path.join(root, 'harness-core');
@@ -71,38 +109,73 @@ export function verifyHarnessCoreCutover({ root = defaultRoot } = {}) {
   for (const required of [
     'https://github.com/rhein1/agoragentic-harness-core',
     'https://www.npmjs.com/package/agoragentic-harness-core',
-    'releases/tag/v0.3.1',
+    `releases/tag/v${CURRENT_VERSION}`,
+    'CURRENT_RELEASE_EVIDENCE.json',
+    'STANDALONE_RELEASE_EVIDENCE.json',
     'thin pointer',
   ]) {
     check(readme.includes(required), `harness-core/README.md is missing ${required}`, errors);
   }
   check(/not\s+settlement receipts/.test(readme), 'harness-core/README.md is missing the settlement-receipt boundary', errors);
 
-  const evidence = readJson(path.join(pointerRoot, 'STANDALONE_RELEASE_EVIDENCE.json'));
-  check(evidence.schema === 'agoragentic.harness-core.standalone-release-evidence.v1', 'unexpected cutover evidence schema', errors);
-  check(evidence.canonical_repository === 'https://github.com/rhein1/agoragentic-harness-core', 'canonical Harness Core repository is not standalone', errors);
-  check(evidence.source_cutover?.duplicate_canonical_implementation_removed === true, 'duplicate canonical implementation is not recorded as removed', errors);
-  check(evidence.release?.tag === `v${EXPECTED_VERSION}`, `release evidence must target v${EXPECTED_VERSION}`, errors);
-  check(evidence.release?.target_commit === 'be6ecc806c87d332434efa265d0c44efe432028a', 'release evidence target commit changed', errors);
-  check(evidence.npm?.version === EXPECTED_VERSION, `npm evidence must target ${EXPECTED_VERSION}`, errors);
-  check(evidence.npm?.provenance_predicate === 'https://slsa.dev/provenance/v1', 'SLSA provenance evidence is missing', errors);
-  check(evidence.publishing?.trusted_publisher_repository === 'rhein1/agoragentic-harness-core', 'trusted publisher still points at the monorepo', errors);
-  check(evidence.publishing?.trusted_publisher_workflow === 'publish.yml', 'trusted publisher workflow must be publish.yml', errors);
-  check(evidence.publishing?.conclusion === 'success', 'standalone publish workflow is not recorded as successful', errors);
-  check(evidence.clean_room?.result === 'passed', 'clean-room published-package verification is not recorded as passed', errors);
-  check(Object.values(evidence.authority || {}).every((value) => value === false), 'cutover evidence grants authority', errors);
+  const cutoverEvidence = readJson(path.join(pointerRoot, 'STANDALONE_RELEASE_EVIDENCE.json'));
+  check(cutoverEvidence.schema === 'agoragentic.harness-core.standalone-release-evidence.v1', 'unexpected cutover evidence schema', errors);
+  check(cutoverEvidence.canonical_repository === 'https://github.com/rhein1/agoragentic-harness-core', 'canonical Harness Core repository is not standalone', errors);
+  check(cutoverEvidence.source_cutover?.duplicate_canonical_implementation_removed === true, 'duplicate canonical implementation is not recorded as removed', errors);
+  check(cutoverEvidence.release?.tag === `v${CUTOVER_VERSION}`, `cutover evidence must remain pinned to v${CUTOVER_VERSION}`, errors);
+  check(cutoverEvidence.release?.target_commit === 'be6ecc806c87d332434efa265d0c44efe432028a', 'cutover evidence target commit changed', errors);
+  check(cutoverEvidence.npm?.version === CUTOVER_VERSION, `cutover npm evidence must remain pinned to ${CUTOVER_VERSION}`, errors);
+  check(cutoverEvidence.npm?.provenance_predicate === 'https://slsa.dev/provenance/v1', 'cutover SLSA provenance evidence is missing', errors);
+  check(cutoverEvidence.publishing?.trusted_publisher_repository === 'rhein1/agoragentic-harness-core', 'cutover trusted publisher points at the wrong repository', errors);
+  check(cutoverEvidence.publishing?.trusted_publisher_workflow === 'publish.yml', 'cutover trusted publisher workflow must be publish.yml', errors);
+  check(cutoverEvidence.publishing?.conclusion === 'success', 'standalone cutover publish workflow is not recorded as successful', errors);
+  check(cutoverEvidence.clean_room?.result === 'passed', 'cutover clean-room verification is not recorded as passed', errors);
+  errors.push(...validateAllFalseAuthority(cutoverEvidence.authority, CUTOVER_AUTHORITY_KEYS, 'cutover'));
+
+  const currentEvidence = readJson(path.join(pointerRoot, 'CURRENT_RELEASE_EVIDENCE.json'));
+  check(currentEvidence.schema === 'agoragentic.harness-core.current-release-evidence.v1', 'unexpected current release evidence schema', errors);
+  check(currentEvidence.canonical_repository === 'https://github.com/rhein1/agoragentic-harness-core', 'current release repository is not standalone', errors);
+  check(currentEvidence.release?.tag === `v${CURRENT_VERSION}`, `current release evidence must target v${CURRENT_VERSION}`, errors);
+  check(currentEvidence.release?.target_commit === 'd858f955023df8094855e36ca23d8399d9460000', 'current release target commit changed', errors);
+  check(currentEvidence.npm?.version === CURRENT_VERSION, `current npm evidence must target ${CURRENT_VERSION}`, errors);
+  check(currentEvidence.npm?.latest === CURRENT_VERSION, `current npm latest must be ${CURRENT_VERSION}`, errors);
+  check(currentEvidence.npm?.shasum === '085288174ab553e81e1dd8e41159c97b81dccb98', 'current npm shasum changed', errors);
+  check(currentEvidence.npm?.provenance_predicate === 'https://slsa.dev/provenance/v1', 'current SLSA provenance evidence is missing', errors);
+  check(currentEvidence.publishing?.trusted_publisher_workflow === 'publish.yml', 'current trusted publisher workflow must be publish.yml', errors);
+  check(currentEvidence.publishing?.github_environment === 'npm-publish', 'current publish evidence must use npm-publish', errors);
+  check(currentEvidence.publishing?.workflow_run_id === 33138725802, 'current publish workflow run changed', errors);
+  check(currentEvidence.publishing?.event === 'push', 'current publish workflow must be tag-push triggered', errors);
+  check(currentEvidence.publishing?.conclusion === 'success', 'current publish workflow is not recorded as successful', errors);
+  check(currentEvidence.publishing?.environment_approval?.independent_human_review === false, 'solo-maintainer environment approval is misclassified', errors);
+  check(currentEvidence.clean_room?.declared_exports === 38, 'current clean-room evidence must cover all 38 exports', errors);
+  check(currentEvidence.clean_room?.result === 'passed', 'current clean-room published-package verification is not recorded as passed', errors);
+  check(currentEvidence.ahp_observer?.protocol_version === '0.8.0', 'current AHP protocol evidence changed', errors);
+  check(currentEvidence.ahp_observer?.authority_flags_false === 20, 'current AHP adapter authority evidence is incomplete', errors);
+  check(currentEvidence.ahp_observer?.base_authority_booleans_false === 30, 'current AHP base-authority evidence is incomplete', errors);
+  check(Object.keys(currentEvidence.ahp_observer?.authority_flags || {}).length === 20, 'current AHP adapter authority flag inventory is incomplete', errors);
+  check(Object.values(currentEvidence.ahp_observer?.authority_flags || {}).every((value) => value === false), 'current AHP adapter authority inventory grants authority', errors);
+  const baseAuthority = currentEvidence.ahp_observer?.base_authority || {};
+  check(baseAuthority.mode === 'local_no_spend', 'current AHP base-authority mode changed', errors);
+  const baseAuthorityFlags = Object.entries(baseAuthority).filter(([key]) => key !== 'mode');
+  check(baseAuthorityFlags.length === 30, 'current AHP base-authority flag inventory is incomplete', errors);
+  check(baseAuthorityFlags.every(([, value]) => value === false), 'current AHP base-authority inventory grants authority', errors);
+  errors.push(...validateAllFalseAuthority(currentEvidence.authority, CURRENT_AUTHORITY_KEYS, 'current release'));
 
   const manifest = readJson(path.join(root, 'integrations.json'));
+  check(manifest.packages?.harness_core?.version === CURRENT_VERSION, `manifest Harness Core package must be ${CURRENT_VERSION}`, errors);
   const integrations = new Map(manifest.integrations.map((entry) => [entry.id, entry]));
   for (const id of ['harness-core', 'codex-harness-mapping']) {
     const entry = integrations.get(id);
     check(entry?.path === 'harness-core/README.md', `${id}.path must resolve to the thin pointer`, errors);
     check(entry?.docs === 'harness-core/README.md', `${id}.docs must resolve to the thin pointer`, errors);
-    check(entry?.capability_record?.evidence?.evidence_ref === 'harness-core/STANDALONE_RELEASE_EVIDENCE.json', `${id} must use the standalone release evidence`, errors);
+    check(entry?.capability_record?.evidence?.evidence_ref === 'harness-core/CURRENT_RELEASE_EVIDENCE.json', `${id} must use the current release evidence`, errors);
   }
   check(manifest.discovery?.harness_core_canonical_repository === 'https://github.com/rhein1/agoragentic-harness-core', 'discovery is missing the standalone repository', errors);
   check(manifest.discovery?.harness_core_npm === 'https://www.npmjs.com/package/agoragentic-harness-core', 'discovery is missing the npm package', errors);
-  check(manifest.discovery?.harness_core_release === 'https://github.com/rhein1/agoragentic-harness-core/releases/tag/v0.3.1', 'discovery is missing the v0.3.1 release', errors);
+  check(manifest.discovery?.harness_core_release === `https://github.com/rhein1/agoragentic-harness-core/releases/tag/v${CURRENT_VERSION}`, `discovery is missing the v${CURRENT_VERSION} release`, errors);
+  check(manifest.discovery?.harness_core_release_evidence === 'harness-core/CURRENT_RELEASE_EVIDENCE.json', 'discovery is missing current release evidence', errors);
+  check(manifest.discovery?.harness_core_cutover_release === `https://github.com/rhein1/agoragentic-harness-core/releases/tag/v${CUTOVER_VERSION}`, 'discovery is missing the historical cutover release', errors);
+  check(manifest.discovery?.harness_core_cutover_evidence === 'harness-core/STANDALONE_RELEASE_EVIDENCE.json', 'discovery is missing historical cutover evidence', errors);
 
   const ecosystem = readJson(path.join(root, 'ecosystem.json'));
   const product = ecosystem.products.find((entry) => entry.id === 'harness-core');
@@ -112,9 +185,9 @@ export function verifyHarnessCoreCutover({ root = defaultRoot } = {}) {
   for (const consumer of ['gstack', 'opencode']) {
     const packageJson = readJson(path.join(root, consumer, 'package.json'));
     const lock = readJson(path.join(root, consumer, 'package-lock.json'));
-    check(packageJson.dependencies?.['agoragentic-harness-core'] === EXPECTED_VERSION, `${consumer} must pin agoragentic-harness-core ${EXPECTED_VERSION}`, errors);
-    check(lock.packages?.['']?.dependencies?.['agoragentic-harness-core'] === EXPECTED_VERSION, `${consumer} lock root must pin ${EXPECTED_VERSION}`, errors);
-    check(lock.packages?.['node_modules/agoragentic-harness-core']?.version === EXPECTED_VERSION, `${consumer} lock must resolve ${EXPECTED_VERSION}`, errors);
+    check(packageJson.dependencies?.['agoragentic-harness-core'] === CURRENT_VERSION, `${consumer} must pin agoragentic-harness-core ${CURRENT_VERSION}`, errors);
+    check(lock.packages?.['']?.dependencies?.['agoragentic-harness-core'] === CURRENT_VERSION, `${consumer} lock root must pin ${CURRENT_VERSION}`, errors);
+    check(lock.packages?.['node_modules/agoragentic-harness-core']?.version === CURRENT_VERSION, `${consumer} lock must resolve ${CURRENT_VERSION}`, errors);
   }
 
   for (const retired of [
@@ -130,7 +203,7 @@ export function verifyHarnessCoreCutover({ root = defaultRoot } = {}) {
 
   const gstackCompat = fs.readFileSync(path.join(root, 'gstack', 'scripts', 'test-harness-core-compat.mjs'), 'utf8');
   check(!gstackCompat.includes("'..', 'harness-core'"), 'gstack compatibility test still packs sibling monorepo source', errors);
-  check(gstackCompat.includes(`expectedPublishedVersion = '${EXPECTED_VERSION}'`), 'gstack compatibility test does not pin the published exact version', errors);
+  check(gstackCompat.includes(`expectedPublishedVersion = '${CURRENT_VERSION}'`), 'gstack compatibility test does not pin the current published exact version', errors);
   check(gstackCompat.includes('agoragentic-harness-core@${expectedPublishedVersion}'), 'gstack compatibility test does not install the pinned published package', errors);
 
   return { ok: errors.length === 0, errors };
@@ -143,7 +216,7 @@ function main() {
     process.exitCode = 1;
     return;
   }
-  console.log(`Harness Core standalone cutover verified at ${EXPECTED_VERSION}.`);
+  console.log(`Harness Core cutover ${CUTOVER_VERSION} and current release ${CURRENT_VERSION} verified.`);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/test/harness-core-cutover.test.mjs
+++ b/test/harness-core-cutover.test.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 
 import {
   EXPECTED_POINTER_FILES,
+  validateAllFalseAuthority,
   validateHarnessPointerFiles,
   verifyHarnessCoreCutover,
 } from '../scripts/verify-harness-core-cutover.mjs';
@@ -21,4 +22,12 @@ test('a duplicate package implementation fails the pointer-only contract', () =>
     validateHarnessPointerFiles([...EXPECTED_POINTER_FILES, 'src/index.mjs'])[0],
     /must contain only/,
   );
+});
+
+test('missing or non-false authority evidence fails closed', () => {
+  const expectedKeys = ['read', 'spend'];
+  assert.match(validateAllFalseAuthority(undefined, expectedKeys, 'fixture')[0], /keys must equal/);
+  assert.match(validateAllFalseAuthority({ read: false, spend: true }, expectedKeys, 'fixture')[0], /spend/);
+  assert.match(validateAllFalseAuthority({ placeholder: false, spend: false }, expectedKeys, 'fixture')[0], /keys must equal/);
+  assert.deepEqual(validateAllFalseAuthority({ read: false, spend: false }, expectedKeys, 'fixture'), []);
 });


### PR DESCRIPTION
## Summary
- synchronize the integrations catalog and discovery surfaces to the verified `agoragentic-harness-core@0.4.2` release
- retain `STANDALONE_RELEASE_EVIDENCE.json` as the historical `0.3.1` cutover record and add a separate current-release evidence artifact
- pin the source-only gstack and OpenCode consumers to exact `0.4.2`
- fail closed on missing, enabled, or same-count substituted authority keys

## Release evidence
- Harness release: https://github.com/rhein1/agoragentic-harness-core/releases/tag/v0.4.2
- release commit: `d858f955023df8094855e36ca23d8399d9460000`
- protected-main CI: https://github.com/rhein1/agoragentic-harness-core/actions/runs/32921588959
- protected OIDC publish: https://github.com/rhein1/agoragentic-harness-core/actions/runs/33138725802
- npm provenance: https://registry.npmjs.org/-/npm/v1/attestations/agoragentic-harness-core@0.4.2

The registry artifact was independently installed from npm: all 38 exports loaded, both unique bin targets passed syntax checks, signature audit passed, and the AHP observer reported all 20 adapter authority flags plus all 30 base-authority booleans false.

## Validation
- Harness cutover/current-release verifier and 3 tests
- ecosystem claim-boundary verifier and 3 tests
- integrations JSON and JSON Schema validation
- generated capability, count, and rename-preflight checks
- documentation link contract and generated client-distribution checks
- gstack check + 6 tests + clean-room `0.4.2` registry compatibility
- OpenCode check + 14 tests + dry-run pack
- `git diff --check`
- independent read-only diff review: no remaining findings

## Safety and review boundary
No provider/model call, payment, wallet, x402 action, deployment, marketplace publication, trust mutation, hosted-memory write, or owner-approval bypass is added or exercised. The eventual second-account approval, if checks pass, is owner-authorized mechanical separation for a solo maintainer and is not independent human or organizational review.

This PR is based directly on current `main`; it does not stack on draft PR #347. Because #347 overlaps generated catalog surfaces and is already conflicted, #347 should rebase and regenerate after this lands.