### PR TITLE
fix(risk-fork): accept opaque MCP request metadata

### DIFF
--- a/risk-fork/hackathon/scripts/mcp-client-conformance.mjs
+++ b/risk-fork/hackathon/scripts/mcp-client-conformance.mjs
@@ -151,20 +151,30 @@ export async function runMcpClientConformance({ entrypoint } = {}) {
       throw new Error('MCP initialization contract drifted');
     }
     await client.send({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} });
-    const listed = await client.send({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
+    const listed = await client.send({
+      jsonrpc: '2.0', id: 2, method: 'tools/list', params: { _meta: { progressToken: 0 } },
+    });
     const toolNames = listed.tools.map((tool) => tool.name).sort();
     if (JSON.stringify(toolNames) !== JSON.stringify(EXPECTED_TOOLS)) {
       throw new Error('MCP tool inventory drifted from the served demo surface');
     }
     const planned = await client.send({
       jsonrpc: '2.0', id: 3, method: 'tools/call',
-      params: { name: 'risk_fork_demo_plan', arguments: { scenario: 'low-read-only' } },
+      params: {
+        _meta: { progressToken: 1 },
+        name: 'risk_fork_demo_plan',
+        arguments: { scenario: 'low-read-only' },
+      },
     });
     assertTruth(planned.structuredContent, 'plan');
     if (planned.structuredContent.writes_performed !== false) throw new Error('MCP plan wrote state');
     const ran = await client.send({
       jsonrpc: '2.0', id: 4, method: 'tools/call',
-      params: { name: 'risk_fork_demo_run', arguments: { scenario: 'high-filesystem-write' } },
+      params: {
+        _meta: { progressToken: 2 },
+        name: 'risk_fork_demo_run',
+        arguments: { scenario: 'high-filesystem-write' },
+      },
     });
     const run = ran.structuredContent;
     assertTruth(run, 'run');
@@ -178,7 +188,11 @@ export async function runMcpClientConformance({ entrypoint } = {}) {
     }
     const receiptResult = await client.send({
       jsonrpc: '2.0', id: 5, method: 'tools/call',
-      params: { name: 'risk_fork_demo_receipt', arguments: { run_id: run.run_id } },
+      params: {
+        _meta: { progressToken: 3 },
+        name: 'risk_fork_demo_receipt',
+        arguments: { run_id: run.run_id },
+      },
     });
     assertTruth(receiptResult.structuredContent, 'receipt');
     if (receiptResult.isError === true

--- a/risk-fork/hackathon/src/mcp-server.mjs
+++ b/risk-fork/hackathon/src/mcp-server.mjs
@@ -83,6 +83,30 @@ function validatedRequestId(message) {
   throw invalidRequest();
 }
 
+function stripMcpRequestMetadata(message) {
+  const params = message?.params;
+  if (!params || typeof params !== 'object' || Array.isArray(params) || !Object.hasOwn(params, '_meta')) {
+    assertDemoSecretFree(message, 'MCP request envelope');
+    return message;
+  }
+  const meta = params._meta;
+  if (!meta || typeof meta !== 'object' || Array.isArray(meta)) throw invalidRequest();
+
+  // MCP reserves `params._meta` for opaque protocol/client metadata. Codex and
+  // other clients can place local workspace details there. This demo neither
+  // emits progress notifications nor consumes any client metadata, so erase the
+  // complete object before security scanning and dispatch. The raw 64 KiB wire
+  // cap still bounds it; effect-bearing params continue through the strict scan.
+  const screenedParams = Object.fromEntries(
+    Object.entries(params).filter(([key]) => key !== '_meta'),
+  );
+  const screenedMessage = Object.fromEntries(
+    Object.entries(message).map(([key, value]) => [key, key === 'params' ? screenedParams : value]),
+  );
+  assertDemoSecretFree(screenedMessage, 'MCP request envelope');
+  return screenedMessage;
+}
+
 function assertExactArguments(value, allowedKeys) {
   if (value === undefined) value = {};
   if (value === null || typeof value !== 'object' || Array.isArray(value)) {
@@ -187,7 +211,7 @@ export function createMcpMessageHandler({ engine, onResult } = {}) {
       return failure(null, Number(error?.rpcCode ?? -32600), 'Risk Fork demo request rejected');
     }
     try {
-      assertDemoSecretFree(message, 'MCP request envelope');
+      message = stripMcpRequestMetadata(message);
     } catch {
       return failure(requestId, -32600, 'Risk Fork demo request rejected');
     }

--- a/risk-fork/hackathon/test/mcp-streaming.test.mjs
+++ b/risk-fork/hackathon/test/mcp-streaming.test.mjs
@@ -78,7 +78,7 @@ test('stdio MCP parses normal fragmented UTF-8 and CRLF messages without changin
   );
 });
 
-test('stdio MCP scans the full envelope and only echoes bounded secret-free request ids', { timeout: 5_000 }, async (t) => {
+test('stdio MCP scans the effect-bearing envelope and only echoes bounded secret-free request ids', { timeout: 5_000 }, async (t) => {
   const streams = streamHarness();
   t.after(() => {
     streams.input.destroy();
@@ -117,6 +117,131 @@ test('stdio MCP scans the full envelope and only echoes bounded secret-free requ
   assert.doesNotMatch(streams.text(), new RegExp(syntheticSecret));
   assert.equal(streams.text().includes(privateId), false);
   assert.equal(streams.text().includes(oversizedId), false);
+});
+
+test('stdio MCP erases opaque request metadata before dispatch without weakening effect-bearing scans', { timeout: 5_000 }, async (t) => {
+  const streams = streamHarness();
+  t.after(() => {
+    streams.input.destroy();
+    streams.output.destroy();
+  });
+  const received = [];
+  const callbackResults = [];
+  const engine = inertEngine({
+    run(scenario) {
+      received.push({ scenario, argument_count: arguments.length });
+      return createDemoTruth({
+        schema: 'agoragentic.risk-fork.demo-test-run.v1',
+        scenario_id: scenario,
+        exit_code: 0,
+      });
+    },
+  });
+  const serving = serveStdioMcp({
+    engine,
+    input: streams.input,
+    output: streams.output,
+    onResult(result) { callbackResults.push(result); },
+  });
+  const syntheticSecret = `github_pat_${'P'.repeat(32)}`;
+  const windowsPrivatePath = 'C:\\private\\agent-workspace';
+  const posixPrivatePath = '/home/private/agent-workspace';
+  const remoteUrl = 'https://github.com/example/private-agent.git';
+  const callId = 'call_synthetic_demo';
+  const threadId = '00000000-0000-4000-8000-000000000001';
+  const itemId = 'item_synthetic_demo';
+  const codexMetadata = {
+    callId,
+    threadId,
+    itemId,
+    progressToken: 0,
+    'x-codex-turn-metadata': {
+      workspaces: {
+        [windowsPrivatePath]: { associated_remote_urls: { origin: remoteUrl } },
+        [posixPrivatePath]: { has_changes: true },
+      },
+    },
+    arbitrary_vendor_extension: {
+      access_token: syntheticSecret,
+      constructor: { prototype: { polluted: true } },
+      __proto_marker__: 'must-not-propagate',
+    },
+  };
+  const requests = [
+    { jsonrpc: '2.0', id: 31, method: 'tools/list', params: { _meta: codexMetadata } },
+    {
+      jsonrpc: '2.0',
+      id: 32,
+      method: 'tools/call',
+      params: {
+        _meta: codexMetadata,
+        name: 'risk_fork_demo_run',
+        arguments: { scenario: 'low-read-only' },
+      },
+    },
+  ];
+  streams.input.end(`${requests.map((request) => JSON.stringify(request)).join('\n')}\n`);
+  await serving;
+
+  const messages = streams.messages();
+  assert.deepEqual(
+    messages[0].result.tools.map((tool) => tool.name),
+    RISK_FORK_DEMO_MCP_TOOLS.map((tool) => tool.name),
+  );
+  assert.equal(messages[1].result.structuredContent.scenario_id, 'low-read-only');
+  assert.deepEqual(received, [{ scenario: 'low-read-only', argument_count: 1 }]);
+  assert.equal(callbackResults.length, 1);
+  assert.equal(callbackResults[0].scenario_id, 'low-read-only');
+  assert.doesNotMatch(streams.text(), new RegExp(syntheticSecret));
+  for (const marker of [
+    windowsPrivatePath, posixPrivatePath, remoteUrl, callId, threadId, itemId, '__proto_marker__',
+  ]) {
+    assert.equal(streams.text().includes(marker), false);
+    assert.equal(JSON.stringify(received).includes(marker), false);
+    assert.equal(JSON.stringify(callbackResults).includes(marker), false);
+  }
+  assert.equal(Object.prototype.polluted, undefined);
+});
+
+test('stdio MCP rejects malformed metadata and metadata aliases without echo', { timeout: 5_000 }, async (t) => {
+  const streams = streamHarness();
+  t.after(() => {
+    streams.input.destroy();
+    streams.output.destroy();
+  });
+  const serving = serveStdioMcp({ engine: inertEngine(), input: streams.input, output: streams.output });
+  const syntheticSecret = `github_pat_${'Q'.repeat(32)}`;
+  const requests = [
+    { jsonrpc: '2.0', id: 41, method: 'tools/list', params: { _meta: null } },
+    { jsonrpc: '2.0', id: 42, method: 'tools/list', params: { _meta: 'metadata' } },
+    { jsonrpc: '2.0', id: 43, method: 'tools/list', params: { _meta: [] } },
+    { jsonrpc: '2.0', id: 44, method: 'tools/list', params: { progressToken: 1 } },
+    { jsonrpc: '2.0', id: 45, method: 'tools/list', _meta: { access_token: syntheticSecret } },
+    { jsonrpc: '2.0', id: 46, method: 'tools/list', params: { metadata: { access_token: syntheticSecret } } },
+    {
+      jsonrpc: '2.0',
+      id: 47,
+      method: 'tools/call',
+      params: {
+        _meta: { benign_vendor_data: true },
+        name: 'risk_fork_demo_plan',
+        arguments: { scenario: 'low-read-only', access_token: syntheticSecret },
+      },
+    },
+  ];
+  streams.input.end(`${requests.map((request) => JSON.stringify(request)).join('\n')}\n`);
+  await serving;
+
+  const messages = streams.messages();
+  assert.equal(messages.length, requests.length);
+  for (let index = 0; index < messages.length; index += 1) {
+    assert.deepEqual(messages[index], {
+      jsonrpc: '2.0',
+      id: 41 + index,
+      error: { code: -32600, message: 'Risk Fork demo request rejected' },
+    });
+  }
+  assert.doesNotMatch(streams.text(), new RegExp(syntheticSecret));
 });
 
 test('stdio MCP rejects and closes exactly when a no-newline message reaches 64 KiB plus one', { timeout: 5_000 }, async (t) => {


### PR DESCRIPTION
## Summary

- erase exact MCP `params._meta` transport metadata before secret scanning and dispatch
- keep request IDs and all effect-bearing parameters under the existing strict no-secret/no-private-path scan
- exercise standard progress metadata in release conformance and cover realistic Codex metadata, aliases, malformed metadata, prototype markers, and no-echo behavior

## Why

Codex CLI 0.152.0 sends MCP `_meta.progressToken` during discovery and adds opaque turn/workspace metadata during `tools/call`. The previous full-envelope scan correctly failed closed but rejected those protocol requests before any Risk Fork tool could run. The server does not consume or emit metadata, so it now removes the entire exact `params._meta` object before dispatch while retaining the 64 KiB raw-wire limit.

## Verification

- exact three-path diff; signed commit `027b3fcfdd62c6eae449f30a11cf3b6e449d079c`
- focused MCP tests: 11/11 passed
- hackathon suite: 106/106 passed
- Risk Fork core suite: 441 passed, 15 environment-gated skipped, 0 failed
- source checks, repository rename preflight, packed-consumer verification: passed
- real Codex CLI 0.152.0 MCP sequence: list -> plan `high-filesystem-write` -> run -> receipt; all four calls succeeded, cleanup verified, provider calls 0, network false

## Truth boundary

This fixes local MCP client interoperability. It does not create a VM or kernel isolation boundary, qualify E2B, deploy hosted interception, publish npm, spend funds, or protect live agent traffic.