### PR TITLE
feat(risk-fork): add fail-closed risk-forkd shell

### DIFF
--- a/docs/repository-rename-preflight.json
+++ b/docs/repository-rename-preflight.json
@@ -1325,8 +1325,8 @@
       "path": "risk-fork-hosted-mcp/dist/runtime/index.mjs",
       "occurrences": 2,
       "line_numbers": [
-        98,
-        103
+        103,
+        108
       ],
       "categories": [
         "installer_or_clone",

--- a/docs/repository-rename-preflight.json
+++ b/docs/repository-rename-preflight.json
@@ -1165,8 +1165,8 @@
       "path": "mcp/package.json",
       "occurrences": 2,
       "line_numbers": [
-        46,
-        51
+        51,
+        56
       ],
       "categories": [
         "installer_or_clone",

--- a/integrations.json
+++ b/integrations.json
@@ -17,7 +17,7 @@
       "distribution_status": "source_only",
       "source": "mcp",
       "min_node": "20",
-      "compatibility_scope": "Unpublished, non-installable 2.0.0 source candidate. The npm registry resolves a legacy direct relay and must not be used. Owned metadata only by default; remote discovery and tools require a separately qualified host enforcement boundary"
+      "compatibility_scope": "Unpublished, non-installable 2.0.0 source candidate. The npm registry resolves a legacy direct relay and must not be used. Owned metadata only by default; remote discovery and tools require a separately qualified host enforcement boundary. The risk-forkd programmatic shell accepts only the exact in-process boundary brand; its CLI is diagnostic-only, and no executor, provider, hosted, E2B, production, or live-traffic qualification is claimed"
     },
     "node_sdk": {
       "name": "agoragentic",
@@ -38,7 +38,7 @@
       "distribution_status": "source_only",
       "source": "mcp",
       "min_node": "20",
-      "compatibility_scope": "Unpublished, non-installable 2.0.0 source candidate only; remote calls fail closed and AGORAGENTIC_API_KEY is neither consumed nor forwarded"
+      "compatibility_scope": "Unpublished, non-installable 2.0.0 source candidate only; remote calls fail closed and AGORAGENTIC_API_KEY is neither consumed nor forwarded. The risk-forkd programmatic shell requires an exact in-process MCP boundary while its standalone CLI refuses startup; executor/provider/hosted/E2B/production authority remains false"
     },
     "agent_client_protocol": {
       "name": "agoragentic-mcp",
@@ -785,7 +785,7 @@
       "path": "mcp/mcp-server.js",
       "install": "npm --prefix mcp ci && npm --prefix mcp run build",
       "docs": "mcp/README.md",
-      "compatibility_scope": "Unpublished, non-installable source candidate with owned local metadata plus a tested fail-closed host-enforcement contract; no qualified hosted enforcement, credential transport, live isolation, or production MCP traffic claim",
+      "compatibility_scope": "Unpublished, non-installable source candidate with owned local metadata plus a tested fail-closed host-enforcement contract and a default-off risk-forkd programmatic shell that accepts only the exact in-process boundary brand; its CLI refuses standalone startup, and there is no bound executor, qualified provider or hosted enforcement, credential transport, live isolation, or production MCP traffic claim",
       "capability_record": {
         "capabilities": {
           "router_client": "none",

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -125,6 +125,36 @@ node mcp/dist/mcp-server.cjs --acp
 
 ACP mode supports `initialize`, `session/new`, `session/prompt`, `session/cancel`, `tools/list`, and `shutdown` locally. `tools/call` is restricted to the advertised ACP tool names and remains fail-closed without an embedding host capability.
 
+## `risk-forkd` source shell
+
+This source candidate also contains a small `risk-forkd` front door. Its programmatic factory accepts exactly one value: an enforcement boundary created by the matching bundled `createMcpEnforcementBoundary()` instance. Structural copies, boundaries created by another module instance, accessors, extra options, and runtime overrides are rejected before relay startup. The returned service exposes only `schema`, `mode`, immutable `status`, and a single-use `start()` method; the boundary remains private and `start()` delegates only to `runMcpRelay({ enforcementBoundary })`.
+
+```js
+const mcp = require('./dist/mcp-server.cjs');
+const { createRiskForkdService } = require('./risk-forkd.js');
+
+// Construct this separately with createRiskForkMcpHostAdapter() only after an
+// owner has supplied and qualified its exact host boundary and phase-plan path.
+const riskForkHostAdapter = ownerSuppliedRiskForkHostAdapter;
+const enforcementBoundary = mcp.createMcpEnforcementBoundary(riskForkHostAdapter);
+const service = createRiskForkdService({ enforcementBoundary });
+
+console.error(service.status);
+await service.start();
+```
+
+The factory brand proves only that the boundary came from this MCP module instance. It does not prove that the hidden adapter is a Risk Fork adapter, that an `mcp_http_phase` executor is bound, or that any provider or hosted runtime is qualified. Accordingly, the status keeps the executor, Risk Fork provider, hosted runtime, E2B live, production authority, live-traffic protection, bundled-network, and `commitPrepared` flags false. This shell never calls `commitPrepared`.
+
+The checked-in CLI is intentionally diagnostic-only:
+
+```bash
+node mcp/risk-forkd.js
+```
+
+It emits a machine-readable source-only/default-off status and exits with code 78. It does not load an arbitrary config module or accept a serialized boundary because the identity brand is process-local. A future owner-supplied provider binding needs a separately reviewed closed API that connects a branded `mcp_http_phase` runtime to the Risk Fork controller/host-adapter path, plus provider and live qualification evidence. Until then, only an embedding process that already owns the exact in-process boundary can start the service. Relay cleanup remains the existing bounded MCP cleanup on signal or stdio EOF.
+
+The private package metadata includes the `risk-forkd` bin and `agoragentic-mcp/risk-forkd` subpath so a locally packed source checkout can verify their exact shared-module identity. This is not a registry installation claim: the package remains `private`, publication is hard-blocked, and the public npm name still resolves the unsafe legacy relay.
+
 ## Target configuration
 
 `AGORAGENTIC_MCP_URL` selects the desired MCP target placed in enforcement descriptors. It defaults to `https://agoragentic.com/api/mcp`.

--- a/mcp/mcp-server.js
+++ b/mcp/mcp-server.js
@@ -1248,6 +1248,10 @@ function createMcpEnforcementBoundary(hostAdapter = {}) {
     return boundary;
 }
 
+function isMcpEnforcementBoundary(value) {
+    return enforcementBoundaryAdapters.has(value);
+}
+
 const ACP_ENFORCEMENT_NOTE = ' Network execution is fail-closed unless an embedding host supplies a separately qualified enforcement implementation.';
 const ACP_TOOLS = [
     {
@@ -2542,7 +2546,7 @@ if (require.main === module) {
     });
 }
 
-module.exports = {
+module.exports = Object.freeze({
     MCP_ENFORCEMENT_SCHEMAS,
     MCP_V2_PROTOCOL_VERSION,
     buildFallbackToolList,
@@ -2552,7 +2556,8 @@ module.exports = {
     createMcpEnforcementBoundary,
     createRemoteToolDirectory,
     executeFallbackTool,
+    isMcpEnforcementBoundary,
     runAcpAdapter,
     runMcpRelay,
     stripOpaqueMcpMetadata,
-};
+});

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -10,7 +10,8 @@
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {
-                "agoragentic-mcp": "dist/mcp-server.cjs"
+                "agoragentic-mcp": "dist/mcp-server.cjs",
+                "risk-forkd": "risk-forkd.js"
             },
             "devDependencies": {
                 "@modelcontextprotocol/client": "2.0.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -5,16 +5,21 @@
     "mcpName": "io.github.rhein1/agoragentic",
     "description": "Unpublished, non-installable 2.0.0 source candidate for the fail-closed Agoragentic MCP protocol adapter. Remote and fallback network execution require a separately qualified host enforcement implementation.",
     "main": "dist/mcp-server.cjs",
+    "exports": {
+        ".": "./dist/mcp-server.cjs",
+        "./risk-forkd": "./risk-forkd.js"
+    },
     "bin": {
-        "agoragentic-mcp": "dist/mcp-server.cjs"
+        "agoragentic-mcp": "dist/mcp-server.cjs",
+        "risk-forkd": "risk-forkd.js"
     },
     "scripts": {
         "start": "node dist/mcp-server.cjs",
         "dev": "node mcp-server.js",
         "build": "node scripts/build.js",
-        "check": "node --check mcp-server.js && node --check scripts/build.js && node --check scripts/postinstall.js && node --check scripts/verify-packed-install.js && node --check test/activation-blockers.test.js && node --check test/fallback-preview.test.js && node --check test/metadata-boundary.test.js && node --check test/security-enforcement.test.js && node --check test/v2-remote-relay.test.js && node --check test/fixtures/enforced-relay-entry.js",
-        "test": "node --test test/*.test.js",
-        "verify:packed-install": "node scripts/verify-packed-install.js",
+        "check": "node --check mcp-server.js && node --check risk-forkd.js && node --check scripts/build.js && node --check scripts/postinstall.js && node --check scripts/verify-packed-install.js && node --check scripts/verify-risk-forkd-packed-install.js && node --check test/activation-blockers.test.js && node --check test/fallback-preview.test.js && node --check test/metadata-boundary.test.js && node --check test/risk-forkd.test.js && node --check test/security-enforcement.test.js && node --check test/v2-remote-relay.test.js && node --check test/fixtures/enforced-relay-entry.js && node --check test/fixtures/risk-forkd-entry.js",
+        "test": "npm run build && node --test test/*.test.js",
+        "verify:packed-install": "node scripts/verify-packed-install.js && node scripts/verify-risk-forkd-packed-install.js",
         "prepack": "npm run build",
         "prepublishOnly": "node -e \"throw new Error('MCP_PUBLISH_DISABLED_UNQUALIFIED_SOURCE_CANDIDATE')\"",
         "postinstall": "node scripts/postinstall.js || true"
@@ -67,6 +72,7 @@
     },
     "files": [
         "dist/mcp-server.cjs",
+        "risk-forkd.js",
         "scripts/postinstall.js",
         "README.md",
         "LICENSE"

--- a/mcp/risk-forkd.js
+++ b/mcp/risk-forkd.js
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+'use strict';
+
+const { types: { isProxy } } = require('node:util');
+
+const SERVICE_SCHEMA = 'agoragentic.risk-forkd.service.v1';
+const STATUS_SCHEMA = 'agoragentic.risk-forkd.status.v1';
+const SERVICE_MODE = 'source_only_default_off';
+const serviceRecords = new WeakMap();
+
+function fail(code, message) {
+    const error = new TypeError(message);
+    error.code = code;
+    return error;
+}
+
+function readExactOptions(options) {
+    let descriptors;
+    try {
+        if (options === null
+            || typeof options !== 'object'
+            || isProxy(options)
+            || Array.isArray(options)
+            || Object.getPrototypeOf(options) !== Object.prototype) {
+            throw new TypeError('not a plain object');
+        }
+        descriptors = Object.getOwnPropertyDescriptors(options);
+    } catch {
+        throw fail(
+            'RISK_FORKD_CONFIGURATION_INVALID',
+            'risk-forkd options must be a plain data-only object',
+        );
+    }
+
+    const keys = Reflect.ownKeys(descriptors);
+    if (keys.length !== 1 || keys[0] !== 'enforcementBoundary') {
+        throw fail(
+            'RISK_FORKD_CONFIGURATION_INVALID',
+            'risk-forkd options must contain exactly enforcementBoundary',
+        );
+    }
+    const descriptor = descriptors.enforcementBoundary;
+    if (!descriptor || !Object.prototype.hasOwnProperty.call(descriptor, 'value')) {
+        throw fail(
+            'RISK_FORKD_CONFIGURATION_INVALID',
+            'risk-forkd enforcementBoundary must be a data property',
+        );
+    }
+    return descriptor.value;
+}
+
+function loadMcpRuntime() {
+    // The checked-in source CLI remains diagnostic-only. A source build creates
+    // this bundle, and the packed subpath shares its module-private boundary
+    // brand with the package main entrypoint.
+    return require('./dist/mcp-server.cjs');
+}
+
+function assertExactBoundary(runtime, boundary) {
+    if (!runtime.isMcpEnforcementBoundary(boundary)) {
+        throw fail(
+            'RISK_FORKD_ENFORCEMENT_BOUNDARY_REQUIRED',
+            'risk-forkd requires an exact factory-created MCP enforcement boundary from this package instance',
+        );
+    }
+
+    const descriptors = Object.getOwnPropertyDescriptors(boundary);
+    const keys = Reflect.ownKeys(descriptors);
+    const schema = descriptors.schema;
+    const mode = descriptors.mode;
+    if (Object.getPrototypeOf(boundary) !== Object.prototype
+        || !Object.isFrozen(boundary)
+        || keys.length !== 2
+        || keys[0] !== 'schema'
+        || keys[1] !== 'mode'
+        || !schema
+        || !Object.prototype.hasOwnProperty.call(schema, 'value')
+        || schema.value !== runtime.MCP_ENFORCEMENT_SCHEMAS.boundary
+        || !mode
+        || !Object.prototype.hasOwnProperty.call(mode, 'value')
+        || mode.value !== 'host_owns_network_and_clean_import') {
+        throw fail(
+            'RISK_FORKD_ENFORCEMENT_BOUNDARY_INVALID',
+            'risk-forkd received a branded boundary with an unexpected public interface',
+        );
+    }
+}
+
+function buildStatus(enforcementBoundaryBound) {
+    return Object.freeze({
+        schema: STATUS_SCHEMA,
+        service: 'risk-forkd',
+        mode: SERVICE_MODE,
+        source_candidate: true,
+        default_on: false,
+        mcp_enforcement_boundary_bound: enforcementBoundaryBound,
+        mcp_http_phase_executor_bound: false,
+        risk_fork_provider_qualified: false,
+        provider_authority_granted: false,
+        hosted_runtime_qualified: false,
+        hosted_authority_granted: false,
+        e2b_live_qualified: false,
+        e2b_authority_granted: false,
+        production_authority_granted: false,
+        authority_granted: false,
+        live_traffic_protected: false,
+        network_implementation_included: false,
+        commit_prepared_supported: false,
+    });
+}
+
+const RISK_FORKD_DIAGNOSTIC = buildStatus(false);
+
+function createRiskForkdService(options) {
+    const enforcementBoundary = readExactOptions(options);
+    const runtime = loadMcpRuntime();
+    if (!Object.isFrozen(runtime)
+        || typeof runtime.isMcpEnforcementBoundary !== 'function'
+        || typeof runtime.runMcpRelay !== 'function') {
+        throw fail(
+            'RISK_FORKD_RUNTIME_INCOMPATIBLE',
+            'risk-forkd requires the matching fail-closed MCP runtime',
+        );
+    }
+    assertExactBoundary(runtime, enforcementBoundary);
+
+    const status = buildStatus(true);
+    const service = Object.freeze({
+        schema: SERVICE_SCHEMA,
+        mode: SERVICE_MODE,
+        status,
+        start: async function start() {
+            if (arguments.length !== 0) {
+                throw fail(
+                    'RISK_FORKD_START_ARGUMENTS_UNSUPPORTED',
+                    'risk-forkd start does not accept runtime overrides',
+                );
+            }
+            const record = serviceRecords.get(service);
+            if (!record || record.started) {
+                throw fail(
+                    'RISK_FORKD_ALREADY_STARTED',
+                    'risk-forkd service instances are single-start',
+                );
+            }
+            record.started = true;
+            await record.runMcpRelay({ enforcementBoundary: record.enforcementBoundary });
+        },
+    });
+    serviceRecords.set(service, {
+        enforcementBoundary,
+        runMcpRelay: runtime.runMcpRelay,
+        started: false,
+    });
+    return service;
+}
+
+function emitStandaloneDiagnostic() {
+    const diagnostic = {
+        ...RISK_FORKD_DIAGNOSTIC,
+        startup: 'refused',
+        reason_code: 'RISK_FORKD_IN_PROCESS_BOUNDARY_REQUIRED',
+        message: 'Standalone risk-forkd startup is disabled. An embedding owner must create and inject the exact in-process MCP enforcement boundary.',
+    };
+    process.stderr.write(`${JSON.stringify(diagnostic)}\n`);
+    process.exitCode = 78;
+}
+
+if (require.main === module) emitStandaloneDiagnostic();
+
+module.exports = Object.freeze({
+    RISK_FORKD_DIAGNOSTIC,
+    createRiskForkdService,
+});

--- a/mcp/scripts/verify-risk-forkd-packed-install.js
+++ b/mcp/scripts/verify-risk-forkd-packed-install.js
@@ -1,0 +1,128 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync, spawnSync } = require('child_process');
+
+const packageRoot = path.resolve(__dirname, '..');
+const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agoragentic-risk-forkd-pack-'));
+const packRoot = path.join(temporaryRoot, 'pack');
+const consumerRoot = path.join(temporaryRoot, 'consumer');
+const npmCli = process.env.npm_execpath;
+const npmCommand = npmCli
+    ? process.execPath
+    : process.platform === 'win32'
+        ? process.env.ComSpec || 'cmd.exe'
+        : 'npm';
+
+function runNpm(args, cwd) {
+    const commandArgs = npmCli
+        ? [npmCli, ...args]
+        : process.platform === 'win32'
+            ? ['/d', '/s', '/c', 'npm.cmd', ...args]
+            : args;
+    return execFileSync(npmCommand, commandArgs, {
+        cwd,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+    });
+}
+
+try {
+    fs.mkdirSync(packRoot, { recursive: true });
+    fs.mkdirSync(consumerRoot, { recursive: true });
+    fs.writeFileSync(path.join(consumerRoot, 'package.json'), JSON.stringify({
+        name: 'risk-forkd-packed-consumer',
+        version: '1.0.0',
+        private: true,
+    }, null, 2));
+
+    const packed = JSON.parse(runNpm([
+        'pack',
+        '--json',
+        '--pack-destination',
+        packRoot,
+    ], packageRoot));
+    assert.equal(packed.length, 1);
+    const tarball = path.join(packRoot, packed[0].filename);
+    runNpm([
+        'install',
+        '--ignore-scripts',
+        '--no-audit',
+        '--no-fund',
+        tarball,
+    ], consumerRoot);
+
+    const installedRoot = path.join(consumerRoot, 'node_modules', 'agoragentic-mcp');
+    const installedPackage = JSON.parse(fs.readFileSync(
+        path.join(installedRoot, 'package.json'),
+        'utf8',
+    ));
+    assert.equal(installedPackage.private, true);
+    assert.equal(installedPackage.exports['./risk-forkd'], './risk-forkd.js');
+    assert.equal(installedPackage.bin['risk-forkd'], 'risk-forkd.js');
+    assert.equal(fs.existsSync(path.join(installedRoot, 'risk-forkd.js')), true);
+    assert.equal(fs.existsSync(path.join(
+        consumerRoot,
+        'node_modules',
+        '.bin',
+        process.platform === 'win32' ? 'risk-forkd.cmd' : 'risk-forkd',
+    )), true);
+
+    const consumerProbe = `
+        const assert = require('assert');
+        const mcp = require('agoragentic-mcp');
+        const riskForkd = require('agoragentic-mcp/risk-forkd');
+        const adapter = {
+            async openSession() { throw new Error('packed probe must not start'); },
+            async executeFallback() { throw new Error('packed probe must not execute fallback'); },
+        };
+        const boundary = mcp.createMcpEnforcementBoundary(adapter);
+        assert.equal(mcp.isMcpEnforcementBoundary(boundary), true);
+        const service = riskForkd.createRiskForkdService({ enforcementBoundary: boundary });
+        assert.deepEqual(Reflect.ownKeys(service), ['schema', 'mode', 'status', 'start']);
+        assert.equal(service.status.mcp_enforcement_boundary_bound, true);
+        assert.equal(service.status.mcp_http_phase_executor_bound, false);
+        assert.equal(service.status.risk_fork_provider_qualified, false);
+        assert.equal(service.status.provider_authority_granted, false);
+        assert.equal(service.status.hosted_runtime_qualified, false);
+        assert.equal(service.status.hosted_authority_granted, false);
+        assert.equal(service.status.e2b_live_qualified, false);
+        assert.equal(service.status.e2b_authority_granted, false);
+        assert.equal(service.status.production_authority_granted, false);
+        assert.equal(service.status.authority_granted, false);
+        assert.throws(
+            () => riskForkd.createRiskForkdService({ enforcementBoundary: { ...boundary } }),
+            (error) => error && error.code === 'RISK_FORKD_ENFORCEMENT_BOUNDARY_REQUIRED',
+        );
+        process.stdout.write('RISK_FORKD_PACKED_CONSUMER_OK\\n');
+    `;
+    const probeOutput = execFileSync(process.execPath, ['-e', consumerProbe], {
+        cwd: consumerRoot,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    assert.equal(probeOutput.trim(), 'RISK_FORKD_PACKED_CONSUMER_OK');
+
+    const cli = spawnSync(process.execPath, [path.join(installedRoot, 'risk-forkd.js')], {
+        cwd: consumerRoot,
+        encoding: 'utf8',
+    });
+    assert.equal(cli.status, 78, cli.stderr);
+    assert.equal(cli.stdout, '');
+    const diagnostic = JSON.parse(cli.stderr.trim());
+    assert.equal(diagnostic.startup, 'refused');
+    assert.equal(diagnostic.reason_code, 'RISK_FORKD_IN_PROCESS_BOUNDARY_REQUIRED');
+    assert.equal(diagnostic.mcp_enforcement_boundary_bound, false);
+    assert.equal(diagnostic.mcp_http_phase_executor_bound, false);
+    assert.equal(diagnostic.provider_authority_granted, false);
+    assert.equal(diagnostic.hosted_authority_granted, false);
+    assert.equal(diagnostic.e2b_authority_granted, false);
+    assert.equal(diagnostic.production_authority_granted, false);
+
+    console.log('risk-forkd packed install verification passed');
+} finally {
+    fs.rmSync(temporaryRoot, { recursive: true, force: true });
+}

--- a/mcp/test/fixtures/risk-forkd-entry.js
+++ b/mcp/test/fixtures/risk-forkd-entry.js
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+'use strict';
+
+const mcp = require('../../dist/mcp-server.cjs');
+const { createRiskForkdService } = require('../../risk-forkd.js');
+
+let eventIndex = 0;
+let holdOpen;
+
+function record(event, details = {}) {
+    eventIndex += 1;
+    console.error(`RISK_FORKD_EVENT ${JSON.stringify({ index: eventIndex, event, ...details })}`);
+}
+
+function cleanImported(request, result) {
+    const evidenceRef = `risk-forkd-loopback:${request.request_id}`;
+    return {
+        schema: mcp.MCP_ENFORCEMENT_SCHEMAS.cleanImportedResult,
+        request_id: request.request_id,
+        request_hash: request.request_hash,
+        phase: request.phase,
+        clean_imported: true,
+        authority_granted: false,
+        evidence_ref: evidenceRef,
+        evidence_hash: mcp.computeMcpCleanImportEvidenceHash(
+            request.request_hash,
+            result,
+            evidenceRef,
+        ),
+        result,
+    };
+}
+
+const readOnlyTool = {
+    name: 'risk_forkd_loopback_read',
+    description: 'Deterministic in-memory read-only risk-forkd fixture.',
+    inputSchema: {
+        type: 'object',
+        properties: {
+            value: { type: 'string' },
+        },
+        additionalProperties: false,
+    },
+    annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+    },
+    capabilities: {
+        network_access: false,
+        filesystem_read: false,
+        filesystem_write: false,
+        credential_access: false,
+        wallet_or_payment: false,
+        deployment: false,
+        publication: false,
+        communication: false,
+        database_mutation: false,
+        trust_or_reputation_mutation: false,
+        external_side_effect: false,
+        unknown_or_unclassified: false,
+    },
+};
+
+const enforcementBoundary = mcp.createMcpEnforcementBoundary({
+    async openSession(openRequest) {
+        record('host_request', { phase: openRequest.phase });
+        holdOpen = setInterval(() => {}, 1000);
+        return {
+            schema: mcp.MCP_ENFORCEMENT_SCHEMAS.hostSession,
+            discovery: cleanImported(openRequest, {
+                protocol_version: mcp.MCP_V2_PROTOCOL_VERSION,
+                stateless: true,
+            }),
+            async request(request) {
+                record('host_request', { phase: request.phase });
+                if (request.phase === 'tools/list') {
+                    return cleanImported(request, { tools: [readOnlyTool] });
+                }
+                if (request.phase === 'tools/call') {
+                    return cleanImported(request, {
+                        content: [{
+                            type: 'text',
+                            text: JSON.stringify({
+                                ok: true,
+                                value: request.params.arguments?.value ?? null,
+                            }),
+                        }],
+                    });
+                }
+                throw new Error(`unexpected loopback phase ${request.phase}`);
+            },
+            async close() {
+                clearInterval(holdOpen);
+                record('host_close');
+            },
+        };
+    },
+    async executeFallback(request) {
+        record('fallback_bypass', { phase: request.phase });
+        throw new Error('risk-forkd loopback fixture forbids fallback execution');
+    },
+});
+
+const service = createRiskForkdService({ enforcementBoundary });
+record('service_created', {
+    service_keys: Reflect.ownKeys(service),
+    status: service.status,
+});
+service.start().catch((error) => {
+    console.error(error instanceof Error ? error.stack || error.message : String(error));
+    process.exit(1);
+});

--- a/mcp/test/risk-forkd.test.js
+++ b/mcp/test/risk-forkd.test.js
@@ -1,0 +1,259 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+const { spawn, spawnSync } = require('child_process');
+const test = require('node:test');
+
+const PACKAGE_ROOT = path.resolve(__dirname, '..');
+const MCP_SOURCE_ENTRYPOINT = path.join(PACKAGE_ROOT, 'mcp-server.js');
+const MCP_PACKED_ENTRYPOINT = path.join(PACKAGE_ROOT, 'dist', 'mcp-server.cjs');
+const RISK_FORKD_ENTRYPOINT = path.join(PACKAGE_ROOT, 'risk-forkd.js');
+const RISK_FORKD_FIXTURE = path.join(PACKAGE_ROOT, 'test', 'fixtures', 'risk-forkd-entry.js');
+
+function createFakeAdapter() {
+    return {
+        async openSession() {
+            throw new Error('unit-only boundary must not be opened');
+        },
+        async executeFallback() {
+            throw new Error('unit-only boundary must not execute fallback');
+        },
+    };
+}
+
+test('risk-forkd refuses missing, structural, foreign, and accessor configuration', () => {
+    const mcp = require(MCP_PACKED_ENTRYPOINT);
+    const sourceMcp = require(MCP_SOURCE_ENTRYPOINT);
+    const riskForkd = require(RISK_FORKD_ENTRYPOINT);
+    const exactBoundary = mcp.createMcpEnforcementBoundary(createFakeAdapter());
+    const foreignBoundary = sourceMcp.createMcpEnforcementBoundary(createFakeAdapter());
+    let accessorReads = 0;
+    let proxyTraps = 0;
+    const accessorOptions = {};
+    Object.defineProperty(accessorOptions, 'enforcementBoundary', {
+        enumerable: true,
+        get() {
+            accessorReads += 1;
+            return exactBoundary;
+        },
+    });
+    const proxyOptions = new Proxy({ enforcementBoundary: exactBoundary }, {
+        getOwnPropertyDescriptor() {
+            proxyTraps += 1;
+            throw new Error('proxy descriptor trap must not run');
+        },
+        getPrototypeOf() {
+            proxyTraps += 1;
+            throw new Error('proxy prototype trap must not run');
+        },
+        ownKeys() {
+            proxyTraps += 1;
+            throw new Error('proxy ownKeys trap must not run');
+        },
+    });
+
+    assert.equal(Object.isFrozen(mcp), true);
+    assert.throws(() => {
+        mcp.isMcpEnforcementBoundary = () => true;
+    }, TypeError);
+    assert.throws(() => {
+        mcp.runMcpRelay = async () => {};
+    }, TypeError);
+    assert.equal(mcp.isMcpEnforcementBoundary(exactBoundary), true);
+    assert.equal(mcp.isMcpEnforcementBoundary({ ...exactBoundary }), false);
+    assert.throws(
+        () => riskForkd.createRiskForkdService(),
+        (error) => error?.code === 'RISK_FORKD_CONFIGURATION_INVALID',
+    );
+    assert.throws(
+        () => riskForkd.createRiskForkdService({}),
+        (error) => error?.code === 'RISK_FORKD_CONFIGURATION_INVALID',
+    );
+    assert.throws(
+        () => riskForkd.createRiskForkdService({
+            enforcementBoundary: { ...exactBoundary },
+        }),
+        (error) => error?.code === 'RISK_FORKD_ENFORCEMENT_BOUNDARY_REQUIRED',
+    );
+    assert.throws(
+        () => riskForkd.createRiskForkdService({ enforcementBoundary: foreignBoundary }),
+        (error) => error?.code === 'RISK_FORKD_ENFORCEMENT_BOUNDARY_REQUIRED',
+    );
+    assert.throws(
+        () => riskForkd.createRiskForkdService(accessorOptions),
+        (error) => error?.code === 'RISK_FORKD_CONFIGURATION_INVALID',
+    );
+    assert.throws(
+        () => riskForkd.createRiskForkdService(proxyOptions),
+        (error) => error?.code === 'RISK_FORKD_CONFIGURATION_INVALID',
+    );
+    assert.equal(accessorReads, 0);
+    assert.equal(proxyTraps, 0);
+});
+
+test('risk-forkd exposes a closed source-only service with no direct executor or commit surface', async () => {
+    const mcp = require(MCP_PACKED_ENTRYPOINT);
+    const riskForkd = require(RISK_FORKD_ENTRYPOINT);
+    const enforcementBoundary = mcp.createMcpEnforcementBoundary(createFakeAdapter());
+    const service = riskForkd.createRiskForkdService({ enforcementBoundary });
+    const source = fs.readFileSync(RISK_FORKD_ENTRYPOINT, 'utf8');
+
+    assert.equal(Object.isFrozen(service), true);
+    assert.deepEqual(Reflect.ownKeys(service), ['schema', 'mode', 'status', 'start']);
+    assert.equal(service.mode, 'source_only_default_off');
+    assert.equal(service.status.mcp_enforcement_boundary_bound, true);
+    for (const field of [
+        'mcp_http_phase_executor_bound',
+        'risk_fork_provider_qualified',
+        'provider_authority_granted',
+        'hosted_runtime_qualified',
+        'hosted_authority_granted',
+        'e2b_live_qualified',
+        'e2b_authority_granted',
+        'production_authority_granted',
+        'authority_granted',
+        'live_traffic_protected',
+        'network_implementation_included',
+        'commit_prepared_supported',
+    ]) {
+        assert.equal(service.status[field], false, field);
+    }
+    assert.equal('enforcementBoundary' in service, false);
+    assert.equal('executor' in service, false);
+    assert.equal('adapter' in service, false);
+    assert.equal('commitPrepared' in service, false);
+    assert.doesNotMatch(source, /\b(?:fetch|https?\.request|connectRemoteClient|commitPrepared)\b/);
+    assert.doesNotMatch(source, /require\(['"](?:node:)?(?:dns|http|https|net|tls|undici)['"]\)/);
+    assert.match(source, /runMcpRelay/);
+    await assert.rejects(
+        service.start({ runMcpRelay() {} }),
+        (error) => error?.code === 'RISK_FORKD_START_ARGUMENTS_UNSUPPORTED',
+    );
+});
+
+test('standalone risk-forkd CLI is diagnostic-only and refuses startup', () => {
+    const result = spawnSync(process.execPath, [RISK_FORKD_ENTRYPOINT], {
+        cwd: PACKAGE_ROOT,
+        encoding: 'utf8',
+    });
+    assert.equal(result.status, 78, result.stderr);
+    assert.equal(result.stdout, '');
+    const diagnostic = JSON.parse(result.stderr.trim());
+    assert.equal(diagnostic.startup, 'refused');
+    assert.equal(diagnostic.reason_code, 'RISK_FORKD_IN_PROCESS_BOUNDARY_REQUIRED');
+    assert.equal(diagnostic.mode, 'source_only_default_off');
+    assert.equal(diagnostic.mcp_enforcement_boundary_bound, false);
+    assert.equal(diagnostic.mcp_http_phase_executor_bound, false);
+    assert.equal(diagnostic.provider_authority_granted, false);
+    assert.equal(diagnostic.hosted_authority_granted, false);
+    assert.equal(diagnostic.e2b_authority_granted, false);
+    assert.equal(diagnostic.production_authority_granted, false);
+});
+
+test('risk-forkd delegates every phase through the branded boundary and cleans up on EOF', async () => {
+    const env = {
+        ...process.env,
+        AGORAGENTIC_MCP_URL: 'https://risk-forkd-loopback.example.invalid/api/mcp',
+    };
+    delete env.AGORAGENTIC_API_KEY;
+    delete env.AGORAGENTIC_BASE_URL;
+    const child = spawn(process.execPath, [RISK_FORKD_FIXTURE], {
+        cwd: PACKAGE_ROOT,
+        env,
+        stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const pending = new Map();
+    const stderr = [];
+    const output = readline.createInterface({ input: child.stdout });
+    let nextId = 1;
+
+    output.on('line', (line) => {
+        let message;
+        try {
+            message = JSON.parse(line);
+        } catch {
+            return;
+        }
+        const waiter = pending.get(message.id);
+        if (!waiter) return;
+        pending.delete(message.id);
+        waiter.resolve(message);
+    });
+    child.stderr.on('data', (chunk) => stderr.push(chunk.toString()));
+    const exit = new Promise((resolve) => child.once('exit', (code, signal) => resolve({ code, signal })));
+
+    function request(method, params = {}) {
+        const id = nextId++;
+        return new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => {
+                pending.delete(id);
+                reject(new Error(`risk-forkd timed out waiting for ${method}\n${stderr.join('')}`));
+            }, 5000);
+            pending.set(id, {
+                resolve(message) {
+                    clearTimeout(timeout);
+                    resolve(message);
+                },
+            });
+            child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`);
+        });
+    }
+
+    try {
+        const initialized = await request('initialize', {
+            protocolVersion: '2025-06-18',
+            capabilities: {},
+            clientInfo: { name: 'risk-forkd-test', version: '1.0.0' },
+        });
+        assert.equal(initialized.error, undefined, JSON.stringify(initialized));
+        child.stdin.write(`${JSON.stringify({
+            jsonrpc: '2.0',
+            method: 'notifications/initialized',
+            params: {},
+        })}\n`);
+
+        const listed = await request('tools/list');
+        assert.equal(listed.error, undefined, JSON.stringify(listed));
+        assert.equal(
+            listed.result.tools.some((tool) => tool.name === 'risk_forkd_loopback_read'),
+            true,
+        );
+
+        const called = await request('tools/call', {
+            name: 'risk_forkd_loopback_read',
+            arguments: { value: 'through-boundary' },
+        });
+        assert.equal(called.error, undefined, JSON.stringify(called));
+        assert.deepEqual(
+            JSON.parse(called.result.content[0].text),
+            { ok: true, value: 'through-boundary' },
+        );
+
+        child.stdin.end();
+        const outcome = await Promise.race([
+            exit.then((value) => ({ exited: true, value })),
+            new Promise((resolve) => setTimeout(() => resolve({ exited: false }), 2000)),
+        ]);
+        assert.equal(outcome.exited, true, `risk-forkd remained alive after EOF\n${stderr.join('')}`);
+        assert.equal(outcome.value.code, 0, stderr.join(''));
+
+        const events = stderr.join('')
+            .split(/\r?\n/)
+            .filter((line) => line.startsWith('RISK_FORKD_EVENT '))
+            .map((line) => JSON.parse(line.slice('RISK_FORKD_EVENT '.length)));
+        assert.deepEqual(
+            events.filter((event) => event.event === 'host_request').map((event) => event.phase),
+            ['server/discover', 'tools/list', 'tools/list', 'tools/call'],
+        );
+        assert.equal(events.some((event) => event.event === 'fallback_bypass'), false);
+        assert.equal(events.filter((event) => event.event === 'host_close').length, 1);
+        assert.equal(events.at(-1).event, 'host_close');
+    } finally {
+        output.close();
+        if (child.exitCode === null && !child.killed) child.kill();
+        if (child.exitCode === null) await exit;
+    }
+});

--- a/risk-fork-hosted-mcp/dist/runtime/index.mjs
+++ b/risk-fork-hosted-mcp/dist/runtime/index.mjs
@@ -57,16 +57,21 @@ var require_package = __commonJS({
       mcpName: "io.github.rhein1/agoragentic",
       description: "Unpublished, non-installable 2.0.0 source candidate for the fail-closed Agoragentic MCP protocol adapter. Remote and fallback network execution require a separately qualified host enforcement implementation.",
       main: "dist/mcp-server.cjs",
+      exports: {
+        ".": "./dist/mcp-server.cjs",
+        "./risk-forkd": "./risk-forkd.js"
+      },
       bin: {
-        "agoragentic-mcp": "dist/mcp-server.cjs"
+        "agoragentic-mcp": "dist/mcp-server.cjs",
+        "risk-forkd": "risk-forkd.js"
       },
       scripts: {
         start: "node dist/mcp-server.cjs",
         dev: "node mcp-server.js",
         build: "node scripts/build.js",
-        check: "node --check mcp-server.js && node --check scripts/build.js && node --check scripts/postinstall.js && node --check scripts/verify-packed-install.js && node --check test/activation-blockers.test.js && node --check test/fallback-preview.test.js && node --check test/metadata-boundary.test.js && node --check test/security-enforcement.test.js && node --check test/v2-remote-relay.test.js && node --check test/fixtures/enforced-relay-entry.js",
-        test: "node --test test/*.test.js",
-        "verify:packed-install": "node scripts/verify-packed-install.js",
+        check: "node --check mcp-server.js && node --check risk-forkd.js && node --check scripts/build.js && node --check scripts/postinstall.js && node --check scripts/verify-packed-install.js && node --check scripts/verify-risk-forkd-packed-install.js && node --check test/activation-blockers.test.js && node --check test/fallback-preview.test.js && node --check test/metadata-boundary.test.js && node --check test/risk-forkd.test.js && node --check test/security-enforcement.test.js && node --check test/v2-remote-relay.test.js && node --check test/fixtures/enforced-relay-entry.js && node --check test/fixtures/risk-forkd-entry.js",
+        test: "npm run build && node --test test/*.test.js",
+        "verify:packed-install": "node scripts/verify-packed-install.js && node scripts/verify-risk-forkd-packed-install.js",
         prepack: "npm run build",
         prepublishOnly: `node -e "throw new Error('MCP_PUBLISH_DISABLED_UNQUALIFIED_SOURCE_CANDIDATE')"`,
         postinstall: "node scripts/postinstall.js || true"
@@ -119,6 +124,7 @@ var require_package = __commonJS({
       },
       files: [
         "dist/mcp-server.cjs",
+        "risk-forkd.js",
         "scripts/postinstall.js",
         "README.md",
         "LICENSE"
@@ -36400,6 +36406,9 @@ var require_mcp_server = __commonJS({
       }));
       return boundary;
     }
+    function isMcpEnforcementBoundary(value) {
+      return enforcementBoundaryAdapters.has(value);
+    }
     var ACP_ENFORCEMENT_NOTE = " Network execution is fail-closed unless an embedding host supplies a separately qualified enforcement implementation.";
     var ACP_TOOLS = [
       {
@@ -37512,7 +37521,7 @@ var require_mcp_server = __commonJS({
         process.exit(1);
       });
     }
-    module.exports = {
+    module.exports = Object.freeze({
       MCP_ENFORCEMENT_SCHEMAS: MCP_ENFORCEMENT_SCHEMAS2,
       MCP_V2_PROTOCOL_VERSION: MCP_V2_PROTOCOL_VERSION2,
       buildFallbackToolList: buildFallbackToolList2,
@@ -37522,10 +37531,11 @@ var require_mcp_server = __commonJS({
       createMcpEnforcementBoundary: createMcpEnforcementBoundary2,
       createRemoteToolDirectory: createRemoteToolDirectory2,
       executeFallbackTool: executeFallbackTool2,
+      isMcpEnforcementBoundary,
       runAcpAdapter: runAcpAdapter2,
       runMcpRelay: runMcpRelay2,
       stripOpaqueMcpMetadata
-    };
+    });
   }
 });
 
@@ -61553,7 +61563,7 @@ function createE2BAuthorityFreeSourceVerifier(options = {}) {
 }
 
 // risk-fork-hosted-mcp/src/index.mjs
-var REVIEWED_SOURCE_INTEGRITY = true ? "sha256:42be5386e702b9a92f862691d8464dc428b382674466075007cde3c5904d93bd" : null;
+var REVIEWED_SOURCE_INTEGRITY = true ? "sha256:a9dbbce2fb425b4c765908d270323abefbc8b0a2d922f1b913d9638eeccbc5f2" : null;
 var HOSTED_MCP_BUNDLE_METADATA = Object.freeze({
   package_name: "@agoragentic/risk-fork-hosted-mcp",
   package_version: "0.1.0-alpha.0",

--- a/risk-fork-hosted-mcp/integrity-manifest.json
+++ b/risk-fork-hosted-mcp/integrity-manifest.json
@@ -9,18 +9,18 @@
     "schema": "agoragentic.risk-fork-hosted-mcp.reviewed-sources.v2",
     "normalization": "utf8_crlf_to_lf_lone_cr_preserved",
     "files": 49,
-    "sha256": "sha256:42be5386e702b9a92f862691d8464dc428b382674466075007cde3c5904d93bd"
+    "sha256": "sha256:a9dbbce2fb425b4c765908d270323abefbc8b0a2d922f1b913d9638eeccbc5f2"
   },
   "reviewed_sources": [
     {
       "path": "mcp/mcp-server.js",
-      "bytes": 104394,
-      "sha256": "sha256:c8284414174a4d8d85dc6245285c17d76cbfc8c38f22e0383897c820a4f3caa1"
+      "bytes": 104536,
+      "sha256": "sha256:f20571c15099474ff907b0cef7ddc1c1f09482490cf7827776db07f952f9df21"
     },
     {
       "path": "mcp/package.json",
-      "bytes": 2711,
-      "sha256": "sha256:3767e7abe9f4b73f0ba8a253307ebac723faba05366a8d1da64b5b5087c4152f"
+      "bytes": 3128,
+      "sha256": "sha256:344b93e85381f7d80b6ac581a1469108b83ba3992a86c9e9670b60233047ec17"
     },
     {
       "path": "risk-fork/LICENSE",
@@ -422,14 +422,14 @@
     {
       "path": "mcp/mcp-server.js",
       "source": "reviewed_source",
-      "bytes": 104394,
-      "sha256": "sha256:c8284414174a4d8d85dc6245285c17d76cbfc8c38f22e0383897c820a4f3caa1"
+      "bytes": 104536,
+      "sha256": "sha256:f20571c15099474ff907b0cef7ddc1c1f09482490cf7827776db07f952f9df21"
     },
     {
       "path": "mcp/package.json",
       "source": "reviewed_source",
-      "bytes": 2711,
-      "sha256": "sha256:3767e7abe9f4b73f0ba8a253307ebac723faba05366a8d1da64b5b5087c4152f"
+      "bytes": 3128,
+      "sha256": "sha256:344b93e85381f7d80b6ac581a1469108b83ba3992a86c9e9670b60233047ec17"
     },
     {
       "path": "risk-fork-hosted-mcp/node_modules/@modelcontextprotocol/sdk/LICENSE",
@@ -2729,8 +2729,8 @@
   },
   "artifact": {
     "path": "dist/runtime/index.mjs",
-    "bytes": 2444445,
-    "sha256": "sha256:b6bda4f783fb47816c9f8a6c3d171a0aae6a6f7d4927c1200d52ae35e94f8e4f"
+    "bytes": 2445017,
+    "sha256": "sha256:fe3010d66ba92eff7ce4c937df6d07f9d445858abb87bcba1f3a92a954f3a8db"
   },
   "packaged_assets": [
     {


### PR DESCRIPTION
## Summary

- add an exact-brand, fail-closed `risk-forkd` programmatic shell around the existing MCP relay
- add a diagnostic-only CLI that exits 78 unless an embedding process already owns the exact in-process enforcement boundary
- freeze the MCP export surface so the boundary predicate and relay cannot be substituted after module loading
- add packed-install, no-bypass, phase-ordering, EOF-cleanup, and source-inventory coverage

## Truth boundary

This is a source-only/default-off front door. It does **not** bind an `mcp_http_phase` executor, prove that the hidden boundary is backed by Risk Fork, qualify a provider, call `commitPrepared`, enable E2B, deploy a hosted service, or protect live traffic. The npm package remains private and publication-disabled.

## Validation

- `npm --prefix mcp run check`
- `npm --prefix mcp test` — 49/49
- `npm --prefix mcp run verify:packed-install`
- `node --test test/mcp-direct-bypass.test.mjs` — 11/11
- integration schema/machine-surface/count checks
- `git diff --check`
- independent exact-diff review: no remaining actionable findings

No provider call, credential use, spend, publication, deployment, activation, or live traffic occurred.

Related: #301