### PR TITLE
fix(zoneless): correct payout contracts without enabling payments

### DIFF
--- a/test/solana-payment-safety.test.mjs
+++ b/test/solana-payment-safety.test.mjs
@@ -5,14 +5,23 @@ import {
   SolanaX402DemoClient,
   createMockSolanaX402Fetch,
 } from '../examples/agoragentic-growth/2026-06-21-solana-x402-paid-call-adapter-demo-mjs-c10944a6cc/solana_x402_paid_call_adapter_demo.mjs';
-import {
-  assertSolanaAddress,
-  buildPayoutReceiptDraft,
-  parseUsdcMinorUnits,
-  toZonelessPayoutRequest,
-} from '../zoneless/agoragentic_zoneless_payouts.ts';
+import * as payouts from '../zoneless/agoragentic_zoneless_payouts.ts';
 
+const {
+  assertSolanaAddress,
+  assertZonelessPayoutBoundary,
+  buildPayoutReceiptDraft,
+  buildSellerPayoutDraft,
+  buildZonelessPayoutRequestDraft,
+  parseUsdcMinorUnits,
+  toZonelessCents,
+} = payouts;
+
+// Syntax fixtures only: neither value is evidence of a funded wallet or a transaction.
 const VALID_SOLANA_ADDRESS = '11111111111111111111111111111111';
+const SYNTACTIC_SIGNATURE = '1'.repeat(64);
+const ACCOUNT_ID = 'acct_z_1Nv0FGQ9RKHgCVdK';
+const WALLET_ID = 'wa_z_1Nv0FGQ9RKHgCVdK';
 
 async function runMode(mode) {
   const mock = createMockSolanaX402Fetch({ mode });
@@ -87,50 +96,244 @@ test('Solana address validation is local and requires a 32-byte base58 address',
   assert.throws(() => assertSolanaAddress('1111'), /32 bytes/);
 });
 
-test('Solana USDC payout request uses exact minor-unit string and source receipts', () => {
-  const request = toZonelessPayoutRequest({
+function payoutInput(overrides = {}) {
+  return {
     sellerId: 'seller-1',
     amountUsdc: '12.34',
     solanaWallet: VALID_SOLANA_ADDRESS,
     sourceReceipts: ['receipt-1'],
-  });
-  assert.equal(request.amount, '12340000');
-  assert.equal(request.currency, 'usdc');
-  assert.equal(request.destination, VALID_SOLANA_ADDRESS);
-  assert.throws(() => toZonelessPayoutRequest({
-    sellerId: 'seller-1',
-    amountUsdc: '1',
-    solanaWallet: VALID_SOLANA_ADDRESS,
-    sourceReceipts: [],
-  }), /source Agoragentic receipts/);
+    ...overrides,
+  };
+}
+
+function requestInput(overrides = {}) {
+  return {
+    ...payoutInput(),
+    connectedAccountId: ACCOUNT_ID,
+    walletReference: {
+      seller_id: 'seller-1',
+      id: WALLET_ID,
+      account: ACCOUNT_ID,
+      wallet_address: VALID_SOLANA_ADDRESS,
+      object: 'wallet',
+      network: 'solana',
+      currency: 'usdc',
+      status: 'new',
+    },
+    ...overrides,
+  };
+}
+
+test('internal draft uses explicit atomic units and cannot be mistaken for the API body', () => {
+  const input = payoutInput();
+  const draft = buildSellerPayoutDraft(input);
+  assert.equal(draft.schema, 'agoragentic.seller-payout-draft.v1');
+  assert.equal(draft.amount_atomic_units, '12340000');
+  assert.equal(draft.destination_wallet_address, VALID_SOLANA_ADDRESS);
+  assert.equal(draft.canonical_balance_network, 'base');
+  assert.equal(draft.canonical_balance_asset, 'USDC');
+  assert.equal(draft.execution_authority, 'none');
+  assert.equal('amount' in draft, false);
+  assert.equal('destination' in draft, false);
+  input.sourceReceipts.push('later-receipt');
+  assert.deepEqual(draft.source_receipts, ['receipt-1']);
+  assert.equal('toZonelessPayoutRequest' in payouts, false, 'remove the misleading legacy API, not an alias');
 });
 
-test('submitted is not confirmed and confirmation requires explicit settlement evidence', () => {
-  const submitted = buildPayoutReceiptDraft({
-    sellerId: 'seller-1',
-    amountUsdc: '5.00',
-    sourceReceipts: ['receipt-1'],
-    payoutTx: 'demo-signature',
-  });
-  assert.equal(submitted.status, 'submitted');
-  assert.equal(submitted.settlement_confirmed, false);
+test('one atomic unit is valid internally but is rejected by the cent-based request builder', () => {
+  assert.equal(buildSellerPayoutDraft(payoutInput({ amountUsdc: '0.000001' })).amount_atomic_units, '1');
+  assert.throws(() => buildZonelessPayoutRequestDraft(requestInput({ amountUsdc: '0.000001' })), /whole cents/);
+});
 
-  assert.throws(() => buildPayoutReceiptDraft({
-    sellerId: 'seller-1',
-    amountUsdc: '5.00',
-    sourceReceipts: ['receipt-1'],
-    payoutTx: 'demo-signature',
-    status: 'confirmed',
-  }), /explicit settlement confirmation/);
-
-  const confirmed = buildPayoutReceiptDraft({
-    sellerId: 'seller-1',
-    amountUsdc: '5.00',
-    sourceReceipts: ['receipt-1'],
-    payoutTx: 'demo-signature',
-    status: 'confirmed',
-    settlementConfirmed: true,
+for (const [amount, expected] of [['10', 1000], ['12.34', 1234], ['0.01', 1], ['1.230000', 123], [' 2.00 ', 200]]) {
+  test(`exact upstream cents for ${JSON.stringify(amount)}`, () => {
+    const request = buildZonelessPayoutRequestDraft(requestInput({ amountUsdc: amount }));
+    assert.equal(request.body.amount, expected);
+    assert.equal(typeof request.body.amount, 'number');
+    assert.equal(Number.isSafeInteger(request.body.amount), true);
+    assert.equal(BigInt(request.body.amount) * 10_000n, parseUsdcMinorUnits(amount));
   });
-  assert.equal(confirmed.status, 'confirmed');
-  assert.equal(confirmed.settlement_confirmed, true);
+}
+
+for (const amount of ['0.000001', '0.009999', '1.000001', '1.234567']) {
+  test(`sub-cent conversion rejects ${amount} without rounding`, () => {
+    assert.throws(() => toZonelessCents(amount), /whole cents/);
+  });
+}
+
+for (const amount of ['0', '-1', '1e2', 'NaN', 'Infinity', '1.0000001', '', '01', '1.', 10, null]) {
+  test(`cent conversion rejects invalid input ${JSON.stringify(amount)}`, () => {
+    assert.throws(() => toZonelessCents(amount));
+  });
+}
+
+test('safe integer limit is checked before BigInt becomes a JSON number', () => {
+  assert.equal(toZonelessCents('90071992547409.91'), Number.MAX_SAFE_INTEGER);
+  assert.throws(() => toZonelessCents('90071992547409.92'), /safe integer/);
+  assert.throws(() => toZonelessCents('999999999999999999999999999999.99'), /safe integer/);
+});
+
+test('cent conversion preserves 1001 deterministic round trips', () => {
+  for (let cents = 1n; cents <= 1001n; cents += 1n) {
+    const amount = `${cents / 100n}.${String(cents % 100n).padStart(2, '0')}`;
+    assert.equal(BigInt(toZonelessCents(amount)) * 10_000n, parseUsdcMinorUnits(amount));
+  }
+});
+
+test('offline API draft matches the pinned upstream amount, destination, and account contract', () => {
+  // Zoneless 314414420494f63863015a060d231a7329b620e1: PayoutSchema.ts,
+  // payouts.routes.ts, ExternalWallet.ts. This is not an upstream runtime test.
+  const result = buildZonelessPayoutRequestDraft(requestInput());
+  assert.equal(result.execution_authority, 'none');
+  assert.deepEqual(result.request_options, { zonelessAccount: ACCOUNT_ID });
+  assert.deepEqual(result.body, {
+    amount: 1234,
+    currency: 'usdc',
+    destination: WALLET_ID,
+    metadata: {
+      agoragentic_seller_id: 'seller-1',
+      canonical_network: 'base',
+      source_receipts: '["receipt-1"]',
+      source_receipts_encoding: 'json',
+    },
+  });
+  assert.doesNotThrow(() => JSON.stringify(result));
+});
+
+for (const [field, value, expected] of [
+  ['seller_id', 'seller-2', /seller and connected account/],
+  ['account', 'acct_z_Other', /seller and connected account/],
+  ['wallet_address', 'other-wallet', /does not match/],
+  ['id', VALID_SOLANA_ADDRESS, /registered wa_z_/],
+  ['id', '', /External wallet id/],
+  ['status', 'archived', /unsupported status/],
+  ['status', 'verification_failed', /unsupported status/],
+  ['status', 'errored', /unsupported status/],
+  ['status', 'active', /unsupported status/],
+  ['status', undefined, /unsupported status/],
+  ['network', 'base', /Solana USDC/],
+  ['currency', 'sol', /Solana USDC/],
+  ['object', 'account', /Solana USDC/],
+]) {
+  test(`rejects mismatched wallet reference ${field}=${value}`, () => {
+    const input = requestInput();
+    input.walletReference[field] = value;
+    assert.throws(() => buildZonelessPayoutRequestDraft(input), expected);
+  });
+}
+
+for (const status of ['new', 'validated', 'verified']) {
+  test(`recognizes upstream wallet status ${status} without granting authority`, () => {
+    const input = requestInput();
+    input.walletReference.status = status;
+    assert.equal(buildZonelessPayoutRequestDraft(input).execution_authority, 'none');
+  });
+}
+
+test('requires explicit registered account and wallet, never a default-wallet fallback', () => {
+  for (const connectedAccountId of [undefined, '', 'acct_z_', 'seller-1', ` ${ACCOUNT_ID}`]) {
+    assert.throws(() => buildZonelessPayoutRequestDraft(requestInput({ connectedAccountId })), /Connected account id/);
+  }
+  for (const walletReference of [undefined, null]) {
+    assert.throws(() => buildZonelessPayoutRequestDraft(requestInput({ walletReference })), /External wallet reference/);
+  }
+});
+
+test('source receipt IDs remain lossless in metadata, including commas and quotes', () => {
+  const sourceReceipts = ['receipt,1', 'receipt"2'];
+  const result = buildZonelessPayoutRequestDraft(requestInput({ sourceReceipts }));
+  assert.deepEqual(JSON.parse(result.body.metadata.source_receipts), sourceReceipts);
+});
+
+test('draft builders reject empty and malformed seller/source receipt identifiers', () => {
+  for (const sellerId of ['', ' ', null, 3, ' seller-1']) {
+    assert.throws(() => buildSellerPayoutDraft(payoutInput({ sellerId })), /Seller id/);
+  }
+  for (const sourceReceipts of [[], null, 'receipt', [''], [' '], [2], [' padded']]) {
+    assert.throws(() => buildSellerPayoutDraft(payoutInput({ sourceReceipts })));
+    assert.throws(() => buildPayoutReceiptDraft(payoutInput({ sourceReceipts })));
+  }
+});
+
+test('existing Base-canonical and manual-approval policy boundaries remain required', () => {
+  const preference = {
+    seller_id: 'seller-1', canonical_balance_network: 'base', canonical_balance_asset: 'USDC',
+    preferred_payout_network: 'solana', preferred_payout_asset: 'USDC',
+    solana_wallet: VALID_SOLANA_ADDRESS, payout_mode: 'manual_batch', requires_owner_approval: true,
+  };
+  assert.doesNotThrow(() => assertZonelessPayoutBoundary(preference));
+  for (const change of [
+    { canonical_balance_network: 'solana' }, { canonical_balance_asset: 'SOL' },
+    { preferred_payout_asset: 'SOL' }, { preferred_payout_network: 'unknown' },
+    { solana_wallet: '' }, { payout_mode: 'automatic' }, { requires_owner_approval: false },
+  ]) assert.throws(() => assertZonelessPayoutBoundary({ ...preference, ...change }));
+});
+
+test('receipt drafts default to simulated, unverified, and no settlement authority', () => {
+  const result = buildPayoutReceiptDraft(payoutInput());
+  assert.equal(result.schema, 'agoragentic.seller-payout-receipt-draft.v2');
+  assert.equal(result.receipt_type, 'seller_payout_draft');
+  assert.equal(result.evidence_mode, 'simulated');
+  assert.equal(result.status, 'draft');
+  assert.equal(result.execution_authority, 'none');
+  assert.equal(result.evidence_source, 'caller_supplied_unverified');
+  assert.equal(result.chain_verification, 'not_performed');
+  assert.equal(result.settlement_confirmed, false);
+  assert.equal(result.amount_atomic_units, '12340000');
+});
+
+test('simulated success has its own status and cannot become a submitted payment', () => {
+  const result = buildPayoutReceiptDraft({ ...payoutInput(), status: 'simulated' });
+  assert.equal(result.status, 'simulated');
+  assert.equal(result.settlement_confirmed, false);
+  for (const change of [{ status: 'submitted' }, { payoutTx: 'sim_sig_payout' }, { payoutTx: SYNTACTIC_SIGNATURE }]) {
+    assert.throws(() => buildPayoutReceiptDraft({ ...payoutInput(), ...change }), /Simulated evidence/);
+  }
+  assert.throws(() => buildPayoutReceiptDraft({ ...payoutInput(), status: 'simulated', evidenceMode: 'onchain' }), /simulated evidence mode/);
+});
+
+test('submitted is a caller-reported onchain state, never independent confirmation', () => {
+  const result = buildPayoutReceiptDraft({ ...payoutInput(), payoutTx: SYNTACTIC_SIGNATURE, evidenceMode: 'onchain' });
+  assert.equal(result.status, 'submitted');
+  assert.equal(result.payout_tx, SYNTACTIC_SIGNATURE);
+  assert.equal(result.evidence_mode, 'onchain');
+  assert.equal(result.settlement_confirmed, false);
+  assert.equal(result.chain_verification, 'not_performed');
+  assert.equal(result.evidence_source, 'caller_supplied_unverified');
+});
+
+for (const change of [
+  { status: 'confirmed' }, { status: 'confirmed', settlementConfirmed: true },
+  { settlementConfirmed: true }, { settlementConfirmed: 'true' }, { settlementConfirmed: 1 },
+]) {
+  test(`caller cannot manufacture settlement confirmation with ${JSON.stringify(change)}`, () => {
+    assert.throws(() => buildPayoutReceiptDraft({
+      ...payoutInput(), evidenceMode: 'onchain', payoutTx: SYNTACTIC_SIGNATURE, ...change,
+    }), /cannot confirm payouts/);
+  });
+}
+
+test('receipt draft rejects impossible and unknown states', () => {
+  for (const change of [
+    { evidenceMode: 'unknown' }, { status: 'paid' }, { status: 'unrecognized' },
+    { status: 'submitted', evidenceMode: 'onchain' },
+    { status: 'draft', evidenceMode: 'onchain', payoutTx: SYNTACTIC_SIGNATURE },
+    { status: 'pending_signature', evidenceMode: 'onchain', payoutTx: SYNTACTIC_SIGNATURE },
+  ]) assert.throws(() => buildPayoutReceiptDraft({ ...payoutInput(), ...change }));
+});
+
+test('onchain claims reject synthetic, empty, and malformed signature strings', () => {
+  for (const payoutTx of ['sim_sig_payout', 'demo-signature', '', ' ', '1111', '2'.repeat(89)]) {
+    assert.throws(() => buildPayoutReceiptDraft({ ...payoutInput(), evidenceMode: 'onchain', payoutTx }));
+  }
+});
+
+test('all accepted evidence modes and statuses remain non-authoritative', () => {
+  for (const evidenceMode of ['simulated', 'onchain']) {
+    for (const status of ['draft', 'pending_signature', 'failed']) {
+      const result = buildPayoutReceiptDraft({ ...payoutInput(), evidenceMode, status });
+      assert.equal(result.settlement_confirmed, false);
+      assert.equal(result.execution_authority, 'none');
+    }
+  }
 });

--- a/zoneless/README.md
+++ b/zoneless/README.md
@@ -2,6 +2,8 @@
 
 Zoneless is useful to Agoragentic as a **Solana USDC seller-payout reference**, not as core payment architecture.
 
+**Offline reference only.** This folder has no HTTP client, credentials, signer, broadcaster, chain verifier, or execution authority. It does not change the platform custody freeze, enable payments, or authenticate the reference data supplied by a caller.
+
 ## Terminology
 
 - `gpt-5.6-sol` is a model identifier and is unrelated to cryptocurrency.
@@ -9,6 +11,8 @@ Zoneless is useful to Agoragentic as a **Solana USDC seller-payout reference**, 
 - **SOL** is Solana's native token.
 - **Lamports** are the smallest unit of SOL.
 - **USDC** in this folder means an SPL-token seller payout asset, not SOL.
+- **Atomic units** here are six-decimal USDC units: one USDC is 1,000,000 atomic units.
+- **Zoneless API cents** are a different unit: one USDC is 100 cents.
 
 ## Product boundary
 
@@ -39,7 +43,96 @@ Do not use Zoneless for:
 - Base-canonical accounting replacement
 - public Stripe-compatible payout API exposure
 
-## Safe architecture
+## Two different contracts
+
+The upstream contract was inspected at Zoneless commit `314414420494f63863015a060d231a7329b620e1` on September 8, 2026. This is a pinned source-level comparison, not an upstream deployment or end-to-end qualification.
+
+| Field | Agoragentic internal draft | Upstream payout request body |
+| --- | --- | --- |
+| Amount | `amount_atomic_units`: exact six-decimal string | `amount`: positive integer cents |
+| Destination | `destination_wallet_address`: raw Solana address | `destination`: registered `wa_z_...` wallet ID |
+| Account | Agoragentic seller ID | Connected `acct_z_...` account supplied separately |
+| Authority | None | Requires authenticated platform/account authorization outside this helper |
+
+For **10 USDC**, the internal amount is `"10000000"`, but the upstream amount is `1000`. Coercing the old atomic-unit string to a number would produce a **10,000x unit error**.
+
+`parseUsdcMinorUnits()` retains exact six-decimal accounting. `toZonelessCents()` divides atomic units by 10,000 using `bigint`, rejects any remainder, and checks `Number.MAX_SAFE_INTEGER` before conversion to the JSON number. Sub-cent amounts are not rounded, truncated, or accumulated automatically. The safe-integer check covers the request representation, not downstream chain arithmetic or operational limits.
+
+`buildSellerPayoutDraft()` builds an explicitly internal draft with no API-shaped `amount` or `destination` fields. `buildZonelessPayoutRequestDraft()` separately builds an offline envelope containing `body` and `request_options.zonelessAccount`. The latter corresponds to the upstream SDK option; the HTTP equivalent is the `Zoneless-Account` header. Neither function sends anything.
+
+### Wallet reference checks
+
+The request-draft builder requires an explicit account and wallet reference; it never falls back to an account's default wallet. The local seller ID, connected account ID, registered wallet ID, raw address, object type, Solana network, and USDC currency must agree. It accepts the upstream wallet statuses `new`, `validated`, and `verified` for planning, and rejects archived, failed, errored, missing, or unknown statuses. Upstream creates wallets with status `new`, not `active`.
+
+These checks establish **local consistency only**. A caller can fabricate reference data. In a future live adapter, resolve the seller/account binding from an authenticated, tenant-scoped source, retrieve the wallet under that account, check current payout eligibility, and recheck authority immediately before any mutation. A wallet status or a local policy flag is not an approval receipt.
+
+### Local example: build data, not a payment
+
+The IDs and address below are syntax fixtures, not real seller or wallet onboarding evidence.
+
+```typescript
+import {
+  buildSellerPayoutDraft,
+  buildZonelessPayoutRequestDraft,
+} from './agoragentic_zoneless_payouts.ts';
+
+const input = {
+  sellerId: 'seller-1',
+  amountUsdc: '10.00',
+  solanaWallet: '11111111111111111111111111111111',
+  sourceReceipts: ['receipt-1'],
+};
+
+const internal = buildSellerPayoutDraft(input);
+// internal.amount_atomic_units === '10000000'
+
+const requestDraft = buildZonelessPayoutRequestDraft({
+  ...input,
+  connectedAccountId: 'acct_z_1Nv0FGQ9RKHgCVdK',
+  walletReference: {
+    seller_id: 'seller-1',
+    id: 'wa_z_1Nv0FGQ9RKHgCVdK',
+    account: 'acct_z_1Nv0FGQ9RKHgCVdK',
+    wallet_address: input.solanaWallet,
+    object: 'wallet',
+    network: 'solana',
+    currency: 'usdc',
+    status: 'new',
+  },
+});
+// requestDraft.body.amount === 1000
+// requestDraft.body.destination === 'wa_z_1Nv0FGQ9RKHgCVdK'
+// requestDraft.execution_authority === 'none'
+// No HTTP request, signing, broadcast, or transfer occurs.
+```
+
+## Receipt drafts are not settlement evidence
+
+`buildPayoutReceiptDraft()` emits schema `agoragentic.seller-payout-receipt-draft.v2` and `receipt_type: seller_payout_draft`. Every result has:
+
+```json
+{
+  "execution_authority": "none",
+  "evidence_source": "caller_supplied_unverified",
+  "chain_verification": "not_performed",
+  "settlement_confirmed": false
+}
+```
+
+The default evidence mode is `simulated`. A completed local simulation can use `status: simulated`; it cannot carry an onchain transaction or claim `submitted`. An onchain submission record requires explicit `evidenceMode: onchain` and a syntactically valid 64-byte base58 signature. This is **only a caller-reported submission**, not proof that a transaction exists, succeeded, or became final. Address and signature validation is local syntax checking, not wallet ownership or cryptographic verification.
+
+`confirmed`, upstream `paid`, and caller-supplied `settlementConfirmed: true` are rejected. This folder deliberately does not implement settlement verification, so it cannot produce a confirmed receipt. A simulated upstream `paid` response must not be promoted into real payment evidence. Source receipt IDs are references only; this helper does not retrieve or authenticate those receipts.
+
+## Migration from the old reference
+
+This is an intentional source-reference API correction, not a backwards-compatible live adapter release.
+
+- `toZonelessPayoutRequest()` and `ZonelessPayoutRequest` are removed; no misleading compatibility alias remains. Use `buildSellerPayoutDraft()` for internal accounting or `buildZonelessPayoutRequestDraft()` with explicit wallet/account reference data for an offline upstream-shaped draft.
+- Internal amounts and receipt drafts use `amount_atomic_units`, not an ambiguous API `amount` or the old receipt `amount_minor_units` field.
+- Receipt drafts use the new schema/type above, require explicit onchain mode for submissions, and can no longer attest confirmation through a boolean.
+- `body.metadata.source_receipts` is a JSON-encoded string array with `source_receipts_encoding: json`, not comma-separated text. Decode it with `JSON.parse()` to preserve IDs containing punctuation.
+
+## Future production architecture (not implemented)
 
 ```text
 Seller earns through Agoragentic
@@ -52,7 +145,7 @@ Seller earns through Agoragentic
 -> Agoragentic writes a confirmed seller payout receipt
 ```
 
-A transaction signature or broadcast response is **not** proof of settlement. `submitted` must remain distinct from `confirmed`.
+A transaction signature or broadcast response is **not** proof of settlement. `submitted` must remain distinct from `confirmed`. The offline helpers stop before the authenticated mutation and verification stages above.
 
 ## Example policy
 
@@ -68,9 +161,25 @@ A transaction signature or broadcast response is **not** proof of settlement. `s
 }
 ```
 
-## Files
+## Files and verification
 
-- `agoragentic_zoneless_payouts.ts` provides boundary checks, exact USDC minor-unit parsing, local Solana-address validation, and receipt-shaping helpers.
+- `agoragentic_zoneless_payouts.ts` provides local policy checks, exact unit conversion, wallet-reference consistency checks, and non-authoritative draft builders.
+- `../test/solana-payment-safety.test.mjs` covers the contract and existing no-funds demo. The existing `payment-contracts` CI job runs this file under Node 24; no additional workflow or service is needed.
+
+From the repository root:
+
+```bash
+node --experimental-strip-types --test test/solana-payment-safety.test.mjs
+node examples/agoragentic-growth/2026-06-21-solana-x402-paid-call-adapter-demo-mjs-c10944a6cc/solana_x402_paid_call_adapter_demo.mjs
+```
+
+With TypeScript available, run the focused strict type check:
+
+```bash
+tsc --noEmit --strict --target ES2022 --module nodenext --moduleResolution nodenext zoneless/agoragentic_zoneless_payouts.ts
+```
+
+Tests exercise local contract assertions, simulated/submitted separation, and rejection of fabricated confirmation. They do not execute the upstream Zod schema, contact a Zoneless deployment or blockchain, validate real account ownership, or qualify production settlement.
 
 ## Implementation notes
 
@@ -83,9 +192,14 @@ server/modules/solana-payout-adapter.js
 server/modules/payout-receipt-builder.js
 ```
 
-Do not import the whole Zoneless application into the Agoragentic API server. Production implementation must add trusted signing isolation, RPC confirmation policy, finality requirements, replay protection, webhook authentication, reconciliation, and operator approval receipts before any payout can become live.
+Do not import the whole Zoneless application into the Agoragentic API server. Production implementation must add trusted signing isolation, RPC confirmation policy, finality requirements, replay protection, webhook authentication, reconciliation, and operator approval receipts before any payout can become live. Verification must bind the transaction to the intended seller, recipient, amount, USDC mint, network/cluster, source receipts, and finality policy. Activation and any custody-freeze change require separate review; this reference is not an alternative path around those gates.
 
 ## References
 
-- Zoneless: https://github.com/zonelessdev/zoneless
+- [Pinned upstream payout schema](https://github.com/zonelessdev/zoneless/blob/314414420494f63863015a060d231a7329b620e1/libs/shared-schemas/src/lib/PayoutSchema.ts)
+- [Pinned upstream payout route and account header](https://github.com/zonelessdev/zoneless/blob/314414420494f63863015a060d231a7329b620e1/apps/api/src/routes/payouts.routes.ts)
+- [Pinned external-wallet creation](https://github.com/zonelessdev/zoneless/blob/314414420494f63863015a060d231a7329b620e1/apps/api/src/modules/ExternalWallet.ts)
+- [Pinned external-wallet status types](https://github.com/zonelessdev/zoneless/blob/314414420494f63863015a060d231a7329b620e1/libs/shared-types/src/lib/ExternalWallet.ts)
+- [Pinned object ID generator](https://github.com/zonelessdev/zoneless/blob/314414420494f63863015a060d231a7329b620e1/apps/api/src/utils/IdGenerator.ts)
+- [Zoneless payout API documentation](https://zoneless.com/docs/payouts)
 - Agoragentic docs: https://agoragentic.com/docs.html

--- a/zoneless/agoragentic_zoneless_payouts.ts
+++ b/zoneless/agoragentic_zoneless_payouts.ts
@@ -1,16 +1,10 @@
 /**
- * Experimental Agoragentic + Zoneless payout bridge.
+ * Experimental, offline Agoragentic + Zoneless seller-payout reference.
  *
- * Terminology:
- * - `gpt-5.6-sol` is a model identifier and is unrelated to crypto.
- * - Solana is the network; SOL is its native token; lamports are SOL's smallest unit.
- * - This helper models optional Solana USDC seller payouts only.
- *
- * Boundary:
- * - Agoragentic remains the Agent OS / Router / Marketplace / receipt system.
- * - Base remains canonical internal accounting and seller settlement in V1.
- * - Solana USDC payout is only an optional future seller payout rail.
- * - Do not use this helper for buyer execution, x402, runtime funding, or Solana intake normalization.
+ * Base remains canonical accounting and V1 seller settlement. This module has
+ * no transport, credentials, signer, chain verifier, or execution authority.
+ * Do not use it for buyer execution, x402, runtime funding, or Solana intake.
+ * A locally consistent draft does not authenticate a seller or authorize spend.
  */
 
 export type AgoragenticSellerPayoutPreference = {
@@ -24,41 +18,90 @@ export type AgoragenticSellerPayoutPreference = {
   requires_owner_approval: true;
 };
 
+export type SellerPayoutInput = {
+  sellerId: string;
+  amountUsdc: string;
+  solanaWallet: string;
+  sourceReceipts: string[];
+};
+
+/** Internal six-decimal accounting draft, NOT a Zoneless API request. */
+export type AgoragenticSellerPayoutDraft = {
+  schema: "agoragentic.seller-payout-draft.v1";
+  execution_authority: "none";
+  seller_id: string;
+  canonical_balance_network: "base";
+  canonical_balance_asset: "USDC";
+  payout_network: "solana";
+  payout_asset: "USDC";
+  amount_usdc: string;
+  amount_atomic_units: string;
+  destination_wallet_address: string;
+  source_receipts: string[];
+};
+
+/** Caller-supplied reference data; consistency checks are NOT authentication. */
+export type ZonelessSellerWalletReference = {
+  seller_id: string;
+  id: string;
+  account: string;
+  wallet_address: string;
+  object: "wallet";
+  network: "solana";
+  currency: "usdc";
+  status: "new" | "validated" | "verified" | "verification_failed" | "errored" | "archived";
+};
+
+/** Offline request shape only. Nothing in this envelope grants spend authority. */
+export type ZonelessPayoutRequestDraft = {
+  schema: "agoragentic.zoneless-payout-request-draft.v1";
+  execution_authority: "none";
+  body: {
+    /** Integer cents, NOT six-decimal USDC atomic units. */
+    amount: number;
+    currency: "usdc";
+    /** Registered external-wallet object ID, NOT a raw Solana address. */
+    destination: string;
+    metadata: {
+      agoragentic_seller_id: string;
+      canonical_network: "base";
+      source_receipts: string;
+      source_receipts_encoding: "json";
+    };
+  };
+  request_options: { zonelessAccount: string };
+};
+
 export type AgoragenticPayoutStatus =
   | "draft"
   | "pending_signature"
+  | "simulated"
   | "submitted"
-  | "confirmed"
   | "failed";
 
 export type AgoragenticPayoutReceiptDraft = {
-  receipt_type: "seller_payout";
+  schema: "agoragentic.seller-payout-receipt-draft.v2";
+  receipt_type: "seller_payout_draft";
+  execution_authority: "none";
+  evidence_mode: "simulated" | "onchain";
+  evidence_source: "caller_supplied_unverified";
+  chain_verification: "not_performed";
   seller_id: string;
   canonical_earnings_network: "base";
   canonical_earnings_asset: "USDC";
   payout_network: "solana";
   payout_asset: "USDC";
   amount_usdc: string;
-  amount_minor_units: string;
+  amount_atomic_units: string;
   source_receipts: string[];
   payout_tx?: string;
   status: AgoragenticPayoutStatus;
-  settlement_confirmed: boolean;
-};
-
-export type ZonelessPayoutRequest = {
-  amount: string;
-  currency: "usdc";
-  destination: string;
-  metadata: {
-    agoragentic_seller_id: string;
-    canonical_network: "base";
-    source_receipts: string;
-  };
+  settlement_confirmed: false;
 };
 
 const BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 const BASE58_INDEX = new Map([...BASE58_ALPHABET].map((char, index) => [char, index]));
+const ATOMIC_UNITS_PER_CENT = 10_000n;
 
 export function parseUsdcMinorUnits(amountUsdc: string): bigint {
   if (typeof amountUsdc !== "string") throw new Error("USDC amount must be a string");
@@ -70,6 +113,19 @@ export function parseUsdcMinorUnits(amountUsdc: string): bigint {
   const minor = BigInt(whole) * 1_000_000n + BigInt(fraction.padEnd(6, "0"));
   if (minor <= 0n) throw new Error("USDC amount must be greater than zero");
   return minor;
+}
+
+/** Exact conversion for the upstream JSON API; never rounds sub-cent amounts. */
+export function toZonelessCents(amountUsdc: string): number {
+  const atomic = parseUsdcMinorUnits(amountUsdc);
+  if (atomic % ATOMIC_UNITS_PER_CENT !== 0n) {
+    throw new Error("Zoneless requires whole cents; sub-cent USDC amounts cannot be rounded");
+  }
+  const cents = atomic / ATOMIC_UNITS_PER_CENT;
+  if (cents > BigInt(Number.MAX_SAFE_INTEGER)) {
+    throw new Error("Zoneless cent amount exceeds the safe integer range");
+  }
+  return Number(cents);
 }
 
 export function decodeBase58(value: string): Uint8Array {
@@ -105,6 +161,9 @@ export function assertZonelessPayoutBoundary(preference: AgoragenticSellerPayout
   if (preference.canonical_balance_asset !== "USDC" || preference.preferred_payout_asset !== "USDC") {
     throw new Error("Only USDC payout assets are in scope");
   }
+  if (!["base", "solana"].includes(preference.preferred_payout_network)) {
+    throw new Error("Unsupported seller payout network");
+  }
   if (preference.preferred_payout_network === "solana") {
     if (!preference.solana_wallet) throw new Error("Solana payout preference requires a seller Solana wallet");
     assertSolanaAddress(preference.solana_wallet);
@@ -114,69 +173,142 @@ export function assertZonelessPayoutBoundary(preference: AgoragenticSellerPayout
   }
 }
 
-export function toZonelessPayoutRequest(input: {
-  sellerId: string;
-  amountUsdc: string;
-  solanaWallet: string;
-  sourceReceipts: string[];
-}): ZonelessPayoutRequest {
-  if (!input.sellerId.trim()) throw new Error("Seller id is required");
-  if (!input.sourceReceipts.length || input.sourceReceipts.some((receipt) => !receipt.trim())) {
+function assertIdentifier(value: unknown, label: string): asserts value is string {
+  if (typeof value !== "string" || !value.trim() || value !== value.trim()) {
+    throw new Error(`${label} must be a non-empty string without surrounding whitespace`);
+  }
+}
+
+function assertPayoutIdentity(sellerId: string, sourceReceipts: string[]): void {
+  assertIdentifier(sellerId, "Seller id");
+  if (!Array.isArray(sourceReceipts) || !sourceReceipts.length) {
     throw new Error("Seller payout must link to non-empty source Agoragentic receipts");
   }
+  for (const receipt of sourceReceipts) assertIdentifier(receipt, "Source receipt id");
+}
+
+export function buildSellerPayoutDraft(input: SellerPayoutInput): AgoragenticSellerPayoutDraft {
+  assertPayoutIdentity(input.sellerId, input.sourceReceipts);
   assertSolanaAddress(input.solanaWallet);
-  const minorUnits = parseUsdcMinorUnits(input.amountUsdc);
+  const atomic = parseUsdcMinorUnits(input.amountUsdc);
   return {
-    amount: minorUnits.toString(),
-    currency: "usdc",
-    destination: input.solanaWallet,
-    metadata: {
-      agoragentic_seller_id: input.sellerId,
-      canonical_network: "base",
-      source_receipts: input.sourceReceipts.join(","),
-    },
+    schema: "agoragentic.seller-payout-draft.v1",
+    execution_authority: "none",
+    seller_id: input.sellerId,
+    canonical_balance_network: "base",
+    canonical_balance_asset: "USDC",
+    payout_network: "solana",
+    payout_asset: "USDC",
+    amount_usdc: input.amountUsdc.trim(),
+    amount_atomic_units: atomic.toString(),
+    destination_wallet_address: input.solanaWallet,
+    source_receipts: [...input.sourceReceipts],
   };
 }
 
+export function buildZonelessPayoutRequestDraft(input: SellerPayoutInput & {
+  connectedAccountId: string;
+  walletReference: ZonelessSellerWalletReference;
+}): ZonelessPayoutRequestDraft {
+  const draft = buildSellerPayoutDraft(input);
+  assertIdentifier(input.connectedAccountId, "Connected account id");
+  if (!/^acct_z_[A-Za-z0-9]+$/.test(input.connectedAccountId)) {
+    throw new Error("Connected account id must be a Zoneless acct_z_ object id");
+  }
+  const wallet = input.walletReference;
+  if (!wallet || typeof wallet !== "object") throw new Error("External wallet reference is required");
+  assertIdentifier(wallet.id, "External wallet id");
+  if (!/^wa_z_[A-Za-z0-9]+$/.test(wallet.id)) {
+    throw new Error("Destination must be a registered wa_z_ external wallet id, not a raw address");
+  }
+  if (wallet.seller_id !== draft.seller_id || wallet.account !== input.connectedAccountId) {
+    throw new Error("External wallet reference must match the seller and connected account");
+  }
+  if (wallet.wallet_address !== draft.destination_wallet_address) {
+    throw new Error("External wallet address does not match the seller payout draft");
+  }
+  if (wallet.object !== "wallet" || wallet.network !== "solana" || wallet.currency !== "usdc") {
+    throw new Error("External wallet reference must describe a Solana USDC wallet");
+  }
+  if (!["new", "validated", "verified"].includes(wallet.status)) {
+    throw new Error("External wallet reference is archived, failed, or has an unsupported status");
+  }
+  return {
+    schema: "agoragentic.zoneless-payout-request-draft.v1",
+    execution_authority: "none",
+    body: {
+      amount: toZonelessCents(draft.amount_usdc),
+      currency: "usdc",
+      destination: wallet.id,
+      metadata: {
+        agoragentic_seller_id: draft.seller_id,
+        canonical_network: "base",
+        source_receipts: JSON.stringify(draft.source_receipts),
+        source_receipts_encoding: "json",
+      },
+    },
+    request_options: { zonelessAccount: input.connectedAccountId },
+  };
+}
+
+/** This draft builder deliberately cannot produce a confirmed settlement. */
 export function buildPayoutReceiptDraft(input: {
   sellerId: string;
   amountUsdc: string;
   sourceReceipts: string[];
   payoutTx?: string;
   status?: AgoragenticPayoutStatus;
+  evidenceMode?: "simulated" | "onchain";
+  /** Legacy input retained only to fail closed on caller-supplied confirmation. */
   settlementConfirmed?: boolean;
 }): AgoragenticPayoutReceiptDraft {
-  if (!input.sellerId.trim()) throw new Error("Seller id is required");
-  if (!input.sourceReceipts.length || input.sourceReceipts.some((receipt) => !receipt.trim())) {
-    throw new Error("Payout receipt requires non-empty source receipts");
+  assertPayoutIdentity(input.sellerId, input.sourceReceipts);
+  const atomic = parseUsdcMinorUnits(input.amountUsdc);
+  if (String(input.status) === "confirmed"
+    || (input.settlementConfirmed !== undefined && input.settlementConfirmed !== false)) {
+    throw new Error("Independent settlement verification is not implemented; this helper cannot confirm payouts");
   }
-  const minorUnits = parseUsdcMinorUnits(input.amountUsdc);
+  const mode = input.evidenceMode ?? "simulated";
+  if (mode !== "simulated" && mode !== "onchain") throw new Error("Unknown payout evidence mode");
   const status = input.status ?? (input.payoutTx ? "submitted" : "draft");
-  const settlementConfirmed = input.settlementConfirmed === true;
-  if (status === "confirmed" && !input.payoutTx) {
-    throw new Error("Confirmed payout requires a transaction signature");
+  if (!["draft", "pending_signature", "simulated", "submitted", "failed"].includes(status)) {
+    throw new Error("Unknown payout draft status");
   }
-  if (status === "confirmed" && !settlementConfirmed) {
-    throw new Error("Confirmed payout requires explicit settlement confirmation");
+  if (mode === "simulated" && (status === "submitted" || input.payoutTx !== undefined)) {
+    throw new Error("Simulated evidence cannot claim an onchain submission or transaction");
   }
-  if (settlementConfirmed && status !== "confirmed") {
-    throw new Error("Settlement confirmation is only valid for confirmed payouts");
+  if (mode === "onchain" && status === "simulated") {
+    throw new Error("Simulated status requires simulated evidence mode");
   }
-  if (input.payoutTx && status === "draft") {
-    throw new Error("A payout with a transaction signature cannot remain draft");
+  if (status === "submitted" && !input.payoutTx) {
+    throw new Error("Submitted payout requires a transaction signature");
+  }
+  if (input.payoutTx !== undefined) {
+    assertIdentifier(input.payoutTx, "Transaction signature");
+    if (input.payoutTx.length > 88 || decodeBase58(input.payoutTx).length !== 64) {
+      throw new Error("Transaction signature must decode to 64 bytes");
+    }
+    if (status !== "submitted" && status !== "failed") {
+      throw new Error("A transaction signature requires submitted or failed status");
+    }
   }
   return {
-    receipt_type: "seller_payout",
+    schema: "agoragentic.seller-payout-receipt-draft.v2",
+    receipt_type: "seller_payout_draft",
+    execution_authority: "none",
+    evidence_mode: mode,
+    evidence_source: "caller_supplied_unverified",
+    chain_verification: "not_performed",
     seller_id: input.sellerId,
     canonical_earnings_network: "base",
     canonical_earnings_asset: "USDC",
     payout_network: "solana",
     payout_asset: "USDC",
-    amount_usdc: input.amountUsdc,
-    amount_minor_units: minorUnits.toString(),
+    amount_usdc: input.amountUsdc.trim(),
+    amount_atomic_units: atomic.toString(),
     source_receipts: [...input.sourceReceipts],
     payout_tx: input.payoutTx,
     status,
-    settlement_confirmed: settlementConfirmed,
+    settlement_confirmed: false,
   };
 }


### PR DESCRIPTION
## Summary

Implements the requested small, no-funds correction to the **existing** Zoneless reference. This is implemented code and regression coverage, not a plan-only PR. Exactly three files change; no new service, payment rail, workflow, package dependency, deployment, or production setting is added.

### Correct the two contract mismatches

- Remove the misleading `toZonelessPayoutRequest()` / `ZonelessPayoutRequest` API instead of preserving an unsafe alias.
- Introduce `buildSellerPayoutDraft()` with explicit six-decimal `amount_atomic_units` and `destination_wallet_address` fields.
- Introduce the separate offline `buildZonelessPayoutRequestDraft()` envelope: integer-cent `body.amount`, registered `wa_z_...` `body.destination`, and explicit `request_options.zonelessAccount`.
- Convert with BigInt: **10 USDC = 10,000,000 internal atomic units = 1,000 upstream cents**. Reject sub-cent remainders and amounts beyond the safe JSON integer range rather than rounding or coercing.
- Check caller-supplied seller/account/wallet/address/network/currency consistency, with no default-wallet fallback. Use the actual upstream wallet statuses (`new`, `validated`, `verified`), rejecting archived/failed/unknown states. These are local consistency checks, NOT authentication or approval.
- Preserve source receipt IDs losslessly as JSON-encoded metadata, with an explicit encoding marker.

### Stop draft data from claiming verified settlement

Receipt drafts now identify themselves with `agoragentic.seller-payout-receipt-draft.v2` and `receipt_type: seller_payout_draft`. Every accepted result retains `execution_authority: none`, `evidence_source: caller_supplied_unverified`, `chain_verification: not_performed`, and `settlement_confirmed: false`.

Simulation is the default. Simulated records cannot claim an onchain submission. Caller-reported submissions require explicit onchain mode and a syntactically valid signature, but remain unverified. `confirmed`, upstream `paid`, and caller-supplied confirmation flags are rejected because this reference does not implement independent settlement verification.

### Compatibility and documentation

This intentionally corrects a source-only experimental reference API; it is not a backwards-compatible live adapter release. The README documents removed names, new fields, receipt schema migration, JSON metadata encoding, local-only examples, and separately reviewed production gates. The existing index remains experimental and unchanged.

## Evidence and scope

- Integrations baseline: `46509e8f97efa4a4d85ca2dca79201b76817117f`.
- Upstream comparison: `zonelessdev/zoneless@314414420494f63863015a060d231a7329b620e1`, inspected September 8, 2026.
- Pinned source links for the payout schema, account header, wallet creation/statuses, and ID generator are in `zoneless/README.md`.
- Caller search found the existing Solana payment-safety test importing the removed helper; it is migrated here.

## Validation performed locally

- **65/65 tests passed**, zero skips: `node --experimental-strip-types --test test/solana-payment-safety.test.mjs` (Node 22.16.0).
- The suite includes 1,001 deterministic amount round trips, safe-integer limits, sub-cent rejection, wallet/account mismatches, malformed references, simulated/submitted separation, and rejection of manufactured settlement confirmation.
- Strict TypeScript 5.8.3 check passed: `tsc --noEmit --strict --target ES2022 --module nodenext --moduleResolution nodenext zoneless/agoragentic_zoneless_payouts.ts`.
- Existing no-funds Solana demo passed. Its unchanged local source blob matched upstream `db3667697695d11e9e5ed3b560cfc6170b14f808`.
- Existing `payment-contracts` CI already runs this test file on Node 24; no workflow change is needed.

## Not verified / explicitly not activated

The full repository was not cloned locally because container DNS could not resolve GitHub; focused validation used the files fetched through the GitHub connector. Full repository/index-schema/count/rename-preflight checks are left to the existing CI and are not claimed passed here.

The tests do not execute the upstream Zod schema or a real Zoneless deployment. No authenticated account lookup, signer, broadcast, RPC, finality proof, webhook verification, live payout, or production qualification was performed. Production custody-freeze code and settings, Base accounting/settlement, buyer x402, and the marketplace repository are untouched. No funds moved and no auto-merge is enabled.

## Reviewer / Codex handoff

Review the three-file diff and the intentional source API migration. Keep this reference offline. Do not implement activation, add a signing/transport fallback, change custody settings, or treat a local wallet reference or caller-reported signature as authenticated evidence. Merge only after the relevant checks and review; any live adapter is a separate change with authenticated bindings, approval/freeze rechecks, independent verification, replay protection, and reconciliation.

Subagents: none_available.