### PR TITLE
Build offline front-door release candidates

### DIFF
--- a/.github/workflows/front-door-release-candidate.yml
+++ b/.github/workflows/front-door-release-candidate.yml
@@ -1,0 +1,55 @@
+name: Front-door release candidate
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/front-door-release-candidate.yml'
+      - 'scripts/build-front-door-release-candidates.mjs'
+      - 'scripts/verify-front-door-release-candidates.mjs'
+      - 'sdk/node/**'
+      - 'sdk/python/**'
+      - 'test/front-door-release-candidate.test.mjs'
+      - 'docs/FRONT_DOOR_RELEASE_CANDIDATE.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: '24'
+
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: '3.13'
+
+      - name: Install pinned Python build frontend
+        run: python -m pip install build==1.6.0 setuptools==84.0.0 wheel==0.48.0
+
+      - name: Verify non-publishing release contract
+        run: node --test test/front-door-release-candidate.test.mjs
+
+      - name: Build release candidates
+        run: node scripts/build-front-door-release-candidates.mjs --output "${RUNNER_TEMP}/front-door-rc"
+
+      - name: Verify clean-room installs and local results
+        run: node scripts/verify-front-door-release-candidates.mjs --artifacts "${RUNNER_TEMP}/front-door-rc"
+
+      - name: Retain verified candidate artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: agoragentic-front-door-1.8.0-rc.0
+          path: ${{ runner.temp }}/front-door-rc/
+          if-no-files-found: error
+          retention-days: 7

--- a/docs/FRONT_DOOR_RELEASE_CANDIDATE.md
+++ b/docs/FRONT_DOOR_RELEASE_CANDIDATE.md
@@ -1,0 +1,35 @@
+# Front-door release candidate
+
+This repository prepares, but does not publish, the first package candidates
+that contain the canonical `agoragentic` CLI and the JavaScript and Python local
+governance APIs introduced for issue #334.
+
+The candidate versions are:
+
+- npm: `agoragentic@1.8.0-rc.0`
+- Python: `agoragentic==1.8.0rc0`
+
+Build into a new empty directory:
+
+```sh
+python -m pip install build==1.6.0 setuptools==84.0.0 wheel==0.48.0
+node scripts/build-front-door-release-candidates.mjs --output /tmp/front-door-rc
+```
+
+Then verify clean installs without registry access:
+
+```sh
+node scripts/verify-front-door-release-candidates.mjs --artifacts /tmp/front-door-rc
+```
+
+The verifier installs the npm tarball with `--offline` and the Python wheel
+with `--no-index --no-deps`. It confirms all three CLI aliases, creates a real
+local policy through the installed umbrella CLI, executes an installed Python
+tool through the governance boundary, and verifies that its local receipt does
+not retain the fixture payload.
+
+The build emits a SHA-256 manifest with `publish_authorized: false`. The
+candidate workflow has read-only repository permissions and retains the
+verified files as a short-lived workflow artifact. Registry publication and a
+post-publication `npx`/`pip` new-user trial remain separate owner-reviewed
+release actions.

--- a/scripts/build-front-door-release-candidates.mjs
+++ b/scripts/build-front-door-release-candidates.mjs
@@ -1,0 +1,112 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { cpSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+export const NODE_RC_VERSION = '1.8.0-rc.0';
+export const PYTHON_RC_VERSION = '1.8.0rc0';
+const SOURCE_VERSION = '1.7.1';
+
+function parseOutputDirectory(argv) {
+  const index = argv.indexOf('--output');
+  if (index === -1 || !argv[index + 1] || index + 2 !== argv.length) {
+    throw new Error('Usage: node scripts/build-front-door-release-candidates.mjs --output <empty-directory>');
+  }
+  return path.resolve(argv[index + 1]);
+}
+
+function ensureEmptyDirectory(directory) {
+  mkdirSync(directory, { recursive: true });
+  if (readdirSync(directory).length !== 0) {
+    throw new Error(`Release-candidate output directory must be empty: ${directory}`);
+  }
+}
+
+function replaceExactly(file, expected, replacement) {
+  const source = readFileSync(file, 'utf8');
+  if (source.split(expected).length - 1 !== 1) {
+    throw new Error(`${file} must contain exactly one ${JSON.stringify(expected)} marker`);
+  }
+  writeFileSync(file, source.replace(expected, replacement), 'utf8');
+}
+
+function run(command, args, cwd) {
+  execFileSync(command, args, {
+    cwd,
+    env: { ...process.env, PIP_DISABLE_PIP_VERSION_CHECK: '1', PYTHONDONTWRITEBYTECODE: '1' },
+    stdio: 'inherit',
+  });
+}
+
+function sha256(file) {
+  return `sha256:${createHash('sha256').update(readFileSync(file)).digest('hex')}`;
+}
+
+function build() {
+  const repositoryRoot = path.resolve(import.meta.dirname, '..');
+  const outputDirectory = parseOutputDirectory(process.argv.slice(2));
+  ensureEmptyDirectory(outputDirectory);
+  const stagingRoot = mkdtempSync(path.join(tmpdir(), 'agoragentic-front-door-rc-'));
+  const nodeStage = path.join(stagingRoot, 'node');
+  const pythonStage = path.join(stagingRoot, 'python');
+  const npmCommand = process.platform === 'win32' ? process.execPath : 'npm';
+  const npmArgs = process.platform === 'win32'
+    ? [path.join(path.dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npm-cli.js')]
+    : [];
+  const pythonExecutable = process.env.PYTHON || 'python';
+
+  try {
+    cpSync(path.join(repositoryRoot, 'sdk', 'node'), nodeStage, { recursive: true });
+    cpSync(path.join(repositoryRoot, 'sdk', 'python'), pythonStage, { recursive: true });
+
+    const nodePackagePath = path.join(nodeStage, 'package.json');
+    const nodePackage = JSON.parse(readFileSync(nodePackagePath, 'utf8'));
+    if (nodePackage.version !== SOURCE_VERSION) {
+      throw new Error(`Expected Node source version ${SOURCE_VERSION}; received ${nodePackage.version}`);
+    }
+    nodePackage.version = NODE_RC_VERSION;
+    writeFileSync(nodePackagePath, `${JSON.stringify(nodePackage, null, 2)}\n`, 'utf8');
+    replaceExactly(path.join(nodeStage, 'index.js'), `const SDK_VERSION = '${SOURCE_VERSION}';`, `const SDK_VERSION = '${NODE_RC_VERSION}';`);
+    replaceExactly(path.join(nodeStage, 'agent-os.js'), "'User-Agent': 'agoragentic-os-cli/1.6.5'", `'User-Agent': 'agoragentic-os-cli/${NODE_RC_VERSION}'`);
+    replaceExactly(path.join(nodeStage, 'agent-os.js'), "'User-Agent': 'agora-cli/1.6.5'", `'User-Agent': 'agora-cli/${NODE_RC_VERSION}'`);
+
+    replaceExactly(path.join(pythonStage, 'pyproject.toml'), `version = "${SOURCE_VERSION}"`, `version = "${PYTHON_RC_VERSION}"`);
+    replaceExactly(path.join(pythonStage, 'src', 'agoragentic', '__init__.py'), `__version__ = "${SOURCE_VERSION}"`, `__version__ = "${PYTHON_RC_VERSION}"`);
+    replaceExactly(path.join(pythonStage, 'src', 'agoragentic', 'client.py'), `_SDK_VERSION = "${SOURCE_VERSION}"`, `_SDK_VERSION = "${PYTHON_RC_VERSION}"`);
+
+    run(npmCommand, [...npmArgs, 'pack', '--pack-destination', outputDirectory], nodeStage);
+    run(pythonExecutable, ['-m', 'build', '--no-isolation', '--outdir', outputDirectory, pythonStage], repositoryRoot);
+
+    const artifacts = readdirSync(outputDirectory)
+      .filter((name) => name !== 'manifest.json')
+      .sort()
+      .map((name) => {
+        const artifactPath = path.join(outputDirectory, name);
+        if (!statSync(artifactPath).isFile()) throw new Error(`Unexpected artifact entry: ${name}`);
+        return { name, bytes: statSync(artifactPath).size, sha256: sha256(artifactPath) };
+      });
+    const expected = [
+      `agoragentic-${NODE_RC_VERSION}.tgz`,
+      `agoragentic-${PYTHON_RC_VERSION}.tar.gz`,
+      `agoragentic-${PYTHON_RC_VERSION}-py3-none-any.whl`,
+    ].sort();
+    if (JSON.stringify(artifacts.map(({ name }) => name)) !== JSON.stringify(expected)) {
+      throw new Error(`Unexpected release-candidate artifacts: ${artifacts.map(({ name }) => name).join(', ')}`);
+    }
+    const manifest = {
+      schema: 'agoragentic.front-door-release-candidate-manifest.v1',
+      publish_authorized: false,
+      source_version: SOURCE_VERSION,
+      node_version: NODE_RC_VERSION,
+      python_version: PYTHON_RC_VERSION,
+      artifacts,
+    };
+    writeFileSync(path.join(outputDirectory, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+    process.stdout.write(`${JSON.stringify(manifest, null, 2)}\n`);
+  } finally {
+    rmSync(stagingRoot, { recursive: true, force: true });
+  }
+}
+
+build();

--- a/scripts/verify-front-door-release-candidates.mjs
+++ b/scripts/verify-front-door-release-candidates.mjs
@@ -1,0 +1,175 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SOURCE_VERSION = '1.7.1';
+const NODE_RC_VERSION = '1.8.0-rc.0';
+const PYTHON_RC_VERSION = '1.8.0rc0';
+const EXPECTED_ARTIFACTS = Object.freeze([
+  'agoragentic-1.8.0-rc.0.tgz',
+  'agoragentic-1.8.0rc0-py3-none-any.whl',
+  'agoragentic-1.8.0rc0.tar.gz',
+]);
+
+function parseArtifactsDirectory(argv) {
+  const index = argv.indexOf('--artifacts');
+  if (index === -1 || !argv[index + 1] || index + 2 !== argv.length) {
+    throw new Error('Usage: node scripts/verify-front-door-release-candidates.mjs --artifacts <directory>');
+  }
+  return path.resolve(argv[index + 1]);
+}
+
+function run(command, args, cwd) {
+  return execFileSync(command, args, {
+    cwd,
+    env: { ...process.env, PIP_DISABLE_PIP_VERSION_CHECK: '1', PYTHONDONTWRITEBYTECODE: '1' },
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function hash(file) {
+  return `sha256:${createHash('sha256').update(readFileSync(file)).digest('hex')}`;
+}
+
+export function verifyManifest(directory) {
+  const manifest = JSON.parse(readFileSync(path.join(directory, 'manifest.json'), 'utf8'));
+  const manifestKeys = Object.keys(manifest).sort();
+  const expectedManifestKeys = [
+    'artifacts',
+    'node_version',
+    'publish_authorized',
+    'python_version',
+    'schema',
+    'source_version',
+  ].sort();
+  if (JSON.stringify(manifestKeys) !== JSON.stringify(expectedManifestKeys)
+    || manifest.schema !== 'agoragentic.front-door-release-candidate-manifest.v1'
+    || manifest.publish_authorized !== false
+    || manifest.source_version !== SOURCE_VERSION
+    || manifest.node_version !== NODE_RC_VERSION
+    || manifest.python_version !== PYTHON_RC_VERSION
+    || !Array.isArray(manifest.artifacts)) {
+    throw new Error('Release-candidate manifest contract is invalid');
+  }
+  const names = manifest.artifacts.map(({ name }) => name).sort();
+  if (JSON.stringify(names) !== JSON.stringify(EXPECTED_ARTIFACTS.slice().sort())) {
+    throw new Error('Release-candidate manifest contains an unexpected artifact set');
+  }
+  const directoryEntries = readdirSync(directory, { withFileTypes: true });
+  const directoryNames = directoryEntries.map(({ name }) => name).sort();
+  const expectedDirectoryNames = ['manifest.json', ...EXPECTED_ARTIFACTS].sort();
+  if (directoryEntries.some((entry) => !entry.isFile())
+    || JSON.stringify(directoryNames) !== JSON.stringify(expectedDirectoryNames)) {
+    throw new Error('Release-candidate directory contains an unexpected entry');
+  }
+  for (const artifact of manifest.artifacts) {
+    if (Object.keys(artifact).sort().join(',') !== 'bytes,name,sha256'
+      || !Number.isSafeInteger(artifact.bytes)
+      || artifact.bytes < 1
+      || !/^sha256:[a-f0-9]{64}$/.test(artifact.sha256)) {
+      throw new Error(`Release-candidate manifest entry is invalid: ${artifact.name}`);
+    }
+    const artifactPath = path.join(directory, artifact.name);
+    if (statSync(artifactPath).size !== artifact.bytes || hash(artifactPath) !== artifact.sha256) {
+      throw new Error(`Release-candidate hash mismatch: ${artifact.name}`);
+    }
+  }
+  return manifest;
+}
+
+function verifyNode(directory, manifest, cleanRoot) {
+  const npmCommand = process.platform === 'win32' ? process.execPath : 'npm';
+  const npmArgs = process.platform === 'win32'
+    ? [path.join(path.dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npm-cli.js')]
+    : [];
+  const project = path.join(cleanRoot, 'node-consumer');
+  mkdirSync(project);
+  const tarball = path.join(directory, manifest.artifacts.find(({ name }) => name.endsWith('.tgz')).name);
+  run(npmCommand, [...npmArgs, 'init', '--yes'], project);
+  run(npmCommand, [...npmArgs, 'install', '--offline', '--ignore-scripts', '--no-audit', '--no-fund', tarball], project);
+  const installedPackage = JSON.parse(readFileSync(path.join(project, 'node_modules', 'agoragentic', 'package.json'), 'utf8'));
+  if (installedPackage.version !== manifest.node_version
+    || installedPackage.bin.agoragentic !== 'agent-os.js'
+    || installedPackage.bin['agoragentic-os'] !== 'agent-os.js'
+    || installedPackage.bin.agora !== 'agent-os.js') {
+    throw new Error('Installed Node release candidate lost its binary compatibility contract');
+  }
+  const installedIndex = readFileSync(path.join(project, 'node_modules', 'agoragentic', 'index.js'), 'utf8');
+  const installedCli = readFileSync(path.join(project, 'node_modules', 'agoragentic', 'agent-os.js'), 'utf8');
+  if (!installedIndex.includes(`const SDK_VERSION = '${manifest.node_version}';`)
+    || !installedCli.includes(`agoragentic-os-cli/${manifest.node_version}`)
+    || !installedCli.includes(`agora-cli/${manifest.node_version}`)) {
+    throw new Error('Installed Node runtime identifiers do not match the candidate version');
+  }
+  const requireFromConsumer = createRequire(path.join(project, 'package.json'));
+  const governance = requireFromConsumer('agoragentic/governance');
+  const policy = governance.createDefaultPolicy();
+  if (policy.authority.spend !== 'owner_only' || policy.authority.retry !== 'owner_only') {
+    throw new Error('Installed Node governance policy delegated owner authority');
+  }
+  const cliOutput = run(npmCommand, [...npmArgs, 'exec', '--offline', '--', 'agoragentic', 'init', '--yes'], project);
+  if (!JSON.parse(cliOutput).result.written) {
+    throw new Error('Installed Node umbrella CLI did not produce a clean-room policy');
+  }
+  run(npmCommand, [...npmArgs, 'exec', '--offline', '--', 'agoragentic-os', '--help'], project);
+  run(npmCommand, [...npmArgs, 'exec', '--offline', '--', 'agora', '--help'], project);
+}
+
+function verifyPython(directory, manifest, cleanRoot) {
+  const pythonExecutable = process.env.PYTHON || 'python';
+  const project = path.join(cleanRoot, 'python-consumer');
+  const wheel = path.join(directory, manifest.artifacts.find(({ name }) => name.endsWith('.whl')).name);
+  run(pythonExecutable, ['-m', 'venv', project], cleanRoot);
+  const venvPython = process.platform === 'win32' ? path.join(project, 'Scripts', 'python.exe') : path.join(project, 'bin', 'python');
+  run(venvPython, ['-m', 'pip', 'install', '--no-index', '--no-deps', wheel], project);
+  const verifier = path.join(project, 'verify.py');
+  writeFileSync(verifier, [
+    'import json',
+    'from pathlib import Path',
+    'from agoragentic import __version__, create_default_policy, govern',
+    'from agoragentic.client import _SDK_VERSION',
+    `assert __version__ == ${JSON.stringify(manifest.python_version)}`,
+    `assert _SDK_VERSION == ${JSON.stringify(manifest.python_version)}`,
+    'policy = create_default_policy()',
+    "policy['actions']['fixture.read'] = {'decision': 'allow'}",
+    "safe_tool = govern(lambda value: {'accepted': True, 'value': value}, action='fixture.read', policy=policy, cwd='.')",
+    "secret = 'clean-room-private-value'",
+    'assert safe_tool(secret)["value"] == secret',
+    "receipts = list(Path('.agoragentic/receipts').glob('*.json'))",
+    'assert len(receipts) == 1',
+    "raw = receipts[0].read_text(encoding='utf-8')",
+    'receipt = json.loads(raw)',
+    "assert receipt['classification'] == 'local_tool_evidence'",
+    'assert secret not in raw',
+  ].join('\n'), 'utf8');
+  run(venvPython, [verifier], project);
+}
+
+function verify() {
+  const artifactsDirectory = parseArtifactsDirectory(process.argv.slice(2));
+  const manifest = verifyManifest(artifactsDirectory);
+  const cleanRoot = mkdtempSync(path.join(tmpdir(), 'agoragentic-front-door-clean-room-'));
+  try {
+    verifyNode(artifactsDirectory, manifest, cleanRoot);
+    verifyPython(artifactsDirectory, manifest, cleanRoot);
+    process.stdout.write(`${JSON.stringify({
+      ok: true,
+      network_registry_access: false,
+      publication_performed: false,
+      node_version: manifest.node_version,
+      python_version: manifest.python_version,
+      artifacts: readdirSync(artifactsDirectory).sort(),
+    }, null, 2)}\n`);
+  } finally {
+    rmSync(cleanRoot, { recursive: true, force: true });
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  verify();
+}

--- a/test/front-door-release-candidate.test.mjs
+++ b/test/front-door-release-candidate.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { verifyManifest } from '../scripts/verify-front-door-release-candidates.mjs';
+
+const root = path.resolve(import.meta.dirname, '..');
+const read = (relativePath) => readFileSync(path.join(root, relativePath), 'utf8');
+const artifactNames = [
+  'agoragentic-1.8.0-rc.0.tgz',
+  'agoragentic-1.8.0rc0-py3-none-any.whl',
+  'agoragentic-1.8.0rc0.tar.gz',
+];
+
+function writeFixture(directory, overrides = {}) {
+  const artifacts = artifactNames.map((name) => {
+    const content = Buffer.from(`fixture:${name}`);
+    writeFileSync(path.join(directory, name), content);
+    return {
+      name,
+      bytes: content.length,
+      sha256: `sha256:${createHash('sha256').update(content).digest('hex')}`,
+    };
+  });
+  const manifest = {
+    schema: 'agoragentic.front-door-release-candidate-manifest.v1',
+    publish_authorized: false,
+    source_version: '1.7.1',
+    node_version: '1.8.0-rc.0',
+    python_version: '1.8.0rc0',
+    artifacts,
+    ...overrides,
+  };
+  writeFileSync(path.join(directory, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+}
+
+test('front-door candidate build is versioned, non-publishing, and offline-verifiable', () => {
+  const build = read('scripts/build-front-door-release-candidates.mjs');
+  const verify = read('scripts/verify-front-door-release-candidates.mjs');
+  const workflow = read('.github/workflows/front-door-release-candidate.yml');
+
+  assert.match(build, /NODE_RC_VERSION = '1\.8\.0-rc\.0'/);
+  assert.match(build, /PYTHON_RC_VERSION = '1\.8\.0rc0'/);
+  assert.match(build, /publish_authorized: false/);
+  assert.match(verify, /'--offline'/);
+  assert.match(verify, /'--no-index'/);
+  assert.match(workflow, /^permissions:\s*\n\s*contents: read$/m);
+  assert.doesNotMatch(
+    `${build}\n${verify}\n${workflow}`,
+    /npm\s+publish|twine\s+upload|gh-action-pypi-publish|id-token:\s*write/i,
+  );
+});
+
+test('candidate verifier rejects false source attribution and unmanifested files', () => {
+  const sourceFixture = mkdtempSync(path.join(tmpdir(), 'agoragentic-front-door-source-mutation-'));
+  const extraFixture = mkdtempSync(path.join(tmpdir(), 'agoragentic-front-door-extra-artifact-'));
+  try {
+    writeFixture(sourceFixture, { source_version: 'tampered-source' });
+    assert.throws(() => verifyManifest(sourceFixture), /manifest contract is invalid/);
+
+    writeFixture(extraFixture);
+    writeFileSync(path.join(extraFixture, 'unmanifested-package.tgz'), 'unreviewed', 'utf8');
+    assert.throws(() => verifyManifest(extraFixture), /directory contains an unexpected entry/);
+  } finally {
+    rmSync(sourceFixture, { recursive: true, force: true });
+    rmSync(extraFixture, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Issue #334 needs reviewable npm and PyPI candidates for the unified Agoragentic front door without publishing either package.

This change builds `agoragentic@1.8.0-rc.0` and `agoragentic==1.8.0rc0` from the current 1.7.1 sources in temporary staging trees, records exact SHA-256 artifacts in a fail-closed manifest, and verifies clean-room installs with registry access disabled. The installed npm aliases are executed, the installed Python governance path is exercised, receipt redaction is checked, and mutation tests reject false source attribution or extra artifacts.

Publication remains a separate owner-reviewed action. The workflow has read-only repository permissions and no package-registry identity token.

Local validation:
- Candidate contract tests: 2/2 passed
- Full build: passed
- npm tarball install with `--offline --ignore-scripts`: passed
- Python wheel install with `--no-index --no-deps`: passed
- Installed `agoragentic`, `agoragentic-os`, and `agora` aliases: passed
- Node governance/release contract tests: 16/16 passed
- Python governance tests: 9/9 passed
- Independent Fable review: LGTM

No package was published, and no provider call, spend, deployment, or activation occurred.

Closes no issue; registry publication and post-publication trials remain tracked by #334.
