### PR TITLE
feat(assurance): implement Nevermined Stage A offline evidence importer

### DIFF
--- a/docs/repository-rename-preflight.json
+++ b/docs/repository-rename-preflight.json
@@ -1803,8 +1803,8 @@
       "path": "transaction-assurance/package.json",
       "occurrences": 2,
       "line_numbers": [
-        66,
-        71
+        68,
+        73
       ],
       "categories": [
         "installer_or_clone",

--- a/risk-fork-hosted-mcp/dist/runtime/index.mjs
+++ b/risk-fork-hosted-mcp/dist/runtime/index.mjs
@@ -72174,7 +72174,7 @@ function createE2BAuthorityFreeSourceVerifier(options = {}) {
 }
 
 // risk-fork-hosted-mcp/src/index.mjs
-var REVIEWED_SOURCE_INTEGRITY = true ? "sha256:dbbf606bdedee4a7363bd953232384a8d7734feb83a50e409dae43ed19b32216" : null;
+var REVIEWED_SOURCE_INTEGRITY = true ? "sha256:5086870d0e8475ae874751e939f6149e51bcc7e4904cad339be935ffa91cb07a" : null;
 var HOSTED_MCP_BUNDLE_METADATA = Object.freeze({
   package_name: "@agoragentic/risk-fork-hosted-mcp",
   package_version: "0.1.0-alpha.0",

--- a/risk-fork-hosted-mcp/integrity-manifest.json
+++ b/risk-fork-hosted-mcp/integrity-manifest.json
@@ -8,8 +8,8 @@
   "source_attestation": {
     "schema": "agoragentic.risk-fork-hosted-mcp.reviewed-sources.v2",
     "normalization": "utf8_crlf_to_lf_lone_cr_preserved",
-    "files": 58,
-    "sha256": "sha256:dbbf606bdedee4a7363bd953232384a8d7734feb83a50e409dae43ed19b32216"
+    "files": 62,
+    "sha256": "sha256:5086870d0e8475ae874751e939f6149e51bcc7e4904cad339be935ffa91cb07a"
   },
   "reviewed_sources": [
     {
@@ -261,6 +261,26 @@
       "path": "risk-fork/src/util.mjs",
       "bytes": 14559,
       "sha256": "sha256:285f3be0caf02b64fc523b1a410a1da5f3baba18b835836494a248bbf31fa064"
+    },
+    {
+      "path": "transaction-assurance/src/adapters/nevermined-cli.mjs",
+      "bytes": 5173,
+      "sha256": "sha256:e03ed124ebd4463172fd06d86fc8d6e12dc98f8fa28209e38c5a8852ab40d81a"
+    },
+    {
+      "path": "transaction-assurance/src/adapters/nevermined-json.mjs",
+      "bytes": 6851,
+      "sha256": "sha256:09a697b02b7b55d72b5d6deadea88c2ae93aaa44ee0d1577c0dea12bfe8218bc"
+    },
+    {
+      "path": "transaction-assurance/src/adapters/nevermined-ledger.mjs",
+      "bytes": 16797,
+      "sha256": "sha256:40c2f68a322ebe1a41601c21c1b15ab11b3547a90db5aaa25400793a301d1164"
+    },
+    {
+      "path": "transaction-assurance/src/adapters/nevermined-profile.mjs",
+      "bytes": 1894,
+      "sha256": "sha256:b166d7e1eb162fe86fc547587cf988c31ab51bd9ee3a48a1176d2c1e4b703d1b"
     },
     {
       "path": "transaction-assurance/src/canonical.mjs",
@@ -2589,7 +2609,7 @@
   "artifact": {
     "path": "dist/runtime/index.mjs",
     "bytes": 2970455,
-    "sha256": "sha256:8af5d618ce77d7c6d534fb72e54fc8241a29fd86479d4c3f1f4098b93f4e5053"
+    "sha256": "sha256:6f87b881d518f4dca2ff8fa584853ba9b9df5a40b2b3a64bd4d73e70a70adee1"
   },
   "packaged_assets": [
     {

--- a/transaction-assurance/bin/agora-assure.mjs
+++ b/transaction-assurance/bin/agora-assure.mjs
@@ -2,15 +2,13 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
-import {
-  buildAuthorityRequest,
+let buildAuthorityRequest,
   buildTransactionAssuranceEnvelope,
   canonicalize,
   detectAuthorityProtocol,
   evaluateTransactionAssuranceEnvelope,
   normalizeAuthorityArtifact,
-  sha256Ref,
-} from '../src/index.mjs';
+  sha256Ref;
 
 function usage() {
   return `Agoragentic Transaction Assurance (local/no-network)
@@ -24,6 +22,8 @@ Usage:
   agora-assure canonicalize <input.json>
   agora-assure hash <input.json>
   agora-assure self-test
+  agora-assure nevermined import --input <file> --profile <id> [--namespace <namespace>]
+  agora-assure nevermined --help
 
 The CLI never calls a network, signs a payment, moves money, creates a wallet,
 approves authority, deploys, publishes, or mutates marketplace trust.
@@ -148,7 +148,21 @@ function selfTest() {
   };
 }
 
-function main() {
+async function main() {
+  if (process.argv[2] === 'nevermined') {
+    const { runNeverminedCLI } = await import('../src/adapters/nevermined-cli.mjs');
+    process.exitCode = runNeverminedCLI(process.argv.slice(3));
+    return;
+  }
+  ({
+  buildAuthorityRequest,
+  buildTransactionAssuranceEnvelope,
+  canonicalize,
+  detectAuthorityProtocol,
+  evaluateTransactionAssuranceEnvelope,
+  normalizeAuthorityArtifact,
+  sha256Ref,
+} = await import('../src/index.mjs'));
   const [command, file] = process.argv.slice(2);
   if (!command || command === '--help' || command === '-h' || command === 'help') {
     process.stdout.write(usage());
@@ -195,9 +209,7 @@ function main() {
   }
 }
 
-try {
-  main();
-} catch (error) {
+main().catch((error) => {
   process.stderr.write(`agora-assure: ${error.message}\n`);
   process.exitCode = 1;
-}
+});

--- a/transaction-assurance/docs/nevermined-stage-a.md
+++ b/transaction-assurance/docs/nevermined-stage-a.md
@@ -1,0 +1,188 @@
+# Nevermined evidence importer: Stage A
+
+Source-only extension of `@agoragentic/transaction-assurance`, not another product.
+This module imports caller-supplied records locally. It cannot access accounts,
+read credentials, call a merchant, invoke RPC, move money, create delegations,
+change custody, or attach settlement checks. The existing package stays private
+and unpublished. No compatibility with a deployed Nevermined backend is claimed.
+
+## Supported evidence and fixture amendment
+
+The one built-in profile is `nevermined.merchant-payment.7c3e0c1dd00119f8e72983572c1807e78a9c1ee2`.
+It pins the **documentation**, not an API-version guarantee:
+
+- Repository: `nevermined-io/docs`
+- Commit: `7c3e0c1dd00119f8e72983572c1807e78a9c1ee2`
+- File: `products/catalog/router/ledger.mdx`, section **List payments**
+- Git blob: `40c5314dba599315497bf6a3d240f5ea8598b433`
+- Documented endpoint: `GET /api/v1/router/payments`
+- Source: <https://github.com/nevermined-io/docs/blob/7c3e0c1dd00119f8e72983572c1807e78a9c1ee2/products/catalog/router/ledger.mdx>
+
+This is the merchant-payment ledger, **not** the delegation charge ledger.
+Merchant `amount` is an atomic string with explicit `assetDecimals`; fee atomic
+amount and budget cents are different evidence fields. No cent conversion or
+netting is performed. A supplied `Settled` status remains a caller-supplied
+provider assertion, not an independently confirmed transfer.
+
+The September 9 implementation decision permits a vendor documentation example
+and separately labeled synthetic fixtures for Stage A development. This narrowly
+amends the v0.2 PDF's stronger real-export fixture gate; **that original gate has
+not passed**. Real-export validation, API-version-header guarantees, production
+interoperability, and external adoption remain unproven.
+
+`examples/nevermined/7c3e0c1/vendor-docs-example.json` preserves the published JSON
+block and its abbreviations. `provenance.json` identifies the source and exact
+fixture-byte digest. `synthetic-import.json` changes identifiers, wallets, amounts,
+and fee data as individually recorded in that sidecar. Synthetic values are not
+observed payments and must never be submitted as evidence of actual settlement.
+The abbreviated vendor example imports as incomplete and has no stable payment
+identity or valid transaction-hash interpretation.
+
+## Run locally
+
+From `transaction-assurance/`:
+
+```sh
+npm ci --ignore-scripts --no-audit --no-fund
+npm run test:nevermined
+node bin/agora-assure.mjs nevermined import \
+  --input examples/nevermined/7c3e0c1/synthetic-import.json \
+  --profile nevermined.merchant-payment.7c3e0c1dd00119f8e72983572c1807e78a9c1ee2
+```
+
+Dependency installation is a separate development step; the importer itself has
+no third-party runtime dependency and makes no network calls. JSON is written to
+stdout and a bounded human diagnosis to stderr. Use `--output <new-file>` to write
+JSON with exclusive creation and private file permissions. Existing files and
+symlinks are not overwritten. Nothing is saved unless the caller requests it.
+
+A raw vendor-shaped object or array is also accepted by the CLI with an explicit
+`--namespace sandbox:my-evidence-source`. Choose a stable non-secret namespace
+that separates environments and unrelated source datasets. The wrapper form
+shown in the fixture declares its namespace, profile and revision explicitly.
+The CLI does not consult a saved account, environment variable, or network to
+infer any of these values. Arbitrary mappings are not supported.
+
+```js
+import {
+  normalizeNeverminedLedger,
+  normalizeNeverminedExport,
+  NEVERMINED_PROFILE_ID,
+} from '@agoragentic/transaction-assurance/nevermined';
+
+const record = normalizeNeverminedLedger(suppliedEnvelope, {
+  profileId: NEVERMINED_PROFILE_ID,
+  history: suppliedPreviousEnvelopes,
+});
+const batch = normalizeNeverminedExport(suppliedBatchEnvelope);
+```
+
+`history` contains **raw single-record import envelopes**, not previously asserted
+assessment results. Supply it in either the envelope or the library option, never
+both. The CLI's `--history` reads such a JSON array. History is re-normalized and
+has no ability to add a trusted check. No hidden storage is used.
+
+## Three clarified contracts
+
+### Complete output and units
+
+The closed output schema includes identifiers, delegation references, source
+revision/profile provenance, original allowlisted scalars, merchant and buyer
+wallets, provider-created time, settlement reference classification, and a
+separate Router fee record. The fee record preserves atomic amount, scale,
+network/asset, rate basis points, budget cents, status, transaction reference,
+and authorization nonce. `feeCents: "0"` does not erase a nonzero atomic fee.
+The pinned vendor shape has at most one flattened Router-fee leg; it does not
+invent an array of additional fees or accept arbitrary vendor mappings.
+
+Atomic money is accepted only as an integer **string**, capped at 78 digits.
+Decimals must be explicit integers from 0 to 30. Invalid or unknown monetary
+values remain visible in `core.original` but have no normalized amount/display.
+Unknown networks, assets, protocols and opaque references are preserved, never
+coerced into Base USDC. A Base-USDC candidate is eligibility metadata only; it
+is not a chain observation, a balance check, or a payment approval.
+
+### Immutable core versus assessment
+
+`core` contains only stable source facts under the pinned interpretation and
+redaction profile. Its byte-equivalence is defined by canonical serialization,
+not JavaScript object prototypes or JSON indentation. `observation_context`
+contains caller capture time and a non-secret record-reference digest; it is not
+part of core identity. Processing timestamps are deliberately not generated.
+
+The payment identity key uses provider + namespace + full stable payment ID.
+The observation key additionally binds the redacted-source and profile digests.
+Missing or abbreviated payment IDs yield null keys, never synthesized ones.
+History changes `assessment.import_disposition` but cannot change the source core.
+An added check, when Stage B is separately implemented, must change assessment
+rather than invent a new provider snapshot.
+
+A compatible different observation is labeled `update`; it does not assert that
+it is newer by wall-clock time, select a latest winner, or discard earlier facts.
+Missing facts are not incompatible facts. Conflicting non-null immutable fields,
+merchant `Settled` versus `Failed`, or fee `Settled` versus `Released` are explicit
+conflicts between **supplied assertions**. Fee budget-cents changes are preserved,
+not used as a reason to fabricate settled or released money.
+
+### Contradiction precedence
+
+For one payment identity, contradictory supplied facts produce `conflict` and
+`contradicted`, even if an exact duplicate also exists or delivery evidence is
+missing. All chain, matching, amount-comparison, authority and outcome fields
+still remain `not_checked`: the conflict is not a trusted chain finding. Full
+batch comparison exposes conflicts on both affected observations; nothing is
+automatically overwritten or retried. Known but unsupported checks are preserved
+independently, and missing delivery cannot clear a contradiction.
+
+## Privacy and digest scope
+
+`core.original` is the **allowlisted, redacted projection**, not the original file.
+Unknown properties and `feeFailureReason` are dropped before hashing and output.
+HTTP(S) resource URLs lose userinfo, query and fragment; other URL schemes are
+omitted. Recognized credential patterns in retained evidence fields cause a
+value-free error. Never put secrets in source namespace/reference fields.
+Pattern detection is not a universal secret detector: callers must not supply
+credentials disguised as ordinary identifiers or paths.
+
+`redacted_source_hash` hashes exactly that bounded projection using adapter-local
+RFC 8785 serialization. It is not a byte hash of the export and deliberately
+ignores removed fields. The extraction profile, redaction rules, digest scope
+and canonicalization identifier accompany the digest. A hash is not an
+attestation; every imported record stays `caller_supplied`. The shared legacy
+canonicalizer is unchanged.
+
+Strict parsing rejects duplicate decoded keys, unsafe prototype names, malformed
+UTF-8, BOM, lone surrogates, non-finite/unsafe numeric literals, and executable
+object values. Fixed limits are 1 MiB input, 32 nesting levels, 1,000 bounded
+records/history entries and 64 KiB strings. The in-process API snapshots inert
+JSON values and rejects proxies, accessors, cycles and custom prototypes.
+
+## Process exits and stages
+
+Default exit `0` means a report was emitted, not that a commercial event completed.
+Invalid input/arguments return `64` with a stable error code and no report core;
+unexpected internal failures return `70`. Repeated `--fail-on` flags opt into
+`contradicted` (3), `unsupported` (4), then `unresolved` (2) precedence across the
+batch. Empty exports remain explicit empty batches, not successful transactions.
+
+Stage A never emits `evidence_complete`, validates authority, or promotes provider
+status to settlement. `nevermined attach-settlement` explicitly returns
+`stage_b_gated`. No Stage B API is exported. The stronger golden test involving
+trusted chain checks/exact settlement is deferred; the Stage A golden snapshot
+shows only a supplied assertion plus unassessed dimensions.
+
+Before Stage B, pin a checker-artifact contract with complete binding and adequate
+transfer evidence, implement an actual caller-configured trust path, and test
+untrusted artifacts, incorrect binding, missing/pending/reverted transactions and
+incomplete transfers. No fixture in this PR satisfies those gates.
+
+## Validation
+
+`test/nevermined-ledger.test.mjs` exercises parser, redaction, exact amounts,
+provenance, snapshots/history, report generation, CLI exits and exclusive output.
+The actual CLI is spawned with HTTP, fetch, sockets and DNS blocked before module
+imports by `test/fixtures/nevermined-no-network-preload.mjs`.
+`test/nevermined-schema.test.mjs` validates input/output/batch schemas and rejects
+invented verification, identities and invalid output states with locked Ajv.
+Existing package CI runs both files and the legacy regressions on Node 20/22/24.
+Do not describe a test run on one runtime as that entire matrix passing.

--- a/transaction-assurance/examples/nevermined/7c3e0c1/README.md
+++ b/transaction-assurance/examples/nevermined/7c3e0c1/README.md
@@ -1,0 +1,20 @@
+# Nevermined Stage A evidence fixtures
+
+Read [the importer contract](../../../docs/nevermined-stage-a.md) before using
+these fixtures. They are offline documentation-derived test data, not production
+records or proof of payment.
+
+- `vendor-docs-example.json`: unchanged JSON example, including ellipses, from
+  `nevermined-io/docs` commit `7c3e0c1dd00119f8e72983572c1807e78a9c1ee2`,
+  `products/catalog/router/ledger.mdx`, **List payments**.
+- `provenance.json`: source identity, precise fixture-byte digest, claim boundary,
+  and field-by-field synthetic modifications.
+- `synthetic-import.json`: a wrapper with fully formatted **synthetic** values
+  for deterministic parser tests, including independent merchant and fee fields.
+- `synthetic-expected.json`: Stage A golden output; every independent check remains
+  `not_checked` and the commercial outcome remains `unresolved`.
+
+From the package root, run `npm run test:nevermined`, or the import command in the
+linked contract. Never send these synthetic transaction hashes to a payment or
+settlement service as evidence of actual activity. Real-export and deployed
+backend compatibility remain untested.

--- a/transaction-assurance/examples/nevermined/7c3e0c1/provenance.json
+++ b/transaction-assurance/examples/nevermined/7c3e0c1/provenance.json
@@ -1,0 +1,66 @@
+{
+  "basis": "vendor_documentation_example",
+  "provider": "nevermined",
+  "repository": "nevermined-io/docs",
+  "commit": "7c3e0c1dd00119f8e72983572c1807e78a9c1ee2",
+  "path": "products/catalog/router/ledger.mdx",
+  "section": "List payments",
+  "endpoint": "GET /api/v1/router/payments",
+  "git_blob": "40c5314dba599315497bf6a3d240f5ea8598b433",
+  "source_url": "https://github.com/nevermined-io/docs/blob/7c3e0c1dd00119f8e72983572c1807e78a9c1ee2/products/catalog/router/ledger.mdx",
+  "fixture": "vendor-docs-example.json",
+  "fixture_hash": "sha256:3cb34a79d187301de455e5da0bb55999d740faa6398b7927f68ab6de582e9bdf",
+  "hash_scope": "UTF-8 JSON block content with trailing LF; not the complete MDX file",
+  "unchanged_abbreviations_preserved": true,
+  "observed_transaction": false,
+  "sanitized_real_export": false,
+  "api_version_header_contract_verified": false,
+  "synthetic_fixture": "synthetic-import.json",
+  "synthetic_changed_fields": {
+    "id": {
+      "vendor_example": "b1f9c2e4-…",
+      "synthetic": "synthetic-payment-001"
+    },
+    "amount": {
+      "vendor_example": "1000",
+      "synthetic": "10000"
+    },
+    "merchantAddress": {
+      "vendor_example": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+      "synthetic": "0x1111111111111111111111111111111111111111"
+    },
+    "txHash": {
+      "vendor_example": "0xfc8af37b…",
+      "synthetic": "0x3333333333333333333333333333333333333333333333333333333333333333"
+    },
+    "delegationId": {
+      "vendor_example": "5e7481c3-…",
+      "synthetic": "synthetic-delegation-001"
+    },
+    "requestId": {
+      "vendor_example": "order-1234",
+      "synthetic": "synthetic-request-001"
+    },
+    "buyer": {
+      "vendor_example": "0x8D6A5233…",
+      "synthetic": "0x2222222222222222222222222222222222222222"
+    },
+    "feeAtomic": {
+      "vendor_example": "0",
+      "synthetic": "200"
+    },
+    "feeBps": {
+      "vendor_example": 0,
+      "synthetic": 200
+    },
+    "feeStatus": {
+      "vendor_example": "None",
+      "synthetic": "Submitted"
+    },
+    "feeNonce": {
+      "vendor_example": null,
+      "synthetic": "0x4444444444444444444444444444444444444444444444444444444444444444"
+    }
+  },
+  "claim_boundary": "Documentation-derived parser tests only. No payment, account, live export, chain lookup, partnership, or production compatibility is established."
+}

--- a/transaction-assurance/examples/nevermined/7c3e0c1/synthetic-expected.json
+++ b/transaction-assurance/examples/nevermined/7c3e0c1/synthetic-expected.json
@@ -1,0 +1,121 @@
+{
+  "schema": "agoragentic.nevermined-evidence.v1",
+  "core": {
+    "source": {
+      "provider": "nevermined",
+      "namespace": "synthetic:sandbox:example",
+      "record_kind": "merchant_payment_ledger",
+      "schema_revision": "7c3e0c1dd00119f8e72983572c1807e78a9c1ee2",
+      "provenance": "caller_supplied",
+      "redacted_source_hash": "sha256:b2af6e1fc6b8dd667b07df9e502dea74aae118b07d917503baefc6bacb68eb0d",
+      "hash_scope": "redacted_bounded_source",
+      "canonicalization": "rfc8785-jcs",
+      "redaction_profile": "agoragentic.nevermined-allowlist-redaction.v1",
+      "extraction_profile": {
+        "id": "nevermined.merchant-payment.7c3e0c1dd00119f8e72983572c1807e78a9c1ee2",
+        "version": "1.0.0",
+        "digest": "sha256:420d609f4e69849ecc6c0203cf4c1c67bf3cad108128f13a70b639fe1850c1b7"
+      },
+      "source_artifact_embedded": false
+    },
+    "identity": {
+      "payment_identity_key": "sha256:e9cd7b0ca303612d53443bb10d55e1a886e976f4ac06abefa8e4ae1accfa03d0",
+      "observation_key": "sha256:10e4e230a0bdc5460b7cc9c0794eec0b03e2929249ace730cdec9fcb2eb94787"
+    },
+    "identifiers": {
+      "payment_id": "synthetic-payment-001",
+      "request_id": "synthetic-request-001"
+    },
+    "authority_refs": {
+      "delegation_ref": "synthetic-delegation-001",
+      "principal_ref": null,
+      "agent_ref": null
+    },
+    "merchant_payment": {
+      "provider_status": "Settled",
+      "status_family": "settled",
+      "protocol": "x402",
+      "network": "eip155:8453",
+      "asset": "USDC",
+      "amount_atomic": "10000",
+      "decimals": 6,
+      "amount_display": "0.01",
+      "buyer_wallet": "0x2222222222222222222222222222222222222222",
+      "merchant_wallet": "0x1111111111111111111111111111111111111111",
+      "settlement_ref": "0x3333333333333333333333333333333333333333333333333333333333333333",
+      "settlement_ref_kind": "evm_tx_hash",
+      "resource_url": "https://service.example/api/resource",
+      "created_at": "2026-07-01T09:00:55.605Z"
+    },
+    "fee_legs": [
+      {
+        "leg": "router_fee",
+        "provider_status": "Submitted",
+        "amount_atomic": "200",
+        "decimals": 6,
+        "network": "eip155:8453",
+        "asset": "USDC",
+        "rate_bps": 200,
+        "budget_cents": "0",
+        "settlement_ref": null,
+        "settlement_ref_kind": "absent",
+        "authorization_nonce": "0x4444444444444444444444444444444444444444444444444444444444444444",
+        "reconciliation": "not_checked"
+      }
+    ],
+    "original": {
+      "id": "synthetic-payment-001",
+      "createdAt": "2026-07-01T09:00:55.605Z",
+      "status": "Settled",
+      "protocol": "x402",
+      "network": "base",
+      "asset": "USDC",
+      "amount": "10000",
+      "merchantAddress": "0x1111111111111111111111111111111111111111",
+      "txHash": "0x3333333333333333333333333333333333333333333333333333333333333333",
+      "delegationId": "synthetic-delegation-001",
+      "requestId": "synthetic-request-001",
+      "resourceUrl": "https://service.example/api/resource",
+      "buyer": "0x2222222222222222222222222222222222222222",
+      "feeAtomic": "200",
+      "feeBps": 200,
+      "feeCents": "0",
+      "feeStatus": "Submitted",
+      "feeTxHash": null,
+      "feeNonce": "0x4444444444444444444444444444444444444444444444444444444444444444",
+      "assetSymbol": "USDC",
+      "assetDecimals": 6
+    }
+  },
+  "observation_context": {
+    "captured_at": "2026-09-09T00:00:00Z",
+    "record_ref_hash": "sha256:3e578f1961b827c749edbbadcefba2297157ef843fc2eb1c4a08299ef26d0536"
+  },
+  "assessment": {
+    "parse_status": "accepted",
+    "import_disposition": "new",
+    "prior_observation_keys": [],
+    "conflicts": [],
+    "support": {
+      "pinned_profile": true,
+      "base_usdc_candidate": true
+    },
+    "independent_settlement": {
+      "provenance": "reported_observation",
+      "chain_status": "not_checked",
+      "matching_status": "not_checked",
+      "evidence_ref": null
+    },
+    "amount_reconciliation": {
+      "ledger_amount": "not_checked",
+      "commercial_price": "not_checked"
+    },
+    "authority": "not_checked",
+    "outcome": "not_checked",
+    "overall_evidence_status": "unresolved",
+    "warnings": [
+      "atomic_fee_with_zero_budget_cents",
+      "source_fields_omitted"
+    ]
+  }
+}

--- a/transaction-assurance/examples/nevermined/7c3e0c1/synthetic-import.json
+++ b/transaction-assurance/examples/nevermined/7c3e0c1/synthetic-import.json
@@ -1,0 +1,38 @@
+{
+  "schema": "agoragentic.nevermined-import.v1",
+  "source": {
+    "provider": "nevermined",
+    "namespace": "synthetic:sandbox:example",
+    "record_kind": "merchant_payment_ledger",
+    "schema_revision": "7c3e0c1dd00119f8e72983572c1807e78a9c1ee2",
+    "captured_at": "2026-09-09T00:00:00Z",
+    "record_ref": "fixture:synthetic-payment-001"
+  },
+  "profile_id": "nevermined.merchant-payment.7c3e0c1dd00119f8e72983572c1807e78a9c1ee2",
+  "record": {
+    "raw": {
+      "id": "synthetic-payment-001",
+      "createdAt": "2026-07-01T09:00:55.605Z",
+      "status": "Settled",
+      "protocol": "x402",
+      "network": "base",
+      "asset": "USDC",
+      "amount": "10000",
+      "merchantAddress": "0x1111111111111111111111111111111111111111",
+      "txHash": "0x3333333333333333333333333333333333333333333333333333333333333333",
+      "delegationId": "synthetic-delegation-001",
+      "requestId": "synthetic-request-001",
+      "resourceUrl": "https://service.example/api/resource",
+      "buyer": "0x2222222222222222222222222222222222222222",
+      "feeAtomic": "200",
+      "feeBps": 200,
+      "feeCents": "0",
+      "feeStatus": "Submitted",
+      "feeTxHash": null,
+      "feeNonce": "0x4444444444444444444444444444444444444444444444444444444444444444",
+      "feeFailureReason": null,
+      "assetSymbol": "USDC",
+      "assetDecimals": 6
+    }
+  }
+}

--- a/transaction-assurance/examples/nevermined/7c3e0c1/vendor-docs-example.json
+++ b/transaction-assurance/examples/nevermined/7c3e0c1/vendor-docs-example.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "b1f9c2e4-…",
+    "createdAt": "2026-07-01T09:00:55.605Z",
+    "status": "Settled",
+    "protocol": "x402",
+    "network": "base",
+    "asset": "USDC",
+    "amount": "1000",
+    "merchantAddress": "0x209693Bc6afc0C5328bA36FaF03C514EF312287C",
+    "txHash": "0xfc8af37b…",
+    "delegationId": "5e7481c3-…",
+    "requestId": "order-1234",
+    "resourceUrl": "https://service.example/api/resource",
+    "buyer": "0x8D6A5233…",
+    "feeAtomic": "0",
+    "feeBps": 0,
+    "feeCents": "0",
+    "feeStatus": "None",
+    "feeTxHash": null,
+    "feeNonce": null,
+    "feeFailureReason": null,
+    "assetSymbol": "USDC",
+    "assetDecimals": 6
+  }
+]

--- a/transaction-assurance/package.json
+++ b/transaction-assurance/package.json
@@ -20,7 +20,8 @@
     "./external-verification-adapters": "./src/external-verification-adapters.mjs",
     "./conformance": "./src/conformance.mjs",
     "./evaluation-evidence": "./src/evaluation-evidence.mjs",
-    "./toploc-evidence": "./src/toploc-evidence.mjs"
+    "./toploc-evidence": "./src/toploc-evidence.mjs",
+    "./nevermined": "./src/adapters/nevermined-ledger.mjs"
   },
   "files": [
     "bin/",
@@ -40,10 +41,11 @@
   ],
   "scripts": {
     "test": "node --test test/*.test.mjs",
-    "check": "node --check src/canonical.mjs && node --check src/index.mjs && node --check src/protocol-adapters.mjs && node --check src/external-verification-adapters.mjs && node --check src/conformance.mjs && node --check src/evaluation-evidence.mjs && node --check src/toploc-evidence.mjs && node --check bin/agora-assure.mjs && node --check bin/run-conformance.mjs && node --check bin/verify-conformance-receipt.mjs && node --check examples/x402-generic-middleware.mjs && node --check examples/conformance-targets/x402-resource-server.mjs && node --check examples/conformance-targets/mcp-paid-tool.mjs && node --check examples/conformance-targets/agent-wallet-policy.mjs && node --check examples/conformance-targets/marketplace-listing.mjs && node --check examples/external-adopters/anchor-x402/target.mjs && node --check examples/external-adopters/anchor-x402/run.mjs",
+    "check": "node --check src/canonical.mjs && node --check src/index.mjs && node --check src/protocol-adapters.mjs && node --check src/external-verification-adapters.mjs && node --check src/conformance.mjs && node --check src/evaluation-evidence.mjs && node --check src/toploc-evidence.mjs && node --check bin/agora-assure.mjs && node --check bin/run-conformance.mjs && node --check bin/verify-conformance-receipt.mjs && node --check examples/x402-generic-middleware.mjs && node --check examples/conformance-targets/x402-resource-server.mjs && node --check examples/conformance-targets/mcp-paid-tool.mjs && node --check examples/conformance-targets/agent-wallet-policy.mjs && node --check examples/conformance-targets/marketplace-listing.mjs && node --check examples/external-adopters/anchor-x402/target.mjs && node --check examples/external-adopters/anchor-x402/run.mjs && node --check src/adapters/nevermined-json.mjs && node --check src/adapters/nevermined-profile.mjs && node --check src/adapters/nevermined-ledger.mjs && node --check src/adapters/nevermined-cli.mjs",
     "self-test": "node bin/agora-assure.mjs self-test",
     "conformance": "node bin/run-conformance.mjs --target-name agoragentic-reference-evaluator --target-commit local",
-    "pack:dry": "npm pack --dry-run"
+    "pack:dry": "npm pack --dry-run",
+    "test:nevermined": "node --test test/nevermined-ledger.test.mjs test/nevermined-schema.test.mjs"
   },
   "dependencies": {
     "ajv": "8.20.0",

--- a/transaction-assurance/schema/nevermined-evidence-batch.v1.json
+++ b/transaction-assurance/schema/nevermined-evidence-batch.v1.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agoragentic.com/schema/nevermined-evidence-batch.v1.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "records"
+  ],
+  "properties": {
+    "schema": {
+      "const": "agoragentic.nevermined-evidence-batch.v1"
+    },
+    "records": {
+      "type": "array",
+      "maxItems": 1000,
+      "items": {
+        "$ref": "https://agoragentic.com/schema/nevermined-evidence.v1.json"
+      }
+    }
+  }
+}

--- a/transaction-assurance/schema/nevermined-evidence.v1.json
+++ b/transaction-assurance/schema/nevermined-evidence.v1.json
@@ -1,0 +1,558 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agoragentic.com/schema/nevermined-evidence.v1.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "core",
+    "observation_context",
+    "assessment"
+  ],
+  "properties": {
+    "schema": {
+      "const": "agoragentic.nevermined-evidence.v1"
+    },
+    "core": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source",
+        "identity",
+        "identifiers",
+        "authority_refs",
+        "merchant_payment",
+        "fee_legs",
+        "original"
+      ],
+      "properties": {
+        "source": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "provider",
+            "namespace",
+            "record_kind",
+            "schema_revision",
+            "provenance",
+            "redacted_source_hash",
+            "hash_scope",
+            "canonicalization",
+            "redaction_profile",
+            "extraction_profile",
+            "source_artifact_embedded"
+          ],
+          "properties": {
+            "provider": {
+              "const": "nevermined"
+            },
+            "namespace": {
+              "$ref": "#/$defs/source_identifier"
+            },
+            "record_kind": {
+              "const": "merchant_payment_ledger"
+            },
+            "schema_revision": {
+              "$ref": "#/$defs/source_identifier"
+            },
+            "provenance": {
+              "const": "caller_supplied"
+            },
+            "redacted_source_hash": {
+              "$ref": "#/$defs/nullable_digest"
+            },
+            "hash_scope": {
+              "const": "redacted_bounded_source"
+            },
+            "canonicalization": {
+              "const": "rfc8785-jcs"
+            },
+            "redaction_profile": {
+              "const": "agoragentic.nevermined-allowlist-redaction.v1"
+            },
+            "extraction_profile": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "id",
+                "version",
+                "digest"
+              ],
+              "properties": {
+                "id": {
+                  "$ref": "#/$defs/source_identifier"
+                },
+                "version": {
+                  "$ref": "#/$defs/nullable_text"
+                },
+                "digest": {
+                  "$ref": "#/$defs/nullable_digest"
+                }
+              }
+            },
+            "source_artifact_embedded": {
+              "const": false
+            }
+          }
+        },
+        "identity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "payment_identity_key",
+            "observation_key"
+          ],
+          "properties": {
+            "payment_identity_key": {
+              "$ref": "#/$defs/nullable_digest"
+            },
+            "observation_key": {
+              "$ref": "#/$defs/nullable_digest"
+            }
+          }
+        },
+        "identifiers": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "payment_id",
+            "request_id"
+          ],
+          "properties": {
+            "payment_id": {
+              "$ref": "#/$defs/nullable_text"
+            },
+            "request_id": {
+              "$ref": "#/$defs/nullable_text"
+            }
+          }
+        },
+        "authority_refs": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "delegation_ref",
+            "principal_ref",
+            "agent_ref"
+          ],
+          "properties": {
+            "delegation_ref": {
+              "$ref": "#/$defs/nullable_text"
+            },
+            "principal_ref": {
+              "const": null
+            },
+            "agent_ref": {
+              "const": null
+            }
+          }
+        },
+        "merchant_payment": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "provider_status",
+            "status_family",
+            "protocol",
+            "network",
+            "asset",
+            "amount_atomic",
+            "decimals",
+            "amount_display",
+            "buyer_wallet",
+            "merchant_wallet",
+            "settlement_ref",
+            "settlement_ref_kind",
+            "resource_url",
+            "created_at"
+          ],
+          "properties": {
+            "provider_status": {
+              "$ref": "#/$defs/nullable_text"
+            },
+            "status_family": {
+              "enum": [
+                "issued",
+                "settled",
+                "failed",
+                "unknown"
+              ]
+            },
+            "protocol": {
+              "$ref": "#/$defs/nullable_text"
+            },
+            "network": {
+              "$ref": "#/$defs/nullable_text"
+            },
+            "asset": {
+              "$ref": "#/$defs/nullable_text"
+            },
+            "amount_atomic": {
+              "$ref": "#/$defs/atomic_units"
+            },
+            "decimals": {
+              "$ref": "#/$defs/decimal_scale"
+            },
+            "amount_display": {
+              "$ref": "#/$defs/nullable_text"
+            },
+            "buyer_wallet": {
+              "$ref": "#/$defs/nullable_text"
+            },
+            "merchant_wallet": {
+              "$ref": "#/$defs/nullable_text"
+            },
+            "settlement_ref": {
+              "$ref": "#/$defs/nullable_text"
+            },
+            "settlement_ref_kind": {
+              "$ref": "#/$defs/reference_kind"
+            },
+            "resource_url": {
+              "$ref": "#/$defs/nullable_text"
+            },
+            "created_at": {
+              "$ref": "#/$defs/nullable_text"
+            }
+          }
+        },
+        "fee_legs": {
+          "type": "array",
+          "maxItems": 32,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "leg",
+              "provider_status",
+              "amount_atomic",
+              "decimals",
+              "network",
+              "asset",
+              "rate_bps",
+              "budget_cents",
+              "settlement_ref",
+              "settlement_ref_kind",
+              "authorization_nonce",
+              "reconciliation"
+            ],
+            "properties": {
+              "leg": {
+                "const": "router_fee"
+              },
+              "provider_status": {
+                "$ref": "#/$defs/nullable_text"
+              },
+              "amount_atomic": {
+                "$ref": "#/$defs/atomic_units"
+              },
+              "decimals": {
+                "$ref": "#/$defs/decimal_scale"
+              },
+              "network": {
+                "$ref": "#/$defs/nullable_text"
+              },
+              "asset": {
+                "$ref": "#/$defs/nullable_text"
+              },
+              "rate_bps": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "minimum": 0
+              },
+              "budget_cents": {
+                "$ref": "#/$defs/atomic_units"
+              },
+              "settlement_ref": {
+                "$ref": "#/$defs/nullable_text"
+              },
+              "settlement_ref_kind": {
+                "$ref": "#/$defs/reference_kind"
+              },
+              "authorization_nonce": {
+                "$ref": "#/$defs/nullable_text"
+              },
+              "reconciliation": {
+                "const": "not_checked"
+              }
+            }
+          }
+        },
+        "original": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [],
+          "properties": {
+            "id": {
+              "$ref": "#/$defs/source_scalar"
+            },
+            "createdAt": {
+              "$ref": "#/$defs/source_scalar"
+            },
+            "status": {
+              "$ref": "#/$defs/source_scalar"
+            },
+            "protocol": {
+              "$ref": "#/$defs/source_scalar"
+            },
+            "network": {
+              "$ref": "#/$defs/source_scalar"
+            },
+            "asset": {
+              "$ref": "#/$defs/source_scalar"
+            },
+            "amount": {
+              "$ref": "#/$defs/source_scalar"
+            },
+            "merchantAddress": {
+              "$ref": "#/$defs/source_scalar"
+            },
+            "txHash": {
+              "$ref": "#/$defs/source_scalar"
+            },
+            "delegationId": {
+              "$ref": "#/$defs/source_scalar"
+            },
+            "requestId": {
+              "$ref": "#/$defs/source_scalar"
+            },
+            "resourceUrl": {
+              "$ref": "#/$defs/source_scalar"
+            },
+            "buyer": {
+              "$ref": "#/$defs/source_scalar"
+            },
+            "feeAtomic": {
+              "$ref": "#/$defs/source_scalar"
+            },
+            "feeBps": {
+              "$ref": "#/$defs/source_scalar"
+            },
+            "feeCents": {
+              "$ref": "#/$defs/source_scalar"
+            },
+            "feeStatus": {
+              "$ref": "#/$defs/source_scalar"
+            },
+            "feeTxHash": {
+              "$ref": "#/$defs/source_scalar"
+            },
+            "feeNonce": {
+              "$ref": "#/$defs/source_scalar"
+            },
+            "assetSymbol": {
+              "$ref": "#/$defs/source_scalar"
+            },
+            "assetDecimals": {
+              "$ref": "#/$defs/source_scalar"
+            }
+          }
+        }
+      }
+    },
+    "observation_context": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "captured_at",
+        "record_ref_hash"
+      ],
+      "properties": {
+        "captured_at": {
+          "$ref": "#/$defs/nullable_text"
+        },
+        "record_ref_hash": {
+          "$ref": "#/$defs/nullable_digest"
+        }
+      }
+    },
+    "assessment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "parse_status",
+        "import_disposition",
+        "prior_observation_keys",
+        "conflicts",
+        "support",
+        "independent_settlement",
+        "amount_reconciliation",
+        "authority",
+        "outcome",
+        "overall_evidence_status",
+        "warnings"
+      ],
+      "properties": {
+        "parse_status": {
+          "enum": [
+            "accepted",
+            "incomplete"
+          ]
+        },
+        "import_disposition": {
+          "enum": [
+            "new",
+            "duplicate",
+            "update",
+            "conflict"
+          ]
+        },
+        "prior_observation_keys": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/nullable_digest"
+          }
+        },
+        "conflicts": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "support": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "pinned_profile",
+            "base_usdc_candidate"
+          ],
+          "properties": {
+            "pinned_profile": {
+              "type": "boolean"
+            },
+            "base_usdc_candidate": {
+              "type": "boolean"
+            }
+          }
+        },
+        "independent_settlement": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "provenance",
+            "chain_status",
+            "matching_status",
+            "evidence_ref"
+          ],
+          "properties": {
+            "provenance": {
+              "const": "reported_observation"
+            },
+            "chain_status": {
+              "const": "not_checked"
+            },
+            "matching_status": {
+              "const": "not_checked"
+            },
+            "evidence_ref": {
+              "const": null
+            }
+          }
+        },
+        "amount_reconciliation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "ledger_amount",
+            "commercial_price"
+          ],
+          "properties": {
+            "ledger_amount": {
+              "const": "not_checked"
+            },
+            "commercial_price": {
+              "const": "not_checked"
+            }
+          }
+        },
+        "authority": {
+          "const": "not_checked"
+        },
+        "outcome": {
+          "const": "not_checked"
+        },
+        "overall_evidence_status": {
+          "enum": [
+            "unresolved",
+            "contradicted",
+            "unsupported"
+          ]
+        },
+        "warnings": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "nullable_text": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "source_scalar": {
+      "type": [
+        "string",
+        "number",
+        "boolean",
+        "null"
+      ]
+    },
+    "nullable_digest": {
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "atomic_units": {
+      "anyOf": [
+        {
+          "type": "string",
+          "pattern": "^(0|[1-9][0-9]{0,77})$"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "decimal_scale": {
+      "anyOf": [
+        {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 30
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "reference_kind": {
+      "enum": [
+        "absent",
+        "abbreviated",
+        "opaque",
+        "evm_tx_hash"
+      ]
+    },
+    "source_identifier": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    }
+  }
+}

--- a/transaction-assurance/schema/nevermined-import.v1.json
+++ b/transaction-assurance/schema/nevermined-import.v1.json
@@ -1,0 +1,183 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://agoragentic.com/schema/nevermined-import.v1.json",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "source",
+    "profile_id",
+    "record"
+  ],
+  "properties": {
+    "schema": {
+      "const": "agoragentic.nevermined-import.v1"
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider",
+        "namespace",
+        "record_kind",
+        "schema_revision"
+      ],
+      "properties": {
+        "provider": {
+          "const": "nevermined"
+        },
+        "namespace": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "record_kind": {
+          "const": "merchant_payment_ledger"
+        },
+        "schema_revision": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "captured_at": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "record_ref": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 2048
+        }
+      }
+    },
+    "profile_id": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "profile_digest": {
+      "type": "string",
+      "pattern": "^sha256:[a-f0-9]{64}$"
+    },
+    "record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "raw"
+      ],
+      "properties": {
+        "raw": {
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": true
+            },
+            {
+              "type": "array",
+              "maxItems": 1000,
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          ]
+        }
+      }
+    },
+    "history": {
+      "type": "array",
+      "maxItems": 1000,
+      "items": {
+        "$ref": "#/$defs/history"
+      }
+    }
+  },
+  "$defs": {
+    "history": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema",
+        "source",
+        "profile_id",
+        "record"
+      ],
+      "properties": {
+        "schema": {
+          "const": "agoragentic.nevermined-import.v1"
+        },
+        "source": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "provider",
+            "namespace",
+            "record_kind",
+            "schema_revision"
+          ],
+          "properties": {
+            "provider": {
+              "const": "nevermined"
+            },
+            "namespace": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256
+            },
+            "record_kind": {
+              "const": "merchant_payment_ledger"
+            },
+            "schema_revision": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 256
+            },
+            "captured_at": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "record_ref": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "maxLength": 2048
+            }
+          }
+        },
+        "profile_id": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "profile_digest": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        },
+        "record": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "raw"
+          ],
+          "properties": {
+            "raw": {
+              "type": "object",
+              "additionalProperties": true
+            }
+          }
+        },
+        "history": {
+          "type": "array",
+          "maxItems": 0
+        }
+      }
+    }
+  }
+}

--- a/transaction-assurance/src/adapters/nevermined-cli.mjs
+++ b/transaction-assurance/src/adapters/nevermined-cli.mjs
@@ -1,0 +1,101 @@
+import fs from 'node:fs';
+import {
+  NEVERMINED_PROFILE_ID, NEVERMINED_PROFILE_DIGEST, NEVERMINED_REVISION,
+  NeverminedImportError, parseNeverminedJson, normalizeNeverminedExport,
+  renderNeverminedReport,
+} from './nevermined-ledger.mjs';
+import { LIMITS } from './nevermined-json.mjs';
+
+const fail = (code) => { throw new NeverminedImportError(code); };
+const HELP = `Nevermined evidence importer — Stage A, local only
+agora-assure nevermined import --input ledger.json --profile ${NEVERMINED_PROFILE_ID}
+  [--namespace sandbox:example] [--history envelopes.json] [--output evidence.json]
+  [--fail-on unresolved|contradicted|unsupported ...]
+Use --namespace with a raw record/array. Wrapped imports declare their own namespace.
+History is an array of raw import envelopes, not previously claimed verification results.
+JSON goes to stdout, or a NEW file at --output. Human report goes to stderr.
+Profile basis: vendor documentation, not a real export. Stage B remains gated.
+`;
+
+function readBounded(file, budget) {
+  let fd;
+  try {
+    fd = fs.openSync(file, 'r');
+    const stat = fs.fstatSync(fd);
+    if (!stat.isFile()) fail('invalid_input_file');
+    if (stat.size > budget) fail('input_too_large');
+    // Cap the actual read too: the file may change after fstat.
+    const buffer = Buffer.alloc(budget + 1);
+    let size = 0; let n;
+    do { n = fs.readSync(fd, buffer, size, buffer.length - size, null); size += n; }
+    while (n && size < buffer.length);
+    if (size > budget) fail('input_too_large');
+    return buffer.subarray(0, size);
+  } catch (error) {
+    if (error instanceof NeverminedImportError) throw error;
+    fail('input_read_failed');
+  } finally { if (fd !== undefined) fs.closeSync(fd); }
+}
+
+export function neverminedExitCode(records, selected = []) {
+  const states = new Set(records.map((record) => record.assessment.overall_evidence_status));
+  if (selected.includes('contradicted') && states.has('contradicted')) return 3;
+  if (selected.includes('unsupported') && states.has('unsupported')) return 4;
+  if (selected.includes('unresolved') && states.has('unresolved')) return 2;
+  return 0;
+}
+
+export function runNeverminedCLI(argv, io = { stdout: process.stdout, stderr: process.stderr }) {
+  try {
+    if (!argv.length || ['help', '--help', '-h'].includes(argv[0])) { io.stdout.write(HELP); return 0; }
+    if (argv[0] === 'attach-settlement') fail('stage_b_gated');
+    if (argv[0] !== 'import') fail('invalid_command');
+    const options = Object.create(null); const selected = [];
+    for (let i = 1; i < argv.length; i += 2) {
+      const key = argv[i]; const value = argv[i + 1];
+      if (!['--input', '--profile', '--namespace', '--output', '--history', '--fail-on'].includes(key) || !value || value.startsWith('--')) fail('invalid_arguments');
+      if (key === '--fail-on') {
+        if (!['unresolved', 'contradicted', 'unsupported'].includes(value)) fail('invalid_arguments');
+        selected.push(value);
+      } else {
+        if (Object.hasOwn(options, key)) fail('invalid_arguments');
+        options[key] = value;
+      }
+    }
+    if (!options['--input'] || !options['--profile']) fail('invalid_arguments');
+    const inputBytes = readBounded(options['--input'], LIMITS.bytes);
+    const input = parseNeverminedJson(inputBytes);
+    let envelope;
+    if (input && !Array.isArray(input) && Object.hasOwn(input, 'schema')) {
+      envelope = input;
+      if (envelope.profile_id !== options['--profile']) fail('profile_id_mismatch');
+      if (options['--namespace'] && options['--namespace'] !== envelope.source?.namespace) fail('namespace_mismatch');
+    } else {
+      if (!options['--namespace']) fail('namespace_required');
+      if (options['--profile'] !== NEVERMINED_PROFILE_ID) fail('unsupported_profile');
+      envelope = {
+        schema: 'agoragentic.nevermined-import.v1',
+        source: { provider: 'nevermined', namespace: options['--namespace'], record_kind: 'merchant_payment_ledger', schema_revision: NEVERMINED_REVISION },
+        profile_id: NEVERMINED_PROFILE_ID, profile_digest: NEVERMINED_PROFILE_DIGEST,
+        record: { raw: input },
+      };
+    }
+    if (options['--history']) {
+      if (Object.hasOwn(envelope, 'history')) fail('ambiguous_history');
+      envelope.history = parseNeverminedJson(readBounded(options['--history'], LIMITS.bytes - inputBytes.length));
+    }
+    const report = normalizeNeverminedExport(envelope);
+    const json = JSON.stringify(report, null, 2) + '\n';
+    if (options['--output']) {
+      // Never overwrite an existing artifact, input, credential file, or symlink.
+      try { fs.writeFileSync(options['--output'], json, { flag: 'wx', mode: 0o600 }); }
+      catch { fail('output_write_failed'); }
+    } else io.stdout.write(json);
+    io.stderr.write(report.records.map(renderNeverminedReport).join('\n'));
+    return neverminedExitCode(report.records, selected);
+  } catch (error) {
+    const code = error instanceof NeverminedImportError ? error.code : 'internal_error';
+    io.stderr.write(JSON.stringify({ schema: 'agoragentic.nevermined-import-error.v1', code, retryable: false }) + '\n');
+    return code === 'internal_error' ? 70 : 64;
+  }
+}

--- a/transaction-assurance/src/adapters/nevermined-json.mjs
+++ b/transaction-assurance/src/adapters/nevermined-json.mjs
@@ -1,0 +1,160 @@
+import { createHash } from 'node:crypto';
+import { types } from 'node:util';
+
+export const LIMITS = Object.freeze({ bytes: 1048576, depth: 32, records: 1000, stringBytes: 65536, amountDigits: 78, decimals: 30, feeLegs: 32 });
+
+/** Stable errors never include input values, filenames, keys, or parser excerpts. */
+export class NeverminedImportError extends Error {
+  constructor(code) {
+    super(code);
+    this.name = 'NeverminedImportError';
+    this.code = code;
+  }
+}
+const fail = (code) => { throw new NeverminedImportError(code); };
+const forbiddenKey = (key) => ['__proto__', 'prototype', 'constructor'].includes(key);
+
+function checkString(text) {
+  if (Buffer.byteLength(text, 'utf8') > LIMITS.stringBytes) fail('limit_exceeded');
+  for (let i = 0; i < text.length; i++) {
+    const c = text.charCodeAt(i);
+    if (c >= 0xd800 && c <= 0xdbff) {
+      const next = text.charCodeAt(++i);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) fail('invalid_unicode');
+    } else if (c >= 0xdc00 && c <= 0xdfff) fail('invalid_unicode');
+  }
+}
+
+/** Strict literal JSON, including duplicate decoded property names at every level. */
+export function parseNeverminedJson(input) {
+  if (typeof input !== 'string' && !Buffer.isBuffer(input)) fail('invalid_input');
+  if (Buffer.byteLength(input, 'utf8') > LIMITS.bytes) fail('input_too_large');
+  let text;
+  try { text = Buffer.isBuffer(input) ? new TextDecoder('utf-8', { fatal: true, ignoreBOM: true }).decode(input) : input; }
+  catch { fail('invalid_utf8'); }
+  let pos = 0;
+  const ws = () => { while (/[\x20\x09\x0a\x0d]/.test(text[pos] ?? '\uFFFF')) pos++; };
+  function string() {
+    const start = pos++;
+    let escaped = false;
+    while (pos < text.length) {
+      const char = text[pos++];
+      if (!escaped && char === '"') {
+        let value;
+        try { value = JSON.parse(text.slice(start, pos)); } catch { fail('invalid_json'); }
+        checkString(value);
+        return value;
+      }
+      if (!escaped && char === '\\') escaped = true;
+      else escaped = false;
+    }
+    fail('invalid_json');
+  }
+  function value(depth) {
+    ws();
+    const c = text[pos];
+    if (c === '"') return string();
+    if (c === '{' || c === '[') {
+      if (depth >= LIMITS.depth) fail('limit_exceeded');
+      const object = c === '{';
+      const result = object ? Object.create(null) : [];
+      const seen = new Set();
+      const end = object ? '}' : ']';
+      pos++; ws();
+      if (text[pos] === end) { pos++; return result; }
+      while (pos < text.length) {
+        if (object) {
+          if (text[pos] !== '"') fail('invalid_json');
+          const key = string();
+          if (seen.has(key)) fail('duplicate_key');
+          if (forbiddenKey(key)) fail('unsafe_key');
+          seen.add(key); ws();
+          if (text[pos++] !== ':') fail('invalid_json');
+          result[key] = value(depth + 1);
+        } else {
+          if (result.length >= LIMITS.records) fail('limit_exceeded');
+          result.push(value(depth + 1));
+        }
+        ws();
+        if (text[pos] === end) { pos++; return result; }
+        if (text[pos++] !== ',') fail('invalid_json');
+        ws();
+      }
+      fail('invalid_json');
+    }
+    for (const [literal, result] of [['true', true], ['false', false], ['null', null]]) {
+      if (text.startsWith(literal, pos)) { pos += literal.length; return result; }
+    }
+    const match = /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?/.exec(text.slice(pos));
+    if (!match) fail('invalid_json');
+    pos += match[0].length;
+    const number = Number(match[0]);
+    if (!Number.isFinite(number)) fail('unsafe_number');
+    if (Number.isInteger(number) && !Number.isSafeInteger(number)) fail('unsafe_number');
+    return number;
+  }
+  const result = value(0); ws();
+  if (pos !== text.length) fail('invalid_json');
+  return result;
+}
+
+/** Snapshot inert JSON data without executing getters, proxies, toJSON, or coercions. */
+export function snapshotJson(input) {
+  if (typeof input === 'string' || Buffer.isBuffer(input)) return parseNeverminedJson(input);
+  const ancestors = new Set();
+  let bytes = 0;
+  function clone(value, depth) {
+    if (types.isProxy(value)) fail('invalid_input');
+    if (typeof value === 'string') { checkString(value); bytes += Buffer.byteLength(JSON.stringify(value)); }
+    else if (typeof value === 'number') {
+      if (!Number.isFinite(value) || (Number.isInteger(value) && !Number.isSafeInteger(value))) fail('unsafe_number');
+      bytes += String(value).length;
+    } else if (value === null || typeof value === 'boolean') bytes += 5;
+    else if (typeof value === 'object') {
+      if (depth >= LIMITS.depth || ancestors.has(value)) fail('limit_exceeded');
+      const array = Array.isArray(value);
+      if (!array && ![Object.prototype, null].includes(Object.getPrototypeOf(value))) fail('invalid_input');
+      const keys = Reflect.ownKeys(value);
+      const desc = Object.getOwnPropertyDescriptors(value);
+      if (array && value.length > LIMITS.records) fail('limit_exceeded');
+      const result = array ? [] : Object.create(null);
+      ancestors.add(value);
+      for (const key of keys) {
+        if (array && key === 'length') continue;
+        if (typeof key !== 'string' || forbiddenKey(key)) fail('unsafe_key');
+        checkString(key);
+        if (!('value' in desc[key]) || !desc[key].enumerable) fail('invalid_input');
+        if (array && !/^(0|[1-9]\d*)$/.test(key)) fail('invalid_input');
+        bytes += array ? 1 : Buffer.byteLength(JSON.stringify(key)) + 2;
+        result[key] = clone(desc[key].value, depth + 1);
+      }
+      if (array && Object.keys(result).length !== value.length) fail('invalid_input');
+      ancestors.delete(value);
+      bytes += 2;
+      if (bytes > LIMITS.bytes) fail('input_too_large');
+      return result;
+    } else fail('invalid_input');
+    if (bytes > LIMITS.bytes) fail('input_too_large');
+    return value;
+  }
+  const result = clone(input, 0);
+  if (Buffer.byteLength(JSON.stringify(result)) > LIMITS.bytes) fail('input_too_large');
+  return result;
+}
+
+/** RFC 8785 serialization for already validated I-JSON; emit keys directly, not via object enumeration. */
+export function canonicalNeverminedJson(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalNeverminedJson).join(',')}]`;
+  if (value !== null && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${canonicalNeverminedJson(value[key])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+export const digestJson = (value) => `sha256:${createHash('sha256').update(canonicalNeverminedJson(value), 'utf8').digest('hex')}`;
+export function freezeDeep(value) {
+  if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+    Object.values(value).forEach(freezeDeep);
+    Object.freeze(value);
+  }
+  return value;
+}

--- a/transaction-assurance/src/adapters/nevermined-ledger.mjs
+++ b/transaction-assurance/src/adapters/nevermined-ledger.mjs
@@ -1,0 +1,260 @@
+import { snapshotJson, digestJson, freezeDeep, NeverminedImportError, LIMITS } from './nevermined-json.mjs';
+import { NEVERMINED_PROFILE, NEVERMINED_PROFILE_ID, NEVERMINED_PROFILE_DIGEST, NEVERMINED_REVISION } from './nevermined-profile.mjs';
+export { NEVERMINED_PROFILE_ID, NEVERMINED_PROFILE_DIGEST, NEVERMINED_REVISION, NEVERMINED_PROFILE };
+export { NeverminedImportError, parseNeverminedJson, canonicalNeverminedJson } from './nevermined-json.mjs';
+
+const fail = (code) => { throw new NeverminedImportError(code); };
+const object = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
+const has = (value, key) => Object.hasOwn(value, key);
+const text = (value) => typeof value === 'string' && value.length ? value : null;
+const abbreviated = (value) => typeof value === 'string' && /…|\.\.\./u.test(value);
+const digestPattern = /^sha256:[a-f0-9]{64}$/;
+const secretLike = (value) => typeof value === 'string' && /(?:\b(?:bearer|basic)\s+\S+|\b(?:amk_|sk_(?:live|test)_|sk-proj-|nvm_(?:live|sandbox)_)[A-Za-z0-9_-]+|-----BEGIN [A-Z ]*PRIVATE KEY-----|\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)/i.test(value);
+const allKeys = (obj, allowed) => { if (Object.keys(obj).some((key) => !allowed.includes(key))) fail('invalid_envelope'); };
+
+function validateEnvelope(input, allowArray = false) {
+  if (!object(input)) fail('invalid_envelope');
+  allKeys(input, ['schema', 'source', 'profile_id', 'profile_digest', 'record', 'history']);
+  if (input.schema !== 'agoragentic.nevermined-import.v1' || !object(input.source) || !object(input.record)) fail('invalid_envelope');
+  allKeys(input.source, ['provider', 'namespace', 'record_kind', 'schema_revision', 'captured_at', 'record_ref']);
+  allKeys(input.record, ['raw']);
+  if (input.source.provider !== 'nevermined' || input.source.record_kind !== 'merchant_payment_ledger') fail('invalid_envelope');
+  for (const value of [input.source.namespace, input.source.schema_revision, input.profile_id]) {
+    if (!text(value) || value.length > 256 || /[\x00-\x20\x7f]/.test(value) || secretLike(value)) fail('invalid_envelope');
+  }
+  for (const value of [input.source.record_ref, input.source.captured_at]) {
+    if (value !== undefined && value !== null && (typeof value !== 'string' || value.length > 2048 || secretLike(value))) fail('invalid_envelope');
+  }
+  if (input.profile_digest !== undefined && (typeof input.profile_digest !== 'string' || !digestPattern.test(input.profile_digest))) fail('invalid_envelope');
+  if (!object(input.record.raw) && !(allowArray && Array.isArray(input.record.raw))) fail('invalid_envelope');
+  if (input.history !== undefined && !Array.isArray(input.history)) fail('invalid_history');
+  if ((input.history?.length ?? 0) > LIMITS.records) fail('limit_exceeded');
+}
+
+/** Retain only declared scalar evidence; unknown and diagnostic fields never reach a digest. */
+function redactedSource(raw) {
+  if (!object(raw)) fail('invalid_record');
+  const retained = Object.create(null);
+  const warnings = [];
+  for (const key of Object.keys(raw)) {
+    if (!NEVERMINED_PROFILE.fields.includes(key) || NEVERMINED_PROFILE.redaction.dropped_fields.includes(key)) {
+      warnings.push('source_fields_omitted'); continue;
+    }
+    const value = raw[key];
+    if (value !== null && !['string', 'number', 'boolean'].includes(typeof value)) fail('invalid_record_field');
+    if (key === 'resourceUrl') {
+      if (typeof value !== 'string') { retained[key] = null; warnings.push('resource_url_omitted'); continue; }
+      let url;
+      try { url = new URL(value); } catch { warnings.push('resource_url_omitted'); continue; }
+      if (!['https:', 'http:'].includes(url.protocol)) { warnings.push('resource_url_omitted'); continue; }
+      url.username = ''; url.password = ''; url.search = ''; url.hash = '';
+      if (secretLike(url.href) || /[\x00-\x1f\x7f]/.test(value)) fail('secret_in_evidence_field');
+      retained[key] = url.href;
+      if (retained[key] !== value) warnings.push('resource_url_redacted');
+    } else {
+      if (secretLike(value)) fail('secret_in_evidence_field');
+      if (typeof value === 'string' && /[\x00-\x1f\x7f]/.test(value)) fail('invalid_record_field');
+      retained[key] = value;
+    }
+  }
+  return { retained, warnings };
+}
+
+function atomic(value) {
+  if (typeof value !== 'string' || !/^\d+$/.test(value)) return null;
+  if (value.length > LIMITS.amountDigits) fail('limit_exceeded');
+  return BigInt(value).toString();
+}
+function scale(value) { return Number.isInteger(value) && value >= 0 && value <= LIMITS.decimals ? value : null; }
+function displayAmount(value, decimals) {
+  if (value === null || decimals === null) return null;
+  if (decimals === 0) return value;
+  const digits = value.padStart(decimals + 1, '0');
+  const fraction = digits.slice(-decimals).replace(/0+$/, '');
+  return `${digits.slice(0, -decimals)}${fraction ? `.${fraction}` : ''}`;
+}
+function wallet(value) { return typeof value === 'string' && /^0x[a-fA-F0-9]{40}$/.test(value) ? value.toLowerCase() : null; }
+function reference(value) {
+  const ref = text(value);
+  if (!ref) return { value: null, kind: 'absent' };
+  if (abbreviated(ref)) return { value: ref, kind: 'abbreviated' };
+  return /^0x[a-fA-F0-9]{64}$/.test(ref) ? { value: ref.toLowerCase(), kind: 'evm_tx_hash' } : { value: ref, kind: 'opaque' };
+}
+const status = (value) => (has(NEVERMINED_PROFILE.merchant_statuses, value) ? NEVERMINED_PROFILE.merchant_statuses[value] : 'unknown');
+const notChecked = () => ({
+  independent_settlement: { provenance: 'reported_observation', chain_status: 'not_checked', matching_status: 'not_checked', evidence_ref: null },
+  amount_reconciliation: { ledger_amount: 'not_checked', commercial_price: 'not_checked' },
+  authority: 'not_checked', outcome: 'not_checked',
+});
+
+function baseRecord(input) {
+  validateEnvelope(input);
+  const { retained, warnings } = redactedSource(input.record.raw);
+  const known = input.profile_id === NEVERMINED_PROFILE_ID && input.source.schema_revision === NEVERMINED_REVISION;
+  if (known && input.profile_digest !== undefined && input.profile_digest !== NEVERMINED_PROFILE_DIGEST) fail('profile_digest_mismatch');
+  const source = {
+    provider: 'nevermined', namespace: input.source.namespace,
+    record_kind: 'merchant_payment_ledger', schema_revision: input.source.schema_revision,
+    provenance: 'caller_supplied',
+    redacted_source_hash: digestJson(retained), hash_scope: 'redacted_bounded_source',
+    canonicalization: 'rfc8785-jcs', redaction_profile: NEVERMINED_PROFILE.redaction.id,
+    extraction_profile: { id: input.profile_id, version: known ? NEVERMINED_PROFILE.version : null, digest: known ? NEVERMINED_PROFILE_DIGEST : null },
+    source_artifact_embedded: false,
+  };
+  const r = known ? retained : Object.create(null);
+  if (!known) warnings.push('unsupported_profile');
+  const amount = atomic(r.amount);
+  const decimals = scale(r.assetDecimals);
+  const settlement = reference(r.txHash);
+  const paymentId = text(r.id);
+  const stableId = paymentId && paymentId.length <= 256 && !/\s/u.test(paymentId) && !abbreviated(paymentId) ? paymentId : null;
+  const network = text(r.network) ? (has(NEVERMINED_PROFILE.network_aliases, r.network) ? NEVERMINED_PROFILE.network_aliases[r.network] : r.network) : null;
+  const asset = text(r.asset);
+  const eligible = known && r.protocol === 'x402' && network === 'eip155:8453' && asset?.toUpperCase() === 'USDC' && decimals === 6;
+  const merchant = {
+    provider_status: text(r.status), status_family: status(r.status),
+    protocol: text(r.protocol), network, asset,
+    amount_atomic: amount, decimals, amount_display: displayAmount(amount, decimals),
+    buyer_wallet: wallet(r.buyer), merchant_wallet: wallet(r.merchantAddress),
+    settlement_ref: settlement.value, settlement_ref_kind: settlement.kind,
+    resource_url: text(r.resourceUrl), created_at: text(r.createdAt),
+  };
+  const feeKeys = NEVERMINED_PROFILE.fields.filter((key) => key.startsWith('fee') && key !== 'feeFailureReason');
+  const fees = known && feeKeys.some((key) => has(r, key)) ? [{
+    leg: 'router_fee', provider_status: text(r.feeStatus),
+    amount_atomic: atomic(r.feeAtomic), decimals, network, asset,
+    rate_bps: Number.isSafeInteger(r.feeBps) && r.feeBps >= 0 ? r.feeBps : null,
+    budget_cents: atomic(r.feeCents),
+    settlement_ref: reference(r.feeTxHash).value, settlement_ref_kind: reference(r.feeTxHash).kind,
+    authorization_nonce: text(r.feeNonce),
+    reconciliation: 'not_checked',
+  }] : [];
+  if (known) {
+    if (!stableId) warnings.push('payment_identity_unavailable');
+    if (amount === null) warnings.push('amount_uncheckable');
+    if (decimals === null) warnings.push('decimals_uncheckable');
+    if (!wallet(r.merchantAddress)) warnings.push('merchant_wallet_unavailable');
+    if (!wallet(r.buyer)) warnings.push('buyer_wallet_unavailable');
+    if (settlement.kind !== 'evm_tx_hash') warnings.push('settlement_reference_unavailable');
+    if (merchant.status_family === 'unknown') warnings.push('unknown_provider_status');
+    if (!eligible) warnings.push('settlement_subset_unavailable');
+    if (fees.some((fee) => !NEVERMINED_PROFILE.fee_statuses.includes(fee.provider_status))) warnings.push('unknown_fee_status');
+    if (fees.some((fee) => fee.amount_atomic === null)) warnings.push('fee_amount_uncheckable');
+    if (fees.some((fee) => fee.amount_atomic !== '0' && fee.budget_cents === '0')) warnings.push('atomic_fee_with_zero_budget_cents');
+  }
+  const paymentKey = known && stableId ? digestJson(['nevermined.payment.v1', 'nevermined', input.source.namespace, stableId]) : null;
+  const observationKey = paymentKey ? digestJson(['nevermined.observation.v1', paymentKey, source.redacted_source_hash, source.extraction_profile.digest]) : null;
+  const core = {
+    source, identity: { payment_identity_key: paymentKey, observation_key: observationKey },
+    identifiers: { payment_id: known ? paymentId : null, request_id: text(r.requestId) },
+    authority_refs: { delegation_ref: text(r.delegationId), principal_ref: null, agent_ref: null },
+    merchant_payment: merchant, fee_legs: fees,
+    // This is only the redacted allowlisted projection, not the full source export.
+    original: retained,
+  };
+  const unsupported = !known || (text(r.protocol) && r.protocol !== 'x402') || (network && network !== 'eip155:8453') || (asset && asset.toUpperCase() !== 'USDC');
+  const incomplete = known && (!stableId || !text(r.protocol) || !network || !asset || amount === null || decimals === null || merchant.status_family === 'unknown' || settlement.kind !== 'evm_tx_hash' || !merchant.merchant_wallet || !merchant.buyer_wallet);
+  return {
+    schema: 'agoragentic.nevermined-evidence.v1', core,
+    observation_context: { captured_at: input.source.captured_at ?? null, record_ref_hash: input.source.record_ref ? digestJson(input.source.record_ref) : null },
+    assessment: {
+      parse_status: incomplete ? 'incomplete' : 'accepted', import_disposition: 'new',
+      prior_observation_keys: [], conflicts: [],
+      support: { pinned_profile: known, base_usdc_candidate: eligible },
+      ...notChecked(), overall_evidence_status: unsupported ? 'unsupported' : 'unresolved',
+      warnings: [...new Set(warnings)].sort(),
+    },
+  };
+}
+
+function facts(core) {
+  return { ...core.identifiers, delegation_ref: core.authority_refs.delegation_ref, ...core.merchant_payment };
+}
+function compare(current, previous) {
+  const a = facts(current.core); const b = facts(previous.core);
+  const conflicts = NEVERMINED_PROFILE.immutable_fields.filter((key) => a[key] !== null && b[key] !== null && a[key] !== b[key]);
+  if (NEVERMINED_PROFILE.merchant_incompatible_pairs.some(([x, y]) => [x, y].includes(a.status_family) && [x, y].includes(b.status_family) && a.status_family !== b.status_family)) conflicts.push('provider_status');
+  const af = current.core.fee_legs[0]; const bf = previous.core.fee_legs[0];
+  if (af && bf) {
+    for (const key of ['amount_atomic', 'rate_bps', 'settlement_ref', 'authorization_nonce']) {
+      if (af[key] !== null && bf[key] !== null && af[key] !== bf[key]) conflicts.push(`fee.${key}`);
+    }
+    if (NEVERMINED_PROFILE.fee_incompatible_pairs.some(([x, y]) => [x, y].includes(af.provider_status) && [x, y].includes(bf.provider_status) && af.provider_status !== bf.provider_status)) conflicts.push('fee.provider_status');
+  }
+  return conflicts;
+}
+
+function assessHistory(record, history) {
+  const key = record.core.identity.payment_identity_key;
+  if (!key) return freezeDeep(record);
+  const peers = history.filter((p) => p.core.identity.payment_identity_key === key && p.core.source.extraction_profile.digest === record.core.source.extraction_profile.digest);
+  const refs = peers.map((p) => p.core.identity.observation_key).filter(Boolean);
+  record.assessment.prior_observation_keys = [...new Set(refs)].sort();
+  const conflicts = [...new Set(peers.flatMap((p) => compare(record, p)))].sort();
+  record.assessment.conflicts = conflicts;
+  // Contradictory supplied assertions are not independently established chain facts.
+  // Missing delivery or an exact duplicate must never erase an existing conflict.
+  if (conflicts.length) {
+    record.assessment.import_disposition = 'conflict';
+    record.assessment.overall_evidence_status = 'contradicted';
+  } else if (refs.includes(record.core.identity.observation_key)) record.assessment.import_disposition = 'duplicate';
+  else if (peers.length) record.assessment.import_disposition = 'update';
+  return freezeDeep(record);
+}
+
+function historyRecords(input, options) {
+  if (options.history !== undefined && input.history !== undefined) fail('ambiguous_history');
+  const history = options.history ?? input.history ?? [];
+  if (!Array.isArray(history) || history.length > LIMITS.records) fail('invalid_history');
+  return history.map((entry) => {
+    if (!object(entry) || (entry.history?.length ?? 0) > 0) fail('invalid_history');
+    return baseRecord(entry);
+  });
+}
+
+/** Local only. History consists of raw import envelopes, re-normalized rather than trusting supplied assessments. */
+export function normalizeNeverminedLedger(input, options = {}) {
+  const data = snapshotJson(input); const opts = snapshotJson(options);
+  if (Buffer.byteLength(JSON.stringify(data)) + Buffer.byteLength(JSON.stringify(opts)) > LIMITS.bytes) fail('input_too_large');
+  if (!object(opts) || !object(data)) fail('invalid_envelope');
+  allKeys(opts, ['profileId', 'history']);
+  if (opts.profileId !== undefined && opts.profileId !== data.profile_id) fail('profile_id_mismatch');
+  const record = baseRecord(data);
+  return assessHistory(record, historyRecords(data, opts));
+}
+
+/** Bounded export. Every row is compared to the entire batch; no last-write-wins selection. */
+export function normalizeNeverminedExport(input) {
+  const data = snapshotJson(input);
+  validateEnvelope(data, true);
+  const rows = Array.isArray(data.record.raw) ? data.record.raw : [data.record.raw];
+  if (rows.length > LIMITS.records) fail('limit_exceeded');
+  const prior = historyRecords(data, {});
+  if (rows.length + prior.length > LIMITS.records) fail('limit_exceeded');
+  const records = rows.map((raw) => baseRecord({ ...data, record: { raw }, history: [] }));
+  // Earlier duplicates get 'new'; contradictions anywhere in a batch affect both observations.
+  return freezeDeep({
+    schema: 'agoragentic.nevermined-evidence-batch.v1',
+    records: records.map((record, index) => {
+      const peers = [...prior, ...records.filter((other, i) => i !== index && (i < index || other.core.identity.observation_key !== record.core.identity.observation_key))];
+      return assessHistory(record, peers);
+    }),
+  });
+}
+
+/** No invocation of a verifier exists in Stage A. */
+export function renderNeverminedReport(record) {
+  const c = record.core; const a = record.assessment;
+  const quote = (value) => JSON.stringify(value ?? null);
+  return [
+    'NEVERMINED EVIDENCE — STAGE A (OFFLINE)',
+    `Provider reported: ${quote(c.merchant_payment.provider_status)}; payment ${quote(c.identifiers.payment_id)}.`,
+    `Merchant amount: ${quote(c.merchant_payment.amount_atomic)} atomic units; scale ${quote(c.merchant_payment.decimals)}.`,
+    `Router fee records: ${c.fee_legs.length}; kept separate from the merchant payment.`,
+    'Independently checked: nothing. Settlement, authority, commercial price, and outcome remain not_checked.',
+    `Import: ${a.import_disposition}; overall evidence: ${a.overall_evidence_status}.`,
+    `Warnings: ${a.warnings.join(', ') || 'none'}.`,
+    `Conflicting supplied fields: ${a.conflicts.join(', ') || 'none'}.`,
+    'Next safe step: inspect the report and supply missing evidence locally. No purchase or automatic retry.',
+  ].join('\n') + '\n';
+}

--- a/transaction-assurance/src/adapters/nevermined-profile.mjs
+++ b/transaction-assurance/src/adapters/nevermined-profile.mjs
@@ -1,0 +1,35 @@
+import { digestJson, freezeDeep, LIMITS } from './nevermined-json.mjs';
+
+export const NEVERMINED_REVISION = '7c3e0c1dd00119f8e72983572c1807e78a9c1ee2';
+export const NEVERMINED_PROFILE_ID = `nevermined.merchant-payment.${NEVERMINED_REVISION}`;
+export const NEVERMINED_PROFILE = freezeDeep({
+  id: NEVERMINED_PROFILE_ID,
+  version: '1.0.0',
+  revision: NEVERMINED_REVISION,
+  basis: 'vendor_documentation_example',
+  source: `https://github.com/nevermined-io/docs/blob/${NEVERMINED_REVISION}/products/catalog/router/ledger.mdx`,
+  source_git_blob: '40c5314dba599315497bf6a3d240f5ea8598b433',
+  section: 'List payments',
+  endpoint: 'GET /api/v1/router/payments',
+  limits: LIMITS,
+  fields: [
+    'id', 'createdAt', 'status', 'protocol', 'network', 'asset', 'amount',
+    'merchantAddress', 'txHash', 'delegationId', 'requestId', 'resourceUrl', 'buyer',
+    'feeAtomic', 'feeBps', 'feeCents', 'feeStatus', 'feeTxHash', 'feeNonce',
+    'feeFailureReason', 'assetSymbol', 'assetDecimals',
+  ],
+  network_aliases: { base: 'eip155:8453', 'eip155:8453': 'eip155:8453' },
+  merchant_statuses: { Issued: 'issued', Settled: 'settled', Failed: 'failed' },
+  fee_statuses: ['None', 'Accrued', 'Submitted', 'Settled', 'Failed', 'Released'],
+  immutable_fields: ['request_id', 'delegation_ref', 'protocol', 'network', 'asset', 'amount_atomic', 'decimals', 'buyer_wallet', 'merchant_wallet', 'settlement_ref', 'created_at'],
+  merchant_incompatible_pairs: [['settled', 'failed']],
+  fee_incompatible_pairs: [['Settled', 'Released']],
+  redaction: {
+    id: 'agoragentic.nevermined-allowlist-redaction.v1',
+    dropped_fields: ['feeFailureReason'],
+    resource_url: 'drop_userinfo_query_fragment_or_entire_non_http_url',
+    unknown_fields: 'drop_before_hash_and_output',
+    secret_like_allowed_values: 'reject_without_echo',
+  },
+});
+export const NEVERMINED_PROFILE_DIGEST = digestJson(NEVERMINED_PROFILE);

--- a/transaction-assurance/test/fixtures/nevermined-no-network-preload.mjs
+++ b/transaction-assurance/test/fixtures/nevermined-no-network-preload.mjs
@@ -1,0 +1,17 @@
+// Loaded before the module graph by the CLI tests. No network is attempted.
+import http from 'node:http';
+import https from 'node:https';
+import net from 'node:net';
+import tls from 'node:tls';
+import dns from 'node:dns';
+import dgram from 'node:dgram';
+import { syncBuiltinESMExports } from 'node:module';
+const denied = () => { throw new Error('NEVERMINED_TEST_NETWORK_FORBIDDEN'); };
+globalThis.fetch = denied;
+if (globalThis.WebSocket) globalThis.WebSocket = class { constructor() { denied(); } };
+http.request = http.get = https.request = https.get = denied;
+net.connect = net.createConnection = net.Socket.prototype.connect = tls.connect = denied;
+dgram.createSocket = denied;
+for (const key of Object.keys(dns)) if (key === 'lookup' || key.startsWith('resolve')) if (typeof dns[key] === 'function') dns[key] = denied;
+for (const key of Object.keys(dns.promises)) if (key === 'lookup' || key.startsWith('resolve')) if (typeof dns.promises[key] === 'function') dns.promises[key] = denied;
+syncBuiltinESMExports();

--- a/transaction-assurance/test/nevermined-ledger.test.mjs
+++ b/transaction-assurance/test/nevermined-ledger.test.mjs
@@ -1,0 +1,251 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  normalizeNeverminedLedger as normalize, normalizeNeverminedExport,
+  NEVERMINED_PROFILE_ID, NEVERMINED_PROFILE_DIGEST,
+  parseNeverminedJson as parse, canonicalNeverminedJson as jcs,
+  renderNeverminedReport,
+} from '../src/adapters/nevermined-ledger.mjs';
+import { neverminedExitCode } from '../src/adapters/nevermined-cli.mjs';
+const base = path.dirname(fileURLToPath(import.meta.url));
+const example = path.join(base, '../examples/nevermined/7c3e0c1');
+const fixture = () => JSON.parse(fs.readFileSync(path.join(example, 'synthetic-import.json'), 'utf8'));
+const withRaw = (changes) => { const input = fixture(); Object.assign(input.record.raw, changes); return input; };
+const code = (expected) => (error) => error?.code === expected;
+
+// Negative fixtures first: parsing cannot erase ambiguous syntax before normalization.
+for (const [name, input, expected] of [
+  ['duplicate root keys', '{"x":1,"x":2}', 'duplicate_key'],
+  ['duplicate nested keys', '{"nested":{"x":1,"x":2}}', 'duplicate_key'],
+  ['escaped duplicate keys', '{"x":1,"\\u0078":2}', 'duplicate_key'],
+  ['prototype keys', '{"__proto__":{}}', 'unsafe_key'],
+  ['trailing tokens', '{} true', 'invalid_json'],
+  ['trailing comma', '[1,]', 'invalid_json'],
+  ['lone surrogate', '"\\ud800"', 'invalid_unicode'],
+  ['non-finite number', '1e400', 'unsafe_number'],
+  ['unsafe integer', '9007199254740993', 'unsafe_number'],
+  ['leading zero literal', '01', 'invalid_json'],
+  ['bad escape', '"\\q"', 'invalid_json'],
+  ['expression', 'process.env', 'invalid_json'],
+  ['oversize JSON', ' '.repeat(1048577), 'input_too_large'],
+  ['oversize string', JSON.stringify('x'.repeat(65537)), 'limit_exceeded'],
+  ['too many entries', JSON.stringify(Array(1001).fill(0)), 'limit_exceeded'],
+  ['too deep', '['.repeat(33) + '0' + ']'.repeat(33), 'limit_exceeded'],
+]) test(name, () => assert.throws(() => parse(input), code(expected)));
+
+test('invalid UTF-8 and BOM are rejected consistently', () => {
+  assert.throws(() => parse(Buffer.from([0xc3, 0x28])), code('invalid_utf8'));
+  for (const input of ['\ufeff{}', Buffer.from('\ufeff{}')]) assert.throws(() => parse(input), code('invalid_json'));
+});
+test('valid Unicode, escapes, 32 levels and literals parse', () => {
+  assert.equal(parse('"\\ud83d\\ude00"'), '😀');
+  assert.equal(parse('"a\\\\\\\"b"'), 'a\\"b');
+  assert.equal(parse('null'), null); assert.equal(parse('true'), true);
+  assert.doesNotThrow(() => parse('['.repeat(32) + '0' + ']'.repeat(32)));
+});
+test('JCS sorts numeric-looking and Unicode keys by UTF-16 without normalization', () => {
+  assert.equal(jcs(parse('{"2":0,"10":0,"1":0}')), '{"1":0,"10":0,"2":0}');
+  assert.equal(jcs(parse('{"דּ":0,"😀":0,"€":0,"ö":0,"1":0,"\\r":0}')), '{"\\r":0,"1":0,"ö":0,"€":0,"😀":0,"דּ":0}');
+  assert.notEqual(jcs(parse('"é"')), jcs(parse('"e\\u0301"')));
+  assert.equal(jcs(parse('{"a":-0,"b":1e-7,"c":4.50}')), '{"a":0,"b":1e-7,"c":4.5}');
+});
+test('JS input getters, proxies and toJSON are not executed', () => {
+  let calls = 0; const value = fixture();
+  Object.defineProperty(value.record.raw, 'id', { enumerable: true, get() { calls++; return 'unsafe'; } });
+  assert.throws(() => normalize(value), code('invalid_input')); assert.equal(calls, 0);
+  assert.throws(() => normalize(new Proxy({}, { ownKeys() { calls++; return []; } })), code('invalid_input'));
+  assert.throws(() => normalize({ toJSON() { calls++; return fixture(); } }), code('invalid_input'));
+  assert.equal(calls, 0);
+});
+test('cycles and sparse arrays reject', () => {
+  const input = fixture(); input.record.raw.loop = input;
+  assert.throws(() => normalize(input), code('limit_exceeded'));
+  input.record.raw.loop = Array(3); assert.throws(() => normalize(input), code('invalid_input'));
+});
+test('caller-supplied settled status never self-verifies', () => {
+  const result = normalize(fixture());
+  assert.equal(result.assessment.parse_status, 'accepted');
+  assert.equal(result.core.merchant_payment.provider_status, 'Settled');
+  assert.equal(result.assessment.overall_evidence_status, 'unresolved');
+  assert.deepEqual(result.assessment.independent_settlement, { provenance: 'reported_observation', chain_status: 'not_checked', matching_status: 'not_checked', evidence_ref: null });
+  assert.equal(result.assessment.authority, 'not_checked'); assert.equal(result.assessment.outcome, 'not_checked');
+  assert.equal(result.core.authority_refs.principal_ref, null);
+  assert.equal(result.core.authority_refs.agent_ref, null);
+});
+test('all identifiers, timestamps, originals and separate fee units survive', () => {
+  const source = fixture(); const c = normalize(source).core;
+  assert.equal(c.identifiers.request_id, source.record.raw.requestId);
+  assert.equal(c.authority_refs.delegation_ref, source.record.raw.delegationId);
+  assert.equal(c.merchant_payment.created_at, source.record.raw.createdAt);
+  assert.equal(c.merchant_payment.amount_atomic, '10000');
+  assert.equal(c.merchant_payment.amount_display, '0.01');
+  assert.equal(c.original.network, 'base'); assert.equal(c.merchant_payment.network, 'eip155:8453');
+  assert.equal(c.fee_legs[0].amount_atomic, '200'); assert.equal(c.fee_legs[0].budget_cents, '0');
+  assert.equal(c.fee_legs[0].settlement_ref, null); assert.equal(c.fee_legs[0].authorization_nonce, source.record.raw.feeNonce);
+});
+test('exact money never rounds or uses a float', () => {
+  const r = normalize(withRaw({ amount: '9'.repeat(78), assetDecimals: 30 }));
+  assert.equal(r.core.merchant_payment.amount_atomic, '9'.repeat(78));
+  assert.equal(r.core.merchant_payment.amount_display, '9'.repeat(48) + '.' + '9'.repeat(30));
+  assert.equal(normalize(withRaw({ amount: '0001000', assetDecimals: 0 })).core.merchant_payment.amount_display, '1000');
+  assert.throws(() => normalize(withRaw({ amount: '9'.repeat(79) })), code('limit_exceeded'));
+});
+for (const value of [null, 1000, '1.1', '1e3', '-2', true, '']) test(`amount ${JSON.stringify(value)} remains uncheckable`, () => {
+  const r = normalize(withRaw({ amount: value }));
+  assert.equal(r.core.merchant_payment.amount_atomic, null);
+  assert.equal(r.core.original.amount, value);
+  assert.equal(r.assessment.amount_reconciliation.ledger_amount, 'not_checked');
+});
+for (const value of [null, '6', -1, 31, 1.5, true]) test(`scale ${JSON.stringify(value)} is not guessed`, () => {
+  const r = normalize(withRaw({ assetDecimals: value }));
+  assert.equal(r.core.merchant_payment.decimals, null); assert.equal(r.core.merchant_payment.amount_display, null);
+});
+for (const values of [{ protocol: 'mpp' }, { network: 'solana' }, { asset: 'EURC' }, { network: 'toString' }]) test(`unsupported ${JSON.stringify(values)} is preserved`, () => {
+  const r = normalize(withRaw(values));
+  assert.equal(r.assessment.overall_evidence_status, 'unsupported');
+  assert.equal(r.assessment.independent_settlement.chain_status, 'not_checked');
+  for (const [k, v] of Object.entries(values)) assert.equal(r.core.original[k], v);
+});
+test('opaque processor and abbreviated hashes are not chain hashes', () => {
+  assert.equal(normalize(withRaw({ txHash: 'pi_synthetic' })).core.merchant_payment.settlement_ref_kind, 'opaque');
+  assert.equal(normalize(withRaw({ txHash: '0x123…' })).core.merchant_payment.settlement_ref_kind, 'abbreviated');
+  assert.equal(normalize(withRaw({ status: 'constructor' })).core.merchant_payment.status_family, 'unknown');
+});
+test('unknown profiles preserve projected digest, not guessed identifiers', () => {
+  const input = fixture(); input.source.schema_revision = 'unknown';
+  const r = normalize(input); assert.equal(r.assessment.overall_evidence_status, 'unsupported');
+  assert.equal(r.core.identity.payment_identity_key, null); assert.equal(r.core.identifiers.payment_id, null);
+  assert.equal(r.core.original.id, input.record.raw.id);
+  input.source.schema_revision = fixture().source.schema_revision; input.profile_digest = 'sha256:' + '0'.repeat(64);
+  assert.throws(() => normalize(input), code('profile_digest_mismatch'));
+});
+test('pin and namespace cannot be omitted or silently overridden', () => {
+  const input = fixture(); delete input.source.namespace;
+  assert.throws(() => normalize(input), code('invalid_envelope'));
+  assert.throws(() => normalize(fixture(), { profileId: 'wrong' }), code('profile_id_mismatch'));
+});
+test('immutable core excludes capture metadata and history-dependent assessment', () => {
+  const input = fixture(); const first = normalize(input);
+  const later = fixture(); later.source.captured_at = '2026-09-10T00:00:00Z'; later.source.record_ref = 'another:local-capture';
+  const duplicate = normalize(later, { history: [input] });
+  assert.equal(duplicate.assessment.import_disposition, 'duplicate');
+  assert.equal(jcs(first.core), jcs(duplicate.core));
+  assert.notDeepEqual(first.observation_context, duplicate.observation_context);
+  assert(Object.isFrozen(first.core));
+});
+test('namespace prevents unrelated payment IDs from colliding', () => {
+  const a = fixture(); const b = fixture(); b.source.namespace = 'synthetic:other';
+  assert.notEqual(normalize(a).core.identity.payment_identity_key, normalize(b).core.identity.payment_identity_key);
+  assert.equal(normalize(b, { history: [a] }).assessment.import_disposition, 'new');
+});
+test('compatible snapshot is an update, preserving prior reference', () => {
+  const prior = withRaw({ status: 'Issued', txHash: null });
+  const result = normalize(fixture(), { history: [prior] });
+  assert.equal(result.assessment.import_disposition, 'update');
+  assert.equal(result.assessment.overall_evidence_status, 'unresolved');
+  assert.equal(result.assessment.prior_observation_keys.length, 1);
+});
+test('actual incompatible supplied claims are never overwritten by missing delivery', () => {
+  const result = normalize(withRaw({ amount: '20000' }), { history: [fixture()] });
+  assert.equal(result.assessment.import_disposition, 'conflict');
+  assert.equal(result.assessment.overall_evidence_status, 'contradicted');
+  assert(result.assessment.conflicts.includes('amount_atomic'));
+  assert.equal(result.assessment.outcome, 'not_checked');
+  assert.equal(result.assessment.independent_settlement.chain_status, 'not_checked');
+});
+test('conflict survives duplicates and permutations of supplied history', () => {
+  const good = fixture(); const bad = withRaw({ status: 'Failed' });
+  for (const history of [[good, bad], [bad, good]]) {
+    const r = normalize(good, { history });
+    assert.equal(r.assessment.import_disposition, 'conflict'); assert.equal(r.assessment.overall_evidence_status, 'contradicted');
+  }
+});
+test('absence in an older snapshot is not contradictory evidence', () => {
+  const r = normalize(withRaw({ txHash: null }), { history: [fixture()] });
+  assert.equal(r.assessment.import_disposition, 'update'); assert.equal(r.assessment.overall_evidence_status, 'unresolved');
+});
+test('history must be raw, bounded evidence; claimed checks cannot promote', () => {
+  assert.throws(() => normalize(fixture(), { history: [normalize(fixture())] }), code('invalid_envelope'));
+  const injected = fixture(); injected.independent_settlement = { chain_status: 'settled' };
+  assert.throws(() => normalize(injected), code('invalid_envelope'));
+  const r = normalize(withRaw({ settlement_confirmed: true, authority: 'verified' }));
+  assert.equal(r.assessment.authority, 'not_checked'); assert(!hasOwn(r.core.original, 'settlement_confirmed'));
+});
+function hasOwn(value, key) { return Object.hasOwn(value, key); }
+test('batch detects duplicates and conflicts on all affected observations', () => {
+  const input = fixture(); input.record.raw = [fixture().record.raw, fixture().record.raw];
+  assert.deepEqual(normalizeNeverminedExport(input).records.map((r) => r.assessment.import_disposition), ['new', 'duplicate']);
+  input.record.raw.push(withRaw({ amount: '777' }).record.raw);
+  assert(normalizeNeverminedExport(input).records.every((r) => r.assessment.import_disposition === 'conflict'));
+});
+test('redaction occurs before digest, output, and human reporting', () => {
+  const input = withRaw({ apiKey: 'SECRET_CANARY_ONE', feeFailureReason: 'SECRET_CANARY_ONE', extra: { prompt: 'SECRET_CANARY_ONE' }, resourceUrl: 'https://user:SECRET_CANARY_ONE@service.example/path?token=SECRET_CANARY_ONE#SECRET_CANARY_ONE' });
+  const a = normalize(input); const json = JSON.stringify(a) + renderNeverminedReport(a);
+  assert(!json.includes('SECRET_CANARY_ONE')); assert(!json.includes('user:'));
+  const changed = JSON.parse(JSON.stringify(input).replaceAll('SECRET_CANARY_ONE', 'SECRET_CANARY_TWO'));
+  assert.equal(a.core.source.redacted_source_hash, normalize(changed).core.source.redacted_source_hash);
+  assert.equal(a.core.merchant_payment.resource_url, 'https://service.example/path');
+});
+test('recognized secrets in allowed fields reject without echoing', () => {
+  const token = 'Bearer TEST_ONLY_NEVER_A_REAL_TOKEN';
+  let error; try { normalize(withRaw({ id: token })); } catch (e) { error = e; }
+  assert.equal(error.code, 'secret_in_evidence_field'); assert(!String(error).includes(token));
+});
+test('vendor fixture is unchanged and never labeled observed', () => {
+  const original = fs.readFileSync(path.join(example, 'vendor-docs-example.json'));
+  const provenance = JSON.parse(fs.readFileSync(path.join(example, 'provenance.json')));
+  assert.equal(provenance.fixture_hash, 'sha256:' + createHash('sha256').update(original).digest('hex'));
+  assert.equal(provenance.observed_transaction, false); assert.equal(provenance.sanitized_real_export, false);
+  const input = fixture(); input.record.raw = JSON.parse(original)[0];
+  const r = normalize(input); assert.equal(r.core.identity.payment_identity_key, null);
+  assert.equal(r.core.merchant_payment.settlement_ref_kind, 'abbreviated');
+  assert.equal(r.assessment.independent_settlement.chain_status, 'not_checked');
+});
+test('golden Stage A report and profile digest are reproducible', () => {
+  assert.equal(jcs(normalize(fixture())), jcs(JSON.parse(fs.readFileSync(path.join(example, 'synthetic-expected.json')))));
+  assert.match(NEVERMINED_PROFILE_DIGEST, /^sha256:[a-f0-9]{64}$/);
+  const reordered = fixture(); reordered.record.raw = Object.fromEntries(Object.entries(reordered.record.raw).reverse());
+  assert.equal(jcs(normalize(fixture()).core), jcs(normalize(reordered).core));
+});
+test('CLI strict precedence and default unresolved are explicit', () => {
+  const states = ['unresolved', 'unsupported', 'contradicted'].map((state) => ({ assessment: { overall_evidence_status: state } }));
+  assert.equal(neverminedExitCode(states), 0);
+  assert.equal(neverminedExitCode(states, ['unresolved', 'unsupported', 'contradicted']), 3);
+  assert.equal(neverminedExitCode(states, ['unresolved', 'unsupported']), 4);
+  assert.equal(neverminedExitCode(states, ['unresolved']), 2);
+});
+test('actual CLI import works with network and DNS disabled before imports', () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'nevermined-stage-a-'));
+  try {
+    const cli = path.join(base, '../bin/agora-assure.mjs');
+    const loader = path.join(base, 'fixtures/nevermined-no-network-preload.mjs');
+    const args = ['--import', loader, cli, 'nevermined', 'import', '--input', path.join(example, 'synthetic-import.json'), '--profile', NEVERMINED_PROFILE_ID];
+    const call = (extra = []) => spawnSync(process.execPath, [...args, ...extra], { encoding: 'utf8', env: { ...process.env, NVM_API_KEY: 'NEVERMINED_ENV_SECRET_CANARY' }, timeout: 10000 });
+    const result = call(); assert.equal(result.status, 0, result.stderr);
+    assert.equal(JSON.parse(result.stdout).records[0].assessment.overall_evidence_status, 'unresolved');
+    assert(!result.stdout.includes('NEVERMINED_ENV_SECRET_CANARY')); assert(!result.stderr.includes('NEVERMINED_ENV_SECRET_CANARY'));
+    assert.equal(call(['--fail-on', 'unresolved']).status, 2);
+    const output = path.join(temp, 'result.json'); assert.equal(call(['--output', output]).status, 0);
+    assert.equal(call(['--output', output]).status, 64); // Never clobber a prior report.
+    const gated = spawnSync(process.execPath, [cli, 'nevermined', 'attach-settlement'], { encoding: 'utf8' });
+    assert.equal(gated.status, 64); assert(gated.stderr.includes('stage_b_gated'));
+    const bad = path.join(temp, 'bad.json'); fs.writeFileSync(bad, '{"api_key":"SECRET_CANARY","api_key":1}');
+    const invalid = spawnSync(process.execPath, [cli, 'nevermined', 'import', '--input', bad, '--profile', NEVERMINED_PROFILE_ID], { encoding: 'utf8' });
+    assert.equal(invalid.status, 64); assert.equal(invalid.stdout, ''); assert(!invalid.stderr.includes('SECRET_CANARY'));
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test('blank or whitespace-bearing payment identifiers never establish identity', () => {
+  for (const id of [' ', ' payment-1', 'payment 1', 'x'.repeat(257)]) {
+    const result = normalize(withRaw({ id }));
+    assert.equal(result.core.identity.payment_identity_key, null);
+    assert.equal(result.core.identifiers.payment_id, id);
+    assert.equal(result.assessment.parse_status, 'incomplete');
+  }
+});

--- a/transaction-assurance/test/nevermined-schema.test.mjs
+++ b/transaction-assurance/test/nevermined-schema.test.mjs
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import Ajv2020 from 'ajv/dist/2020.js';
+import { normalizeNeverminedLedger, normalizeNeverminedExport } from '../src/adapters/nevermined-ledger.mjs';
+const read = (path) => JSON.parse(fs.readFileSync(new URL(path, import.meta.url), 'utf8'));
+const inputSchema = read('../schema/nevermined-import.v1.json');
+const outputSchema = read('../schema/nevermined-evidence.v1.json');
+const batchSchema = read('../schema/nevermined-evidence-batch.v1.json');
+const ajv = new Ajv2020({ strict: true, allErrors: true, allowUnionTypes: true });
+ajv.addSchema(inputSchema).addSchema(outputSchema).addSchema(batchSchema);
+const validInput = ajv.getSchema(inputSchema.$id);
+const validOutput = ajv.getSchema(outputSchema.$id);
+const validBatch = ajv.getSchema(batchSchema.$id);
+const fixture = () => read('../examples/nevermined/7c3e0c1/synthetic-import.json');
+
+test('Nevermined input, output, batch and immutable golden fixture validate', () => {
+  const input = fixture();
+  assert(validInput(input), ajv.errorsText(validInput.errors));
+  assert(validOutput(normalizeNeverminedLedger(input)), ajv.errorsText(validOutput.errors));
+  assert(validBatch(normalizeNeverminedExport(input)), ajv.errorsText(validBatch.errors));
+  assert(validOutput(read('../examples/nevermined/7c3e0c1/synthetic-expected.json')), ajv.errorsText(validOutput.errors));
+});
+test('documentation example, unsupported profile and conflicting outputs validate', () => {
+  const input = fixture(); input.record.raw = read('../examples/nevermined/7c3e0c1/vendor-docs-example.json')[0];
+  assert(validOutput(normalizeNeverminedLedger(input)), ajv.errorsText(validOutput.errors));
+  input.source.schema_revision = 'unknown';
+  assert(validOutput(normalizeNeverminedLedger(input)), ajv.errorsText(validOutput.errors));
+  const changed = fixture(); changed.record.raw.amount = '999';
+  assert(validOutput(normalizeNeverminedLedger(changed, { history: [fixture()] })), ajv.errorsText(validOutput.errors));
+});
+for (const [name, mutate] of [
+  ['promoted chain result', (r) => { r.assessment.independent_settlement.chain_status = 'settled'; }],
+  ['complete outcome', (r) => { r.assessment.overall_evidence_status = 'evidence_complete'; }],
+  ['principal invented', (r) => { r.core.authority_refs.principal_ref = 'owner:invented'; }],
+  ['unscoped raw payload', (r) => { r.raw = { arbitrary: true }; }],
+  ['secret raw field', (r) => { r.core.original.apiKey = 'TEST_CANARY'; }],
+  ['amount converted to number', (r) => { r.core.merchant_payment.amount_atomic = 10000; }],
+  ['fee silently removed', (r) => { delete r.core.fee_legs; }],
+  ['overloaded state', (r) => { r.assessment.import_disposition = 'rejected attach'; }],
+]) test(`Nevermined schema rejects ${name}`, () => {
+  const result = JSON.parse(JSON.stringify(normalizeNeverminedLedger(fixture())));
+  mutate(result); assert.equal(validOutput(result), false);
+});


### PR DESCRIPTION
## Result

Implements the agreed **Stage A**, rather than another handoff brief, inside the existing `@agoragentic/transaction-assurance` package.

A caller can import a bounded Nevermined Router merchant-payment record/export, preserve the reported payment and separate fee evidence, identify duplicates/compatible observations/conflicts, and receive deterministic JSON plus a human diagnosis. No provider assertion becomes a trusted chain, authority, or delivery result.

## What changes

- Strict bounded UTF-8/JSON parsing with duplicate-key rejection at every level, inert-object snapshotting, explicit money/scale limits, and value-free errors.
- One adapter-maintained, digest-addressed documentation profile for `GET /api/v1/router/payments`.
- Separate merchant and Router-fee evidence, identifiers, wallets-as-wallets, provider-created time, raw allowlisted scalars, exact atomic strings and explicit decimal scale.
- Immutable `core` and observation key separated from capture metadata and history-dependent `assessment`.
- Explicit caller-owned raw-envelope history; every same-identity peer is compared once per group, and both sides of batch conflicts remain visible.
- Scoped redacted-source digest with adapter-local RFC 8785 serialization; the existing shared canonicalizer is unchanged.
- Closed input/output/batch schemas, documentation/synthetic fixtures, golden output, CLI, and tests.
- `./nevermined` export and `agora-assure nevermined import` subcommand; original commands retain their implementation and load only on their own path.

## Fixture provenance and narrow acceptance amendment

Pinned source: `nevermined-io/docs@7c3e0c1dd00119f8e72983572c1807e78a9c1ee2`, `products/catalog/router/ledger.mdx`, **List payments**. Source Git blob: `40c5314dba599315497bf6a3d240f5ea8598b433`.

The unchanged vendor JSON example (including abbreviated identifiers) has a provenance sidecar and byte digest. Fully formatted identifiers and nonzero fee cases are separately labeled synthetic, with changed fields recorded.

**This is documentation-derived development evidence, not a sanitized real export.** Actual export compatibility, deployed API behavior, Nevermined-Version guarantees, external adoption, and real settlement remain unproven. The delegation charge ledger was not substituted for the merchant-payment ledger.

## Review-driven repairs

Exact reviewed head: `5839440aa303fe828ed3e030f6ba689082040e22`, based on current `main` `56896f21174c4ef912a024af6426b0f9a904125e`.

- Generic credential assignments are rejected without echoing their values, including spaced/quoted labels, multiword values, unterminated quotes, trailing escape characters, JSON forms, and recursively percent-encoded URL paths.
- ASCII percent decoding reaches an eight-pass bounded fixed point; inputs still changing at the cap fail closed.
- Every supplied peer-to-peer history observation is compared once per identity/profile group, removing the previous cubic path while preserving conflict dominance.
- The no-network ESM preload uses a Windows-compatible file URL.
- The documentation-derived fixture is pinned to LF bytes for cross-platform reproducibility.
- The integrity-bound hosted package and reviewed-source manifest were regenerated from the repaired source.

## Safety / non-goals

No account access, API-key collection or environment-based credential reads, catalog calls, Router calls, RPC, wallets, card enrollment, delegations, purchases, refunds, spend activation, custody changes, telemetry, deployment, package publication, or trust/ranking changes.

**Stage B remains gated**: no settlement-attachment API is exported, and the corresponding CLI command returns `stage_b_gated`. Schemas reject positive settlement results, invented principal/agent identity, and `evidence_complete` in Stage A. Documentation-derived and synthetic fixtures remain explicitly labeled.

## Exact-head local verification

Windows / Node 24.13.0:

- full Transaction Assurance suite: **191/191 passed**;
- focused Nevermined suite: **73/73 passed**;
- package check, offline/no-spend self-test, and dry pack: passed;
- hosted MCP bundle: **15/15 passed**, source/artifact integrity `sha256:f43de78b2015511498d9d87df8ec6c5d3bb33ed98666d1411d71fc25669d8a1b`;
- capability/count generators, ecosystem/integrations machine surfaces, repository-rename preflight (LF-normalized **168 files / 327 references**), and **302 Markdown links**: current/passed;
- adversarial malformed-quote, trailing-backslash, one/two/three/mixed-case/eight/nine/64-layer percent-encoding, benign-control, no-echo, and near-limit probes: passed;
- 1,000 same-identity records completed in 342 ms on Node 20 and 428 ms on Node 24 in independent runs;
- signed commit, clean detached review checkout, and `git diff --check`: passed.

Independent exact-head code review: **LGTM**, with no blocking findings. Hosted exact-head CI is the remaining merge gate and is running after the Node 20 repair push.

## Reproduce

```sh
cd transaction-assurance
npm ci --ignore-scripts --no-audit --no-fund
npm run test:nevermined
npm test
npm run check
npm run self-test
npm run pack:dry
node bin/agora-assure.mjs nevermined import \
  --input examples/nevermined/7c3e0c1/synthetic-import.json \
  --profile nevermined.merchant-payment.7c3e0c1dd00119f8e72983572c1807e78a9c1ee2
```

Review contract and limitations: `transaction-assurance/docs/nevermined-stage-a.md`.

